### PR TITLE
Add workflow-v0 + plan-standard-v1 JSON Schemas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ Pre-alpha. Most code referenced in `docs/MVP_SPEC.md` doesn't exist yet — it's
 - `docs/ARCHITECTURE.md` — current technical realization (stack, lifecycle, storage, invariants). Read before designing anything cross-component.
 - `docs/BRAND_FOUNDATIONS.md` — voice, naming, positioning.
 - `docs/METHODOLOGY.md` — autonomy tiers (low/medium/high).
+- `docs/spec/` — canonical JSON Schemas + reference docs for the workflow spec (`.fishhawk/workflows.yaml`) and the plan artifact (`standard_v1`). Validate with `check-jsonschema --schemafile <schema> <yaml-or-json>`.
 - `.fishhawk/workflows.yaml` — placeholder; executed by the product itself starting Day 21 (~2026-05-20).
 
 ## Documentation surfaces

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -146,7 +146,8 @@ GitHub OAuth (E4.2 / #49) is the sign-in flow that mints the cookie session. App
 | Why a decision was made | The corresponding closed ADR issue (`gh issue list --label adr --state closed`) |
 | Voice / naming for new surfaces | `docs/BRAND_FOUNDATIONS.md` §5–§7 |
 | Autonomy tier of a change | `docs/METHODOLOGY.md` |
-| Workflow primitive grammar | `.fishhawk/workflows.yaml` (canonical example) and the spec's §4.2 |
+| Workflow spec grammar | `docs/spec/workflow-v0.md` + `docs/spec/workflow-v0.schema.json` |
+| Plan artifact structure | `docs/spec/plan-standard-v1.md` + `docs/spec/plan-standard-v1.schema.json` |
 | HTTP middleware order / context keys | `backend/internal/server/middleware.go` |
 | How a new Go module gets added | `CLAUDE.md` "Adding a Go module" |
 

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -1,0 +1,48 @@
+# Fishhawk specs
+
+Machine-readable schemas and reference docs for the v0 surfaces that span the runner, the backend, and customer repos. Both schemas freeze at Day 21 of the v0 build (`MVP_SPEC.md` §8) — never break in place; bump to a new version (`workflow-v1`, `standard_v2`...) and keep the old schema readable.
+
+## Files
+
+| Spec | Reference doc | JSON Schema | Example(s) |
+|---|---|---|---|
+| Workflow spec v0 (`.fishhawk/workflows.yaml`) | [`workflow-v0.md`](workflow-v0.md) | [`workflow-v0.schema.json`](workflow-v0.schema.json) | [`examples/workflow-v0-feature-change.yaml`](examples/workflow-v0-feature-change.yaml), [`examples/workflow-v0-routine-change.yaml`](examples/workflow-v0-routine-change.yaml) |
+| Plan artifact `standard_v1` | [`plan-standard-v1.md`](plan-standard-v1.md) | [`plan-standard-v1.schema.json`](plan-standard-v1.schema.json) | [`examples/plan-standard-v1-example.json`](examples/plan-standard-v1-example.json) |
+
+Both schemas are JSON Schema Draft 2020-12.
+
+## Validating locally
+
+```sh
+# install once
+brew install check-jsonschema
+
+# validate the schemas themselves against the JSON Schema meta-schema
+check-jsonschema --check-metaschema docs/spec/*.schema.json
+
+# validate examples (and the live placeholder workflow file)
+check-jsonschema --schemafile docs/spec/workflow-v0.schema.json \
+    docs/spec/examples/workflow-v0-feature-change.yaml \
+    docs/spec/examples/workflow-v0-routine-change.yaml \
+    .fishhawk/workflows.yaml
+
+check-jsonschema --schemafile docs/spec/plan-standard-v1.schema.json \
+    docs/spec/examples/plan-standard-v1-example.json
+```
+
+The Go-based validators that ship in the runner and backend (E1.3 / #18, E1.5 / #20) are the canonical enforcement point; this CLI is for local sanity-checks and review.
+
+## Versioning
+
+- The schema's filename pins the version (`workflow-v0.schema.json`, `plan-standard-v1.schema.json`).
+- Inside each schema, the `$id` URL also pins the version.
+- `version` (workflow spec) and `plan_version` (plan artifact) are required, single-value enums.
+- Breaking changes go to a new file (`workflow-v1.schema.json`, `plan-standard-v2.schema.json`). The validators carry every version forever so old audit log entries stay readable.
+
+Additive, non-breaking changes within a major version are permitted (e.g., adding an optional field) — but these are still rare and require a corresponding update to the validator's tests.
+
+## See also
+
+- `docs/MVP_SPEC.md` §4.1–§4.3 — the primitives, the canonical example, and the plan-artifact requirements.
+- `docs/ARCHITECTURE.md` §4 — workflow run lifecycle, where these artifacts flow.
+- `CLAUDE.md` — the canonical-references list that points future agents here.

--- a/docs/spec/examples/plan-standard-v1-example.json
+++ b/docs/spec/examples/plan-standard-v1-example.json
@@ -1,0 +1,49 @@
+{
+  "plan_version": "standard_v1",
+  "ticket_reference": {
+    "type": "github_issue",
+    "url": "https://github.com/kuhlman-labs/fishhawk/issues/1247",
+    "id": "kuhlman-labs/fishhawk#1247"
+  },
+  "generated_by": {
+    "agent": "claude-code",
+    "model": "claude-opus-4-7",
+    "version": "build-abc123",
+    "timestamp": "2026-04-30T14:22:11Z"
+  },
+  "summary": "Add a bulk export endpoint for the audit log so customers can hand a date-ranged JSON dump to their compliance officer without scraping the UI.",
+  "scope": {
+    "files": [
+      { "path": "backend/internal/api/audit_export.go", "operation": "create" },
+      { "path": "backend/internal/api/audit_export_test.go", "operation": "create" },
+      { "path": "backend/internal/api/router.go", "operation": "modify" }
+    ],
+    "estimated_lines_changed": 280
+  },
+  "approach": [
+    {
+      "step": 1,
+      "description": "Add GET /v0/audit/export with --from and --to query parameters validated as RFC-3339 timestamps."
+    },
+    {
+      "step": 2,
+      "description": "Stream JSON Lines from audit_entries with cursor-based pagination (limit 1000 rows per page); cursor is the (created_at, entry_id) of the last row."
+    },
+    {
+      "step": 3,
+      "description": "Reuse existing rate-limit middleware; document the endpoint in docs/api/v0.md."
+    },
+    {
+      "step": 4,
+      "description": "Add an integration test that seeds 1000 entries across 3 dates and exercises pagination end-to-end."
+    }
+  ],
+  "verification": {
+    "test_strategy": "Integration test under backend/internal/api/audit_export_test.go uses testcontainers Postgres, seeds entries, asserts (a) date filtering correctness, (b) pagination cursor stability across pages, (c) JSON Lines output framing. Manual smoke: curl against local docker-compose to confirm streaming works end-to-end.",
+    "rollback_plan": "Revert the PR. The endpoint is purely additive and reads existing tables; no data migration to roll back."
+  },
+  "risks_and_assumptions": [
+    "Assumes audit_entries (created_at, entry_id) is the natural sort order; if a future migration adds an `inserted_at` distinct from `created_at` the cursor format will need to be revisited.",
+    "Risk: very large date ranges (months) could pull millions of rows; mitigated by the per-page cap of 1000 rows and a server-side total cap of 100k rows per request, with a clear error advising the caller to narrow the range."
+  ]
+}

--- a/docs/spec/examples/workflow-v0-feature-change.yaml
+++ b/docs/spec/examples/workflow-v0-feature-change.yaml
@@ -1,0 +1,85 @@
+# Canonical workflow example — mirrors MVP_SPEC.md §4.2.
+#
+# Validates against ../workflow-v0.schema.json. Used as a regression
+# fixture: any change to the schema must keep this example valid, and
+# any change to this example must remain valid against the schema.
+
+version: "0.1"
+
+roles:
+  tech_lead:
+    members: ["@org/tech-leads"]
+  senior_engineer:
+    members: ["@org/senior-engineers", "@org/tech-leads"]
+  any_engineer:
+    members: ["@org/engineering"]
+
+workflows:
+  feature_change:
+    description: "Default workflow for new features and non-trivial changes."
+
+    stages:
+      - id: plan
+        type: plan
+        executor:
+          agent: claude-code
+        inputs:
+          - source: github_issue
+            required: true
+        produces:
+          - artifact: plan
+            schema: standard_v1
+            persistence:
+              - target: originating_issue
+                mode: rendered_comment
+                update_on_change: true
+              - target: fishhawk_audit_log
+                mode: canonical
+        budget:
+          max_tokens: 200000
+          max_runtime_minutes: 15
+          enforcement: advisory
+        gates:
+          - type: approval
+            approvers:
+              any_of: [tech_lead, senior_engineer]
+            sla: 4_business_hours
+
+      - id: implement
+        type: implement
+        executor:
+          agent: claude-code
+        inputs:
+          - artifact: plan
+            from_stage: plan
+        produces:
+          - artifact: pull_request
+        constraints:
+          - max_files_changed: 30
+          - forbidden_paths:
+              - "infra/**"
+              - ".github/workflows/**"
+              - "security/**"
+              - ".fishhawk/**"
+          - required_outcomes:
+              - tests_added_or_updated
+              - ci_green
+        budget:
+          max_tokens: 500000
+          max_runtime_minutes: 30
+          enforcement: advisory
+
+      - id: review
+        type: review
+        executor:
+          human: true
+        inputs:
+          - artifact: pull_request
+            from_stage: implement
+        gates:
+          - type: approval
+            approvers:
+              any_of: [senior_engineer]
+            blocking_checks:
+              - ci_pass
+              - fishhawk_audit_complete

--- a/docs/spec/examples/workflow-v0-routine-change.yaml
+++ b/docs/spec/examples/workflow-v0-routine-change.yaml
@@ -1,0 +1,47 @@
+# High-autonomy workflow example — agent implements and merges if all
+# gates pass. Mirrors the routine_change workflow in
+# /.fishhawk/workflows.yaml. Used to exercise the schema's:
+# - check-gate path (no human approver)
+# - allowed_paths constraint kind
+# - executor on a review stage being an agent
+# - omitted optional sections (no inputs, no budget on either stage)
+
+version: "0.1"
+
+roles:
+  founder:
+    members: ["@kuhlman-labs"]
+
+workflows:
+  routine_change:
+    description: >-
+      Workflow for documentation, dependency bumps, lint/format fixes,
+      and tests for existing behavior. Agent may merge if all gates pass.
+
+    stages:
+      - id: implement
+        type: implement
+        executor:
+          agent: claude-code
+        produces:
+          - artifact: pull_request
+        constraints:
+          - max_files_changed: 20
+          - allowed_paths:
+              - "docs/**"
+              - "**/*.md"
+              - "go.mod"
+              - "go.sum"
+              - "**/*_test.go"
+          - required_outcomes:
+              - ci_green
+
+      - id: review
+        type: review
+        executor:
+          agent: claude-code
+        gates:
+          - type: check
+            blocking_checks:
+              - ci_pass
+              - fishhawk_audit_complete

--- a/docs/spec/plan-standard-v1.md
+++ b/docs/spec/plan-standard-v1.md
@@ -1,0 +1,137 @@
+# Plan artifact `standard_v1`
+
+The output of every `type: plan` stage. Validated by the runner (E5.4 / #31) before a stage is considered successful, persisted into the audit log as the canonical record of agent intent, and rendered as a comment on the originating GitHub issue.
+
+The canonical schema is [`plan-standard-v1.schema.json`](plan-standard-v1.schema.json). An example plan that validates lives at [`examples/plan-standard-v1-example.json`](examples/plan-standard-v1-example.json).
+
+> **Frozen at Day 21** of the v0 build. Old plans in the audit log remain readable forever — never break this schema in place. Future versions land as `standard_v2` etc., and the plan validator (E1.5 / #20) keeps every version readable.
+
+## Top-level shape
+
+```json
+{
+  "plan_version": "standard_v1",
+
+  "ticket_reference": { "type": "...", "url": "...", "id": "..." },
+  "generated_by":     { "agent": "...", "model": "...", "timestamp": "..." },
+
+  "summary":      "...",
+  "scope":        { "files": [...], "estimated_lines_changed": 0 },
+  "approach":     [ { "step": 1, "description": "..." }, ... ],
+  "verification": { "test_strategy": "...", "rollback_plan": "..." },
+
+  "risks_and_assumptions": ["..."]
+}
+```
+
+`plan_version` is required and pins the document to this schema. The validator routes versions to their respective schemas; an unknown version is a category-A failure.
+
+## Required fields
+
+### `ticket_reference`
+
+```json
+{
+  "type": "github_issue",
+  "url":  "https://github.com/kuhlman-labs/fishhawk/issues/1247",
+  "id":   "kuhlman-labs/fishhawk#1247"
+}
+```
+
+`type` is `github_issue` in v0 (closed set; v0.x adds Linear and Jira). `url` is the canonical web URL; `id` is a stable identifier suitable for indexing.
+
+### `generated_by`
+
+```json
+{
+  "agent":     "claude-code",
+  "model":     "claude-opus-4-7",
+  "version":   "build-abc123",
+  "timestamp": "2026-04-30T14:22:11Z"
+}
+```
+
+`agent` matches the workflow spec's `executor.agent`. `model` is the specific model. `timestamp` is RFC 3339, recorded at agent invocation. `version` is optional and used when the agent surfaces a build SHA.
+
+### `summary`
+
+A non-empty human-readable description. The plan-review UI renders this as the lead paragraph; the GitHub issue comment uses it as the headline. One to three sentences.
+
+### `scope`
+
+```json
+{
+  "files": [
+    { "path": "backend/internal/api/audit_export.go", "operation": "create" },
+    { "path": "backend/internal/api/router.go",        "operation": "modify" }
+  ],
+  "estimated_lines_changed": 250
+}
+```
+
+`files` lists every file the agent intends to touch with one of `create | modify | delete`. The runner's post-hoc constraint check (E5.5 / #53) compares this list against the actual diff and against the stage's `forbidden_paths` / `allowed_paths` constraints.
+
+`estimated_lines_changed` is a reviewer cue, not enforced.
+
+### `approach`
+
+Ordered list of steps. Each step has a 1-indexed `step` number and a `description`. At least one step is required. Steps are how reviewers grok intent quickly; the runner does not consume them programmatically.
+
+```json
+[
+  { "step": 1, "description": "Add /v0/audit/export endpoint with date-range filters" },
+  { "step": 2, "description": "Stream JSON Lines from audit_entries with cursor-based pagination" },
+  { "step": 3, "description": "Add an integration test that seeds 1000 entries and asserts ordering" }
+]
+```
+
+### `verification`
+
+```json
+{
+  "test_strategy": "Integration test: seed 1000 audit entries across 3 dates, exercise --from/--to filters, assert pagination cursor is stable.",
+  "rollback_plan": "Revert the PR. Endpoint is additive and reads existing tables; no data migration to roll back."
+}
+```
+
+Reviewers expect concrete tests, not "add tests." Rollback plans flag whether a change is purely additive or has data migration consequences.
+
+## Optional fields
+
+### `risks_and_assumptions`
+
+```json
+[
+  "Assumes audit_entries.payload_jsonb has indexed fields the filter uses",
+  "Risk: large date ranges could be expensive; mitigated by a cursor-based limit of 1000 rows per page"
+]
+```
+
+Free-form strings. The plan-review UI surfaces these in a sidebar. Useful for the agent to flag uncertainty rather than over-claim confidence.
+
+## Validation rules beyond the schema
+
+JSON Schema enforces structure. The validator (E1.5 / #20) layers on:
+
+- `scope.files[].path` matches at least one of the stage's `allowed_paths` (when set) and none of the `forbidden_paths`.
+- `generated_by.timestamp` is within the run's wall-clock window (catches clock-skew or replay).
+- `generated_by.agent` matches the workflow spec's `executor.agent` for the active stage.
+
+These cross-references aren't expressible in JSON Schema cleanly.
+
+## Persistence
+
+Per `MVP_SPEC.md` §4.3:
+
+| Surface | Mode | Notes |
+|---|---|---|
+| `fishhawk_audit_log` | `canonical` | Full structure, immutable. The audit log is the source of truth. |
+| `originating_issue`  | `rendered_comment` | Rendered Markdown comment on the GitHub issue. Updated if the plan is regenerated. |
+
+The runner ships the canonical JSON to the backend; the backend renders the Markdown view and posts it via the GitHub App's installation token.
+
+## See also
+
+- `MVP_SPEC.md` §4.3 — original specification of required and optional fields.
+- `MVP_SPEC.md` §4.4 — audit log persistence.
+- `workflow-v0.md` — the workflow spec that produces these artifacts.

--- a/docs/spec/plan-standard-v1.schema.json
+++ b/docs/spec/plan-standard-v1.schema.json
@@ -1,0 +1,168 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://fishhawk.dev/spec/plan-standard-v1.schema.json",
+  "title": "Fishhawk plan artifact (standard_v1)",
+  "description": "The plan-stage output produced by the agent and validated by the runner before the stage is considered successful. Frozen at Day 21 of the v0 build per MVP_SPEC.md §8 — old plans in the audit log remain readable forever; never break this schema in place. Future versions land as standard_v2, etc.",
+
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "plan_version",
+    "ticket_reference",
+    "generated_by",
+    "summary",
+    "scope",
+    "approach",
+    "verification"
+  ],
+
+  "properties": {
+    "plan_version": {
+      "type": "string",
+      "enum": ["standard_v1"],
+      "description": "Schema version the document was authored against."
+    },
+    "ticket_reference": { "$ref": "#/$defs/ticket-reference" },
+    "generated_by":     { "$ref": "#/$defs/generated-by" },
+    "summary": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human-readable description of the change. Rendered as the lead paragraph in the issue comment."
+    },
+    "scope":              { "$ref": "#/$defs/scope" },
+    "approach": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/approach-step" },
+      "description": "Ordered steps the agent intends to take."
+    },
+    "verification":       { "$ref": "#/$defs/verification" },
+    "risks_and_assumptions": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "description": "Optional. Things the agent flagged as uncertain or assumed; surfaces in the review UI."
+    }
+  },
+
+  "$defs": {
+    "ticket-reference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "url", "id"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["github_issue"],
+          "description": "v0 closed set; v0.x adds linear_ticket and jira_ticket."
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Canonical URL of the originating ticket."
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Stable identifier — e.g. \"kuhlman-labs/fishhawk#1247\"."
+        }
+      }
+    },
+
+    "generated-by": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["agent", "model", "timestamp"],
+      "properties": {
+        "agent": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Agent identifier matching the workflow spec's executor.agent."
+        },
+        "model": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Specific model used (e.g. claude-opus-4-7)."
+        },
+        "version": {
+          "type": "string",
+          "description": "Optional. Model version or build SHA when agent reports it."
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "RFC 3339 timestamp of generation. The runner wall-clock at agent invocation."
+        }
+      }
+    },
+
+    "scope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["files"],
+      "properties": {
+        "files": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/scope-file" },
+          "description": "Files the agent intends to create, modify, or delete."
+        },
+        "estimated_lines_changed": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Rough estimate. Used by reviewers to gauge change size; not enforced."
+        }
+      }
+    },
+
+    "scope-file": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "operation"],
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Repo-relative path."
+        },
+        "operation": {
+          "type": "string",
+          "enum": ["create", "modify", "delete"]
+        }
+      }
+    },
+
+    "approach-step": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["step", "description"],
+      "properties": {
+        "step": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+
+    "verification": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["test_strategy", "rollback_plan"],
+      "properties": {
+        "test_strategy": {
+          "type": "string",
+          "minLength": 1,
+          "description": "How the change will be tested. Free-form prose; reviewers expect concrete tests, not just \"add tests\"."
+        },
+        "rollback_plan": {
+          "type": "string",
+          "minLength": 1,
+          "description": "How a regression would be undone. \"Revert PR\" is a valid answer for purely-additive changes; data migrations need more."
+        }
+      }
+    }
+  }
+}

--- a/docs/spec/workflow-v0.md
+++ b/docs/spec/workflow-v0.md
@@ -1,0 +1,151 @@
+# Workflow spec v0
+
+Reference for `.fishhawk/workflows.yaml`. The canonical schema is [`workflow-v0.schema.json`](workflow-v0.schema.json) (JSON Schema Draft 2020-12). Examples live in [`examples/`](examples/).
+
+> **Frozen at Day 21** of the v0 build (MVP_SPEC.md §8). Old workflow runs in the audit log remain readable forever; never break this schema in place — bump to a new spec version (`workflow-v1`, `workflow-v2`...) instead.
+
+## Top-level shape
+
+```yaml
+version: "0.1"          # required, exactly "0.1" in v0
+roles:                  # optional; named groups referenced by gates
+  <role_id>:
+    members: ["@org/team", "@user"]
+workflows:              # required; at least one workflow
+  <workflow_id>:
+    description: "..."
+    stages: [...]
+```
+
+Identifiers (`<role_id>`, `<workflow_id>`, stage `id`s) are `snake_case` — `^[a-z][a-z0-9_]*$`. Member refs are GitHub conventions: `@user` for a single user, `@org/team` for a team. Resolution happens at run time against the GitHub App installation.
+
+## Stages
+
+```yaml
+- id: plan
+  type: plan | implement | review     # closed set; no custom types
+  executor:                           # exactly one of agent or human
+    agent: claude-code                # any string; v0 ships claude-code
+    # OR
+    human: true
+  inputs:      [<input>...]           # optional
+  produces:    [<artifact>...]        # optional
+  constraints: [<constraint>...]      # optional, only meaningful for implement
+  budget:      <budget>               # optional
+  gates:       [<gate>...]            # optional
+```
+
+Stage `id` is unique within the workflow. The `from_stage` field on inputs cross-references it; the validator (E1.3 / #18) enforces this beyond the schema.
+
+## Inputs
+
+Two shapes:
+
+```yaml
+# External trigger (issue, PR)
+- source: github_issue | pull_request
+  required: true
+
+# Artifact from a prior stage in the same run
+- artifact: plan | pull_request
+  from_stage: <stage_id>
+```
+
+## Produces
+
+```yaml
+- artifact: plan | pull_request
+  schema: standard_v1                 # plan only; identifies the artifact schema version
+  persistence:
+    - target: originating_issue | fishhawk_audit_log
+      mode: rendered_comment | canonical
+      update_on_change: true          # republish if the artifact is regenerated
+```
+
+`canonical` is the authoritative copy (stored in the audit log). `rendered_comment` is the human-readable echo on the originating tracker (the GitHub issue), kept in sync.
+
+## Constraints (implement stages)
+
+Exactly one kind per constraint object — combine multiple kinds in the array. Closed set per MVP_SPEC §4.1.
+
+```yaml
+constraints:
+  - max_files_changed: 30
+  - forbidden_paths:
+      - "infra/**"
+      - ".github/workflows/**"
+  - allowed_paths:                    # mutually informative with forbidden
+      - "docs/**"
+      - "**/*.md"
+  - required_outcomes:
+      - tests_added_or_updated
+      - ci_green
+```
+
+Constraints are evaluated **post-hoc on the runner** (E5.5 / #53) against the produced diff. Hits become **category B** failures (MVP_SPEC §6).
+
+## Budget
+
+```yaml
+budget:
+  max_tokens: 200000
+  max_runtime_minutes: 15
+  enforcement: advisory | blocking
+```
+
+v0 ships `advisory` enforcement only — the runner reports overruns but does not abort. `blocking` arrives in v0.x once Fishhawk issues ephemeral agent keys (so the proxy can hard-cap).
+
+## Gates
+
+Two types:
+
+```yaml
+# Approval gate — blocks until an approver acts.
+- type: approval
+  approvers:
+    any_of: [tech_lead, senior_engineer]   # or all_of
+  sla: 4_business_hours                    # optional; D-category timeout
+  blocking_checks: [ci_pass]               # optional pre-checks
+
+# Check gate — passes when all named checks succeed; no human approval.
+- type: check
+  blocking_checks: [ci_pass, fishhawk_audit_complete]
+```
+
+`blocking_checks` are GitHub status check contexts (e.g. `ci_pass`) plus Fishhawk-internal ones (`fishhawk_audit_complete`).
+
+## Identifier namespaces
+
+| Field | Pattern / values | Notes |
+|---|---|---|
+| `version` | `"0.1"` | v0 frozen value |
+| Role / workflow / stage IDs | `^[a-z][a-z0-9_]*$` | snake_case |
+| Member refs | `^@[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)?$` | GitHub user or team |
+| Stage `type` | `plan` \| `implement` \| `review` | closed set |
+| Executor | `agent: <string>` xor `human: true` | mutually exclusive |
+| Input `source` | `github_issue` \| `pull_request` | v0; v0.x adds Linear/Jira |
+| Artifact | `plan` \| `pull_request` | closed set |
+| Persistence target | `originating_issue` \| `fishhawk_audit_log` | closed set |
+| Persistence mode | `rendered_comment` \| `canonical` | closed set |
+| Constraint kind | `max_files_changed`, `forbidden_paths`, `allowed_paths`, `required_outcomes` | exactly one per constraint |
+| `required_outcomes` items | `tests_added_or_updated`, `ci_green` | closed set |
+| Budget enforcement | `advisory` \| `blocking` | v0 ships advisory only |
+| Gate `type` | `approval` \| `check` | closed set |
+| Approvers shape | `any_of: [<role_id>...]` xor `all_of: [<role_id>...]` | one shape per gate |
+
+## Validation rules beyond the schema
+
+The schema enforces structure. The validator (E1.3 / #18) layers on:
+
+- Every `inputs[].from_stage` references an existing stage `id` within the same workflow.
+- Every `approvers.any_of` / `approvers.all_of` entry references a key in the top-level `roles` map.
+- Within a workflow, stage `id`s are unique.
+- A stage that produces `plan` includes `schema: standard_v1`.
+
+These are graph-shape checks JSON Schema can't express cleanly.
+
+## See also
+
+- `MVP_SPEC.md` §4.1 — the six primitives and what they're for.
+- `MVP_SPEC.md` §4.2 — canonical example (mirrored under [`examples/workflow-v0-feature-change.yaml`](examples/workflow-v0-feature-change.yaml)).
+- `plan-standard-v1.md` — the plan artifact schema produced by `type: plan` stages.

--- a/docs/spec/workflow-v0.schema.json
+++ b/docs/spec/workflow-v0.schema.json
@@ -1,0 +1,312 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://fishhawk.dev/spec/workflow-v0.schema.json",
+  "title": "Fishhawk workflow spec v0",
+  "description": "Schema for .fishhawk/workflows.yaml. Frozen at Day 21 of the v0 build per MVP_SPEC.md §8. Old workflow runs in the audit log remain readable forever — never break this schema in place; bump to a new spec version instead.",
+
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "workflows"],
+
+  "properties": {
+    "version": {
+      "type": "string",
+      "enum": ["0.1"],
+      "description": "Spec syntax version. v0 freezes at 0.1; future syntax bumps land as 0.2 etc., with new schema files."
+    },
+    "roles": {
+      "type": "object",
+      "description": "Named roles referenced by gate approvers. Keys are snake_case identifiers; values list GitHub user/team refs.",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z][a-z0-9_]*$": { "$ref": "#/$defs/role" }
+      }
+    },
+    "workflows": {
+      "type": "object",
+      "description": "Named workflows. Keys are snake_case identifiers (e.g. feature_change). At least one workflow must be defined.",
+      "minProperties": 1,
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z][a-z0-9_]*$": { "$ref": "#/$defs/workflow" }
+      }
+    }
+  },
+
+  "$defs": {
+    "role": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["members"],
+      "properties": {
+        "members": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/member-ref" }
+        }
+      }
+    },
+
+    "member-ref": {
+      "type": "string",
+      "pattern": "^@[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)?$",
+      "description": "GitHub user (@user) or team (@org/team) reference. Resolved against the GitHub App installation at run time."
+    },
+
+    "workflow": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["stages"],
+      "properties": {
+        "description": { "type": "string" },
+        "stages": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/stage" }
+        }
+      }
+    },
+
+    "stage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "type", "executor"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_]*$",
+          "description": "Unique within the parent workflow. Referenced by inputs.from_stage."
+        },
+        "type": {
+          "type": "string",
+          "enum": ["plan", "implement", "review"],
+          "description": "v0 closed set. Custom stage types are deliberately disallowed."
+        },
+        "executor": { "$ref": "#/$defs/executor" },
+        "inputs": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/input" }
+        },
+        "produces": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/produces" }
+        },
+        "constraints": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/constraint" }
+        },
+        "budget":  { "$ref": "#/$defs/budget" },
+        "gates": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/gate" }
+        }
+      }
+    },
+
+    "executor": {
+      "type": "object",
+      "description": "Exactly one of agent (string) or human (true).",
+      "unevaluatedProperties": false,
+      "oneOf": [
+        {
+          "required": ["agent"],
+          "properties": {
+            "agent": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Agent identifier. v0 ships with claude-code; v0.x adds cursor and copilot."
+            }
+          }
+        },
+        {
+          "required": ["human"],
+          "properties": {
+            "human": { "type": "boolean", "const": true }
+          }
+        }
+      ]
+    },
+
+    "input": {
+      "type": "object",
+      "unevaluatedProperties": false,
+      "oneOf": [
+        {
+          "description": "Trigger input from outside the workflow (an issue, a PR).",
+          "required": ["source"],
+          "properties": {
+            "source": {
+              "type": "string",
+              "enum": ["github_issue", "pull_request"]
+            },
+            "required": { "type": "boolean" }
+          }
+        },
+        {
+          "description": "Artifact input from a prior stage in the same run.",
+          "required": ["artifact", "from_stage"],
+          "properties": {
+            "artifact": {
+              "type": "string",
+              "enum": ["plan", "pull_request"]
+            },
+            "from_stage": {
+              "type": "string",
+              "pattern": "^[a-z][a-z0-9_]*$"
+            }
+          }
+        }
+      ]
+    },
+
+    "produces": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["artifact"],
+      "properties": {
+        "artifact": {
+          "type": "string",
+          "enum": ["plan", "pull_request"],
+          "description": "v0 closed set. Custom artifacts deferred."
+        },
+        "schema": {
+          "type": "string",
+          "description": "Artifact schema version (e.g. standard_v1 for plan)."
+        },
+        "persistence": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/persistence" }
+        }
+      }
+    },
+
+    "persistence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["target", "mode"],
+      "properties": {
+        "target": {
+          "type": "string",
+          "enum": ["originating_issue", "fishhawk_audit_log"]
+        },
+        "mode": {
+          "type": "string",
+          "enum": ["rendered_comment", "canonical"],
+          "description": "rendered_comment: posted as a formatted comment on the target. canonical: stored as the authoritative copy in the audit log."
+        },
+        "update_on_change": {
+          "type": "boolean",
+          "description": "Re-publish to the target if the artifact is regenerated."
+        }
+      }
+    },
+
+    "constraint": {
+      "type": "object",
+      "description": "Exactly one constraint kind per object. Closed set per MVP_SPEC §4.1.",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "maxProperties": 1,
+      "properties": {
+        "max_files_changed": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "forbidden_paths": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 },
+          "description": "Glob patterns (gitignore-style) that the stage's diff must not touch."
+        },
+        "allowed_paths": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 },
+          "description": "Glob patterns; the stage's diff must touch only these paths."
+        },
+        "required_outcomes": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "enum": ["tests_added_or_updated", "ci_green"]
+          }
+        }
+      }
+    },
+
+    "budget": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "max_tokens": { "type": "integer", "minimum": 1 },
+        "max_runtime_minutes": { "type": "integer", "minimum": 1 },
+        "enforcement": {
+          "type": "string",
+          "enum": ["advisory", "blocking"],
+          "description": "v0 ships advisory only; blocking arrives in v0.x with the Fishhawk-issued ephemeral key path."
+        }
+      }
+    },
+
+    "gate": {
+      "type": "object",
+      "unevaluatedProperties": false,
+      "required": ["type"],
+      "oneOf": [
+        {
+          "description": "Approval gate — blocks until an approver acts.",
+          "required": ["type", "approvers"],
+          "properties": {
+            "type": { "const": "approval" },
+            "approvers": { "$ref": "#/$defs/approvers" },
+            "sla": {
+              "type": "string",
+              "description": "SLA before timeout fires a category-D failure (e.g. '4_business_hours', '24_hours')."
+            },
+            "blocking_checks": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "type": "string" }
+            }
+          }
+        },
+        {
+          "description": "Check gate — passes when all blocking_checks succeed; no human approval.",
+          "required": ["type", "blocking_checks"],
+          "properties": {
+            "type": { "const": "check" },
+            "blocking_checks": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "type": "string" }
+            }
+          }
+        }
+      ]
+    },
+
+    "approvers": {
+      "type": "object",
+      "description": "Either any_of (one approver suffices) or all_of (every named role must approve).",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "maxProperties": 1,
+      "properties": {
+        "any_of": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "type": "string", "pattern": "^[a-z][a-z0-9_]*$" }
+        },
+        "all_of": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "type": "string", "pattern": "^[a-z][a-z0-9_]*$" }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes [#16 (E1.1)](https://github.com/kuhlman-labs/fishhawk/issues/16) and [#19 (E1.4)](https://github.com/kuhlman-labs/fishhawk/issues/19) — the two foundational schemas the parser, validator, runner, and audit log will all consume. Both freeze at Day 21 of the v0 build (MVP_SPEC §8); old workflow runs and plans in the audit log stay readable forever.

### `docs/spec/`

| File | Purpose |
|---|---|
| `workflow-v0.schema.json` | Schema for `.fishhawk/workflows.yaml`. Encodes the closed sets from MVP_SPEC §4.1: stage types, constraint kinds, persistence targets/modes, trigger sources, gate types. |
| `workflow-v0.md` | Reference doc: top-level shape, every primitive, identifier namespaces, validation rules beyond the schema (graph-shape checks like `from_stage` cross-references). |
| `plan-standard-v1.schema.json` | Schema for the plan artifact per MVP_SPEC §4.3. |
| `plan-standard-v1.md` | Reference doc: required + optional fields, validation rules, persistence model. |
| `examples/workflow-v0-feature-change.yaml` | Mirrors the canonical example in MVP_SPEC §4.2. |
| `examples/workflow-v0-routine-change.yaml` | Exercises the check-gate path, `allowed_paths` constraint, agent-as-reviewer, omitted-budget case. |
| `examples/plan-standard-v1-example.json` | Representative plan for an audit-export feature. |
| `README.md` | Index + local validation instructions. |

Both schemas are JSON Schema Draft 2020-12. `oneOf` branches use `unevaluatedProperties: false` — the 2020-12 idiom that lets parent-level "no extra keys" coexist with branch-level property declarations (`additionalProperties: false` doesn't see oneOf branch properties and would reject all of them).

### Linked from

- `CLAUDE.md` canonical references — future agents land on the schemas via the standard list.
- `docs/ARCHITECTURE.md` "where to look" table.

## Test plan

- [x] `check-jsonschema --check-metaschema docs/spec/*.schema.json` — both schemas are valid against the JSON Schema meta-schema
- [x] `check-jsonschema --schemafile docs/spec/workflow-v0.schema.json examples/workflow-v0-feature-change.yaml examples/workflow-v0-routine-change.yaml .fishhawk/workflows.yaml` — all three workflow files validate
- [x] `check-jsonschema --schemafile docs/spec/plan-standard-v1.schema.json examples/plan-standard-v1-example.json` — example validates
- [x] Negative test: `jq 'del(.summary)' example.json | check-jsonschema ...` — correctly fails with "summary is a required property"
- [x] CI on this PR (path filter routes the YAML/JSON changes through the detect job; no Go changes, so the Go job no-ops; CI Pass rollup gates everything)

## Notes

- The Go-based validators (E1.3 #18 workflow validator, E1.5 #20 plan validator) will be the canonical enforcement point in the runner and backend. `check-jsonschema` is for local sanity-checks and review only — not added as a build dependency.
- Validation rules beyond what JSON Schema can express (cross-stage references, role lookups, agent ID matching) are enumerated in each reference doc and will be enforced by the Go validators.
- Frozen at Day 21 — additive non-breaking changes within `v0` / `standard_v1` are permitted but rare. Breaking changes go to `workflow-v1.schema.json` / `plan-standard-v2.schema.json`.

Closes #16
Closes #19