### PR TITLE
Add /runner module scaffold (E5.1)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -17,7 +17,7 @@ Five surfaces, deployed independently. Each maps to a directory in this monorepo
 | Component | Path | Role | Epic |
 |---|---|---|---|
 | **Backend control plane** (`fishhawkd`) | `/backend` | Workflow state machine, policy evaluator, approval state, audit writer, REST API, GitHub App webhook receiver. | E3 (#3) |
-| **Runner action** (`fishhawk/runner`) | `/runner` (planned) | GitHub Action published as `kuhlman-labs/fishhawk/runner@vX.Y`. Runs on the customer's CI: invokes the agent, captures trace, validates the produced plan, signs and ships the bundle. | E5 (#5) |
+| **Runner action** (`fishhawk/runner`) | `/runner` | GitHub Action published as `kuhlman-labs/fishhawk/runner@vX.Y`. Runs on the customer's CI: invokes the agent, captures trace, validates the produced plan, signs and ships the bundle. Currently a scaffold (E5.1) — flag parsing only, no agent invocation yet. | E5 (#5) |
 | **Web UI** | `/frontend` (planned) | Authenticated SPA — plan review, approval, audit search, run visualization. | E7 (#7) |
 | **CLI** (`fishhawk`) | `/cli` (planned) | Validate workflow specs locally; trigger and inspect runs from the terminal. Plan review and approval explicitly stay in the UI. | E6 (#6) |
 | **GitHub App** | (registered with GitHub; manifest in repo) | Per-installation tokens for repo access; OAuth provider for user sign-in; webhook source for triggers. | E4 (#4) |
@@ -113,7 +113,7 @@ These are load-bearing. Do not break them without explicit ADR.
 The Go monorepo is a workspace, not a single module. Each top-level directory is independently taggable:
 
 - `/backend` — `github.com/kuhlman-labs/fishhawk/backend`. Internal packages only (no exported API to other modules).
-- `/runner` (planned) — `github.com/kuhlman-labs/fishhawk/runner`. The published GitHub Action artifact. Customers pin a tag.
+- `/runner` — `github.com/kuhlman-labs/fishhawk/runner`. The published GitHub Action artifact (composite action manifest at `runner/action.yml`). Customers pin a tag.
 - `/cli` (planned) — `github.com/kuhlman-labs/fishhawk/cli`. Single binary.
 
 Cross-module type sharing is intentionally avoided in v0. If two modules need the same struct (e.g., the `standard_v1` plan schema), the canonical source is a JSON Schema in `/docs/spec/` and each side parses independently. This keeps the runner's dependency graph small and the supply-chain surface minimal.

--- a/go.work
+++ b/go.work
@@ -8,7 +8,7 @@
 //
 // Modules will be added as use directives here as they're scaffolded:
 //   E3.1 (#41) → use ./backend  ✓
-//   E5.1 (#52) → use ./runner
+//   E5.1 (#52) → use ./runner   ✓
 //   E6.1 (#55) → use ./cli
 //
 // See ADR-014 (#78) for the rationale.
@@ -16,3 +16,4 @@
 go 1.25.0
 
 use ./backend
+use ./runner

--- a/runner/README.md
+++ b/runner/README.md
@@ -1,0 +1,63 @@
+# fishhawk/runner
+
+The GitHub Action that runs an agent under a Fishhawk workflow stage and ships the signed trace bundle back to the backend. Customers reference the action as:
+
+    uses: kuhlman-labs/fishhawk/runner@v0.1
+
+This directory is its own Go module (`github.com/kuhlman-labs/fishhawk/runner`) so it can be tagged independently of the backend and the CLI — the customer-facing version pin is on the runner alone. See [ADR-014 (#78)](https://github.com/kuhlman-labs/fishhawk/issues/78) for the multi-module rationale.
+
+## Layout
+
+- `action.yml` — composite action manifest. Defines inputs, sets up the Go toolchain, invokes the binary.
+- `cmd/fishhawk-runner/` — the binary entrypoint. Flag parsing in `flags.go`, dispatch in `main.go`.
+- `internal/version/` — build-version package; set via `-ldflags` at release time.
+
+## Status
+
+E5.1 (#52) — module scaffold. The binary parses its inputs, emits a single JSON startup log line, and exits 0. Customers pinning `v0.1` see a no-op success until later issues land:
+
+- E5.2 (#29) — Claude Code invocation harness
+- E5.3 (#30) — full trace capture + bundling
+- E5.4 (#31) — plan validation against `standard_v1` (reuses `backend/internal/plan`)
+- E5.5 (#53) — post-hoc constraint enforcement on stage output
+- E5.6 (#32) — signed trace shipping to backend (uses `backend/internal/signing` + `backend/internal/tracestore`)
+- E5.7 (#54) — versioned, signed releases of `fishhawk/runner` with SBOM
+
+## Inputs (action.yml)
+
+| Input | Description |
+|---|---|
+| `run-id` | Workflow run identifier (UUID, supplied by backend dispatch). |
+| `backend-url` | Fishhawk backend URL the runner ships its trace bundle to. |
+| `workflow` | Workflow ID matching a key under `workflows:` in `.fishhawk/workflows.yaml`. |
+| `stage` | Stage ID within the workflow (e.g. `plan`, `implement`, `review`). |
+
+## Build and test
+
+From the repo root (workspace-aware):
+
+    go build ./runner/...
+    go test -race ./runner/...
+
+Or from this directory directly:
+
+    go build ./...
+    go test ./...
+
+## Local invocation
+
+The same binary the action runs can be invoked locally for development:
+
+    go run ./cmd/fishhawk-runner \
+      --run-id 11111111-2222-3333-4444-555555555555 \
+      --backend-url http://localhost:8080 \
+      --workflow feature_change \
+      --stage plan
+
+Today this just emits a JSON log line and exits. As E5.2+ land, the same invocation will run the configured agent end-to-end.
+
+## See also
+
+- `docs/MVP_SPEC.md` §5.1.2 — runner component definition.
+- `docs/MVP_SPEC.md` §5.3 — trust model (signing, supply-chain, ephemeral keys).
+- `docs/ARCHITECTURE.md` §4 — workflow run lifecycle, where the runner sits in the dispatch flow.

--- a/runner/action.yml
+++ b/runner/action.yml
@@ -1,0 +1,50 @@
+name: 'Fishhawk Runner'
+description: 'Run an agent under a Fishhawk workflow stage and ship the signed trace bundle to the backend.'
+author: 'Fishhawk'
+branding:
+  icon: 'play-circle'
+  color: 'blue'
+
+# Customers reference this action as
+#   uses: kuhlman-labs/fishhawk/runner@vX.Y
+# and pass the inputs below. The composite action checks out a Go
+# toolchain and invokes ./cmd/fishhawk-runner from this directory.
+#
+# E5.1 (#52) ships the scaffold: the Go binary parses its inputs and
+# exits 0. The agent invocation, trace capture, signing, and trace
+# shipping arrive in E5.2–E5.6. Customers pinning v0.1 see a no-op
+# success until those land — useful for exercising the dispatch
+# path early.
+
+inputs:
+  run-id:
+    description: 'Workflow run identifier (UUID, supplied by the backend dispatch).'
+    required: true
+  backend-url:
+    description: 'Fishhawk backend URL the runner ships its trace bundle to.'
+    required: true
+  workflow:
+    description: 'Workflow ID matching a top-level key in .fishhawk/workflows.yaml.'
+    required: true
+  stage:
+    description: 'Stage ID within the workflow (e.g. plan, implement, review).'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up Go
+      uses: actions/setup-go@v6
+      with:
+        go-version: '1.25'
+        cache: false
+
+    - name: Run fishhawk-runner
+      shell: bash
+      working-directory: ${{ github.action_path }}
+      run: |
+        go run ./cmd/fishhawk-runner \
+          --run-id "${{ inputs.run-id }}" \
+          --backend-url "${{ inputs.backend-url }}" \
+          --workflow "${{ inputs.workflow }}" \
+          --stage "${{ inputs.stage }}"

--- a/runner/cmd/fishhawk-runner/flags.go
+++ b/runner/cmd/fishhawk-runner/flags.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+
+	"github.com/kuhlman-labs/fishhawk/runner/internal/version"
+)
+
+// config is the parsed CLI input that future stages will consume.
+// Every field has a corresponding flag; the action.yml inputs map
+// 1:1 onto these.
+type config struct {
+	runID      string
+	backendURL string
+	workflow   string
+	stage      string
+}
+
+// parseFlags reads args and populates a config. Returns a usage
+// error if any required flag is missing or unparseable.
+func parseFlags(args []string, w io.Writer) (config, error) {
+	fs := flag.NewFlagSet("fishhawk-runner", flag.ContinueOnError)
+	fs.SetOutput(w)
+	fs.Usage = func() {
+		_, _ = fmt.Fprintln(w, "Usage: fishhawk-runner [flags]")
+		_, _ = fmt.Fprintln(w, "")
+		_, _ = fmt.Fprintln(w, "Required flags:")
+		fs.PrintDefaults()
+	}
+
+	cfg := config{}
+	fs.StringVar(&cfg.runID, "run-id", "", "workflow run identifier (UUID)")
+	fs.StringVar(&cfg.backendURL, "backend-url", "", "Fishhawk backend URL")
+	fs.StringVar(&cfg.workflow, "workflow", "", "workflow ID matching .fishhawk/workflows.yaml")
+	fs.StringVar(&cfg.stage, "stage", "", "stage ID within the workflow")
+	if err := fs.Parse(args); err != nil {
+		return cfg, err
+	}
+
+	if cfg.runID == "" {
+		return cfg, fmt.Errorf("missing required --run-id")
+	}
+	if cfg.backendURL == "" {
+		return cfg, fmt.Errorf("missing required --backend-url")
+	}
+	if cfg.workflow == "" {
+		return cfg, fmt.Errorf("missing required --workflow")
+	}
+	if cfg.stage == "" {
+		return cfg, fmt.Errorf("missing required --stage")
+	}
+	return cfg, nil
+}
+
+// runnerVersion returns the build version pulled from
+// internal/version. Wrapped here so the main package doesn't import
+// internal/version directly — that keeps the cmd surface minimal
+// and the version package a true internal detail of the runner
+// module.
+func runnerVersion() string { return version.Version }

--- a/runner/cmd/fishhawk-runner/main.go
+++ b/runner/cmd/fishhawk-runner/main.go
@@ -1,0 +1,59 @@
+// Command fishhawk-runner runs an agent under a Fishhawk workflow
+// stage and ships the trace.
+//
+// E5.1 (https://github.com/kuhlman-labs/fishhawk/issues/52) is just
+// the scaffold: flag parsing, version, structured logging, exit
+// codes. Real work lands in:
+//
+//   - E5.2 (#29) — Claude Code invocation harness
+//   - E5.3 (#30) — full trace capture + bundling
+//   - E5.4 (#31) — plan validation against standard_v1
+//   - E5.5 (#53) — post-hoc constraint enforcement
+//   - E5.6 (#32) — signed trace shipping to backend
+//
+// The current binary parses its inputs, prints a single startup
+// log line acknowledging them, and exits 0. Customers pinning
+// `kuhlman-labs/fishhawk/runner@v0.1` will see this as a no-op
+// until E5.2 lands.
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+const (
+	exitOK      = 0
+	exitFailure = 1
+	exitUsage   = 2
+)
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stderr))
+}
+
+// run is split out so tests can drive it without exiting the test
+// process. Returns the intended process exit code.
+func run(args []string, logSink io.Writer) int {
+	cfg, err := parseFlags(args, logSink)
+	if err != nil {
+		// parseFlags already wrote a usage / error message.
+		return exitUsage
+	}
+
+	logStartup(logSink, cfg)
+
+	// E5.2 onward replaces this no-op with the agent invocation,
+	// trace capture, signing, and shipping. Returning 0 here lets
+	// customers pin the runner at v0.1 and exercise the dispatch
+	// path end-to-end before the runner does real work.
+	return exitOK
+}
+
+func logStartup(w io.Writer, cfg config) {
+	_, _ = fmt.Fprintf(w,
+		`{"event":"runner_started","run_id":%q,"workflow":%q,"stage":%q,"backend_url":%q,"version":%q}`+"\n",
+		cfg.runID, cfg.workflow, cfg.stage, cfg.backendURL, runnerVersion(),
+	)
+}

--- a/runner/cmd/fishhawk-runner/main_test.go
+++ b/runner/cmd/fishhawk-runner/main_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+// TestRun_HappyPath exercises the no-op success path: every
+// required flag set, run() returns 0 and writes a startup log line.
+func TestRun_HappyPath(t *testing.T) {
+	var out strings.Builder
+	got := run([]string{
+		"--run-id", "11111111-2222-3333-4444-555555555555",
+		"--backend-url", "https://api.fishhawk.test",
+		"--workflow", "feature_change",
+		"--stage", "plan",
+	}, &out)
+	if got != exitOK {
+		t.Errorf("run = %d, want %d", got, exitOK)
+	}
+	for _, want := range []string{
+		`"event":"runner_started"`,
+		`"run_id":"11111111-2222-3333-4444-555555555555"`,
+		`"workflow":"feature_change"`,
+		`"stage":"plan"`,
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("startup log missing %s:\n%s", want, out.String())
+		}
+	}
+}
+
+func TestRun_MissingRunID(t *testing.T) {
+	var out strings.Builder
+	got := run([]string{
+		"--backend-url", "https://api.fishhawk.test",
+		"--workflow", "feature_change",
+		"--stage", "plan",
+	}, &out)
+	if got != exitUsage {
+		t.Errorf("run = %d, want %d", got, exitUsage)
+	}
+}
+
+func TestRun_BadFlag(t *testing.T) {
+	got := run([]string{"--no-such-flag"}, io.Discard)
+	if got != exitUsage {
+		t.Errorf("run = %d, want %d", got, exitUsage)
+	}
+}
+
+func TestRun_HelpExitsUsage(t *testing.T) {
+	// flag.ContinueOnError + --help surfaces ErrHelp. We treat that
+	// as a usage exit, same as a malformed flag.
+	got := run([]string{"--help"}, io.Discard)
+	if got != exitUsage {
+		t.Errorf("run = %d, want %d", got, exitUsage)
+	}
+}
+
+func TestRunnerVersion_NonEmpty(t *testing.T) {
+	if runnerVersion() == "" {
+		t.Fatal("runnerVersion() should never be empty")
+	}
+}

--- a/runner/go.mod
+++ b/runner/go.mod
@@ -1,0 +1,3 @@
+module github.com/kuhlman-labs/fishhawk/runner
+
+go 1.25

--- a/runner/internal/version/version.go
+++ b/runner/internal/version/version.go
@@ -1,0 +1,17 @@
+// Package version exposes the fishhawk-runner build version.
+//
+// During development the value is the literal "dev". Release builds
+// inject the real version via -ldflags at link time, the same way
+// fishhawkd does:
+//
+//	go build -ldflags="-X github.com/kuhlman-labs/fishhawk/runner/internal/version.Version=v0.1.0" \
+//	  ./cmd/fishhawk-runner
+//
+// The runner is published as a versioned GitHub Action
+// (kuhlman-labs/fishhawk/runner@vX.Y) per MVP_SPEC §5.1.2; the value
+// here matches the action tag at release time.
+package version
+
+// Version is the fishhawk-runner build version. Set at link time
+// for releases.
+var Version = "dev"

--- a/runner/internal/version/version_test.go
+++ b/runner/internal/version/version_test.go
@@ -1,0 +1,9 @@
+package version
+
+import "testing"
+
+func TestVersionNotEmpty(t *testing.T) {
+	if Version == "" {
+		t.Fatal("Version must not be empty; -ldflags overrides should never produce an empty string")
+	}
+}


### PR DESCRIPTION
## Summary

Closes [#52 (E5.1)](https://github.com/kuhlman-labs/fishhawk/issues/52). The producer counterpart to all the consumer-side audit plumbing landed today (#95–#98): runs, signing keys, trace bundles, chain hashing all exist on the backend; the runner now exists as the artifact that will eventually feed them.

`/runner` is a separate Go module (`github.com/kuhlman-labs/fishhawk/runner`) registered in `go.work`, so `kuhlman-labs/fishhawk/runner@vX.Y` can be tagged and released independently of the backend and the CLI per [ADR-014 (#78)](https://github.com/kuhlman-labs/fishhawk/issues/78).

### Files

| File | Role |
|---|---|
| `runner/go.mod` | New module, `go 1.25` |
| `runner/action.yml` | Composite GitHub Action manifest. Customers reference as `uses: kuhlman-labs/fishhawk/runner@vX.Y` with 4 required inputs: `run-id`, `backend-url`, `workflow`, `stage` |
| `runner/cmd/fishhawk-runner/{main,flags}.go` | Entry point. Today: parse flags, emit one JSON startup log line, exit 0 |
| `runner/internal/version/` | Build version (mirrors backend pattern), `-ldflags`-injected at release |
| `runner/README.md` | Module overview, status, inputs table, build/run commands |

### Roadmap from the scaffold

The binary is a deliberate no-op at v0.1 so customers can pin the action and exercise the dispatch path early. Real work fills in across:

- E5.2 (#29) — Claude Code invocation harness
- E5.3 (#30) — full trace capture + bundling
- E5.4 (#31) — plan validation against `standard_v1` (reuses `backend/internal/plan`)
- E5.5 (#53) — post-hoc constraint enforcement
- E5.6 (#32) — signed trace shipping (uses `backend/internal/signing` + `backend/internal/tracestore`)
- E5.7 (#54) — versioned, signed releases with SBOM

### `go.work` and CI

Workspace gets the second tick on the comment checklist:

```
//   E3.1 (#41) → use ./backend  ✓
//   E5.1 (#52) → use ./runner   ✓
//   E6.1 (#55) → use ./cli
```

CI auto-iterates the new module via the existing `go work edit -json | jq` loop in `.github/workflows/ci.yml`. The `/db/` exclude pattern in the coverage gate handles future sqlc-generated code in `/runner` without workflow edits.

`docs/ARCHITECTURE.md` updated to drop the `(planned)` tag from the Runner action row in the component map and the module-boundaries section. CLAUDE.md already covered the multi-module pattern.

## Test plan

- [x] `go build ./runner/...` — clean
- [x] `go test -race ./runner/...` — passes; covers happy path, missing-required-flag (exits as usage error), unknown flag rejected, `--help` exits as usage error, version helper non-empty
- [x] `golangci-lint run ./...` from both `/backend` and `/runner` — 0 issues each
- [x] **Local smoke**: `go run ./runner/cmd/fishhawk-runner --run-id <uuid> --backend-url http://localhost:8080 --workflow feature_change --stage plan` emits the expected JSON startup log and exits 0
- [x] **Coverage**: `runner/cmd/fishhawk-runner` at **87.1%** (≥ medium-autonomy 75% target). Aggregate across both modules **83.4%** (above the 80% gate)
- [ ] CI on this PR exercises both modules end-to-end

## Notes

- **Composite action vs container action**: chose composite + `setup-go` because it works on every GitHub Actions runner image without needing a published Docker image. Optimization (pre-built binary downloaded by the action) becomes possible once E5.7 ships signed releases — for now `go run` from source is fine.
- **`actionlint` doesn't validate composite action manifests**: it expects workflow shape (`on:`, `jobs:`). The file is correct GitHub Actions composite-action syntax; running actionlint locally on `runner/action.yml` flags spurious "missing 'jobs' section" errors and should be ignored.
- **No deps shared with backend**: `/runner` doesn't import anything from `backend/internal/*` yet. When E5.6 lands signed trace shipping, it will use `signing.ComputeMessage` + `signing.Sign` — the runner will start to depend on `backend/internal/signing` (which is the cleanest seam since signing is already a self-contained package). Workspace handles cross-module imports transparently for local dev; published runner releases will pin to backend versions via `go.mod`.

Closes #52