### PR TITLE
Document coverage targets and gate CI at 80% aggregate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,10 +92,27 @@ jobs:
               cd "$m"
               "$GOLANGCI_LINT" run ./...
               go build ./...
-              go test -race ./...
+              go test -race -coverprofile=coverage.out -covermode=atomic ./...
             )
             echo "::endgroup::"
           done
+
+      - name: Coverage threshold (≥ 80% aggregate, excl. sqlc-generated)
+        if: steps.have-modules.outputs.yes == 'true'
+        run: |
+          set -eu
+          # Build a list of per-module coverage profiles. The threshold
+          # script aggregates across all of them; --exclude drops generated
+          # packages before counting. Targets documented in
+          # docs/ARCHITECTURE.md §9.
+          profiles=()
+          while IFS= read -r m; do
+            profiles+=("$m/coverage.out")
+          done < <(go work edit -json | jq -r '.Use[].DiskPath')
+          python3 scripts/check-coverage.py \
+            --threshold 80 \
+            --exclude 'internal/run/db' \
+            "${profiles[@]}"
 
   ts:
     name: TypeScript (lint + build + test)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,13 @@ done
 
 `.golangci.yml` is **v2 format** (`version: "2"` at top). Local install must be golangci-lint v2.x; v1 binaries reject this config.
 
+**Coverage gate**: aggregate ≥ 80% excluding `internal/run/db` (sqlc-generated). Tiered targets in `docs/ARCHITECTURE.md` §9. CI fails `CI Pass` if the threshold drops. Reproduce locally:
+
+```sh
+(cd backend && go test -race -coverprofile=coverage.out -covermode=atomic ./...)
+python3 scripts/check-coverage.py --threshold 80 --exclude internal/run/db backend/coverage.out
+```
+
 ## Adding a Go module
 
 1. `mkdir <name> && cd <name> && go mod init github.com/kuhlman-labs/fishhawk/<name>`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -136,6 +136,12 @@ GitHub OAuth (E4.2 / #49) is the sign-in flow that mints the cookie session. App
 
 - **CI workflow** at `.github/workflows/ci.yml`. Path-aware via `dorny/paths-filter`. The Go job iterates `go.work` `use` directives — adding a new module Just Works.
 - **Lint config** at `/.golangci.yml` (v2 format). Shared across all Go modules in the workspace.
+- **Coverage targets**, tiered to the autonomy levels in `docs/METHODOLOGY.md`:
+  - **Low-autonomy code** (audit log integrity, signing/crypto, policy evaluator, run state machine, workflow spec parser): ≥ 85% statement coverage.
+  - **Medium-autonomy code** (HTTP handlers, runner adapters, REST endpoints, UI logic): ≥ 75%.
+  - **High-autonomy code** (docs, dep bumps, lint/format): no target.
+  - **Generated code** (sqlc outputs, etc.): excluded from numerator and denominator.
+  - **Aggregate floor (excluding generated): ≥ 80%.** Enforced by `scripts/check-coverage.py` in the Go CI job; PRs that drop below fail `CI Pass`. Run locally with `(cd backend && go test -race -coverprofile=coverage.out -covermode=atomic ./...) && python3 scripts/check-coverage.py --threshold 80 --exclude internal/run/db backend/coverage.out`.
 - **Release**: each module is tagged independently. The runner is the customer-facing one — `kuhlman-labs/fishhawk/runner@v0.1` etc. — built with signed releases + SBOM (E5.7 / #54, E13.6 / #63).
 
 ## 10. Where to look

--- a/scripts/check-coverage.py
+++ b/scripts/check-coverage.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""
+Aggregate Go coverage profiles, filter excluded paths, and exit
+non-zero if the result is below the threshold. Used by CI to enforce
+the coverage targets documented in docs/ARCHITECTURE.md §9.
+
+Usage:
+    scripts/check-coverage.py \\
+        --threshold 80 \\
+        --exclude 'internal/run/db' \\
+        backend/coverage.out [more.out ...]
+
+Reads each profile, sums statement counts (excluding any line whose
+file path contains an --exclude substring), and computes
+covered/total. Prints a per-package breakdown for visibility.
+Profiles must be in Go's standard `go test -coverprofile=` format.
+"""
+
+import argparse
+import sys
+from collections import defaultdict
+
+
+def parse_profile(path, excludes):
+    """Yield (pkg, file_path, num_stmts, count) for non-excluded lines."""
+    with open(path) as f:
+        first = next(f, None)
+        if first is None or not first.startswith("mode:"):
+            raise SystemExit(f"{path}: missing mode line; not a coverage profile")
+        for line in f:
+            line = line.rstrip("\n")
+            if not line:
+                continue
+            # Format: <file>:<startline>.<startcol>,<endline>.<endcol> <numstmts> <count>
+            try:
+                loc, numstmts, count = line.rsplit(" ", 2)
+                file_path = loc.split(":", 1)[0]
+                num_stmts = int(numstmts)
+                run_count = int(count)
+            except (ValueError, IndexError) as e:
+                raise SystemExit(f"{path}: bad line: {line!r}: {e}")
+            if any(ex in file_path for ex in excludes):
+                continue
+            pkg = file_path.rsplit("/", 1)[0]
+            yield pkg, file_path, num_stmts, run_count
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.strip().split("\n", 1)[0])
+    ap.add_argument(
+        "--threshold",
+        type=float,
+        required=True,
+        help="Minimum aggregate coverage percentage (e.g. 80).",
+    )
+    ap.add_argument(
+        "--exclude",
+        action="append",
+        default=[],
+        metavar="SUBSTRING",
+        help="Substring of a file path; profiles entries matching it are dropped before counting. May be repeated.",
+    )
+    ap.add_argument("profile", nargs="+", help="One or more Go coverage profiles.")
+    args = ap.parse_args()
+
+    pkg_stmts = defaultdict(int)
+    pkg_covered = defaultdict(int)
+
+    for path in args.profile:
+        for pkg, _, n, c in parse_profile(path, args.exclude):
+            pkg_stmts[pkg] += n
+            if c > 0:
+                pkg_covered[pkg] += n
+
+    total_stmts = sum(pkg_stmts.values())
+    total_covered = sum(pkg_covered.values())
+
+    if total_stmts == 0:
+        print(
+            "ERROR: zero statements counted; check --exclude patterns and profile paths.",
+            file=sys.stderr,
+        )
+        return 2
+
+    print("Per-package coverage (excluded paths filtered out):")
+    pkg_col = max(len(p) for p in pkg_stmts) + 2
+    for pkg in sorted(pkg_stmts):
+        s = pkg_stmts[pkg]
+        c = pkg_covered[pkg]
+        pct = 100.0 * c / s if s else 0.0
+        # Strip the long module prefix from output for readability.
+        short = pkg.replace("github.com/kuhlman-labs/fishhawk/", "")
+        print(f"  {short:<{pkg_col}}  {c:>5}/{s:<5}  {pct:5.1f}%")
+
+    pct = 100.0 * total_covered / total_stmts
+    print()
+    print(f"Aggregate: {total_covered}/{total_stmts} = {pct:.1f}%")
+    print(f"Threshold: {args.threshold:.1f}%")
+
+    if pct < args.threshold:
+        print(
+            f"FAIL: coverage {pct:.1f}% is below threshold {args.threshold:.1f}%.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Pairs with [#91](https://github.com/kuhlman-labs/fishhawk/pull/91) (the `internal/postgres` backfill that just landed) to turn the coverage discipline into something machine-checked, not aspirational.

### `docs/ARCHITECTURE.md` §9 — recorded targets

Tiered to the autonomy levels in `docs/METHODOLOGY.md`:

| Tier | Examples | Target |
|---|---|---:|
| Low-autonomy | audit integrity, signing/crypto, policy evaluator, run state machine, workflow spec parser | ≥ **85%** |
| Medium-autonomy | HTTP handlers, runner adapters, REST endpoints, UI logic | ≥ **75%** |
| High-autonomy | docs, dep bumps, lint/format | no target |
| Generated code | sqlc outputs (`internal/run/db`), future codegen | excluded |
| **Aggregate floor (excl. generated)** | — | **≥ 80%** |

### `scripts/check-coverage.py` — the gate

Aggregates one or more Go coverage profiles, drops `--exclude` file-path substrings, prints a per-package breakdown for visibility, and exits non-zero if the aggregate is below `--threshold`. Self-contained Python; identical on macOS and Ubuntu runners.

Verified on `backend/coverage.out`:
- `--threshold 80` → **PASS** (80.3% > 80.0%)
- `--threshold 95` → **FAIL** (clear diagnostic with per-package breakdown shown)

### `.github/workflows/ci.yml` — the wiring

The Go job's test step now adds `-coverprofile=coverage.out -covermode=atomic`. A follow-up step collects the per-module profiles (same `go.work` iteration the test step uses, so a new module in `go.work` is picked up without further workflow edits) and invokes the script. Bash array used to pass the file list — shellcheck-clean, no word-splitting reliance.

### `CLAUDE.md` — the local reproduction

The Build/test/lint section gains a Coverage gate paragraph showing the one-liner devs run before pushing.

## Test plan

- [x] `actionlint .github/workflows/ci.yml` — clean
- [x] `python3 scripts/check-coverage.py --threshold 80 --exclude internal/run/db backend/coverage.out` — PASS at current 80.3%
- [x] Negative test at `--threshold 95` — FAIL with clean error
- [x] Negative test missing `--threshold` flag — argparse usage error
- [x] Bash array passing — shellcheck-clean (the previous string-splitting form triggered SC2086)
- [x] CI on this PR — `CI Pass` rollup includes the new step; should still be green at 80.3%

## Notes

- `cmd/fishhawkd` sits at 60.6%, below the medium-autonomy 75% target. The uncovered surface is mostly signal-handler / live-server wiring that's awkward to test without race-y goroutines. Future work to push it up is tracked by the targets doc, not blocked by this PR's gate (the aggregate floor is what's enforced).
- Targets are intentionally tiered to autonomy, not enforced per-package. This catches real regressions while leaving room for honest exceptions in places where unit-testing has poor return.
- Future codegen sources (e.g. when a new sqlc package or grpc/protobuf gen lands) just need an additional `--exclude` arg in the workflow.