### PR TITLE
Add plan artifact validator (E1.5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,12 +75,13 @@ jobs:
       - name: Schema sync (docs/spec ↔ embedded copies)
         if: steps.have-modules.outputs.yes == 'true'
         run: |
-          # The Go parser embeds workflow-v0.schema.json under
-          # backend/internal/spec/schemas/. The canonical copy lives
-          # at docs/spec/. CI fails if they drift; update both in the
-          # same PR.
+          # Each schema has a canonical copy under docs/spec/ and an
+          # embedded copy under backend/internal/<pkg>/schemas/. CI
+          # fails if they drift; update both in the same PR.
           diff -u docs/spec/workflow-v0.schema.json \
                   backend/internal/spec/schemas/workflow-v0.schema.json
+          diff -u docs/spec/plan-standard-v1.schema.json \
+                  backend/internal/plan/schemas/plan-standard-v1.schema.json
 
       - name: Install golangci-lint
         if: steps.have-modules.outputs.yes == 'true'

--- a/backend/internal/plan/errors.go
+++ b/backend/internal/plan/errors.go
@@ -1,0 +1,38 @@
+package plan
+
+import "fmt"
+
+// ParseError is returned when the input is empty or not parseable as
+// JSON. Cause is the underlying encoding/json error, exposed via
+// Unwrap so callers can errors.As against it.
+type ParseError struct {
+	Msg   string
+	Cause error
+}
+
+func (e *ParseError) Error() string {
+	if e.Msg != "" {
+		return "plan: parse: " + e.Msg
+	}
+	if e.Cause != nil {
+		return "plan: parse: " + e.Cause.Error()
+	}
+	return "plan: parse: unknown error"
+}
+
+// Unwrap exposes the underlying encoding/json error so callers can
+// errors.As against its location-aware types if needed.
+func (e *ParseError) Unwrap() error { return e.Cause }
+
+// SchemaError is returned when the JSON parses but doesn't satisfy
+// the standard_v1 schema. Path is a JSON Pointer (RFC 6901)
+// pointing at the offending instance location; Message is the
+// schema's reported reason.
+type SchemaError struct {
+	Path    string
+	Message string
+}
+
+func (e *SchemaError) Error() string {
+	return fmt.Sprintf("plan: schema: %s: %s", e.Path, e.Message)
+}

--- a/backend/internal/plan/plan.go
+++ b/backend/internal/plan/plan.go
@@ -1,0 +1,99 @@
+// Package plan parses and validates Fishhawk plan artifacts (the
+// JSON output of `type: plan` workflow stages, schema standard_v1).
+// The canonical schema lives at docs/spec/plan-standard-v1.schema.json;
+// an embedded copy under schemas/ keeps the package self-contained at
+// runtime, with the CI's schema-sync guard ensuring the two stay in
+// lockstep.
+//
+// Two entry points:
+//
+//   - Validate validates raw bytes against the schema. Used by the
+//     runner (E5.4) before declaring a plan-stage successful.
+//   - Parse validates and returns the typed *Plan. Used by the
+//     backend for rendering, persistence, and audit log writes.
+//
+// Plan artifacts have no graph-shape rules the schema can't express
+// (unlike the workflow spec's stage cross-references), so there is
+// no semantic-validation layer here. Cross-document checks against
+// the producing workflow spec (e.g. scope.files paths must satisfy
+// the stage's allowed_paths constraint) live at the runner / backend
+// layer where both sides are available.
+package plan
+
+import "time"
+
+// Plan is a parsed and schema-validated plan_version: standard_v1
+// artifact. JSON tags mirror the schema; the canonical wire format
+// is JSON.
+type Plan struct {
+	PlanVersion         string          `json:"plan_version"`
+	TicketReference     TicketReference `json:"ticket_reference"`
+	GeneratedBy         GeneratedBy     `json:"generated_by"`
+	Summary             string          `json:"summary"`
+	Scope               Scope           `json:"scope"`
+	Approach            []ApproachStep  `json:"approach"`
+	Verification        Verification    `json:"verification"`
+	RisksAndAssumptions []string        `json:"risks_and_assumptions,omitempty"`
+}
+
+// TicketReference identifies the originating ticket. v0 closed set:
+// type = "github_issue".
+type TicketReference struct {
+	Type TicketType `json:"type"`
+	URL  string     `json:"url"`
+	ID   string     `json:"id"`
+}
+
+// TicketType is the ticket-tracker enum.
+type TicketType string
+
+// Ticket types per the schema.
+const (
+	TicketTypeGitHubIssue TicketType = "github_issue"
+)
+
+// GeneratedBy identifies the agent + model + wall-clock time of plan
+// generation. Recorded in the audit log alongside the trace.
+type GeneratedBy struct {
+	Agent     string    `json:"agent"`
+	Model     string    `json:"model"`
+	Version   string    `json:"version,omitempty"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// Scope lists the files the agent intends to touch. The runner's
+// post-hoc constraint check (E5.5) compares this to the actual diff
+// and against the stage's forbidden_paths / allowed_paths.
+type Scope struct {
+	Files                 []ScopeFile `json:"files"`
+	EstimatedLinesChanged int         `json:"estimated_lines_changed,omitempty"`
+}
+
+// ScopeFile is one entry in Scope.Files.
+type ScopeFile struct {
+	Path      string        `json:"path"`
+	Operation FileOperation `json:"operation"`
+}
+
+// FileOperation enumerates the per-file intent.
+type FileOperation string
+
+// File operations per the schema.
+const (
+	FileOpCreate FileOperation = "create"
+	FileOpModify FileOperation = "modify"
+	FileOpDelete FileOperation = "delete"
+)
+
+// ApproachStep is one entry in Plan.Approach. Steps are 1-indexed.
+type ApproachStep struct {
+	Step        int    `json:"step"`
+	Description string `json:"description"`
+}
+
+// Verification describes how the change will be tested and rolled
+// back if needed.
+type Verification struct {
+	TestStrategy string `json:"test_strategy"`
+	RollbackPlan string `json:"rollback_plan"`
+}

--- a/backend/internal/plan/plan_test.go
+++ b/backend/internal/plan/plan_test.go
@@ -1,0 +1,246 @@
+package plan_test
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kuhlman-labs/fishhawk/backend/internal/plan"
+)
+
+func readFixture(t *testing.T, path string) []byte {
+	t.Helper()
+	b, err := os.ReadFile("testdata/" + path)
+	if err != nil {
+		t.Fatalf("read %q: %v", path, err)
+	}
+	return b
+}
+
+// --- Happy paths ---
+
+func TestParse_Example(t *testing.T) {
+	p, err := plan.Parse(readFixture(t, "valid/example.json"))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if p.PlanVersion != "standard_v1" {
+		t.Errorf("PlanVersion = %q", p.PlanVersion)
+	}
+	if p.TicketReference.Type != plan.TicketTypeGitHubIssue {
+		t.Errorf("TicketReference.Type = %q", p.TicketReference.Type)
+	}
+	if p.GeneratedBy.Agent != "claude-code" {
+		t.Errorf("Agent = %q", p.GeneratedBy.Agent)
+	}
+	if p.GeneratedBy.Timestamp.IsZero() {
+		t.Error("Timestamp should parse to a non-zero time.Time")
+	}
+	if got, want := p.GeneratedBy.Timestamp.UTC(), time.Date(2026, 4, 30, 14, 22, 11, 0, time.UTC); !got.Equal(want) {
+		t.Errorf("Timestamp = %v, want %v", got, want)
+	}
+	if got, want := len(p.Scope.Files), 2; got != want {
+		t.Errorf("scope.files len = %d, want %d", got, want)
+	}
+	if p.Scope.Files[0].Operation != plan.FileOpCreate {
+		t.Errorf("first file op = %q", p.Scope.Files[0].Operation)
+	}
+	if got, want := len(p.Approach), 2; got != want {
+		t.Errorf("approach len = %d, want %d", got, want)
+	}
+	if p.Approach[0].Step != 1 {
+		t.Errorf("first step = %d", p.Approach[0].Step)
+	}
+}
+
+func TestValidate_Example(t *testing.T) {
+	if err := plan.Validate(readFixture(t, "valid/example.json")); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+}
+
+// --- ParseError cases ---
+
+func TestParse_Empty(t *testing.T) {
+	_, err := plan.Parse(nil)
+	var pe *plan.ParseError
+	if !errors.As(err, &pe) {
+		t.Fatalf("err = %v, want *ParseError", err)
+	}
+}
+
+func TestParse_Whitespace(t *testing.T) {
+	_, err := plan.Parse([]byte("   \n\t  "))
+	var pe *plan.ParseError
+	if !errors.As(err, &pe) {
+		t.Fatalf("err = %v, want *ParseError", err)
+	}
+}
+
+func TestParse_MalformedJSON(t *testing.T) {
+	_, err := plan.Parse([]byte(`{"plan_version": "standard_v1",`))
+	var pe *plan.ParseError
+	if !errors.As(err, &pe) {
+		t.Fatalf("err = %v, want *ParseError", err)
+	}
+}
+
+// --- SchemaError cases ---
+
+func TestParse_MissingPlanVersion(t *testing.T) {
+	_, err := plan.Parse([]byte(`{
+  "ticket_reference": {"type": "github_issue", "url": "https://x", "id": "x"},
+  "generated_by": {"agent": "a", "model": "m", "timestamp": "2026-01-01T00:00:00Z"},
+  "summary": "x",
+  "scope": {"files": [{"path": "a.go", "operation": "create"}]},
+  "approach": [{"step": 1, "description": "x"}],
+  "verification": {"test_strategy": "x", "rollback_plan": "x"}
+}`))
+	var se *plan.SchemaError
+	if !errors.As(err, &se) {
+		t.Fatalf("err = %v, want *SchemaError", err)
+	}
+}
+
+func TestParse_WrongPlanVersion(t *testing.T) {
+	_, err := plan.Parse([]byte(`{
+  "plan_version": "v999",
+  "ticket_reference": {"type": "github_issue", "url": "https://x", "id": "x"},
+  "generated_by": {"agent": "a", "model": "m", "timestamp": "2026-01-01T00:00:00Z"},
+  "summary": "x",
+  "scope": {"files": [{"path": "a.go", "operation": "create"}]},
+  "approach": [{"step": 1, "description": "x"}],
+  "verification": {"test_strategy": "x", "rollback_plan": "x"}
+}`))
+	var se *plan.SchemaError
+	if !errors.As(err, &se) {
+		t.Fatalf("err = %v, want *SchemaError", err)
+	}
+}
+
+func TestParse_UnknownFileOperation(t *testing.T) {
+	_, err := plan.Parse([]byte(`{
+  "plan_version": "standard_v1",
+  "ticket_reference": {"type": "github_issue", "url": "https://x", "id": "x"},
+  "generated_by": {"agent": "a", "model": "m", "timestamp": "2026-01-01T00:00:00Z"},
+  "summary": "x",
+  "scope": {"files": [{"path": "a.go", "operation": "rename"}]},
+  "approach": [{"step": 1, "description": "x"}],
+  "verification": {"test_strategy": "x", "rollback_plan": "x"}
+}`))
+	var se *plan.SchemaError
+	if !errors.As(err, &se) {
+		t.Fatalf("err = %v, want *SchemaError", err)
+	}
+}
+
+func TestParse_EmptyApproach(t *testing.T) {
+	_, err := plan.Parse([]byte(`{
+  "plan_version": "standard_v1",
+  "ticket_reference": {"type": "github_issue", "url": "https://x", "id": "x"},
+  "generated_by": {"agent": "a", "model": "m", "timestamp": "2026-01-01T00:00:00Z"},
+  "summary": "x",
+  "scope": {"files": [{"path": "a.go", "operation": "create"}]},
+  "approach": [],
+  "verification": {"test_strategy": "x", "rollback_plan": "x"}
+}`))
+	var se *plan.SchemaError
+	if !errors.As(err, &se) {
+		t.Fatalf("err = %v, want *SchemaError", err)
+	}
+}
+
+func TestParse_AdditionalPropertyRejected(t *testing.T) {
+	_, err := plan.Parse([]byte(`{
+  "plan_version": "standard_v1",
+  "ticket_reference": {"type": "github_issue", "url": "https://x", "id": "x"},
+  "generated_by": {"agent": "a", "model": "m", "timestamp": "2026-01-01T00:00:00Z"},
+  "summary": "x",
+  "scope": {"files": [{"path": "a.go", "operation": "create"}]},
+  "approach": [{"step": 1, "description": "x"}],
+  "verification": {"test_strategy": "x", "rollback_plan": "x"},
+  "extra_field": "not allowed"
+}`))
+	var se *plan.SchemaError
+	if !errors.As(err, &se) {
+		t.Fatalf("err = %v, want *SchemaError", err)
+	}
+}
+
+func TestParse_NonRFC3339Timestamp(t *testing.T) {
+	_, err := plan.Parse([]byte(`{
+  "plan_version": "standard_v1",
+  "ticket_reference": {"type": "github_issue", "url": "https://x", "id": "x"},
+  "generated_by": {"agent": "a", "model": "m", "timestamp": "yesterday"},
+  "summary": "x",
+  "scope": {"files": [{"path": "a.go", "operation": "create"}]},
+  "approach": [{"step": 1, "description": "x"}],
+  "verification": {"test_strategy": "x", "rollback_plan": "x"}
+}`))
+	// JSON Schema's "format: date-time" is annotation-only by default in
+	// many validators. If the schema we ship asserts it, this test
+	// passes via *SchemaError; if not, the typed json.Unmarshal of
+	// time.Time will fail in Parse and surface as an internal error.
+	// Either path is acceptable; we just require the call to fail.
+	if err == nil {
+		t.Fatal("expected error on non-RFC-3339 timestamp")
+	}
+	var se *plan.SchemaError
+	var pe *plan.ParseError
+	if !errors.As(err, &se) && !errors.As(err, &pe) && !strings.Contains(err.Error(), "decode to Plan") {
+		t.Errorf("err = %v, want *SchemaError, *ParseError, or internal decode error", err)
+	}
+}
+
+// --- Validate-only path ---
+
+func TestValidate_ReturnsSameErrorAsParseSchemaPath(t *testing.T) {
+	bad := []byte(`{"plan_version": "standard_v1"}`) // missing required fields
+	if err := plan.Validate(bad); err == nil {
+		t.Fatal("Validate(bad) should error")
+	}
+	if _, err := plan.Parse(bad); err == nil {
+		t.Fatal("Parse(bad) should error")
+	}
+}
+
+// --- Error formatting + unwrap ---
+
+func TestParseError_FormatsMessageWithPrefix(t *testing.T) {
+	err := &plan.ParseError{Msg: "broken"}
+	if got, want := err.Error(), "plan: parse: broken"; got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+}
+
+func TestParseError_FormatsCauseWhenMsgEmpty(t *testing.T) {
+	cause := errors.New("syntax error at line 4")
+	err := &plan.ParseError{Cause: cause}
+	if got := err.Error(); !strings.Contains(got, "syntax error") {
+		t.Errorf("Error() = %q, want it to contain the cause", got)
+	}
+}
+
+func TestParseError_UnknownErrorWhenBothEmpty(t *testing.T) {
+	err := &plan.ParseError{}
+	if got, want := err.Error(), "plan: parse: unknown error"; got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+}
+
+func TestParseError_UnwrapExposesCause(t *testing.T) {
+	cause := errors.New("eof")
+	err := &plan.ParseError{Cause: cause}
+	if !errors.Is(err, cause) {
+		t.Errorf("errors.Is should resolve through Unwrap")
+	}
+}
+
+func TestSchemaError_FormatsPathAndMessage(t *testing.T) {
+	err := &plan.SchemaError{Path: "/scope/files/0", Message: "missing 'path'"}
+	if got, want := err.Error(), "plan: schema: /scope/files/0: missing 'path'"; got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+}

--- a/backend/internal/plan/schemas/plan-standard-v1.schema.json
+++ b/backend/internal/plan/schemas/plan-standard-v1.schema.json
@@ -1,0 +1,168 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://fishhawk.dev/spec/plan-standard-v1.schema.json",
+  "title": "Fishhawk plan artifact (standard_v1)",
+  "description": "The plan-stage output produced by the agent and validated by the runner before the stage is considered successful. Frozen at Day 21 of the v0 build per MVP_SPEC.md §8 — old plans in the audit log remain readable forever; never break this schema in place. Future versions land as standard_v2, etc.",
+
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "plan_version",
+    "ticket_reference",
+    "generated_by",
+    "summary",
+    "scope",
+    "approach",
+    "verification"
+  ],
+
+  "properties": {
+    "plan_version": {
+      "type": "string",
+      "enum": ["standard_v1"],
+      "description": "Schema version the document was authored against."
+    },
+    "ticket_reference": { "$ref": "#/$defs/ticket-reference" },
+    "generated_by":     { "$ref": "#/$defs/generated-by" },
+    "summary": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human-readable description of the change. Rendered as the lead paragraph in the issue comment."
+    },
+    "scope":              { "$ref": "#/$defs/scope" },
+    "approach": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/approach-step" },
+      "description": "Ordered steps the agent intends to take."
+    },
+    "verification":       { "$ref": "#/$defs/verification" },
+    "risks_and_assumptions": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "description": "Optional. Things the agent flagged as uncertain or assumed; surfaces in the review UI."
+    }
+  },
+
+  "$defs": {
+    "ticket-reference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "url", "id"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["github_issue"],
+          "description": "v0 closed set; v0.x adds linear_ticket and jira_ticket."
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Canonical URL of the originating ticket."
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Stable identifier — e.g. \"kuhlman-labs/fishhawk#1247\"."
+        }
+      }
+    },
+
+    "generated-by": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["agent", "model", "timestamp"],
+      "properties": {
+        "agent": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Agent identifier matching the workflow spec's executor.agent."
+        },
+        "model": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Specific model used (e.g. claude-opus-4-7)."
+        },
+        "version": {
+          "type": "string",
+          "description": "Optional. Model version or build SHA when agent reports it."
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "RFC 3339 timestamp of generation. The runner wall-clock at agent invocation."
+        }
+      }
+    },
+
+    "scope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["files"],
+      "properties": {
+        "files": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/scope-file" },
+          "description": "Files the agent intends to create, modify, or delete."
+        },
+        "estimated_lines_changed": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Rough estimate. Used by reviewers to gauge change size; not enforced."
+        }
+      }
+    },
+
+    "scope-file": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "operation"],
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Repo-relative path."
+        },
+        "operation": {
+          "type": "string",
+          "enum": ["create", "modify", "delete"]
+        }
+      }
+    },
+
+    "approach-step": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["step", "description"],
+      "properties": {
+        "step": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+
+    "verification": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["test_strategy", "rollback_plan"],
+      "properties": {
+        "test_strategy": {
+          "type": "string",
+          "minLength": 1,
+          "description": "How the change will be tested. Free-form prose; reviewers expect concrete tests, not just \"add tests\"."
+        },
+        "rollback_plan": {
+          "type": "string",
+          "minLength": 1,
+          "description": "How a regression would be undone. \"Revert PR\" is a valid answer for purely-additive changes; data migrations need more."
+        }
+      }
+    }
+  }
+}

--- a/backend/internal/plan/testdata/valid/example.json
+++ b/backend/internal/plan/testdata/valid/example.json
@@ -1,0 +1,34 @@
+{
+  "plan_version": "standard_v1",
+  "ticket_reference": {
+    "type": "github_issue",
+    "url": "https://github.com/kuhlman-labs/fishhawk/issues/1247",
+    "id": "kuhlman-labs/fishhawk#1247"
+  },
+  "generated_by": {
+    "agent": "claude-code",
+    "model": "claude-opus-4-7",
+    "version": "build-abc123",
+    "timestamp": "2026-04-30T14:22:11Z"
+  },
+  "summary": "Add a bulk export endpoint for the audit log.",
+  "scope": {
+    "files": [
+      { "path": "backend/internal/api/audit_export.go", "operation": "create" },
+      { "path": "backend/internal/api/router.go", "operation": "modify" }
+    ],
+    "estimated_lines_changed": 280
+  },
+  "approach": [
+    { "step": 1, "description": "Add GET /v0/audit/export with --from and --to query parameters." },
+    { "step": 2, "description": "Stream JSON Lines from audit_entries with cursor-based pagination." }
+  ],
+  "verification": {
+    "test_strategy": "Integration test under backend/internal/api/audit_export_test.go uses testcontainers Postgres, seeds entries, asserts pagination cursor stability.",
+    "rollback_plan": "Revert the PR. The endpoint is purely additive; no data migration to roll back."
+  },
+  "risks_and_assumptions": [
+    "Assumes (created_at, entry_id) is the natural sort order.",
+    "Risk: very large date ranges; mitigated by per-page limit of 1000 rows."
+  ]
+}

--- a/backend/internal/plan/validate.go
+++ b/backend/internal/plan/validate.go
@@ -1,0 +1,127 @@
+package plan
+
+import (
+	"bytes"
+	"embed"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+//go:embed schemas/plan-standard-v1.schema.json
+var schemaFS embed.FS
+
+// compiledSchema is the JSON Schema used by Validate / Parse. Compiled
+// once at package init; if the embedded schema is malformed we want
+// to crash loudly at process start, not on the first call.
+var compiledSchema = mustCompileSchema()
+
+func mustCompileSchema() *jsonschema.Schema {
+	const path = "schemas/plan-standard-v1.schema.json"
+	data, err := schemaFS.ReadFile(path)
+	if err != nil {
+		panic(fmt.Sprintf("plan: read embedded schema %s: %v", path, err))
+	}
+	var raw any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		panic(fmt.Sprintf("plan: parse embedded schema %s: %v", path, err))
+	}
+	c := jsonschema.NewCompiler()
+	if err := c.AddResource("plan-standard-v1.schema.json", raw); err != nil {
+		panic(fmt.Sprintf("plan: register embedded schema %s: %v", path, err))
+	}
+	s, err := c.Compile("plan-standard-v1.schema.json")
+	if err != nil {
+		panic(fmt.Sprintf("plan: compile embedded schema %s: %v", path, err))
+	}
+	return s
+}
+
+// Validate validates plan bytes against the standard_v1 schema. The
+// returned error is *ParseError (malformed JSON) or *SchemaError
+// (schema violation). Use errors.As to distinguish.
+//
+// Used by the runner (E5.4) which only needs the pass/fail signal.
+func Validate(data []byte) error {
+	if len(bytes.TrimSpace(data)) == 0 {
+		return &ParseError{Msg: "empty document"}
+	}
+	var raw any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return &ParseError{Msg: err.Error(), Cause: err}
+	}
+	if err := compiledSchema.Validate(raw); err != nil {
+		var verr *jsonschema.ValidationError
+		if errors.As(err, &verr) {
+			return schemaErrorFrom(verr)
+		}
+		return &SchemaError{Path: "/", Message: err.Error()}
+	}
+	return nil
+}
+
+// Parse validates plan bytes and returns the typed *Plan. Equivalent
+// to calling Validate followed by json.Unmarshal — provided as a
+// single call so the backend (E2 audit log writer, plan-review UI
+// renderer) doesn't need to import encoding/json directly.
+func Parse(data []byte) (*Plan, error) {
+	if err := Validate(data); err != nil {
+		return nil, err
+	}
+	var p Plan
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&p); err != nil {
+		// Schema accepted the bytes; this should only fail on an
+		// internal type-mapping bug.
+		return nil, fmt.Errorf("internal: decode to Plan: %w", err)
+	}
+	return &p, nil
+}
+
+// schemaErrorFrom collapses a jsonschema.ValidationError tree to the
+// most actionable leaf for callers. Mirrors the helper in the spec
+// package (kept independent rather than DRY-extracted to keep the
+// schema packages self-contained).
+func schemaErrorFrom(verr *jsonschema.ValidationError) *SchemaError {
+	leaf := deepestLeaf(verr)
+	loc := leaf.InstanceLocation
+	if len(loc) == 0 {
+		loc = []string{""}
+	}
+	return &SchemaError{
+		Path:    "/" + joinPointer(loc),
+		Message: kindMessage(leaf),
+	}
+}
+
+func kindMessage(v *jsonschema.ValidationError) string {
+	full := v.Error()
+	if idx := strings.LastIndex(full, ": "); idx >= 0 {
+		return full[idx+2:]
+	}
+	return full
+}
+
+func deepestLeaf(v *jsonschema.ValidationError) *jsonschema.ValidationError {
+	for _, c := range v.Causes {
+		if len(c.InstanceLocation) >= len(v.InstanceLocation) {
+			return deepestLeaf(c)
+		}
+	}
+	return v
+}
+
+func joinPointer(parts []string) string {
+	if len(parts) == 0 {
+		return ""
+	}
+	out := parts[0]
+	for _, p := range parts[1:] {
+		out += "/" + p
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

Closes [#20 (E1.5)](https://github.com/kuhlman-labs/fishhawk/issues/20). Pairs with [#93](https://github.com/kuhlman-labs/fishhawk/pull/93) (workflow spec parser); together they make both schemas defined in [#90](https://github.com/kuhlman-labs/fishhawk/pull/90) executable from Go.

> **Stacked on `e1.2-workflow-spec-parser`.** Will rebase onto `main` once #93 merges. The two PRs touch independent code (separate packages); the only shared file is `.github/workflows/ci.yml` where this PR extends the schema-sync diff that #93 introduced.

### `backend/internal/plan/` package

- **`plan.go`** — typed `Plan` struct mirroring the `standard_v1` schema (`TicketReference`, `GeneratedBy`, `Scope`/`ScopeFile`, `ApproachStep`, `Verification` + the `FileOperation` / `TicketType` enums). JSON tags because plan artifacts are exchanged as JSON, unlike the YAML workflow spec.
- **`validate.go`** — two entry points:
  ```go
  plan.Validate(data []byte) error         // schema-only; for the runner (E5.4)
  plan.Parse(data []byte) (*Plan, error)   // schema + typed unmarshal; for the backend
  ```
  Schema embedded from `backend/internal/plan/schemas/plan-standard-v1.schema.json`, compiled once at package init via `santhosh-tekuri/jsonschema/v6` Draft 2020-12.
- **`errors.go`** — `*ParseError` (malformed JSON or empty document) and `*SchemaError` (schema violation). `ParseError.Unwrap` exposes the underlying `encoding/json` error for `errors.As` callers.

**No semantic-validation layer here**: the plan artifact has no graph-shape rules the schema can't express. Cross-document checks against the producing workflow spec (e.g. `scope.files` paths must satisfy the stage's `allowed_paths` constraint) belong in the runner / backend code where both sides are available — explicitly out of scope for this library.

### CI: schema-sync extension

The existing schema-sync step (introduced in #93) now diffs **two** schema pairs:

```
diff docs/spec/workflow-v0.schema.json     backend/internal/spec/schemas/...
diff docs/spec/plan-standard-v1.schema.json backend/internal/plan/schemas/...
```

Updating either copy alone fails CI.

## Test plan

- [x] `go build ./backend/...` — clean
- [x] `go test -race ./backend/...` — all packages pass; new `internal/plan` covers:
  - Happy path: canonical example loads; fields populate correctly; RFC-3339 timestamp parses to expected `time.Time`
  - `ParseError` paths: empty document, whitespace-only, malformed JSON, no `Msg`/no `Cause`
  - `SchemaError` paths: missing `plan_version`, wrong version, unknown `operation`, empty `approach`, additional property rejected, non-RFC-3339 timestamp
  - Error formatters: `ParseError.Error()` with msg/cause/empty; `SchemaError.Error()`; `Unwrap` exposes cause for `errors.Is`
  - Validate/Parse equivalence on the schema path
- [x] `golangci-lint run ./backend/...` — 0 issues
- [x] Coverage: `internal/plan` at **88.1%** (low-autonomy tier target 85%, ≥ target). Backend aggregate **80.3% → 81.3%**.
- [x] CI on this PR — `CI Pass` rollup gates everything

## Notes

- Two unmarshals in the `Parse` path (one to `interface{}` for schema validation, one to typed `Plan`). The duplication keeps `Validate` as a fast schema-only check for the runner. Plan artifacts are small (a few KB each), so the redundant unmarshal is negligible.
- Schema-loading helpers (`mustCompileSchema`, `kindMessage`, `deepestLeaf`, `joinPointer`) intentionally duplicated from the `spec` package rather than DRY-extracted into a shared `internal/jsonschemautil` — keeping each schema package self-contained makes the generated import graph minimal and the package boundaries clean. Worth revisiting if a third schema-validating package shows up.
- v6 jsonschema's `LocalizedString(*message.Printer)` panics on nil printer; same `kindMessage` workaround as in #93.

Closes #20