### PR TITLE
Add redaction patterns library (E2.4)

### DIFF
--- a/backend/internal/redaction/redaction.go
+++ b/backend/internal/redaction/redaction.go
@@ -1,0 +1,151 @@
+// Package redaction scans byte payloads for known secret patterns
+// and replaces them with stable, non-sensitive markers (E2.4 / #25).
+//
+// Per MVP_SPEC §4.4, prompts and tool outputs surfaced through agent
+// runs WILL contain secrets — API keys customers pass in, tokens
+// agents stumble across, occasional Authorization headers in pasted
+// HTTP traces. The audit log persists both the unredacted bytes
+// (under stricter access control) and the redacted view (default-
+// readable). This library produces the redacted view.
+//
+// The pattern set is intentionally conservative: each pattern below
+// targets a specific, well-known credential format with low false-
+// positive risk. Callers that need stricter rules pass their own
+// patterns via Redact; the default set via RedactDefault.
+//
+// Hits returned alongside the redacted output drive telemetry —
+// "the runner redacted N GitHub tokens this run" without ever
+// surfacing the tokens themselves.
+package redaction
+
+import (
+	"regexp"
+	"sort"
+)
+
+// Pattern is one redaction rule.
+type Pattern struct {
+	// Name identifies the pattern in Hit telemetry. Stable across
+	// versions of this package; rename only with a heads-up.
+	Name string
+	// Regex matches the secret bytes. The whole match (group 0) is
+	// what gets replaced.
+	Regex *regexp.Regexp
+	// Replace is the replacement string. Defaults to
+	// "[REDACTED:<name>]" when empty.
+	Replace string
+}
+
+// Hit summarizes how often a pattern matched in a given Redact call.
+// Surfaced for telemetry and for tests; the secrets themselves are
+// gone by the time Hit is observed.
+type Hit struct {
+	Pattern string
+	Count   int
+}
+
+// DefaultPatterns is the v0 set. Each pattern aims for a low false-
+// positive rate against typical agent traces; the trade is that
+// some secret formats outside this list will pass through. New
+// formats land here as we encounter them.
+//
+// References: GitHub Token Formats (PAT, fine-grained), OpenAI API
+// Keys, Anthropic API Keys (sk-ant-…), AWS Access Key IDs (AKIA…),
+// Authorization Bearer headers, generic password/token/secret
+// values inside JSON.
+var DefaultPatterns = []Pattern{
+	{
+		Name:  "github-pat-classic",
+		Regex: regexp.MustCompile(`ghp_[A-Za-z0-9]{36}`),
+	},
+	{
+		Name:  "github-pat-fine-grained",
+		Regex: regexp.MustCompile(`github_pat_[A-Za-z0-9_]{82}`),
+	},
+	{
+		Name:  "github-app-token",
+		Regex: regexp.MustCompile(`ghs_[A-Za-z0-9]{36}`),
+	},
+	{
+		Name:  "openai-api-key",
+		Regex: regexp.MustCompile(`sk-[A-Za-z0-9]{48}`),
+	},
+	{
+		Name:  "openai-project-key",
+		Regex: regexp.MustCompile(`sk-proj-[A-Za-z0-9_\-]{40,}`),
+	},
+	{
+		Name:  "anthropic-api-key",
+		Regex: regexp.MustCompile(`sk-ant-api03-[A-Za-z0-9_\-]{40,}`),
+	},
+	{
+		Name:  "aws-access-key-id",
+		Regex: regexp.MustCompile(`AKIA[0-9A-Z]{16}`),
+	},
+	{
+		Name: "authorization-bearer",
+		// Header name is case-insensitive in HTTP but case-sensitive
+		// in JSON map keys; (?i) covers both. Captures the token
+		// portion as the whole match, including the "Authorization:
+		// Bearer " prefix, so the entire credential line goes away.
+		Regex: regexp.MustCompile(`(?i)authorization:\s*bearer\s+[A-Za-z0-9_\-\.~+/=]+`),
+	},
+	{
+		Name: "json-password-field",
+		// Matches "password": "anything-not-quote", "secret": "...",
+		// "token": "...", "api_key": "...", "apikey": "...",
+		// "access_token": "...", "refresh_token": "...". Group 0 is
+		// the entire match, so the field key + value disappear into
+		// the replacement marker.
+		Regex: regexp.MustCompile(`(?i)"(password|secret|token|api[_\-]?key|access_token|refresh_token)"\s*:\s*"[^"]+"`),
+	},
+}
+
+// Redact applies patterns to input in the order given, replacing
+// every match with the pattern's Replace template (or the default
+// "[REDACTED:<name>]" marker). Returns the redacted bytes plus a
+// hits slice describing how many times each pattern fired —
+// suitable for emitting as an audit-log event without leaking the
+// secrets themselves.
+//
+// Patterns are applied in order and may overlap; later patterns see
+// the output of earlier ones. Most use cases are insensitive to
+// order because the default set's regexes don't share prefixes.
+func Redact(input []byte, patterns []Pattern) ([]byte, []Hit) {
+	if len(input) == 0 || len(patterns) == 0 {
+		return input, nil
+	}
+
+	out := input
+	hitMap := make(map[string]int, len(patterns))
+	for _, p := range patterns {
+		repl := p.Replace
+		if repl == "" {
+			repl = "[REDACTED:" + p.Name + "]"
+		}
+		matches := p.Regex.FindAll(out, -1)
+		if len(matches) == 0 {
+			continue
+		}
+		hitMap[p.Name] += len(matches)
+		out = p.Regex.ReplaceAll(out, []byte(repl))
+	}
+
+	// Sort hits by pattern name for deterministic output. Counts
+	// are accumulated above; sorting here doesn't affect totals.
+	hits := make([]Hit, 0, len(hitMap))
+	for name, n := range hitMap {
+		hits = append(hits, Hit{Pattern: name, Count: n})
+	}
+	sort.Slice(hits, func(i, j int) bool {
+		return hits[i].Pattern < hits[j].Pattern
+	})
+	return out, hits
+}
+
+// RedactDefault is shorthand for Redact(input, DefaultPatterns). The
+// runner uses this on the gzip-decompressed trace bytes before
+// re-compressing the redacted variant for upload to S3.
+func RedactDefault(input []byte) ([]byte, []Hit) {
+	return Redact(input, DefaultPatterns)
+}

--- a/backend/internal/redaction/redaction_test.go
+++ b/backend/internal/redaction/redaction_test.go
@@ -1,0 +1,216 @@
+package redaction_test
+
+import (
+	"bytes"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/kuhlman-labs/fishhawk/backend/internal/redaction"
+)
+
+// findHit returns the count for a named pattern in hits, or 0 if the
+// pattern didn't fire. Test helper.
+func findHit(hits []redaction.Hit, name string) int {
+	for _, h := range hits {
+		if h.Pattern == name {
+			return h.Count
+		}
+	}
+	return 0
+}
+
+// TestDefaultPatterns_PositiveCases asserts each default pattern
+// matches a representative live-format example. If a regex regresses,
+// this test fails on the specific pattern name.
+func TestDefaultPatterns_PositiveCases(t *testing.T) {
+	cases := []struct {
+		pattern string
+		sample  string
+	}{
+		{"github-pat-classic", "ghp_" + strings.Repeat("a", 36)},
+		{"github-pat-fine-grained", "github_pat_" + strings.Repeat("a", 82)},
+		{"github-app-token", "ghs_" + strings.Repeat("a", 36)},
+		{"openai-api-key", "sk-" + strings.Repeat("A", 48)},
+		{"openai-project-key", "sk-proj-" + strings.Repeat("A", 50)},
+		{"anthropic-api-key", "sk-ant-api03-" + strings.Repeat("A", 50)},
+		{"aws-access-key-id", "AKIAABCDEFGHIJKLMNOP"},
+		{"authorization-bearer", "Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.payload.sig"},
+		{"json-password-field", `"password": "swordfish"`},
+		{"json-password-field", `"api_key": "abc123"`},
+		{"json-password-field", `"access_token": "xyz789"`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.pattern+"/"+tc.sample[:min(20, len(tc.sample))], func(t *testing.T) {
+			out, hits := redaction.RedactDefault([]byte(tc.sample))
+			if findHit(hits, tc.pattern) == 0 {
+				t.Errorf("expected pattern %q to fire on %q; hits = %+v", tc.pattern, tc.sample, hits)
+			}
+			if bytes.Contains(out, []byte(tc.sample)) {
+				t.Errorf("redacted output still contains the original sample: %s", out)
+			}
+			if !bytes.Contains(out, []byte("[REDACTED:")) {
+				t.Errorf("redacted output missing marker: %s", out)
+			}
+		})
+	}
+}
+
+// TestDefaultPatterns_NegativeCases checks for false positives on
+// strings that look secret-shaped but shouldn't match. If we
+// accidentally redact ordinary text, that's a regression.
+func TestDefaultPatterns_NegativeCases(t *testing.T) {
+	cases := []string{
+		"this is just normal prose with no secrets",
+		"AKIA-but-not-a-key (only 4 trailing chars)",
+		"sk-tooShort",                           // shorter than openai-api-key
+		`Authorization: Basic dXNlcjpwYXNz`,     // Basic, not Bearer
+		`"username": "alice"`,                   // not a redaction-tier field
+		"github_pat_" + strings.Repeat("a", 80), // fine-grained PAT requires 82, not 80
+		"akia0123456789abcdef",                  // lowercase doesn't match aws-access-key-id
+	}
+	for _, sample := range cases {
+		t.Run(sample[:min(30, len(sample))], func(t *testing.T) {
+			out, hits := redaction.RedactDefault([]byte(sample))
+			if len(hits) != 0 {
+				t.Errorf("expected no hits on %q; got %+v", sample, hits)
+			}
+			if !bytes.Equal(out, []byte(sample)) {
+				t.Errorf("expected output unchanged on %q; got %s", sample, out)
+			}
+		})
+	}
+}
+
+func TestRedact_MultipleMatchesInSameInput(t *testing.T) {
+	input := []byte("first ghp_" + strings.Repeat("a", 36) + " then ghp_" + strings.Repeat("b", 36))
+	out, hits := redaction.RedactDefault(input)
+	if got := findHit(hits, "github-pat-classic"); got != 2 {
+		t.Errorf("expected 2 hits, got %d", got)
+	}
+	if bytes.Contains(out, []byte("ghp_aaaa")) || bytes.Contains(out, []byte("ghp_bbbb")) {
+		t.Errorf("redaction missed at least one match: %s", out)
+	}
+	// Both occurrences replaced with the same marker.
+	if bytes.Count(out, []byte("[REDACTED:github-pat-classic]")) != 2 {
+		t.Errorf("expected 2 markers, got: %s", out)
+	}
+}
+
+func TestRedact_MixedPatterns(t *testing.T) {
+	// A realistic-ish trace fragment with two distinct secret types.
+	input := []byte(`{"prompt": "deploy with AKIA1234567890ABCDEF and ghp_` + strings.Repeat("c", 36) + `"}`)
+	_, hits := redaction.RedactDefault(input)
+
+	if findHit(hits, "aws-access-key-id") != 1 {
+		t.Errorf("expected 1 aws-access-key-id hit; hits = %+v", hits)
+	}
+	if findHit(hits, "github-pat-classic") != 1 {
+		t.Errorf("expected 1 github-pat-classic hit; hits = %+v", hits)
+	}
+	// Hits sorted alphabetically for determinism.
+	for i := 1; i < len(hits); i++ {
+		if hits[i].Pattern < hits[i-1].Pattern {
+			t.Errorf("hits should be sorted: %+v", hits)
+		}
+	}
+}
+
+func TestRedact_EmptyInput(t *testing.T) {
+	out, hits := redaction.RedactDefault(nil)
+	if out != nil {
+		t.Errorf("expected nil out, got %v", out)
+	}
+	if hits != nil {
+		t.Errorf("expected nil hits, got %v", hits)
+	}
+}
+
+func TestRedact_EmptyPatternList(t *testing.T) {
+	in := []byte("ghp_" + strings.Repeat("a", 36))
+	out, hits := redaction.Redact(in, nil)
+	if !bytes.Equal(out, in) {
+		t.Errorf("with no patterns, output should equal input")
+	}
+	if len(hits) != 0 {
+		t.Errorf("expected no hits with no patterns; got %v", hits)
+	}
+}
+
+func TestRedact_PreservesSurroundingBytes(t *testing.T) {
+	// Bytes outside the matched region must pass through verbatim.
+	prefix := []byte("BEGIN ")
+	secret := []byte("ghp_" + strings.Repeat("z", 36))
+	suffix := []byte(" END")
+	input := bytes.Join([][]byte{prefix, secret, suffix}, nil)
+
+	out, _ := redaction.RedactDefault(input)
+	if !bytes.HasPrefix(out, prefix) {
+		t.Errorf("prefix changed: %s", out)
+	}
+	if !bytes.HasSuffix(out, suffix) {
+		t.Errorf("suffix changed: %s", out)
+	}
+	if bytes.Contains(out, secret) {
+		t.Errorf("secret leaked through: %s", out)
+	}
+}
+
+func TestRedact_CustomPatternWithCustomReplace(t *testing.T) {
+	custom := []redaction.Pattern{
+		{
+			Name:    "test-pattern",
+			Regex:   regexp.MustCompile(`SECRET-\d+`),
+			Replace: "<masked>",
+		},
+	}
+	out, hits := redaction.Redact([]byte("SECRET-123 and SECRET-456"), custom)
+	if got := findHit(hits, "test-pattern"); got != 2 {
+		t.Errorf("count = %d, want 2", got)
+	}
+	if bytes.Count(out, []byte("<masked>")) != 2 {
+		t.Errorf("expected 2 custom replacements: %s", out)
+	}
+	if bytes.Contains(out, []byte("SECRET-")) {
+		t.Errorf("custom pattern missed a match: %s", out)
+	}
+}
+
+func TestRedact_CustomPatternDefaultsReplace(t *testing.T) {
+	// When Replace is empty, redactor falls back to
+	// "[REDACTED:<name>]". This is the case most pattern definitions
+	// use.
+	custom := []redaction.Pattern{
+		{
+			Name:  "my-secret",
+			Regex: regexp.MustCompile(`xyz-\d{3}`),
+		},
+	}
+	out, _ := redaction.Redact([]byte("xyz-789"), custom)
+	if !bytes.Equal(out, []byte("[REDACTED:my-secret]")) {
+		t.Errorf("got %q, want default marker", out)
+	}
+}
+
+// TestRedact_HitsAreDeterministic confirms multiple Redact calls on
+// the same input produce the same hit slice (sorted by name). This
+// matters because telemetry on hits should be reproducible — the
+// same trace redacted twice should report identical patterns and
+// counts.
+func TestRedact_HitsAreDeterministic(t *testing.T) {
+	input := []byte("AKIA1234567890ABCDEF\nghp_" + strings.Repeat("a", 36))
+	_, h1 := redaction.RedactDefault(input)
+	_, h2 := redaction.RedactDefault(input)
+	if len(h1) != len(h2) {
+		t.Fatalf("hit count differs: %d vs %d", len(h1), len(h2))
+	}
+	for i := range h1 {
+		if h1[i] != h2[i] {
+			t.Errorf("hit %d differs: %v vs %v", i, h1[i], h2[i])
+		}
+	}
+}
+
+// min is needed for substring slicing in test names; Go 1.25 has
+// builtin min for ordered types.
+func _testHelpersUnused() {} //nolint:unused


### PR DESCRIPTION
## Summary

Closes [#25 (E2.4)](https://github.com/kuhlman-labs/fishhawk/issues/25). The runner needs to scrub secrets out of trace bytes before they ship to S3 — without this, the redacted variant is identical to the raw variant and the access-control split from `MVP_SPEC.md` §4.4 has nothing to enforce.

### `backend/internal/redaction` package

- **`Pattern`** struct: Name, Regex, optional Replace template (defaults to `[REDACTED:<name>]`).
- **`DefaultPatterns`** — the v0 set, conservatively scoped to keep the false-positive rate low:

| Name | Format |
|---|---|
| `github-pat-classic` | `ghp_[A-Za-z0-9]{36}` |
| `github-pat-fine-grained` | `github_pat_[A-Za-z0-9_]{82}` |
| `github-app-token` | `ghs_[A-Za-z0-9]{36}` |
| `openai-api-key` | `sk-[A-Za-z0-9]{48}` |
| `openai-project-key` | `sk-proj-[A-Za-z0-9_-]{40,}` |
| `anthropic-api-key` | `sk-ant-api03-[A-Za-z0-9_-]{40,}` |
| `aws-access-key-id` | `AKIA[0-9A-Z]{16}` |
| `authorization-bearer` | `Authorization: Bearer ...` (case-insensitive) |
| `json-password-field` | `"(password\|secret\|token\|api_key\|access_token\|refresh_token)": "..."` |

- **`Redact(input, patterns)`** → `(redacted, hits)`. `hits` is a sorted `[]Hit` summary suitable for telemetry without leaking the secrets ("the runner redacted N github tokens this run").
- **`RedactDefault`** is the runner-side default that calls `Redact` with `DefaultPatterns`.

### Tests

- **Positive case** for every default pattern with a representative live-format sample. If a regex regresses, the test fails on the specific pattern name.
- **Negative cases** for false-positive-shaped strings (lowercase `akia...`, `Authorization: Basic`, `"username":`, fine-grained PAT one char short, etc.). Catches over-eager patterns.
- Multiple matches in one input replaced with the same marker; count is 2.
- Mixed patterns produce **sorted hits** for deterministic telemetry.
- Empty input + empty pattern list pass through cleanly.
- **Surrounding bytes preserved** verbatim across a redacted region.
- Custom pattern with custom Replace + with default-marker fallback both exercised.
- **Determinism**: two runs on the same input produce identical hit slices.

### Coverage

| Metric | Before | After |
|---|---:|---:|
| Aggregate (excl. generated) | 83.4% | **83.8%** |
| `internal/redaction` | — | **100.0%** |

## Test plan

- [x] `go build ./backend/...` — clean
- [x] `go test -race -v ./backend/internal/redaction/` — every positive + negative + edge case passes
- [x] `go test -race ./backend/...` — full suite passes
- [x] `golangci-lint run ./backend/...` — 0 issues
- [x] `python3 scripts/check-coverage.py --threshold 80 --exclude '/db/' …` — PASS at 83.8%
- [x] CI on this PR

## Notes

- **Pluggable**: callers compose `Redact` with extras by appending to a slice — no package-level mutation. Patterns evaluate in slice order, so a caller can short-circuit a default by prepending a higher-priority custom match.
- **Telemetry shape**: `Hit{Pattern, Count}` is sorted by pattern name so a re-run on identical input emits the same summary. Useful for diffing redaction behavior across runs and for compliance reports.
- **What's not here**: structured JSON parsing. The `json-password-field` regex catches the common shape but doesn't tokenize JSON — a string value containing the literal text `"password": "..."` inside another field's value would be redacted too. Acceptable for v0; structured redaction is a v0.x add-on if patterns get richer.
- **Audit log integration**: not yet. The runner (E5.3 #30) will call `RedactDefault` between trace capture and gzip-then-upload, producing the redacted variant. The raw variant is whatever bytes the agent produced.

Closes #25