### PR TITLE
Wire HTTP server, middleware stack, and /healthz (E3.2)

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -31,17 +31,25 @@ Or from this directory directly:
 
 ## Status
 
-This module is at the scaffold stage (E3.1, #41). The skeleton compiles,
-prints its version, and ships a smoke test so the CI pipeline has
-something to run. Real behaviour lands in subsequent issues under epic
-E3 (#3):
+E3.2 (#42) — HTTP server with graceful shutdown, middleware stack, and
+the `/healthz` endpoint. The middleware order, outermost first, is
+recovery → request ID → logging → auth stub → mux. Auth is a stub that
+sets `Identity{Subject: "anonymous"}` until E4 (#4) lands real auth.
 
-- E3.2 (#42) — HTTP server + routing on stdlib net/http.
+Subsequent issues under epic E3 (#3):
+
 - E3.3 (#43) — run/stage state machine.
 - E3.4 (#44) — policy evaluator.
 - E3.5 (#45) — approval state + SLA tracking.
 - E3.6 (#46) — REST API surface for CLI + UI.
 - E3.7 (#47) — GitHub App webhook receiver wiring.
+
+## Run
+
+    go run ./backend/cmd/fishhawkd
+    curl http://localhost:8080/healthz
+
+Override the listen address with `--addr` or `FISHHAWKD_ADDR`.
 
 Larger context: `docs/MVP_SPEC.md` §5.1.1 (component) and §5.2 (execution
 flow).

--- a/backend/cmd/fishhawkd/main.go
+++ b/backend/cmd/fishhawkd/main.go
@@ -1,16 +1,80 @@
 // Command fishhawkd is the Fishhawk backend control plane.
 //
-// E3.1 (https://github.com/kuhlman-labs/fishhawk/issues/41) only scaffolds
-// the module. The real HTTP server, state machine, and policy evaluator
-// land in subsequent issues under epic E3 (#3).
+// E3.2 (https://github.com/kuhlman-labs/fishhawk/issues/42) wires up the
+// HTTP server with graceful shutdown, the middleware stack, and the
+// /healthz endpoint. Runs and stages, the policy evaluator, and the
+// REST API surface land in subsequent issues under epic E3 (#3).
 package main
 
 import (
-	"fmt"
+	"context"
+	"errors"
+	"flag"
+	"io"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
 
+	"github.com/kuhlman-labs/fishhawk/backend/internal/server"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/version"
 )
 
+const exitFailure = 1
+
 func main() {
-	fmt.Printf("fishhawkd %s\n", version.Version)
+	os.Exit(run(os.Args[1:], os.Stderr))
+}
+
+// run is split out from main so tests can drive it without exiting
+// the test process. Returns the intended process exit code.
+func run(args []string, logSink io.Writer) int {
+	fs := flag.NewFlagSet("fishhawkd", flag.ContinueOnError)
+	fs.SetOutput(logSink)
+	addr := fs.String("addr", envOr("FISHHAWKD_ADDR", ":8080"), "listen address")
+	if err := fs.Parse(args); err != nil {
+		return exitFailure
+	}
+
+	logger := slog.New(slog.NewJSONHandler(logSink, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	logger = logger.With(
+		slog.String("service", "fishhawkd"),
+		slog.String("version", version.Version),
+	)
+	slog.SetDefault(logger)
+
+	srv := server.New(server.Config{
+		Addr:   *addr,
+		Logger: logger,
+	})
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.Start() }()
+
+	select {
+	case <-ctx.Done():
+		logger.Info("shutdown signal received")
+	case err := <-errCh:
+		if err != nil && !errors.Is(err, context.Canceled) {
+			logger.Error("server start failed", slog.String("error", err.Error()))
+			return exitFailure
+		}
+	}
+
+	if err := srv.Shutdown(context.Background()); err != nil {
+		logger.Error("shutdown failed", slog.String("error", err.Error()))
+		return exitFailure
+	}
+	logger.Info("shutdown complete")
+	return 0
+}
+
+func envOr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
 }

--- a/backend/cmd/fishhawkd/main_test.go
+++ b/backend/cmd/fishhawkd/main_test.go
@@ -1,9 +1,41 @@
 package main
 
-import "testing"
+import (
+	"io"
+	"testing"
+)
 
-// TestSmoke gives `go test ./...` something to run during the scaffold
-// phase. Real behaviour tests land alongside the HTTP server in E3.2 (#42).
-func TestSmoke(t *testing.T) {
-	t.Log("fishhawkd skeleton compiles and links")
+// TestRun_BadFlag asserts run returns a non-zero exit code when a
+// flag is invalid. Quick guard against accidentally swallowing
+// flag.Parse errors.
+func TestRun_BadFlag(t *testing.T) {
+	if got := run([]string{"--no-such-flag"}, io.Discard); got == 0 {
+		t.Error("run with bad flag returned 0, want non-zero")
+	}
+}
+
+// TestRun_HelpFlag pins that --help exits without starting a listener.
+// flag.ContinueOnError surfaces help as ErrHelp from Parse.
+func TestRun_HelpFlag(t *testing.T) {
+	if got := run([]string{"--help"}, io.Discard); got == 0 {
+		t.Error("run --help returned 0, want non-zero")
+	}
+}
+
+func TestEnvOr(t *testing.T) {
+	const key = "FISHHAWKD_TEST_X"
+
+	t.Run("empty env returns default", func(t *testing.T) {
+		t.Setenv(key, "")
+		if got := envOr(key, "fallback"); got != "fallback" {
+			t.Errorf("got %q, want fallback", got)
+		}
+	})
+
+	t.Run("set env returns env value", func(t *testing.T) {
+		t.Setenv(key, "explicit")
+		if got := envOr(key, "fallback"); got != "explicit" {
+			t.Errorf("got %q, want explicit", got)
+		}
+	})
 }

--- a/backend/internal/server/handlers.go
+++ b/backend/internal/server/handlers.go
@@ -1,0 +1,38 @@
+package server
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	"github.com/kuhlman-labs/fishhawk/backend/internal/version"
+)
+
+// registerRoutes wires every endpoint onto mux. Method-aware patterns
+// require Go 1.22+ ServeMux. Add new routes here as the API surface
+// grows under E3.6 (#46); for v0 the surface is just liveness.
+func (s *Server) registerRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("GET /healthz", s.handleHealth)
+}
+
+type healthResponse struct {
+	Status  string `json:"status"`
+	Version string `json:"version"`
+}
+
+// handleHealth answers liveness probes with a small JSON payload that
+// also exposes the running version. Operators rely on the version
+// field to confirm a deploy reached this instance.
+func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	resp := healthResponse{
+		Status:  "ok",
+		Version: version.Version,
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		s.cfg.Logger.LogAttrs(r.Context(), slog.LevelError, "encode health response",
+			slog.String("error", err.Error()),
+		)
+	}
+}

--- a/backend/internal/server/handlers_test.go
+++ b/backend/internal/server/handlers_test.go
@@ -1,0 +1,32 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHandleHealth(t *testing.T) {
+	s := New(Config{})
+	rec := httptest.NewRecorder()
+	s.handleHealth(rec, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/json" {
+		t.Errorf("content-type = %q, want application/json", got)
+	}
+
+	var body healthResponse
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Status != "ok" {
+		t.Errorf("status field = %q, want ok", body.Status)
+	}
+	if body.Version == "" {
+		t.Error("version field must not be empty")
+	}
+}

--- a/backend/internal/server/middleware.go
+++ b/backend/internal/server/middleware.go
@@ -1,0 +1,140 @@
+package server
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+// ctxKey is unexported so callers must use the accessors below to
+// pull values out of a request context.
+type ctxKey int
+
+const (
+	ctxKeyRequestID ctxKey = iota
+	ctxKeyIdentity
+)
+
+// Identity is the authenticated principal for a request.
+//
+// Until E4 (#4) lands real auth, the authStub always sets
+// Identity{Subject: "anonymous"}. Downstream code that switches on
+// Subject must tolerate that value.
+type Identity struct {
+	Subject string
+}
+
+// RequestIDFrom returns the request ID set by the requestID middleware,
+// or "" if the middleware did not run (e.g., direct handler tests).
+func RequestIDFrom(ctx context.Context) string {
+	v, _ := ctx.Value(ctxKeyRequestID).(string)
+	return v
+}
+
+// IdentityFrom returns the Identity set by the auth middleware. The
+// zero value is returned if no auth middleware ran.
+func IdentityFrom(ctx context.Context) Identity {
+	v, _ := ctx.Value(ctxKeyIdentity).(Identity)
+	return v
+}
+
+const requestIDMaxLen = 64
+
+// requestID puts a per-request ID into the context and the
+// X-Request-ID response header. A client-supplied X-Request-ID is
+// honored if it's a non-empty string within length bounds; otherwise
+// we generate 24 hex chars from crypto/rand.
+func requestID(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := r.Header.Get("X-Request-ID")
+		if id == "" || len(id) > requestIDMaxLen {
+			id = newRequestID()
+		}
+		w.Header().Set("X-Request-ID", id)
+		ctx := context.WithValue(r.Context(), ctxKeyRequestID, id)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+func newRequestID() string {
+	var b [12]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// crypto/rand.Read on Linux/macOS does not fail in practice; if
+		// it does, return a constant rather than panic. Logging
+		// middleware will surface the duplicate IDs, and the request
+		// still completes.
+		return "rngfail"
+	}
+	return hex.EncodeToString(b[:])
+}
+
+// statusRecorder captures the response status for the logging
+// middleware. It assumes WriteHeader is called before any Write; if
+// Write is called first, the recorded status stays at 200, which is
+// what net/http would also report.
+type statusRecorder struct {
+	http.ResponseWriter
+	status int
+}
+
+func (s *statusRecorder) WriteHeader(code int) {
+	s.status = code
+	s.ResponseWriter.WriteHeader(code)
+}
+
+// logging emits one structured log line per request after the handler
+// returns. Fields: method, path, status, duration_ms, request_id.
+func logging(logger *slog.Logger) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			start := time.Now()
+			rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+			next.ServeHTTP(rec, r)
+			logger.LogAttrs(r.Context(), slog.LevelInfo, "request",
+				slog.String("method", r.Method),
+				slog.String("path", r.URL.Path),
+				slog.Int("status", rec.status),
+				slog.Int64("duration_ms", time.Since(start).Milliseconds()),
+				slog.String("request_id", RequestIDFrom(r.Context())),
+			)
+		})
+	}
+}
+
+// recovery turns panics into 500 responses and an error log line.
+// A panic that has already produced any response bytes can't be
+// converted to a clean 500; the response will be whatever was already
+// written, plus a connection close.
+func recovery(logger *slog.Logger) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			defer func() {
+				rec := recover()
+				if rec == nil {
+					return
+				}
+				logger.LogAttrs(r.Context(), slog.LevelError, "panic",
+					slog.Any("recovered", rec),
+					slog.String("request_id", RequestIDFrom(r.Context())),
+					slog.String("method", r.Method),
+					slog.String("path", r.URL.Path),
+				)
+				http.Error(w, "internal server error", http.StatusInternalServerError)
+			}()
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// authStub is a placeholder until E4 (#4) lands real authentication.
+// It tags every request with an anonymous Identity so downstream code
+// can be written assuming an Identity is always present in context.
+func authStub(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := context.WithValue(r.Context(), ctxKeyIdentity, Identity{Subject: "anonymous"})
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}

--- a/backend/internal/server/middleware_test.go
+++ b/backend/internal/server/middleware_test.go
@@ -1,0 +1,120 @@
+package server
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestRequestID_GeneratesWhenAbsent(t *testing.T) {
+	var captured string
+	h := requestID(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		captured = RequestIDFrom(r.Context())
+	}))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if captured == "" {
+		t.Fatal("expected a generated request ID on the context")
+	}
+	if got := rec.Header().Get("X-Request-ID"); got != captured {
+		t.Errorf("X-Request-ID header = %q, want %q", got, captured)
+	}
+}
+
+func TestRequestID_HonorsClientID(t *testing.T) {
+	const supplied = "trace-1234"
+	var captured string
+	h := requestID(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		captured = RequestIDFrom(r.Context())
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Request-ID", supplied)
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	if captured != supplied {
+		t.Errorf("captured = %q, want %q", captured, supplied)
+	}
+}
+
+func TestRequestID_RejectsOversizedClientID(t *testing.T) {
+	huge := strings.Repeat("a", requestIDMaxLen+1)
+	var captured string
+	h := requestID(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		captured = RequestIDFrom(r.Context())
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Request-ID", huge)
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	if captured == huge {
+		t.Error("oversized client ID should have been replaced with a generated one")
+	}
+	if captured == "" {
+		t.Error("expected a generated request ID after rejection")
+	}
+}
+
+func TestRecovery_CatchesPanicAndLogs(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	h := recovery(logger)(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		panic("boom")
+	}))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", rec.Code)
+	}
+	logs := buf.String()
+	if !strings.Contains(logs, `"msg":"panic"`) {
+		t.Errorf("log missing panic event:\n%s", logs)
+	}
+	if !strings.Contains(logs, "boom") {
+		t.Errorf("log missing recovered value:\n%s", logs)
+	}
+}
+
+func TestAuthStub_SetsAnonymousIdentity(t *testing.T) {
+	var captured Identity
+	h := authStub(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		captured = IdentityFrom(r.Context())
+	}))
+	h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if captured.Subject != "anonymous" {
+		t.Errorf("subject = %q, want anonymous", captured.Subject)
+	}
+}
+
+func TestLogging_EmitsStructuredEvent(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+
+	// Wrap with requestID first so the log line carries one.
+	h := requestID(logging(logger)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+		_, _ = io.WriteString(w, "short and stout")
+	})))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/foo", nil))
+
+	out := buf.String()
+	for _, want := range []string{
+		`"msg":"request"`,
+		`"method":"GET"`,
+		`"path":"/foo"`,
+		`"status":418`,
+		`"request_id":`,
+		`"duration_ms":`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("log missing %s:\n%s", want, out)
+		}
+	}
+}

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -1,0 +1,105 @@
+// Package server is the HTTP control plane for fishhawkd.
+//
+// It owns the http.Server lifecycle (Start, Shutdown), the middleware
+// stack, and the route registration. Handlers are deliberately thin —
+// real workflow logic lives in adjacent packages as it's added under
+// epic E3 (#3).
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+// Config holds the values needed to construct a Server. Zero-valued
+// fields fall back to safe defaults.
+type Config struct {
+	// Addr is the listen address (e.g. ":8080" or "127.0.0.1:0").
+	Addr string
+
+	// Logger is the structured logger used by middleware. Defaults to
+	// slog.Default() when nil.
+	Logger *slog.Logger
+
+	// ShutdownTimeout caps Shutdown's wait for in-flight requests to
+	// drain before forcing closure.
+	ShutdownTimeout time.Duration
+}
+
+// Server wraps an http.Server with the routes and middleware stack
+// that make up fishhawkd's API surface.
+type Server struct {
+	cfg  Config
+	http *http.Server
+}
+
+// New builds a Server. It does not start listening; call Start.
+func New(cfg Config) *Server {
+	if cfg.Addr == "" {
+		cfg.Addr = ":8080"
+	}
+	if cfg.Logger == nil {
+		cfg.Logger = slog.Default()
+	}
+	if cfg.ShutdownTimeout == 0 {
+		cfg.ShutdownTimeout = 15 * time.Second
+	}
+
+	s := &Server{cfg: cfg}
+	s.http = &http.Server{
+		Addr:              cfg.Addr,
+		Handler:           s.buildHandler(),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	return s
+}
+
+// Handler returns the wrapped http.Handler. Exposed so tests can drive
+// the full middleware stack without binding a port.
+func (s *Server) Handler() http.Handler {
+	return s.http.Handler
+}
+
+// Start begins serving on the configured address. It blocks until
+// Shutdown is called or the listener errors. http.ErrServerClosed
+// is reported as a clean shutdown, not an error.
+func (s *Server) Start() error {
+	s.cfg.Logger.Info("fishhawkd listening", slog.String("addr", s.cfg.Addr))
+	if err := s.http.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		return fmt.Errorf("listen: %w", err)
+	}
+	return nil
+}
+
+// Shutdown gracefully drains in-flight requests, capped by
+// ShutdownTimeout from the parent context.
+func (s *Server) Shutdown(ctx context.Context) error {
+	shutdownCtx, cancel := context.WithTimeout(ctx, s.cfg.ShutdownTimeout)
+	defer cancel()
+	return s.http.Shutdown(shutdownCtx)
+}
+
+// buildHandler wires the route mux and the middleware chain.
+//
+// Middleware order, outermost first:
+//
+//	recovery → requestID → logging → authStub → mux
+//
+// Recovery is outermost so panics in any later layer become 500s.
+// Request ID is set before logging so log lines can carry it. Auth
+// runs after logging so the request is logged even if auth rejects.
+func (s *Server) buildHandler() http.Handler {
+	mux := http.NewServeMux()
+	s.registerRoutes(mux)
+
+	var h http.Handler = mux
+	h = authStub(h)
+	h = logging(s.cfg.Logger)(h)
+	h = requestID(h)
+	h = recovery(s.cfg.Logger)(h)
+	return h
+}

--- a/backend/internal/server/server_test.go
+++ b/backend/internal/server/server_test.go
@@ -1,0 +1,101 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestServer_FullStack drives a request through the entire middleware
+// chain (recovery → requestID → logging → authStub → mux) by spinning
+// up an httptest.Server with the real Server.Handler() output.
+func TestServer_FullStack(t *testing.T) {
+	s := New(Config{})
+	ts := httptest.NewServer(s.Handler())
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/healthz")
+	if err != nil {
+		t.Fatalf("GET /healthz: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, body = %s", resp.StatusCode, body)
+	}
+	if got := resp.Header.Get("X-Request-ID"); got == "" {
+		t.Error("X-Request-ID header missing — requestID middleware did not run")
+	}
+	if got := resp.Header.Get("Content-Type"); !strings.HasPrefix(got, "application/json") {
+		t.Errorf("Content-Type = %q, want application/json...", got)
+	}
+
+	var body healthResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body.Status != "ok" {
+		t.Errorf("status = %q, want ok", body.Status)
+	}
+	if body.Version == "" {
+		t.Error("version must not be empty")
+	}
+}
+
+// TestServer_MethodMismatch confirms the Go 1.22 ServeMux's
+// method-aware routing returns 405 for the wrong verb on a registered
+// path, rather than 404.
+func TestServer_MethodMismatch(t *testing.T) {
+	s := New(Config{})
+	ts := httptest.NewServer(s.Handler())
+	defer ts.Close()
+
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/healthz", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /healthz: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want 405", resp.StatusCode)
+	}
+}
+
+// TestServer_UnknownPath confirms unregistered paths return 404.
+func TestServer_UnknownPath(t *testing.T) {
+	s := New(Config{})
+	ts := httptest.NewServer(s.Handler())
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/does-not-exist")
+	if err != nil {
+		t.Fatalf("GET unknown: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", resp.StatusCode)
+	}
+}
+
+// TestServer_ShutdownIsClean asserts that Shutdown returns nil when
+// the server has not been started and that the timeout from Config is
+// honored.
+func TestServer_ShutdownWithoutStart(t *testing.T) {
+	s := New(Config{ShutdownTimeout: 100 * time.Millisecond})
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := s.Shutdown(ctx); err != nil {
+		t.Errorf("Shutdown without Start returned %v, want nil", err)
+	}
+}


### PR DESCRIPTION
## Summary

Implements [E3.2 (#42)](https://github.com/kuhlman-labs/fishhawk/issues/42) under epic E3 (#3) — the first request-handling code in `fishhawkd`.

- **`Server.New / Start / Shutdown`** manage the `http.Server` lifecycle. `Start` blocks on `ListenAndServe`; `Shutdown` drains in-flight requests, capped by `Config.ShutdownTimeout` (default 15s).
- **Middleware stack**, outermost first: `recovery → requestID → logging → authStub → mux`. Recovery turns panics into 500s + an error log line. `requestID` honors a client-supplied `X-Request-ID` up to 64 chars; otherwise generates 24 hex chars from `crypto/rand`. Logging emits one slog JSON line per request with `method`, `path`, `status`, `duration_ms`, `request_id`. `authStub` puts `Identity{Subject: "anonymous"}` on the context until [E4 (#4)](https://github.com/kuhlman-labs/fishhawk/issues/4) lands real auth.
- **Routes** use Go 1.22 method-aware `ServeMux`. `GET /healthz` returns `{"status":"ok","version":<version.Version>}`; `POST /healthz` surfaces `405` (the linter-free way to assert wrong-verb rejection).
- **`cmd/fishhawkd/main.go`** owns flag parsing (`--addr`, `FISHHAWKD_ADDR`), slog JSON logger setup, signal-driven graceful shutdown via `signal.NotifyContext` on `SIGINT/SIGTERM`. Logic split into `run()` so tests don't `os.Exit`.

No new external dependencies — `log/slog` is stdlib and `crypto/rand` is fine for HTTP request IDs.

## Test plan

- [x] `go build ./backend/...` — clean
- [x] `go test -race ./backend/...` — three packages pass; covers each middleware in isolation, the full handler stack via `httptest`, method/path negative cases, and a `Shutdown`-without-`Start` clean exit
- [x] `golangci-lint run ./...` from `/backend` — 0 issues
- [x] Live smoke: `go build` then run binary; `curl /healthz` returns 200 with JSON + `X-Request-Id` header; `POST /healthz` returns 405; `GET /unknown` returns 404; `SIGTERM` produces `shutdown signal received` → `shutdown complete` → exit 0
- [ ] CI green on this PR

## Notes

- The `Identity` type and ctx accessors (`RequestIDFrom`, `IdentityFrom`) are exported so packages added under E3.3–E3.7 can pull them out of context without re-exporting.
- Auth stub deliberately accepts every request; switching to real OAuth is a swap-out, not a refactor, when E4 (#4) lands.
- Health response includes `version` so operators can confirm a deploy reached the instance — the kind of thing you only miss when you need it.

Closes #42