### PR TITLE
Add workflow spec parser + validator (E1.2 / E1.3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,16 @@ jobs:
             echo "::notice::No Go modules registered in go.work yet. Skipping lint/build/test."
           fi
 
+      - name: Schema sync (docs/spec ↔ embedded copies)
+        if: steps.have-modules.outputs.yes == 'true'
+        run: |
+          # The Go parser embeds workflow-v0.schema.json under
+          # backend/internal/spec/schemas/. The canonical copy lives
+          # at docs/spec/. CI fails if they drift; update both in the
+          # same PR.
+          diff -u docs/spec/workflow-v0.schema.json \
+                  backend/internal/spec/schemas/workflow-v0.schema.json
+
       - name: Install golangci-lint
         if: steps.have-modules.outputs.yes == 'true'
         run: |

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -6,8 +6,10 @@ require (
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.9.2
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/testcontainers/testcontainers-go v0.42.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.42.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -65,5 +67,4 @@ require (
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -29,6 +29,8 @@ github.com/dhui/dktest v0.4.6 h1:+DPKyScKSEp3VLtbMDHcUq6V5Lm5zfZZVb0Sk7Ahom4=
 github.com/dhui/dktest v0.4.6/go.mod h1:JHTSYDtKkvFNFHJKqCzVzqXecyv+tKt8EzceOmQOgbU=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/docker/docker v28.3.3+incompatible h1:Dypm25kh4rmk49v1eiVbsAtpAsYURjYkaKubwuBdxEI=
 github.com/docker/docker v28.3.3+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.6.0 h1:LlMG9azAe1TqfR7sO+NJttz1gy6KO7VJBh+pMmjSD94=
@@ -112,6 +114,8 @@ github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 h1:o4JXh1EVt
 github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/shirou/gopsutil/v4 v4.26.3 h1:2ESdQt90yU3oXF/CdOlRCJxrP+Am1aBYubTMTfxJ1qc=
 github.com/shirou/gopsutil/v4 v4.26.3/go.mod h1:LZ6ewCSkBqUpvSOf+LsTGnRinC6iaNUNMGBtDkJBaLQ=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=

--- a/backend/internal/spec/errors.go
+++ b/backend/internal/spec/errors.go
@@ -1,0 +1,51 @@
+package spec
+
+import "fmt"
+
+// YAMLError is returned when the input is not parseable as YAML or is
+// empty. The Cause is the underlying yaml package error, useful for
+// extracting line/column info via errors.As.
+type YAMLError struct {
+	Msg   string
+	Cause error
+}
+
+func (e *YAMLError) Error() string {
+	if e.Msg != "" {
+		return "spec: yaml: " + e.Msg
+	}
+	if e.Cause != nil {
+		return "spec: yaml: " + e.Cause.Error()
+	}
+	return "spec: yaml: unknown error"
+}
+
+// Unwrap exposes the underlying error so callers can errors.As against
+// yaml package error types when they need line/column information.
+func (e *YAMLError) Unwrap() error { return e.Cause }
+
+// SchemaError is returned when the YAML parses but doesn't satisfy
+// the workflow-v0 JSON Schema. Path is a JSON Pointer (RFC 6901)
+// pointing at the offending instance location; Message is the
+// schema's reported reason.
+type SchemaError struct {
+	Path    string
+	Message string
+}
+
+func (e *SchemaError) Error() string {
+	return fmt.Sprintf("spec: schema: %s: %s", e.Path, e.Message)
+}
+
+// ValidationError is returned for semantic violations that the JSON
+// Schema can't express (graph-shape checks: cross-stage references,
+// role lookups, schema directives). Path is a JSON-Pointer-shaped
+// path into the document.
+type ValidationError struct {
+	Path    string
+	Message string
+}
+
+func (e *ValidationError) Error() string {
+	return fmt.Sprintf("spec: validation: %s: %s", e.Path, e.Message)
+}

--- a/backend/internal/spec/parse.go
+++ b/backend/internal/spec/parse.go
@@ -1,0 +1,157 @@
+package spec
+
+import (
+	"bytes"
+	"embed"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+	"gopkg.in/yaml.v3"
+)
+
+//go:embed schemas/workflow-v0.schema.json
+var schemaFS embed.FS
+
+// compiledSchema is the JSON Schema used by Parse. Compiled once at
+// package init; if the embedded schema is malformed we want to crash
+// loudly at process start, not on the first Parse call.
+var compiledSchema = mustCompileSchema()
+
+func mustCompileSchema() *jsonschema.Schema {
+	const path = "schemas/workflow-v0.schema.json"
+	data, err := schemaFS.ReadFile(path)
+	if err != nil {
+		panic(fmt.Sprintf("spec: read embedded schema %s: %v", path, err))
+	}
+	var raw any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		panic(fmt.Sprintf("spec: parse embedded schema %s: %v", path, err))
+	}
+	c := jsonschema.NewCompiler()
+	if err := c.AddResource("workflow-v0.schema.json", raw); err != nil {
+		panic(fmt.Sprintf("spec: register embedded schema %s: %v", path, err))
+	}
+	s, err := c.Compile("workflow-v0.schema.json")
+	if err != nil {
+		panic(fmt.Sprintf("spec: compile embedded schema %s: %v", path, err))
+	}
+	return s
+}
+
+// Parse reads YAML from r, validates it against the workflow-v0 JSON
+// Schema and the semantic rules, and returns the typed *Spec. The
+// returned error is one of *YAMLError (parse-time), *SchemaError
+// (structural), or *ValidationError (semantic). Use errors.As to
+// distinguish them.
+func Parse(r io.Reader) (*Spec, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("read: %w", err)
+	}
+	return ParseBytes(data)
+}
+
+// ParseBytes is the in-memory variant of Parse.
+func ParseBytes(data []byte) (*Spec, error) {
+	if len(bytes.TrimSpace(data)) == 0 {
+		return nil, &YAMLError{Msg: "empty document"}
+	}
+
+	// yaml.v3 decodes a document into a generic Go value with
+	// map[string]any keys (unlike yaml.v2 which produces
+	// map[any]any). That makes it directly compatible with the JSON
+	// Schema validator.
+	var raw any
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(false) // permissive at YAML layer; schema is the gate
+	if err := dec.Decode(&raw); err != nil {
+		if errors.Is(err, io.EOF) {
+			return nil, &YAMLError{Msg: "empty document"}
+		}
+		return nil, &YAMLError{Msg: err.Error(), Cause: err}
+	}
+
+	if err := compiledSchema.Validate(raw); err != nil {
+		var verr *jsonschema.ValidationError
+		if errors.As(err, &verr) {
+			return nil, schemaErrorFrom(verr)
+		}
+		return nil, &SchemaError{Path: "/", Message: err.Error()}
+	}
+
+	// Round-trip through JSON to populate the typed struct. The
+	// schema has already enforced shapes/enums, so this only fails
+	// on internal bugs.
+	jsonBytes, err := json.Marshal(raw)
+	if err != nil {
+		return nil, fmt.Errorf("internal: re-marshal to JSON: %w", err)
+	}
+	var spec Spec
+	dec2 := json.NewDecoder(bytes.NewReader(jsonBytes))
+	dec2.DisallowUnknownFields()
+	if err := dec2.Decode(&spec); err != nil {
+		return nil, fmt.Errorf("internal: decode to Spec: %w", err)
+	}
+
+	if err := Validate(&spec); err != nil {
+		return nil, err
+	}
+	return &spec, nil
+}
+
+// schemaErrorFrom collapses a jsonschema.ValidationError tree to the
+// most actionable leaf for callers. The library produces nested
+// errors covering each rule; the leaf with a non-empty
+// InstanceLocation usually points at the offending field.
+func schemaErrorFrom(verr *jsonschema.ValidationError) *SchemaError {
+	leaf := deepestLeaf(verr)
+	loc := leaf.InstanceLocation
+	if len(loc) == 0 {
+		loc = []string{""}
+	}
+	return &SchemaError{
+		Path:    "/" + joinPointer(loc),
+		Message: kindMessage(leaf),
+	}
+}
+
+// kindMessage returns a human-readable description of a single
+// validation failure. The library's ErrorKind.LocalizedString takes
+// a non-nil *message.Printer (passing nil panics inside x/text), so
+// instead we lean on the leaf's Error() output and trim its prefix
+// so the caller-formatted Path isn't repeated.
+func kindMessage(v *jsonschema.ValidationError) string {
+	full := v.Error()
+	if idx := strings.LastIndex(full, ": "); idx >= 0 {
+		return full[idx+2:]
+	}
+	return full
+}
+
+// deepestLeaf walks the validation error tree to the most specific
+// failure; the v6 library wraps each rule violation, so the deepest
+// node is closest to the offending field.
+func deepestLeaf(v *jsonschema.ValidationError) *jsonschema.ValidationError {
+	for _, c := range v.Causes {
+		// Prefer leaves that touch a concrete instance location.
+		if len(c.InstanceLocation) >= len(v.InstanceLocation) {
+			return deepestLeaf(c)
+		}
+	}
+	return v
+}
+
+func joinPointer(parts []string) string {
+	if len(parts) == 0 {
+		return ""
+	}
+	out := parts[0]
+	for _, p := range parts[1:] {
+		out += "/" + p
+	}
+	return out
+}

--- a/backend/internal/spec/schemas/workflow-v0.schema.json
+++ b/backend/internal/spec/schemas/workflow-v0.schema.json
@@ -1,0 +1,312 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://fishhawk.dev/spec/workflow-v0.schema.json",
+  "title": "Fishhawk workflow spec v0",
+  "description": "Schema for .fishhawk/workflows.yaml. Frozen at Day 21 of the v0 build per MVP_SPEC.md §8. Old workflow runs in the audit log remain readable forever — never break this schema in place; bump to a new spec version instead.",
+
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "workflows"],
+
+  "properties": {
+    "version": {
+      "type": "string",
+      "enum": ["0.1"],
+      "description": "Spec syntax version. v0 freezes at 0.1; future syntax bumps land as 0.2 etc., with new schema files."
+    },
+    "roles": {
+      "type": "object",
+      "description": "Named roles referenced by gate approvers. Keys are snake_case identifiers; values list GitHub user/team refs.",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z][a-z0-9_]*$": { "$ref": "#/$defs/role" }
+      }
+    },
+    "workflows": {
+      "type": "object",
+      "description": "Named workflows. Keys are snake_case identifiers (e.g. feature_change). At least one workflow must be defined.",
+      "minProperties": 1,
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z][a-z0-9_]*$": { "$ref": "#/$defs/workflow" }
+      }
+    }
+  },
+
+  "$defs": {
+    "role": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["members"],
+      "properties": {
+        "members": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/member-ref" }
+        }
+      }
+    },
+
+    "member-ref": {
+      "type": "string",
+      "pattern": "^@[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)?$",
+      "description": "GitHub user (@user) or team (@org/team) reference. Resolved against the GitHub App installation at run time."
+    },
+
+    "workflow": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["stages"],
+      "properties": {
+        "description": { "type": "string" },
+        "stages": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/stage" }
+        }
+      }
+    },
+
+    "stage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "type", "executor"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_]*$",
+          "description": "Unique within the parent workflow. Referenced by inputs.from_stage."
+        },
+        "type": {
+          "type": "string",
+          "enum": ["plan", "implement", "review"],
+          "description": "v0 closed set. Custom stage types are deliberately disallowed."
+        },
+        "executor": { "$ref": "#/$defs/executor" },
+        "inputs": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/input" }
+        },
+        "produces": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/produces" }
+        },
+        "constraints": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/constraint" }
+        },
+        "budget":  { "$ref": "#/$defs/budget" },
+        "gates": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/gate" }
+        }
+      }
+    },
+
+    "executor": {
+      "type": "object",
+      "description": "Exactly one of agent (string) or human (true).",
+      "unevaluatedProperties": false,
+      "oneOf": [
+        {
+          "required": ["agent"],
+          "properties": {
+            "agent": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Agent identifier. v0 ships with claude-code; v0.x adds cursor and copilot."
+            }
+          }
+        },
+        {
+          "required": ["human"],
+          "properties": {
+            "human": { "type": "boolean", "const": true }
+          }
+        }
+      ]
+    },
+
+    "input": {
+      "type": "object",
+      "unevaluatedProperties": false,
+      "oneOf": [
+        {
+          "description": "Trigger input from outside the workflow (an issue, a PR).",
+          "required": ["source"],
+          "properties": {
+            "source": {
+              "type": "string",
+              "enum": ["github_issue", "pull_request"]
+            },
+            "required": { "type": "boolean" }
+          }
+        },
+        {
+          "description": "Artifact input from a prior stage in the same run.",
+          "required": ["artifact", "from_stage"],
+          "properties": {
+            "artifact": {
+              "type": "string",
+              "enum": ["plan", "pull_request"]
+            },
+            "from_stage": {
+              "type": "string",
+              "pattern": "^[a-z][a-z0-9_]*$"
+            }
+          }
+        }
+      ]
+    },
+
+    "produces": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["artifact"],
+      "properties": {
+        "artifact": {
+          "type": "string",
+          "enum": ["plan", "pull_request"],
+          "description": "v0 closed set. Custom artifacts deferred."
+        },
+        "schema": {
+          "type": "string",
+          "description": "Artifact schema version (e.g. standard_v1 for plan)."
+        },
+        "persistence": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/persistence" }
+        }
+      }
+    },
+
+    "persistence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["target", "mode"],
+      "properties": {
+        "target": {
+          "type": "string",
+          "enum": ["originating_issue", "fishhawk_audit_log"]
+        },
+        "mode": {
+          "type": "string",
+          "enum": ["rendered_comment", "canonical"],
+          "description": "rendered_comment: posted as a formatted comment on the target. canonical: stored as the authoritative copy in the audit log."
+        },
+        "update_on_change": {
+          "type": "boolean",
+          "description": "Re-publish to the target if the artifact is regenerated."
+        }
+      }
+    },
+
+    "constraint": {
+      "type": "object",
+      "description": "Exactly one constraint kind per object. Closed set per MVP_SPEC §4.1.",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "maxProperties": 1,
+      "properties": {
+        "max_files_changed": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "forbidden_paths": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 },
+          "description": "Glob patterns (gitignore-style) that the stage's diff must not touch."
+        },
+        "allowed_paths": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 },
+          "description": "Glob patterns; the stage's diff must touch only these paths."
+        },
+        "required_outcomes": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "enum": ["tests_added_or_updated", "ci_green"]
+          }
+        }
+      }
+    },
+
+    "budget": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "max_tokens": { "type": "integer", "minimum": 1 },
+        "max_runtime_minutes": { "type": "integer", "minimum": 1 },
+        "enforcement": {
+          "type": "string",
+          "enum": ["advisory", "blocking"],
+          "description": "v0 ships advisory only; blocking arrives in v0.x with the Fishhawk-issued ephemeral key path."
+        }
+      }
+    },
+
+    "gate": {
+      "type": "object",
+      "unevaluatedProperties": false,
+      "required": ["type"],
+      "oneOf": [
+        {
+          "description": "Approval gate — blocks until an approver acts.",
+          "required": ["type", "approvers"],
+          "properties": {
+            "type": { "const": "approval" },
+            "approvers": { "$ref": "#/$defs/approvers" },
+            "sla": {
+              "type": "string",
+              "description": "SLA before timeout fires a category-D failure (e.g. '4_business_hours', '24_hours')."
+            },
+            "blocking_checks": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "type": "string" }
+            }
+          }
+        },
+        {
+          "description": "Check gate — passes when all blocking_checks succeed; no human approval.",
+          "required": ["type", "blocking_checks"],
+          "properties": {
+            "type": { "const": "check" },
+            "blocking_checks": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "type": "string" }
+            }
+          }
+        }
+      ]
+    },
+
+    "approvers": {
+      "type": "object",
+      "description": "Either any_of (one approver suffices) or all_of (every named role must approve).",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "maxProperties": 1,
+      "properties": {
+        "any_of": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "type": "string", "pattern": "^[a-z][a-z0-9_]*$" }
+        },
+        "all_of": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "type": "string", "pattern": "^[a-z][a-z0-9_]*$" }
+        }
+      }
+    }
+  }
+}

--- a/backend/internal/spec/spec.go
+++ b/backend/internal/spec/spec.go
@@ -1,0 +1,187 @@
+// Package spec parses and validates Fishhawk workflow specs (the YAML
+// at .fishhawk/workflows.yaml in customer repos). The canonical schema
+// lives at docs/spec/workflow-v0.schema.json; a copy is embedded under
+// schemas/ in this package so the parser is self-contained at runtime.
+// CI enforces that the two copies stay in sync.
+//
+// Two-stage validation:
+//
+//  1. Schema validation — the parsed YAML is round-tripped through JSON
+//     Schema (Draft 2020-12) using the embedded workflow-v0 schema.
+//     Catches structure errors: missing required fields, unknown stage
+//     types, malformed identifiers, etc.
+//  2. Semantic validation — graph-shape checks the schema can't express:
+//     stage IDs unique within a workflow, from_stage references resolve,
+//     approver role references resolve, plan-producing stages declare
+//     schema: standard_v1.
+//
+// Both layers run inside Parse; callers usually don't need to invoke
+// Validate directly. Build a *Spec programmatically in tests, then call
+// Validate to exercise just the semantic layer.
+package spec
+
+// Spec is a parsed and validated workflow specification document.
+type Spec struct {
+	Version   string              `json:"version" yaml:"version"`
+	Roles     map[string]Role     `json:"roles,omitempty" yaml:"roles,omitempty"`
+	Workflows map[string]Workflow `json:"workflows" yaml:"workflows"`
+}
+
+// Role names a group of GitHub user/team references that gates can
+// resolve to. Member values follow GitHub conventions: "@user" or
+// "@org/team".
+type Role struct {
+	Members []string `json:"members" yaml:"members"`
+}
+
+// Workflow is one named pipeline (e.g. "feature_change") with an
+// ordered list of stages.
+type Workflow struct {
+	Description string  `json:"description,omitempty" yaml:"description,omitempty"`
+	Stages      []Stage `json:"stages" yaml:"stages"`
+}
+
+// Stage is one unit of work in a workflow. The closed set of types
+// (plan / implement / review) is enforced by the schema.
+type Stage struct {
+	ID          string       `json:"id" yaml:"id"`
+	Type        StageType    `json:"type" yaml:"type"`
+	Executor    Executor     `json:"executor" yaml:"executor"`
+	Inputs      []Input      `json:"inputs,omitempty" yaml:"inputs,omitempty"`
+	Produces    []Produces   `json:"produces,omitempty" yaml:"produces,omitempty"`
+	Constraints []Constraint `json:"constraints,omitempty" yaml:"constraints,omitempty"`
+	Budget      *Budget      `json:"budget,omitempty" yaml:"budget,omitempty"`
+	Gates       []Gate       `json:"gates,omitempty" yaml:"gates,omitempty"`
+}
+
+// StageType is the stage's kind, drawn from a closed v0 set.
+type StageType string
+
+// Stage types per MVP_SPEC §4.1.
+const (
+	StageTypePlan      StageType = "plan"
+	StageTypeImplement StageType = "implement"
+	StageTypeReview    StageType = "review"
+)
+
+// Executor describes what runs the stage. Exactly one of Agent or
+// Human is set. The schema enforces the mutual exclusion.
+type Executor struct {
+	Agent string `json:"agent,omitempty" yaml:"agent,omitempty"`
+	Human bool   `json:"human,omitempty" yaml:"human,omitempty"`
+}
+
+// Input is either a trigger (Source set) or an artifact handoff from
+// a prior stage in the same run (Artifact + FromStage set).
+type Input struct {
+	Source    InputSource `json:"source,omitempty" yaml:"source,omitempty"`
+	Required  bool        `json:"required,omitempty" yaml:"required,omitempty"`
+	Artifact  string      `json:"artifact,omitempty" yaml:"artifact,omitempty"`
+	FromStage string      `json:"from_stage,omitempty" yaml:"from_stage,omitempty"`
+}
+
+// InputSource is the trigger kind for inputs that come from outside
+// the workflow (issue, PR).
+type InputSource string
+
+// Input source values per the schema.
+const (
+	InputSourceGitHubIssue InputSource = "github_issue"
+	InputSourcePullRequest InputSource = "pull_request"
+)
+
+// Produces declares an artifact emitted by a stage and how it's
+// persisted.
+type Produces struct {
+	Artifact    ArtifactKind  `json:"artifact" yaml:"artifact"`
+	Schema      string        `json:"schema,omitempty" yaml:"schema,omitempty"`
+	Persistence []Persistence `json:"persistence,omitempty" yaml:"persistence,omitempty"`
+}
+
+// ArtifactKind is the closed v0 artifact set.
+type ArtifactKind string
+
+// Artifact kinds per the schema.
+const (
+	ArtifactPlan        ArtifactKind = "plan"
+	ArtifactPullRequest ArtifactKind = "pull_request"
+)
+
+// Persistence says where an artifact is stored.
+type Persistence struct {
+	Target         PersistenceTarget `json:"target" yaml:"target"`
+	Mode           PersistenceMode   `json:"mode" yaml:"mode"`
+	UpdateOnChange bool              `json:"update_on_change,omitempty" yaml:"update_on_change,omitempty"`
+}
+
+// PersistenceTarget is where the artifact is written.
+type PersistenceTarget string
+
+// Persistence targets per the schema.
+const (
+	PersistenceOriginatingIssue PersistenceTarget = "originating_issue"
+	PersistenceFishhawkAuditLog PersistenceTarget = "fishhawk_audit_log"
+)
+
+// PersistenceMode describes the form of the persisted artifact.
+type PersistenceMode string
+
+// Persistence modes per the schema.
+const (
+	ModeRenderedComment PersistenceMode = "rendered_comment"
+	ModeCanonical       PersistenceMode = "canonical"
+)
+
+// Constraint is exactly one of the closed-set rules (max_files_changed,
+// forbidden_paths, allowed_paths, required_outcomes). At decode time
+// every Constraint has exactly one non-zero field; the schema enforces
+// this with maxProperties: 1.
+type Constraint struct {
+	MaxFilesChanged  int      `json:"max_files_changed,omitempty" yaml:"max_files_changed,omitempty"`
+	ForbiddenPaths   []string `json:"forbidden_paths,omitempty" yaml:"forbidden_paths,omitempty"`
+	AllowedPaths     []string `json:"allowed_paths,omitempty" yaml:"allowed_paths,omitempty"`
+	RequiredOutcomes []string `json:"required_outcomes,omitempty" yaml:"required_outcomes,omitempty"`
+}
+
+// Budget caps token / runtime usage for a stage.
+type Budget struct {
+	MaxTokens         int               `json:"max_tokens,omitempty" yaml:"max_tokens,omitempty"`
+	MaxRuntimeMinutes int               `json:"max_runtime_minutes,omitempty" yaml:"max_runtime_minutes,omitempty"`
+	Enforcement       BudgetEnforcement `json:"enforcement,omitempty" yaml:"enforcement,omitempty"`
+}
+
+// BudgetEnforcement says whether overruns are reported (advisory) or
+// blocked (blocking; v0.x).
+type BudgetEnforcement string
+
+// Budget enforcement modes per the schema.
+const (
+	EnforcementAdvisory BudgetEnforcement = "advisory"
+	EnforcementBlocking BudgetEnforcement = "blocking"
+)
+
+// Gate is either an approval gate (humans must act) or a check gate
+// (named status checks must pass).
+type Gate struct {
+	Type           GateType   `json:"type" yaml:"type"`
+	Approvers      *Approvers `json:"approvers,omitempty" yaml:"approvers,omitempty"`
+	SLA            string     `json:"sla,omitempty" yaml:"sla,omitempty"`
+	BlockingChecks []string   `json:"blocking_checks,omitempty" yaml:"blocking_checks,omitempty"`
+}
+
+// GateType is approval or check.
+type GateType string
+
+// Gate types per the schema.
+const (
+	GateTypeApproval GateType = "approval"
+	GateTypeCheck    GateType = "check"
+)
+
+// Approvers names roles whose members can satisfy the gate. Exactly
+// one of AnyOf or AllOf is set; the schema enforces the mutual
+// exclusion.
+type Approvers struct {
+	AnyOf []string `json:"any_of,omitempty" yaml:"any_of,omitempty"`
+	AllOf []string `json:"all_of,omitempty" yaml:"all_of,omitempty"`
+}

--- a/backend/internal/spec/spec_test.go
+++ b/backend/internal/spec/spec_test.go
@@ -1,0 +1,371 @@
+package spec_test
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/kuhlman-labs/fishhawk/backend/internal/spec"
+)
+
+// readFixture loads a testdata file relative to the package dir.
+func readFixture(t *testing.T, path string) []byte {
+	t.Helper()
+	b, err := os.ReadFile("testdata/" + path)
+	if err != nil {
+		t.Fatalf("read fixture %q: %v", path, err)
+	}
+	return b
+}
+
+// --- Happy paths ---
+
+func TestParse_CanonicalFeatureChange(t *testing.T) {
+	s, err := spec.ParseBytes(readFixture(t, "valid/feature-change.yaml"))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if s.Version != "0.1" {
+		t.Errorf("version = %q, want 0.1", s.Version)
+	}
+	if got, want := len(s.Workflows), 1; got != want {
+		t.Errorf("workflows count = %d, want %d", got, want)
+	}
+	wf, ok := s.Workflows["feature_change"]
+	if !ok {
+		t.Fatal(`workflows["feature_change"] missing`)
+	}
+	if got, want := len(wf.Stages), 3; got != want {
+		t.Fatalf("stage count = %d, want %d", got, want)
+	}
+	plan := wf.Stages[0]
+	if plan.ID != "plan" || plan.Type != spec.StageTypePlan {
+		t.Errorf("first stage = %+v, want id=plan type=plan", plan)
+	}
+	if plan.Executor.Agent != "claude-code" {
+		t.Errorf("plan.executor.agent = %q, want claude-code", plan.Executor.Agent)
+	}
+	review := wf.Stages[2]
+	if !review.Executor.Human {
+		t.Errorf("review stage executor.human should be true")
+	}
+}
+
+func TestParse_Minimal(t *testing.T) {
+	s, err := spec.ParseBytes(readFixture(t, "valid/minimal.yaml"))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if got, want := len(s.Workflows), 1; got != want {
+		t.Errorf("workflows = %d, want %d", got, want)
+	}
+	if len(s.Roles) != 0 {
+		t.Errorf("roles should be empty, got %v", s.Roles)
+	}
+}
+
+// --- YAML errors ---
+
+func TestParse_EmptyDocument(t *testing.T) {
+	_, err := spec.ParseBytes([]byte("\n   \n"))
+	var ye *spec.YAMLError
+	if !errors.As(err, &ye) {
+		t.Fatalf("err = %v, want *YAMLError", err)
+	}
+}
+
+func TestParse_MalformedYAML(t *testing.T) {
+	_, err := spec.ParseBytes([]byte("version: '0.1'\n  bad: indent: again"))
+	var ye *spec.YAMLError
+	if !errors.As(err, &ye) {
+		t.Fatalf("err = %v, want *YAMLError", err)
+	}
+}
+
+// --- Schema errors ---
+
+func TestParse_MissingVersion(t *testing.T) {
+	_, err := spec.ParseBytes([]byte(`
+workflows:
+  trivial:
+    stages:
+      - id: x
+        type: plan
+        executor: { agent: claude-code }
+`))
+	var se *spec.SchemaError
+	if !errors.As(err, &se) {
+		t.Fatalf("err = %v, want *SchemaError", err)
+	}
+}
+
+func TestParse_WrongVersion(t *testing.T) {
+	_, err := spec.ParseBytes([]byte(`
+version: "9.9"
+workflows:
+  trivial:
+    stages:
+      - id: x
+        type: plan
+        executor: { agent: claude-code }
+`))
+	var se *spec.SchemaError
+	if !errors.As(err, &se) {
+		t.Fatalf("err = %v, want *SchemaError", err)
+	}
+}
+
+func TestParse_UnknownStageType(t *testing.T) {
+	_, err := spec.ParseBytes([]byte(`
+version: "0.1"
+workflows:
+  trivial:
+    stages:
+      - id: x
+        type: deploy
+        executor: { agent: claude-code }
+`))
+	var se *spec.SchemaError
+	if !errors.As(err, &se) {
+		t.Fatalf("err = %v, want *SchemaError", err)
+	}
+}
+
+func TestParse_BothExecutorKinds(t *testing.T) {
+	// Schema's oneOf rejects {agent, human} together.
+	_, err := spec.ParseBytes([]byte(`
+version: "0.1"
+workflows:
+  trivial:
+    stages:
+      - id: x
+        type: plan
+        executor:
+          agent: claude-code
+          human: true
+`))
+	var se *spec.SchemaError
+	if !errors.As(err, &se) {
+		t.Fatalf("err = %v, want *SchemaError", err)
+	}
+}
+
+func TestParse_StageIDPattern(t *testing.T) {
+	// Stage IDs must be snake_case (^[a-z][a-z0-9_]*$).
+	_, err := spec.ParseBytes([]byte(`
+version: "0.1"
+workflows:
+  trivial:
+    stages:
+      - id: NotSnakeCase
+        type: plan
+        executor: { agent: claude-code }
+`))
+	var se *spec.SchemaError
+	if !errors.As(err, &se) {
+		t.Fatalf("err = %v, want *SchemaError", err)
+	}
+}
+
+func TestParse_UnknownArtifactKind(t *testing.T) {
+	_, err := spec.ParseBytes([]byte(`
+version: "0.1"
+workflows:
+  trivial:
+    stages:
+      - id: x
+        type: implement
+        executor: { agent: claude-code }
+        produces:
+          - artifact: design_doc
+`))
+	var se *spec.SchemaError
+	if !errors.As(err, &se) {
+		t.Fatalf("err = %v, want *SchemaError", err)
+	}
+}
+
+// --- Semantic (post-schema) errors ---
+
+func TestParse_DuplicateStageIDs(t *testing.T) {
+	_, err := spec.ParseBytes([]byte(`
+version: "0.1"
+workflows:
+  trivial:
+    stages:
+      - id: same
+        type: plan
+        executor: { agent: claude-code }
+        produces:
+          - artifact: plan
+            schema: standard_v1
+      - id: same
+        type: implement
+        executor: { agent: claude-code }
+        produces:
+          - artifact: pull_request
+`))
+	var ve *spec.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("err = %v, want *ValidationError", err)
+	}
+	if !strings.Contains(ve.Message, "duplicate") {
+		t.Errorf("message = %q, expected to mention 'duplicate'", ve.Message)
+	}
+}
+
+func TestParse_DanglingFromStage(t *testing.T) {
+	_, err := spec.ParseBytes([]byte(`
+version: "0.1"
+workflows:
+  trivial:
+    stages:
+      - id: implement
+        type: implement
+        executor: { agent: claude-code }
+        inputs:
+          - artifact: plan
+            from_stage: nonexistent
+        produces:
+          - artifact: pull_request
+`))
+	var ve *spec.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("err = %v, want *ValidationError", err)
+	}
+	if !strings.Contains(ve.Message, "from_stage") {
+		t.Errorf("message = %q, expected to mention 'from_stage'", ve.Message)
+	}
+}
+
+func TestParse_ForwardFromStage(t *testing.T) {
+	// from_stage may reference only earlier stages.
+	_, err := spec.ParseBytes([]byte(`
+version: "0.1"
+workflows:
+  trivial:
+    stages:
+      - id: first
+        type: implement
+        executor: { agent: claude-code }
+        inputs:
+          - artifact: plan
+            from_stage: second
+        produces:
+          - artifact: pull_request
+      - id: second
+        type: review
+        executor: { human: true }
+`))
+	var ve *spec.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("err = %v, want *ValidationError", err)
+	}
+}
+
+func TestParse_UndefinedApproverRole(t *testing.T) {
+	_, err := spec.ParseBytes([]byte(`
+version: "0.1"
+roles:
+  founder:
+    members: ["@kuhlman-labs"]
+workflows:
+  trivial:
+    stages:
+      - id: review
+        type: review
+        executor: { human: true }
+        gates:
+          - type: approval
+            approvers:
+              any_of: [maintainer]   # not defined
+`))
+	var ve *spec.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("err = %v, want *ValidationError", err)
+	}
+	if !strings.Contains(ve.Message, "maintainer") {
+		t.Errorf("message = %q, expected to name the missing role", ve.Message)
+	}
+}
+
+func TestParse_PlanMissingSchema(t *testing.T) {
+	_, err := spec.ParseBytes([]byte(`
+version: "0.1"
+workflows:
+  trivial:
+    stages:
+      - id: plan
+        type: plan
+        executor: { agent: claude-code }
+        produces:
+          - artifact: plan
+            # schema: standard_v1     ← deliberately omitted
+`))
+	var ve *spec.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("err = %v, want *ValidationError", err)
+	}
+	if !strings.Contains(ve.Message, "standard_v1") {
+		t.Errorf("message = %q, expected to mention standard_v1", ve.Message)
+	}
+}
+
+// --- Validate(*Spec) standalone ---
+
+func TestValidate_NilSpec(t *testing.T) {
+	if err := spec.Validate(nil); err == nil {
+		t.Fatal("Validate(nil) should error")
+	}
+}
+
+func TestValidate_BuiltProgrammatically(t *testing.T) {
+	// Confirms callers can build a Spec in-memory and run only the
+	// semantic layer without going through Parse.
+	s := &spec.Spec{
+		Version: "0.1",
+		Roles: map[string]spec.Role{
+			"founder": {Members: []string{"@kuhlman-labs"}},
+		},
+		Workflows: map[string]spec.Workflow{
+			"trivial": {
+				Stages: []spec.Stage{
+					{
+						ID:       "plan",
+						Type:     spec.StageTypePlan,
+						Executor: spec.Executor{Agent: "claude-code"},
+						Produces: []spec.Produces{
+							{Artifact: spec.ArtifactPlan, Schema: "standard_v1"},
+						},
+					},
+				},
+			},
+		},
+	}
+	if err := spec.Validate(s); err != nil {
+		t.Errorf("Validate: %v", err)
+	}
+}
+
+// --- Parse via io.Reader ---
+
+func TestParse_ReaderRoundTrip(t *testing.T) {
+	s, err := spec.Parse(strings.NewReader(`
+version: "0.1"
+workflows:
+  t:
+    stages:
+      - id: i
+        type: implement
+        executor: { agent: claude-code }
+        produces:
+          - artifact: pull_request
+`))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if s.Workflows["t"].Stages[0].ID != "i" {
+		t.Errorf("unexpected parse result: %+v", s)
+	}
+}

--- a/backend/internal/spec/testdata/valid/feature-change.yaml
+++ b/backend/internal/spec/testdata/valid/feature-change.yaml
@@ -1,0 +1,83 @@
+# Mirror of docs/spec/examples/workflow-v0-feature-change.yaml.
+# Used as a regression fixture: any change to the parser must keep
+# this example parseable end-to-end.
+
+version: "0.1"
+
+roles:
+  tech_lead:
+    members: ["@org/tech-leads"]
+  senior_engineer:
+    members: ["@org/senior-engineers", "@org/tech-leads"]
+  any_engineer:
+    members: ["@org/engineering"]
+
+workflows:
+  feature_change:
+    description: "Default workflow for new features and non-trivial changes."
+
+    stages:
+      - id: plan
+        type: plan
+        executor:
+          agent: claude-code
+        inputs:
+          - source: github_issue
+            required: true
+        produces:
+          - artifact: plan
+            schema: standard_v1
+            persistence:
+              - target: originating_issue
+                mode: rendered_comment
+                update_on_change: true
+              - target: fishhawk_audit_log
+                mode: canonical
+        budget:
+          max_tokens: 200000
+          max_runtime_minutes: 15
+          enforcement: advisory
+        gates:
+          - type: approval
+            approvers:
+              any_of: [tech_lead, senior_engineer]
+            sla: 4_business_hours
+
+      - id: implement
+        type: implement
+        executor:
+          agent: claude-code
+        inputs:
+          - artifact: plan
+            from_stage: plan
+        produces:
+          - artifact: pull_request
+        constraints:
+          - max_files_changed: 30
+          - forbidden_paths:
+              - "infra/**"
+              - ".github/workflows/**"
+              - "security/**"
+              - ".fishhawk/**"
+          - required_outcomes:
+              - tests_added_or_updated
+              - ci_green
+        budget:
+          max_tokens: 500000
+          max_runtime_minutes: 30
+          enforcement: advisory
+
+      - id: review
+        type: review
+        executor:
+          human: true
+        inputs:
+          - artifact: pull_request
+            from_stage: implement
+        gates:
+          - type: approval
+            approvers:
+              any_of: [senior_engineer]
+            blocking_checks:
+              - ci_pass
+              - fishhawk_audit_complete

--- a/backend/internal/spec/testdata/valid/minimal.yaml
+++ b/backend/internal/spec/testdata/valid/minimal.yaml
@@ -1,0 +1,15 @@
+# Smallest valid spec: one workflow with one stage, no roles, no
+# gates, no constraints. Useful as a regression baseline that
+# nothing about the parser regressed for the bare-bones case.
+
+version: "0.1"
+
+workflows:
+  trivial:
+    stages:
+      - id: implement
+        type: implement
+        executor:
+          agent: claude-code
+        produces:
+          - artifact: pull_request

--- a/backend/internal/spec/validate.go
+++ b/backend/internal/spec/validate.go
@@ -1,0 +1,124 @@
+package spec
+
+import "fmt"
+
+// Validate runs the semantic checks that the JSON Schema can't
+// express. Schema-level validation (structure, enums, types) has
+// already happened in Parse; this layer enforces graph-shape rules:
+//
+//   - Stage IDs are unique within a workflow.
+//   - inputs[].from_stage references an existing stage in the same
+//     workflow.
+//   - approvers.any_of / approvers.all_of reference roles defined at
+//     the top level.
+//   - Plan-producing stages declare schema: standard_v1.
+//
+// Validate is exported so tests and Spec-builder code can exercise
+// the semantic layer without the YAML→schema round trip.
+func Validate(s *Spec) error {
+	if s == nil {
+		return &ValidationError{Path: "/", Message: "nil spec"}
+	}
+	for wfName, wf := range s.Workflows {
+		if err := validateWorkflow(s, wfName, &wf); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateWorkflow(s *Spec, name string, wf *Workflow) error {
+	stagePath := func(i int, suffix string) string {
+		return fmt.Sprintf("/workflows/%s/stages/%d%s", name, i, suffix)
+	}
+
+	seen := make(map[string]int, len(wf.Stages))
+	for i, stage := range wf.Stages {
+		if prev, ok := seen[stage.ID]; ok {
+			return &ValidationError{
+				Path: stagePath(i, "/id"),
+				Message: fmt.Sprintf(
+					"duplicate stage id %q (also at /workflows/%s/stages/%d/id)",
+					stage.ID, name, prev,
+				),
+			}
+		}
+		seen[stage.ID] = i
+	}
+
+	for i, stage := range wf.Stages {
+		// inputs[].from_stage cross-references must resolve.
+		for j, in := range stage.Inputs {
+			if in.FromStage == "" {
+				continue
+			}
+			if _, ok := seen[in.FromStage]; !ok {
+				return &ValidationError{
+					Path: stagePath(i, fmt.Sprintf("/inputs/%d/from_stage", j)),
+					Message: fmt.Sprintf(
+						"from_stage %q does not match any stage id in workflow %q",
+						in.FromStage, name,
+					),
+				}
+			}
+			// Cannot reference self or a later stage; runs are
+			// linear in v0.
+			refIdx := seen[in.FromStage]
+			if refIdx >= i {
+				return &ValidationError{
+					Path: stagePath(i, fmt.Sprintf("/inputs/%d/from_stage", j)),
+					Message: fmt.Sprintf(
+						"from_stage %q must be a stage earlier in the workflow (got index %d, this stage is index %d)",
+						in.FromStage, refIdx, i,
+					),
+				}
+			}
+		}
+
+		// Plan-producing stages must declare schema: standard_v1.
+		// MVP_SPEC §4.3: plans are schema-versioned for forward
+		// compatibility; a missing schema directive is a
+		// permanent-data-loss risk.
+		for j, p := range stage.Produces {
+			if p.Artifact == ArtifactPlan && p.Schema != "standard_v1" {
+				return &ValidationError{
+					Path: stagePath(i, fmt.Sprintf("/produces/%d/schema", j)),
+					Message: fmt.Sprintf(
+						"plan-producing stage must declare schema: standard_v1, got %q",
+						p.Schema,
+					),
+				}
+			}
+		}
+
+		// Approver role refs must resolve.
+		for j, g := range stage.Gates {
+			if g.Approvers == nil {
+				continue
+			}
+			gatePath := stagePath(i, fmt.Sprintf("/gates/%d/approvers", j))
+			if err := validateApproverRefs(s, gatePath, "any_of", g.Approvers.AnyOf); err != nil {
+				return err
+			}
+			if err := validateApproverRefs(s, gatePath, "all_of", g.Approvers.AllOf); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func validateApproverRefs(s *Spec, gatePath, key string, refs []string) error {
+	for k, role := range refs {
+		if _, ok := s.Roles[role]; !ok {
+			return &ValidationError{
+				Path: fmt.Sprintf("%s/%s/%d", gatePath, key, k),
+				Message: fmt.Sprintf(
+					"approver role %q is not defined in the top-level roles map",
+					role,
+				),
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

Closes [#17 (E1.2)](https://github.com/kuhlman-labs/fishhawk/issues/17) and [#18 (E1.3)](https://github.com/kuhlman-labs/fishhawk/issues/18). The first Go consumers of the workflow-v0 schema landed in [#90](https://github.com/kuhlman-labs/fishhawk/pull/90); this PR makes the schema actually executable.

### Two-stage validation

**1. Schema validation** (`parse.go`). `yaml.v3` decodes the document into `interface{}`; the result is run through the workflow-v0 schema compiled with `santhosh-tekuri/jsonschema/v6` (Draft 2020-12). The schema is embedded from `backend/internal/spec/schemas/workflow-v0.schema.json` — a copy of `docs/spec/workflow-v0.schema.json` kept in sync by a new CI step that diffs the two and fails on drift.

**2. Semantic validation** (`validate.go`). Catches what the schema can't:

- Stage IDs are unique within a workflow.
- `inputs[].from_stage` resolves to an earlier stage in the same workflow (no forward-references — runs are linear in v0).
- `approvers.any_of` / `all_of` resolves to a top-level role.
- Plan-producing stages declare `schema: standard_v1`.

### Public API (`spec.go`, `errors.go`)

```go
spec.Parse(io.Reader) (*Spec, error)
spec.ParseBytes([]byte)  (*Spec, error)
spec.Validate(*Spec)     error   // semantic-only, for hand-built Specs
```

Error types: `*YAMLError`, `*SchemaError`, `*ValidationError`. Each carries a path and a message; `YAMLError` wraps the underlying yaml package error so callers can `errors.As` to extract line/column.

### CI: schema-sync guard

New CI step diffs `docs/spec/workflow-v0.schema.json` against `backend/internal/spec/schemas/workflow-v0.schema.json`. The two must stay byte-identical; updating one without the other fails CI. Trivial protection that catches the drift class of bug at the cheapest possible point.

## Test plan

- [x] `go build ./backend/...` — clean
- [x] `go test -race ./backend/...` — all packages pass; new `internal/spec` covers happy paths (canonical + minimal) + every error class:
  - YAML: empty document, malformed YAML
  - Schema: missing version, wrong version, unknown stage type, both executor kinds set, snake_case violation, unknown artifact kind
  - Semantic: duplicate stage IDs, dangling `from_stage`, forward `from_stage` reference, undefined approver role, plan-stage missing `standard_v1`
  - Programmatic `Validate(*Spec)` exercised with a hand-built spec
- [x] `golangci-lint run ./backend/...` — 0 issues
- [x] `python3 scripts/check-coverage.py --threshold 80 --exclude internal/run/db backend/coverage.out` — **PASS at 80.3%** (aggregate); `internal/spec` lands at 80.6%
- [ ] CI on this PR — `CI Pass` rollup gates everything

## Notes

- **Coverage discipline**: `internal/spec` sits at 80.6%. The package's tier target per `docs/ARCHITECTURE.md` §9 is **85%** (low-autonomy: workflow spec parser is load-bearing — a parsing bug here corrupts every downstream stage). The aggregate gate (80%) is met, so this PR ships, but follow-ups should close the per-tier gap as the parser sees real use under E3.7 (#47) and E5 (#5). Most of the uncovered code is rare error paths in the JSON Schema → SchemaError translation.
- **Schema sync mechanic**: chose duplicate-with-CI-diff over a separate Go module (`/spec/`) because two files that change rarely (frozen at Day 21) didn't justify a new module's workspace ceremony. Worth revisiting if a third Go consumer — the runner or a future SDK — also needs the schemas.
- **No use of `jsonschema.ErrorKind.LocalizedString`**: the v6 library's `LocalizedString(*message.Printer)` panics on a nil printer. We extract the leaf's `Error()` output and trim the prefix instead — equivalent message, no x/text Printer ceremony.

Closes #17
Closes #18