### PR TITLE
Scaffold /backend Go module (E3.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,19 +68,27 @@ jobs:
             echo "::notice::No Go modules registered in go.work yet. Skipping lint/build/test."
           fi
 
-      - name: golangci-lint
+      - name: Install golangci-lint
         if: steps.have-modules.outputs.yes == 'true'
-        uses: golangci/golangci-lint-action@v6
-        with:
-          version: v1.59
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
+            | sh -s -- -b "$(go env GOPATH)/bin" v2.0.0
 
-      - name: Build
+      - name: Lint, build, and test each module
         if: steps.have-modules.outputs.yes == 'true'
-        run: go build ./...
-
-      - name: Test
-        if: steps.have-modules.outputs.yes == 'true'
-        run: go test -race ./...
+        run: |
+          set -eu
+          GOLANGCI_LINT="$(go env GOPATH)/bin/golangci-lint"
+          for m in $(go work edit -json | jq -r '.Use[].DiskPath'); do
+            echo "::group::go module: $m"
+            (
+              cd "$m"
+              "$GOLANGCI_LINT" run ./...
+              go build ./...
+              go test -race ./...
+            )
+            echo "::endgroup::"
+          done
 
   ts:
     name: TypeScript (lint + build + test)

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,47 @@
+# fishhawkd
+
+The Go service that orchestrates workflow runs in Fishhawk. Owns the
+workflow run / stage state machine, the policy evaluator, approval state,
+the audit log writer, the GitHub App webhook receiver, and the REST API
+consumed by the CLI and the Web UI.
+
+This directory is its own Go module. It is tied into the repo via
+`go.work` at the root so it can be tagged and released independently of
+the runner action and the CLI. See
+[ADR-014](https://github.com/kuhlman-labs/fishhawk/issues/78) for the
+multi-module rationale.
+
+## Layout
+
+- `cmd/fishhawkd/` — the binary entrypoint.
+- `internal/` — packages private to this module. The bulk of backend
+  logic lives here as it lands.
+
+## Build and test
+
+From the repo root (workspace-aware):
+
+    go build ./backend/...
+    go test ./backend/...
+
+Or from this directory directly:
+
+    go build ./...
+    go test ./...
+
+## Status
+
+This module is at the scaffold stage (E3.1, #41). The skeleton compiles,
+prints its version, and ships a smoke test so the CI pipeline has
+something to run. Real behaviour lands in subsequent issues under epic
+E3 (#3):
+
+- E3.2 (#42) — HTTP server + routing on stdlib net/http.
+- E3.3 (#43) — run/stage state machine.
+- E3.4 (#44) — policy evaluator.
+- E3.5 (#45) — approval state + SLA tracking.
+- E3.6 (#46) — REST API surface for CLI + UI.
+- E3.7 (#47) — GitHub App webhook receiver wiring.
+
+Larger context: `docs/MVP_SPEC.md` §5.1.1 (component) and §5.2 (execution
+flow).

--- a/backend/cmd/fishhawkd/main.go
+++ b/backend/cmd/fishhawkd/main.go
@@ -1,0 +1,16 @@
+// Command fishhawkd is the Fishhawk backend control plane.
+//
+// E3.1 (https://github.com/kuhlman-labs/fishhawk/issues/41) only scaffolds
+// the module. The real HTTP server, state machine, and policy evaluator
+// land in subsequent issues under epic E3 (#3).
+package main
+
+import (
+	"fmt"
+
+	"github.com/kuhlman-labs/fishhawk/backend/internal/version"
+)
+
+func main() {
+	fmt.Printf("fishhawkd %s\n", version.Version)
+}

--- a/backend/cmd/fishhawkd/main_test.go
+++ b/backend/cmd/fishhawkd/main_test.go
@@ -1,0 +1,9 @@
+package main
+
+import "testing"
+
+// TestSmoke gives `go test ./...` something to run during the scaffold
+// phase. Real behaviour tests land alongside the HTTP server in E3.2 (#42).
+func TestSmoke(t *testing.T) {
+	t.Log("fishhawkd skeleton compiles and links")
+}

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,0 +1,3 @@
+module github.com/kuhlman-labs/fishhawk/backend
+
+go 1.22

--- a/backend/internal/version/version.go
+++ b/backend/internal/version/version.go
@@ -1,0 +1,10 @@
+// Package version exposes the fishhawkd build version.
+//
+// During development the value is the literal "dev". Release builds inject
+// the real version via -ldflags at link time:
+//
+//	go build -ldflags="-X github.com/kuhlman-labs/fishhawk/backend/internal/version.Version=v0.1.0" ./cmd/fishhawkd
+package version
+
+// Version is the fishhawkd build version. Set at link time for releases.
+var Version = "dev"

--- a/backend/internal/version/version_test.go
+++ b/backend/internal/version/version_test.go
@@ -1,0 +1,9 @@
+package version
+
+import "testing"
+
+func TestVersionNotEmpty(t *testing.T) {
+	if Version == "" {
+		t.Fatal("Version must not be empty; -ldflags overrides should never produce an empty string")
+	}
+}

--- a/go.work
+++ b/go.work
@@ -7,10 +7,12 @@
 // `uses: kuhlman-labs/fishhawk/runner@vX.Y` (per MVP_SPEC §5.1.2).
 //
 // Modules will be added as use directives here as they're scaffolded:
-//   E3.1 (#41) → use ./backend
+//   E3.1 (#41) → use ./backend  ✓
 //   E5.1 (#52) → use ./runner
 //   E6.1 (#55) → use ./cli
 //
 // See ADR-014 (#78) for the rationale.
 
 go 1.22
+
+use ./backend


### PR DESCRIPTION
## Summary

Implements [E3.1 (#41)](https://github.com/kuhlman-labs/fishhawk/issues/41) — the first Go module in the multi-module workspace landed by [ADR-014 (#78)](https://github.com/kuhlman-labs/fishhawk/issues/78) / [#80](https://github.com/kuhlman-labs/fishhawk/pull/80).

- **`/backend` Go module** at module path `github.com/kuhlman-labs/fishhawk/backend`.
- **`cmd/fishhawkd/main.go`** — minimal entrypoint; prints the build version and exits. The real HTTP server lands in E3.2 (#42).
- **`internal/version`** — exposes `Version`, documents the `-ldflags` injection used by release builds.
- **Smoke tests** under both packages so the CI test step has something to assert.
- **`/backend/README.md`** describing the module's role and the upcoming child issues under epic E3 (#3).
- **`go.work`** registers `./backend` so the Go pipeline lights up.

### CI fix bundled

This PR is the first to exercise the Go path landed in #80, and it surfaced an issue: `go build ./...` from a workspace root with no root `go.mod` fails with "directory prefix . does not contain modules listed in go.work." Replaced the single root invocation with a loop that reads `go.work` `use` directives via `go work edit -json | jq` and runs lint/build/test inside each module. The loop will pick up `./runner` and `./cli` automatically when E5.1 (#52) and E6.1 (#55) register them.

While in there: switched the linter installer from `golangci/golangci-lint-action@v6` (which defaults to v1.x) to the upstream `install.sh` pinned to **v2.0.0**, so the action stops rejecting the v2-format `.golangci.yml` landed in #80.

## Test plan

- [x] `go build ./backend/...` — passes locally
- [x] `go test -race ./backend/...` — passes locally (smoke tests in `cmd/fishhawkd` and `internal/version`)
- [x] `golangci-lint run ./...` from `/backend` — 0 issues
- [x] `go run ./backend/cmd/fishhawkd` prints `fishhawkd dev`
- [x] `go work edit -print` shows `use ./backend`
- [x] DCO sign-off on the commit
- [ ] CI on the PR exercises the new loop and reports green for the `backend` module

## Notes

- No external dependencies yet; `go.sum` will appear when E3.2 brings in the first import.
- The `_test.go` files are intentional placeholders (a `t.Log` and a non-empty assertion). Real unit tests land alongside real code in subsequent E3 issues.

Closes #41