### PR TITLE
Backfill internal/postgres tests

### DIFF
--- a/backend/internal/postgres/internal_test.go
+++ b/backend/internal/postgres/internal_test.go
@@ -1,0 +1,52 @@
+package postgres
+
+import "testing"
+
+// TestNormalizeDatabaseURL covers every branch of the URL-scheme
+// rewrite. Pure unit test — runs in milliseconds, doesn't need
+// Docker.
+func TestNormalizeDatabaseURL(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "postgres scheme rewritten",
+			in:   "postgres://u:p@host:5432/db",
+			want: "pgx5://u:p@host:5432/db",
+		},
+		{
+			name: "postgresql scheme rewritten",
+			in:   "postgresql://u:p@host:5432/db?sslmode=disable",
+			want: "pgx5://u:p@host:5432/db?sslmode=disable",
+		},
+		{
+			name: "pgx5 passes through unchanged",
+			in:   "pgx5://u:p@host:5432/db",
+			want: "pgx5://u:p@host:5432/db",
+		},
+		{
+			name: "unknown scheme passes through unchanged",
+			in:   "mysql://u:p@host/db",
+			want: "mysql://u:p@host/db",
+		},
+		{
+			name: "empty string passes through",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "scheme-only postgres rewritten to scheme-only pgx5",
+			in:   "postgres://",
+			want: "pgx5://",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := normalizeDatabaseURL(tc.in); got != tc.want {
+				t.Errorf("normalizeDatabaseURL(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/backend/internal/postgres/postgres_test.go
+++ b/backend/internal/postgres/postgres_test.go
@@ -1,0 +1,220 @@
+package postgres_test
+
+import (
+	"context"
+	"io/fs"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/testcontainers/testcontainers-go"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/kuhlman-labs/fishhawk/backend/internal/postgres"
+)
+
+// startContainer spins up a throwaway Postgres 16 container and
+// returns its connection URL. Skips the test if Docker isn't
+// reachable so devs without Docker still pass `go test`.
+func startContainer(t *testing.T) string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	c, err := tcpostgres.Run(ctx,
+		"postgres:16-alpine",
+		tcpostgres.WithDatabase("fishhawk"),
+		tcpostgres.WithUsername("fishhawk"),
+		tcpostgres.WithPassword("fishhawk"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(60*time.Second),
+		),
+	)
+	if err != nil {
+		if isDockerUnavailable(err) {
+			t.Skipf("Docker not available; skipping integration test: %v", err)
+		}
+		t.Fatalf("start postgres: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_ = c.Terminate(ctx)
+	})
+
+	url, err := c.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatalf("conn string: %v", err)
+	}
+	return url
+}
+
+func isDockerUnavailable(err error) bool {
+	if err == nil {
+		return false
+	}
+	if os.Getenv("FISHHAWK_SKIP_INTEGRATION") != "" {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	for _, marker := range []string{
+		"cannot connect to the docker daemon",
+		"docker: not found",
+		"executable file not found",
+		"dial unix /var/run/docker.sock",
+	} {
+		if strings.Contains(msg, strings.ToLower(marker)) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestMigrations_EmbeddedFiles confirms the //go:embed directive
+// captured at least one .up.sql and one .down.sql migration. Catches
+// the failure mode where someone moves the migrations directory and
+// the embed silently empties.
+func TestMigrations_EmbeddedFiles(t *testing.T) {
+	mfs := postgres.Migrations()
+	var entries []string
+	if err := fs.WalkDir(mfs, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			entries = append(entries, path)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("walk migrations: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("expected at least one embedded migration file; got none")
+	}
+
+	var foundUp, foundDown bool
+	for _, e := range entries {
+		switch {
+		case strings.HasSuffix(e, ".up.sql"):
+			foundUp = true
+		case strings.HasSuffix(e, ".down.sql"):
+			foundDown = true
+		}
+	}
+	if !foundUp {
+		t.Errorf("no .up.sql migration found in embed; entries: %v", entries)
+	}
+	if !foundDown {
+		t.Errorf("no .down.sql migration found in embed; entries: %v", entries)
+	}
+}
+
+func TestConnect_HappyPath(t *testing.T) {
+	url := startContainer(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	pool, err := postgres.Connect(ctx, url)
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	defer pool.Close()
+
+	if err := pool.Ping(ctx); err != nil {
+		t.Errorf("post-Connect Ping: %v", err)
+	}
+}
+
+func TestConnect_MalformedURL(t *testing.T) {
+	_, err := postgres.Connect(context.Background(), "not-a-url-at-all")
+	if err == nil {
+		t.Fatal("expected error on malformed URL")
+	}
+}
+
+func TestConnect_UnreachableHost(t *testing.T) {
+	// 127.0.0.1:1 is a privileged port no daemon listens on by default.
+	// Use a tight context deadline so the test completes quickly even
+	// if the OS would otherwise wait for the connect syscall to time
+	// out.
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	_, err := postgres.Connect(ctx, "postgres://x:y@127.0.0.1:1/db?sslmode=disable")
+	if err == nil {
+		t.Fatal("expected error connecting to unreachable host")
+	}
+}
+
+func TestMigrateUp_AppliesAndIsIdempotent(t *testing.T) {
+	url := startContainer(t)
+
+	// First application creates the schema.
+	if err := postgres.MigrateUp(url); err != nil {
+		t.Fatalf("first MigrateUp: %v", err)
+	}
+
+	// Verify a known table exists.
+	pool, err := postgres.Connect(context.Background(), url)
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	defer pool.Close()
+
+	var n int
+	if err := pool.QueryRow(context.Background(),
+		`SELECT count(*) FROM information_schema.tables WHERE table_name = 'runs'`,
+	).Scan(&n); err != nil {
+		t.Fatalf("query runs table: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("'runs' table count after MigrateUp = %d, want 1", n)
+	}
+
+	// Second application is a no-op.
+	if err := postgres.MigrateUp(url); err != nil {
+		t.Errorf("second MigrateUp returned %v, want nil (idempotent)", err)
+	}
+}
+
+func TestMigrateUp_MalformedURL(t *testing.T) {
+	if err := postgres.MigrateUp("not-a-url"); err == nil {
+		t.Fatal("expected error on malformed URL")
+	}
+}
+
+func TestMigrateDown_RemovesTables(t *testing.T) {
+	url := startContainer(t)
+
+	if err := postgres.MigrateUp(url); err != nil {
+		t.Fatalf("MigrateUp: %v", err)
+	}
+	if err := postgres.MigrateDown(url); err != nil {
+		t.Fatalf("MigrateDown: %v", err)
+	}
+
+	pool, err := postgres.Connect(context.Background(), url)
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	defer pool.Close()
+
+	var n int
+	if err := pool.QueryRow(context.Background(),
+		`SELECT count(*) FROM information_schema.tables WHERE table_name = 'runs'`,
+	).Scan(&n); err != nil {
+		t.Fatalf("query runs table: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("'runs' table count after MigrateDown = %d, want 0", n)
+	}
+}
+
+func TestMigrateDown_MalformedURL(t *testing.T) {
+	if err := postgres.MigrateDown("not-a-url"); err == nil {
+		t.Fatal("expected error on malformed URL")
+	}
+}


### PR DESCRIPTION
## Summary

Closes the 0% direct-coverage gap on `backend/internal/postgres` flagged when the user asked about coverage targets. The package shipped under #85 was exercised only indirectly through `internal/run`'s testcontainers tests; this adds tests that pin the public surface against future changes that wouldn't break `internal/run`.

**Coverage 0.0% → 89.6%** on 48 statements:

| Function | Coverage |
|---|---:|
| `Migrations` | 75.0% |
| `MigrateUp` | 87.5% |
| `MigrateDown` | 87.5% |
| `openMigrator` | 85.7% |
| `normalizeDatabaseURL` | 100.0% |
| `Connect` | 93.8% |

Aggregate backend coverage (excl. sqlc-generated) goes from **66.3% → 80.3%**.

## Files

- `internal_test.go` (`package postgres`, same-package) — table-driven `TestNormalizeDatabaseURL` covering `postgres://`, `postgresql://`, `pgx5://` pass-through, unknown-scheme pass-through, empty string, scheme-only edge case. Pure unit; no Docker.
- `postgres_test.go` (`package postgres_test`, external) —
  - `TestMigrations_EmbeddedFiles` walks the embed FS and asserts at least one `.up.sql` + one `.down.sql` exist. Catches the failure mode where migrations silently empty after a directory move.
  - `TestConnect_HappyPath` (testcontainers), `TestConnect_MalformedURL`, `TestConnect_UnreachableHost` (uses a 500ms ctx deadline against 127.0.0.1:1 so it fails fast).
  - `TestMigrateUp_AppliesAndIsIdempotent` — verifies `runs` table exists post-up + second up is a no-op.
  - `TestMigrateDown_RemovesTables` — verifies down drops the table.
  - Both with malformed-URL companions.

## Test plan

- [x] `go build ./backend/...` clean
- [x] `go test -race -coverprofile ./internal/postgres/` — pass, **89.6%** package coverage
- [x] `go test -race ./...` from `backend/` — all packages pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] Aggregate excl. generated: **80.3%** (verified by the same Python script the user ran)
- [x] CI on this PR — green via `CI Pass` rollup

## Notes

- Reuses the testcontainers Postgres 16 pattern from `internal/run/postgres_test.go`. Helper duplicated rather than extracted to `internal/testdb` for now — small enough that DRY isn't winning, but easy to refactor later if a third package needs it.
- **Follow-up:** PR B adds the coverage-targets section to `docs/ARCHITECTURE.md` § "CI and release shape" and a CI gate that enforces the 80% aggregate floor. Could not bundle the gate into this PR because the gate needs to land *after* coverage reaches the threshold.