### PR TITLE
Add dependabot + CI Pass rollup status check

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,62 @@
+# Dependabot keeps Fishhawk's dependencies current.
+#
+# Per docs/METHODOLOGY.md, dependency bumps that pass CI fall under the
+# high-autonomy tier — agents may merge them once all gates are green.
+# The labels below feed Project #7's filters so bump PRs slot into the
+# right Component/Autonomy buckets automatically.
+#
+# Add new entries as new modules land:
+#   /runner under E5.1 (#52)
+#   /cli    under E6.1 (#55)
+#   /frontend under E7.1 (#37)
+
+version: 2
+
+updates:
+  # Backend Go module.
+  - package-ecosystem: gomod
+    directory: /backend
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: America/New_York
+    open-pull-requests-limit: 5
+    labels:
+      - type:chore
+      - area:backend
+      - autonomy:high
+    commit-message:
+      prefix: deps(backend)
+      include: scope
+    groups:
+      pgx:
+        patterns:
+          - "github.com/jackc/pgx/*"
+      otel:
+        patterns:
+          - "go.opentelemetry.io/*"
+      testcontainers:
+        patterns:
+          - "github.com/testcontainers/*"
+      golang-migrate:
+        patterns:
+          - "github.com/golang-migrate/*"
+
+  # GitHub Actions workflows. Especially load-bearing given the
+  # September-2026 deprecation of Node-20-based actions warned about
+  # on PR #85.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: America/New_York
+    open-pull-requests-limit: 5
+    labels:
+      - type:chore
+      - area:infra
+      - autonomy:high
+    commit-message:
+      prefix: ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,3 +107,27 @@ jobs:
       - run: |
           echo "::notice::TypeScript pipeline lands with E7.1 (frontend scaffold, issue #37)."
           echo "Until then this job is a placeholder so the path filter is exercised."
+
+  # Rollup gate. The repo ruleset requires only this job; it inherits
+  # the result of every job listed in `needs`. Add new jobs to that
+  # list and they automatically become part of the gate without
+  # touching the ruleset.
+  ci-pass:
+    name: CI Pass
+    needs: [detect, go, ts]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required jobs
+        run: |
+          # Skipped jobs (e.g. the TS job when no TS files changed)
+          # are NOT failures. Cancellations are.
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+            echo "::error::One or more required jobs failed."
+            exit 1
+          fi
+          if [[ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "::error::One or more required jobs was cancelled."
+            exit 1
+          fi
+          echo "All required jobs passed (or were correctly skipped)."


### PR DESCRIPTION
## Summary

Two small, related pieces — both in service of the [ruleset migration](https://github.com/kuhlman-labs/fishhawk) that comes next as an operational follow-up.

### `.github/dependabot.yml`

Watches `/backend` (gomod) and `/` (github-actions) on a weekly Monday-morning cadence. PRs land with:

- `autonomy:high` (matches the methodology tier — dep bumps that pass CI are merge-eligible)
- `area:backend` or `area:infra`
- `type:chore`

Major ecosystems (pgx, otel, testcontainers, golang-migrate) are grouped so a single PR covers each ecosystem's version bump rather than fragmenting into 5+ PRs. The github-actions block is particularly load-bearing: PR #85 surfaced the September-2026 Node-20 deprecation warning, and this is the mechanism that'll quietly upgrade `actions/checkout`, `actions/setup-go`, `dorny/paths-filter` on schedule.

### `CI Pass` rollup job

The CI workflow gains a job (`ci-pass`, display name "CI Pass") that:

- `needs: [detect, go, ts]` so it inherits the result of every other job
- `if: always()` so it runs even when a dependency fails (and can therefore report failure)
- Treats `skipped` results as success (the TS job is correctly skipped on Go-only PRs) but `failure` and `cancelled` as failure

The ruleset coming next will require only `CI Pass`. Adding a new CI job means just appending to `needs:` — no ruleset change required.

## Test plan

- [x] `actionlint .github/workflows/ci.yml` — clean
- [x] `dependabot.yml` parses (verified via go yaml.Unmarshal as a sanity check)
- [ ] CI run on this PR shows the new "CI Pass" check finishing green alongside the existing checks
- [ ] After merge, "CI Pass" appears as an available status check option on subsequent PRs

## What happens after merge

**Operational, not in this PR:**

1. Configure a ruleset on `main` via `gh api repos/kuhlman-labs/fishhawk/rulesets`:
   - PR required (0 approvals — solo-founder phase)
   - Required status check: `CI Pass`
   - Linear history
   - Conversation resolution required
   - No force-push, no deletion
   - Admin bypass enabled (founder, with audit-log entry — matches `enforce_admins: false` semantics from the classic protection)
2. Delete the classic branch protection on `main` via `gh api -X DELETE repos/kuhlman-labs/fishhawk/branches/main/protection`

That two-step swap can't land in this PR because it's GitHub state, not code, and it has to happen *after* `CI Pass` exists on `main` so it's selectable as a required check.

Closes nothing — meta tooling. Would slot under E13 (Infrastructure & Deployment) if tracked.