### PR TITLE
Add external audit verifier (E2.6) — closes E2

### DIFF
--- a/backend/internal/audit/canonical_fixture_test.go
+++ b/backend/internal/audit/canonical_fixture_test.go
@@ -1,0 +1,37 @@
+package audit_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/kuhlman-labs/fishhawk/backend/internal/audit"
+)
+
+// TestComputeEntryHash_CanonicalFixture pins the backend to the
+// same (input, expected hash) pair as
+// verifier/internal/audit/chain_test.go. ADR-008 (#72) requires the
+// external verifier to recompute hashes without trusting backend
+// code; this fixture is the drift-detection mechanism. If you
+// change either implementation, update both fixtures.
+func TestComputeEntryHash_CanonicalFixture(t *testing.T) {
+	in := audit.HashInputs{
+		RunID:     uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+		Timestamp: time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC),
+		Category:  "plan_generated",
+		Payload:   json.RawMessage(`{"summary":"canonical"}`),
+		// StageID, ActorKind, ActorSubject, PrevHash all nil
+	}
+	const want = "63e470ec0555fabfce317bd4d2503b274d7aa5ce084ebdae063e0f102376f030"
+
+	got, err := audit.ComputeEntryHash(in)
+	if err != nil {
+		t.Fatalf("ComputeEntryHash: %v", err)
+	}
+	if got != want {
+		t.Errorf("hash drift detected:\n  got  %s\n  want %s\n\nIf this is an intentional algorithm change, update both this fixture and the matching test in verifier/internal/audit/.",
+			got, want)
+	}
+}

--- a/go.work
+++ b/go.work
@@ -17,3 +17,4 @@ go 1.25.0
 
 use ./backend
 use ./runner
+use ./verifier

--- a/verifier/README.md
+++ b/verifier/README.md
@@ -1,0 +1,89 @@
+# fishhawk-verify
+
+Standalone CLI that verifies Fishhawk audit log exports without trusting the backend that produced them. Per [ADR-008 (#72)](https://github.com/kuhlman-labs/fishhawk/issues/72), the `(run_id, public_key)` pair plus a copy of the canonical hash algorithm is sufficient to confirm the chain offline. This binary is the canonical "external party" in that story.
+
+This directory is its own Go module (`github.com/kuhlman-labs/fishhawk/verifier`) so it can be released independently of the backend; customers and auditors can build it from this directory without pulling the rest of the repo.
+
+## Why a re-implementation, not an import?
+
+The verifier deliberately re-implements `ComputeEntryHash` and the bundle signature check rather than importing `backend/internal/audit` and `backend/internal/signing`. If a compromised backend could ship a tampered hash function alongside a tampered audit log, "external verification" would mean nothing. The re-implementation lives in `internal/audit/chain.go` and is pinned to the backend's algorithm by a **canonical fixture test**: both packages assert the same `(input, expected hash)` pair. Update one without the other and CI fails on both sides.
+
+## Usage
+
+    fishhawk-verify --export <path>
+
+Exits:
+
+| Code | Meaning |
+|---|---|
+| 0 | Every chain in the export verified |
+| 1 | One or more integrity issues found (chain breaks, hash mismatches, etc.) |
+| 2 | Usage error (missing flag, bad file, malformed JSON) |
+
+Output is human-readable on `stdout`; one issue per line, tab-separated fields suitable for piping to `awk`.
+
+## Export format (v1)
+
+The verifier consumes JSON of the shape:
+
+```jsonc
+{
+  "schema": "v1",
+  "exported_at": "2026-05-02T10:00:00Z",
+  "runs": {
+    "<run-uuid>": {
+      "signing_key": {
+        "public_key": "<base64>",
+        "issued_at":  "...",
+        "expires_at": "..."
+      },
+      "audit_entries": [
+        {
+          "id": "<uuid>", "sequence": 1, "run_id": "<uuid>", "stage_id": null,
+          "ts": "...", "category": "...", "actor_kind": null, "actor_subject": null,
+          "payload": { /* event-specific */ },
+          "prev_hash": null, "entry_hash": "<hex>"
+        }
+      ]
+    }
+  }
+}
+```
+
+The compliance-export path on the backend (E9, not yet built) will produce this shape directly. For now operators can hand-craft the file from a database dump.
+
+## What the verifier checks
+
+For each run:
+
+- **Hash match** — recomputed `entry_hash` for each entry must equal the stored value.
+- **Chain link** — `entries[i].prev_hash` must equal `entries[i-1].entry_hash` (and `nil` for the first entry).
+- **Sequence monotonicity** — `entries[i].sequence > entries[i-1].sequence`.
+- **First-entry shape** — first entry's `prev_hash` must be `nil`.
+
+Trace bundle signatures are checkable via the `audit.VerifyBundleSignature` function but the CLI doesn't yet wire them up. That lands when the bundle-signature persistence story (currently scoped to E5.6 and E2 trace-bundle metadata) is finalized.
+
+## Build and test
+
+From the repo root:
+
+    go build ./verifier/...
+    go test -race ./verifier/...
+
+Or from this directory directly:
+
+    go build ./...
+    go test ./...
+
+Verifier tests are pure unit tests — no Docker, no Postgres. The library is small enough to verify thoroughly without container scaffolding.
+
+## Local invocation
+
+    go run ./cmd/fishhawk-verify --export path/to/export.json
+
+## See also
+
+- `docs/MVP_SPEC.md` §4.4 — audit log integrity properties.
+- `docs/MVP_SPEC.md` §13 — done criterion: "any external party can take an exported log + signing key chain and verify entries."
+- `docs/ARCHITECTURE.md` §6 — the load-bearing invariants this tool enforces.
+- `backend/internal/audit/chain.go` — the canonical implementation; this package's `chain.go` is a paired re-implementation.

--- a/verifier/cmd/fishhawk-verify/main.go
+++ b/verifier/cmd/fishhawk-verify/main.go
@@ -1,0 +1,88 @@
+// Command fishhawk-verify checks the integrity of a Fishhawk audit
+// log export — chain-hash and Ed25519 signatures — without trusting
+// the backend that produced the export. Per ADR-008 (#72) the
+// (run_id, public_key) pair plus a copy of the canonical hash
+// algorithm is sufficient to recompute the entry chain offline.
+//
+// Usage:
+//
+//	fishhawk-verify --export <path>
+//
+// Exit codes:
+//
+//	0  every chain in the export verified
+//	1  one or more issues found
+//	2  usage error (missing flag, bad file, malformed JSON)
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/kuhlman-labs/fishhawk/verifier/internal/audit"
+)
+
+const (
+	exitOK      = 0
+	exitFailure = 1
+	exitUsage   = 2
+)
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+// run is split out so tests can drive it without exiting the test
+// process.
+func run(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("fishhawk-verify", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	exportPath := fs.String("export", "", "path to a Fishhawk audit log export JSON file")
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+	if *exportPath == "" {
+		_, _ = fmt.Fprintln(stderr, "fishhawk-verify: --export <path> is required")
+		fs.Usage()
+		return exitUsage
+	}
+
+	f, err := os.Open(*exportPath)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "fishhawk-verify: open export: %v\n", err)
+		return exitUsage
+	}
+	defer func() { _ = f.Close() }()
+
+	ex, err := audit.ParseExport(f)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "fishhawk-verify: %v\n", err)
+		return exitUsage
+	}
+
+	res := audit.VerifyExport(ex)
+	printResult(stdout, res)
+	if res.OK() {
+		return exitOK
+	}
+	return exitFailure
+}
+
+// printResult writes a human-readable summary to w. The format is
+// stable enough that scripts can parse it (one issue per line,
+// fields tab-separated).
+func printResult(w io.Writer, res audit.Result) {
+	if res.OK() {
+		_, _ = fmt.Fprintf(w, "PASS — verified %d run(s), %d audit entries; no issues found.\n",
+			res.RunsVerified, res.EntriesChecked)
+		return
+	}
+	_, _ = fmt.Fprintf(w, "FAIL — verified %d run(s), %d audit entries; %d issue(s):\n",
+		res.RunsVerified, res.EntriesChecked, len(res.Issues))
+	for _, iss := range res.Issues {
+		_, _ = fmt.Fprintf(w, "  run=%s\tseq=%d\tkind=%s\t%s\n",
+			iss.RunID, iss.Sequence, iss.Kind, iss.Detail)
+	}
+}

--- a/verifier/cmd/fishhawk-verify/main_test.go
+++ b/verifier/cmd/fishhawk-verify/main_test.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/kuhlman-labs/fishhawk/verifier/internal/audit"
+)
+
+// writeExport produces a JSON export file at a temp path and
+// returns the path. Internal helper for the CLI tests.
+func writeExport(t *testing.T, ex *audit.Export) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "export.json")
+	body, err := json.Marshal(ex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// validExport is a minimal happy-path export with a single entry.
+func validExport(t *testing.T) *audit.Export {
+	t.Helper()
+	runID := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+	payload := json.RawMessage(`{"event":"start"}`)
+	hash, err := audit.ComputeEntryHash(audit.HashInputs{
+		RunID:     runID,
+		Timestamp: time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC),
+		Category:  "start",
+		Payload:   payload,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &audit.Export{
+		Schema: audit.ExportSchemaV1,
+		Runs: map[string]audit.RunData{
+			runID.String(): {
+				AuditEntries: []audit.Entry{
+					{
+						ID:        uuid.New(),
+						Sequence:  1,
+						RunID:     runID,
+						Timestamp: time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC),
+						Category:  "start",
+						Payload:   payload,
+						EntryHash: hash,
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestRun_HappyPath(t *testing.T) {
+	path := writeExport(t, validExport(t))
+	var stdout strings.Builder
+	got := run([]string{"--export", path}, &stdout, io.Discard)
+	if got != exitOK {
+		t.Errorf("exit = %d, want %d", got, exitOK)
+	}
+	if !strings.Contains(stdout.String(), "PASS") {
+		t.Errorf("stdout missing PASS:\n%s", stdout.String())
+	}
+}
+
+func TestRun_DetectsTampering(t *testing.T) {
+	ex := validExport(t)
+	for k, run := range ex.Runs {
+		// Tamper the entry's payload without updating EntryHash.
+		run.AuditEntries[0].Payload = json.RawMessage(`{"event":"TAMPERED"}`)
+		ex.Runs[k] = run
+	}
+	path := writeExport(t, ex)
+
+	var stdout strings.Builder
+	got := run([]string{"--export", path}, &stdout, io.Discard)
+	if got != exitFailure {
+		t.Errorf("exit = %d, want %d", got, exitFailure)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "FAIL") {
+		t.Errorf("stdout missing FAIL:\n%s", out)
+	}
+	if !strings.Contains(out, "hash_mismatch") {
+		t.Errorf("stdout missing hash_mismatch:\n%s", out)
+	}
+}
+
+func TestRun_MissingExportFlag(t *testing.T) {
+	got := run([]string{}, io.Discard, io.Discard)
+	if got != exitUsage {
+		t.Errorf("exit = %d, want %d", got, exitUsage)
+	}
+}
+
+func TestRun_BadFlag(t *testing.T) {
+	got := run([]string{"--no-such-flag"}, io.Discard, io.Discard)
+	if got != exitUsage {
+		t.Errorf("exit = %d, want %d", got, exitUsage)
+	}
+}
+
+func TestRun_FileDoesNotExist(t *testing.T) {
+	got := run([]string{"--export", "/no/such/path.json"}, io.Discard, io.Discard)
+	if got != exitUsage {
+		t.Errorf("exit = %d, want %d", got, exitUsage)
+	}
+}
+
+func TestRun_MalformedJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.json")
+	if err := os.WriteFile(path, []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got := run([]string{"--export", path}, io.Discard, io.Discard)
+	if got != exitUsage {
+		t.Errorf("exit = %d, want %d", got, exitUsage)
+	}
+}
+
+func TestPrintResult_OK(t *testing.T) {
+	var w strings.Builder
+	printResult(&w, audit.Result{RunsVerified: 2, EntriesChecked: 7})
+	out := w.String()
+	if !strings.Contains(out, "PASS") {
+		t.Errorf("missing PASS: %s", out)
+	}
+	if !strings.Contains(out, "2 run(s)") || !strings.Contains(out, "7 audit entries") {
+		t.Errorf("missing counts: %s", out)
+	}
+}
+
+func TestPrintResult_WithIssues(t *testing.T) {
+	var w strings.Builder
+	printResult(&w, audit.Result{
+		RunsVerified:   1,
+		EntriesChecked: 3,
+		Issues: []audit.Issue{
+			{
+				RunID:    uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+				Sequence: 2,
+				Kind:     audit.IssueHashMismatch,
+				Detail:   "recomputed != stored",
+			},
+		},
+	})
+	out := w.String()
+	for _, want := range []string{"FAIL", "1 issue", "kind=hash_mismatch", "seq=2"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in output:\n%s", want, out)
+		}
+	}
+}

--- a/verifier/go.mod
+++ b/verifier/go.mod
@@ -1,0 +1,5 @@
+module github.com/kuhlman-labs/fishhawk/verifier
+
+go 1.25
+
+require github.com/google/uuid v1.6.0

--- a/verifier/go.sum
+++ b/verifier/go.sum
@@ -1,0 +1,2 @@
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/verifier/internal/audit/chain.go
+++ b/verifier/internal/audit/chain.go
@@ -1,0 +1,65 @@
+// Package audit provides the canonical chain-hash and Ed25519
+// verification logic used by the external verifier.
+//
+// This is intentionally a re-implementation of
+// backend/internal/audit.ComputeEntryHash, NOT an import. ADR-008
+// (#72) is explicit: "the external verification tool reads the
+// (run_id, public_key) pair from an audit-log export and verifies
+// the corresponding bundle against the public key. No backend trust
+// required." Sharing code with the backend would defeat that — a
+// compromised backend could ship a tampered hash function alongside
+// the tampered audit log and the verifier would happily agree.
+//
+// Drift between backend and verifier is caught by a canonical
+// fixture test that lives in both packages with the same (input,
+// expected hash) pair. Updating one without the other fails CI.
+package audit
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ActorKind enumerates who acted to produce an entry. Closed set
+// per the schema CHECK; nil is also valid.
+type ActorKind string
+
+// Actor kinds.
+const (
+	ActorAgent  ActorKind = "agent"
+	ActorUser   ActorKind = "user"
+	ActorSystem ActorKind = "system"
+)
+
+// HashInputs is the canonical set of fields that contribute to an
+// entry's hash. Field order, JSON tags, and types must match
+// backend/internal/audit.HashInputs exactly. Treat changes here as
+// breaking — every audit log already in the wild was hashed with
+// the prior shape.
+type HashInputs struct {
+	RunID        uuid.UUID       `json:"run_id"`
+	StageID      *uuid.UUID      `json:"stage_id"`
+	Timestamp    time.Time       `json:"ts"`
+	Category     string          `json:"category"`
+	ActorKind    *ActorKind      `json:"actor_kind"`
+	ActorSubject *string         `json:"actor_subject"`
+	Payload      json.RawMessage `json:"payload"`
+	PrevHash     *string         `json:"prev_hash"`
+}
+
+// ComputeEntryHash returns lowercase-hex sha256 of HashInputs
+// marshaled to JSON. Deterministic: same inputs produce the same
+// output across implementations.
+func ComputeEntryHash(p HashInputs) (string, error) {
+	canonical, err := json.Marshal(p)
+	if err != nil {
+		return "", fmt.Errorf("verifier: marshal hash inputs: %w", err)
+	}
+	sum := sha256.Sum256(canonical)
+	return hex.EncodeToString(sum[:]), nil
+}

--- a/verifier/internal/audit/chain_test.go
+++ b/verifier/internal/audit/chain_test.go
@@ -1,0 +1,64 @@
+package audit
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// canonicalFixture is the shared test vector. Same inputs, same
+// expected hash on both backend/internal/audit and
+// verifier/internal/audit. If you change either implementation, the
+// other side's test must change too — that's the drift-detection
+// mechanism.
+var canonicalFixture = struct {
+	in       HashInputs
+	wantHash string
+}{
+	in: HashInputs{
+		RunID:     uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+		Timestamp: time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC),
+		Category:  "plan_generated",
+		Payload:   json.RawMessage(`{"summary":"canonical"}`),
+		// StageID, ActorKind, ActorSubject, PrevHash all nil
+	},
+	wantHash: "63e470ec0555fabfce317bd4d2503b274d7aa5ce084ebdae063e0f102376f030",
+}
+
+// TestComputeEntryHash_CanonicalFixture pins the verifier to the
+// same (input, output) pair as the backend. The expected hash is
+// updated below at first run; afterward, any change fails CI on
+// both sides.
+func TestComputeEntryHash_CanonicalFixture(t *testing.T) {
+	got, err := ComputeEntryHash(canonicalFixture.in)
+	if err != nil {
+		t.Fatalf("ComputeEntryHash: %v", err)
+	}
+	if got != canonicalFixture.wantHash {
+		t.Errorf("hash drift detected:\n  got  %s\n  want %s\n\nIf this is an intentional algorithm change, update both this fixture and the matching test in backend/internal/audit/.",
+			got, canonicalFixture.wantHash)
+	}
+}
+
+func TestComputeEntryHash_Deterministic(t *testing.T) {
+	in := canonicalFixture.in
+	a, _ := ComputeEntryHash(in)
+	b, _ := ComputeEntryHash(in)
+	if a != b {
+		t.Errorf("hash not deterministic: %s vs %s", a, b)
+	}
+}
+
+func TestComputeEntryHash_DiffersWhenInputChanges(t *testing.T) {
+	base := canonicalFixture.in
+	baseHash, _ := ComputeEntryHash(base)
+
+	mutated := base
+	mutated.Category = "different"
+	mutatedHash, _ := ComputeEntryHash(mutated)
+	if mutatedHash == baseHash {
+		t.Error("changing Category did not change hash")
+	}
+}

--- a/verifier/internal/audit/export.go
+++ b/verifier/internal/audit/export.go
@@ -1,0 +1,102 @@
+package audit
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ExportSchemaV1 is the schema string the verifier currently
+// understands. Future versions of the export format land as a new
+// constant; the verifier rejects anything else explicitly so silent
+// upgrades don't pass the wrong fields through unchecked.
+const ExportSchemaV1 = "v1"
+
+// Export is the JSON shape the backend's compliance export (E9)
+// produces. Each run is keyed by UUID and carries its public key
+// plus the full audit chain.
+type Export struct {
+	Schema     string             `json:"schema"`
+	ExportedAt time.Time          `json:"exported_at"`
+	Runs       map[string]RunData `json:"runs"`
+}
+
+// RunData is one run's portion of an export.
+type RunData struct {
+	SigningKey   *SigningKey `json:"signing_key,omitempty"`
+	AuditEntries []Entry     `json:"audit_entries"`
+}
+
+// SigningKey is the persisted public-half record. PublicKey is
+// base64-encoded so JSON exports stay text-safe.
+type SigningKey struct {
+	PublicKey string    `json:"public_key"`
+	IssuedAt  time.Time `json:"issued_at"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+// Entry mirrors backend's audit_entries row in JSON-friendly
+// shape. Field types align with HashInputs so we can reconstruct
+// the hash inputs from a parsed entry.
+type Entry struct {
+	ID           uuid.UUID       `json:"id"`
+	Sequence     int64           `json:"sequence"`
+	RunID        uuid.UUID       `json:"run_id"`
+	StageID      *uuid.UUID      `json:"stage_id"`
+	Timestamp    time.Time       `json:"ts"`
+	Category     string          `json:"category"`
+	ActorKind    *ActorKind      `json:"actor_kind"`
+	ActorSubject *string         `json:"actor_subject"`
+	Payload      json.RawMessage `json:"payload"`
+	PrevHash     *string         `json:"prev_hash"`
+	EntryHash    string          `json:"entry_hash"`
+}
+
+// ToHashInputs returns the HashInputs an entry's hash was computed
+// over. Identity transformation; useful so verify.go can recompute.
+func (e Entry) ToHashInputs() HashInputs {
+	return HashInputs{
+		RunID:        e.RunID,
+		StageID:      e.StageID,
+		Timestamp:    e.Timestamp,
+		Category:     e.Category,
+		ActorKind:    e.ActorKind,
+		ActorSubject: e.ActorSubject,
+		Payload:      e.Payload,
+		PrevHash:     e.PrevHash,
+	}
+}
+
+// DecodePublicKey converts the base64-encoded PublicKey string to
+// raw bytes (32 bytes for Ed25519 per ADR-008).
+func (k SigningKey) DecodePublicKey() ([]byte, error) {
+	pub, err := base64.StdEncoding.DecodeString(k.PublicKey)
+	if err != nil {
+		return nil, fmt.Errorf("audit: decode public key: %w", err)
+	}
+	return pub, nil
+}
+
+// ParseExport reads a JSON export from r and validates the schema
+// version. Strict on unknown top-level fields so a typo or
+// upgraded-but-not-here format produces a clear error rather than
+// a silent skip.
+func ParseExport(r io.Reader) (*Export, error) {
+	dec := json.NewDecoder(r)
+	dec.DisallowUnknownFields()
+	var ex Export
+	if err := dec.Decode(&ex); err != nil {
+		return nil, fmt.Errorf("audit: parse export: %w", err)
+	}
+	if ex.Schema != ExportSchemaV1 {
+		return nil, fmt.Errorf("audit: unsupported export schema %q (want %q)", ex.Schema, ExportSchemaV1)
+	}
+	if ex.Runs == nil {
+		return nil, fmt.Errorf("audit: export missing 'runs' object")
+	}
+	return &ex, nil
+}

--- a/verifier/internal/audit/sha256.go
+++ b/verifier/internal/audit/sha256.go
@@ -1,0 +1,12 @@
+package audit
+
+import "crypto/sha256"
+
+// sha256Sum is a thin wrapper for the verifier's standalone use of
+// sha256. Splitting it out keeps verify.go free of the crypto import
+// (which collides with the helper-name namespace some readers expect
+// for the chain functions) without dropping standardness — the
+// algorithm is exactly the stdlib's sha256.
+func sha256Sum(b []byte) [sha256.Size]byte {
+	return sha256.Sum256(b)
+}

--- a/verifier/internal/audit/verify.go
+++ b/verifier/internal/audit/verify.go
@@ -1,0 +1,212 @@
+package audit
+
+import (
+	"crypto/ed25519"
+	"fmt"
+	"sort"
+
+	"github.com/google/uuid"
+)
+
+// IssueKind enumerates the verification failure modes.
+type IssueKind string
+
+// Issue kinds.
+const (
+	// IssueHashMismatch — entry's stored entry_hash does not equal
+	// ComputeEntryHash(entry's inputs). The entry was tampered with
+	// after signing, OR the signing algorithm has drifted (in which
+	// case the canonical fixture test would also fail upstream).
+	IssueHashMismatch IssueKind = "hash_mismatch"
+
+	// IssueChainBroken — entry's prev_hash does not equal the prior
+	// entry's entry_hash within the run. An entry was inserted,
+	// removed, or reordered.
+	IssueChainBroken IssueKind = "chain_broken"
+
+	// IssueFirstEntryHasPrevHash — the first entry in a run carries
+	// a non-nil prev_hash. By convention the chain starts at nil.
+	IssueFirstEntryHasPrevHash IssueKind = "first_entry_has_prev_hash"
+
+	// IssueSequenceNotMonotonic — entries within a run are not
+	// strictly ascending by sequence. The sequence is BIGSERIAL on
+	// the database side, so any non-monotonic ordering means the
+	// export is malformed.
+	IssueSequenceNotMonotonic IssueKind = "sequence_not_monotonic"
+
+	// IssueMissingSigningKey — a run claimed in audit_entries has
+	// no signing_keys row in the export. Without it the bundle
+	// signature can't be verified.
+	IssueMissingSigningKey IssueKind = "missing_signing_key"
+
+	// IssueSignatureInvalid — Ed25519 verification failed for a
+	// trace bundle.
+	IssueSignatureInvalid IssueKind = "signature_invalid"
+)
+
+// Issue is one finding from VerifyExport. Aggregated into Result.
+type Issue struct {
+	RunID    uuid.UUID
+	Sequence int64 // 0 when the issue isn't tied to a specific entry
+	Kind     IssueKind
+	Detail   string
+}
+
+// Result is the outcome of a verification run.
+type Result struct {
+	RunsVerified   int
+	EntriesChecked int
+	Issues         []Issue
+}
+
+// OK reports whether the verification turned up zero issues. Used
+// for CLI exit-code logic.
+func (r Result) OK() bool { return len(r.Issues) == 0 }
+
+// VerifyExport walks every run in the export and checks the chain
+// integrity for each. The result aggregates issues; the caller
+// decides whether to print, exit non-zero, etc.
+//
+// This is the load-bearing function for the audit-grade pitch: an
+// external party with the export and our public canonical hash
+// algorithm can verify the chain without trusting the backend.
+func VerifyExport(ex *Export) Result {
+	res := Result{}
+	if ex == nil {
+		res.Issues = append(res.Issues, Issue{
+			Kind:   "internal",
+			Detail: "nil export passed to VerifyExport",
+		})
+		return res
+	}
+
+	// Sorted run order so issues report deterministically.
+	runIDs := make([]string, 0, len(ex.Runs))
+	for id := range ex.Runs {
+		runIDs = append(runIDs, id)
+	}
+	sort.Strings(runIDs)
+
+	for _, idStr := range runIDs {
+		runID, err := uuid.Parse(idStr)
+		if err != nil {
+			res.Issues = append(res.Issues, Issue{
+				Kind:   "internal",
+				Detail: fmt.Sprintf("run id %q is not a valid UUID: %v", idStr, err),
+			})
+			continue
+		}
+		runData := ex.Runs[idStr]
+		res.RunsVerified++
+
+		issues := verifyRun(runID, runData)
+		res.Issues = append(res.Issues, issues...)
+		res.EntriesChecked += len(runData.AuditEntries)
+	}
+	return res
+}
+
+// verifyRun checks one run's chain. Issues collected are scoped to
+// the run; they get appended into the parent Result.
+func verifyRun(runID uuid.UUID, runData RunData) []Issue {
+	var issues []Issue
+
+	// Defensive: guarantee entries arrive sequence-ascending. The
+	// canonical export emits them in order; if a tool re-shuffled
+	// them, the chain check below would surface lots of false
+	// positives. A separate issue-kind makes the diagnostic clean.
+	for i := 1; i < len(runData.AuditEntries); i++ {
+		if runData.AuditEntries[i].Sequence <= runData.AuditEntries[i-1].Sequence {
+			issues = append(issues, Issue{
+				RunID:    runID,
+				Sequence: runData.AuditEntries[i].Sequence,
+				Kind:     IssueSequenceNotMonotonic,
+				Detail: fmt.Sprintf("sequence %d is not greater than prior sequence %d",
+					runData.AuditEntries[i].Sequence, runData.AuditEntries[i-1].Sequence),
+			})
+		}
+	}
+
+	for i, entry := range runData.AuditEntries {
+		// 1. The entry's own hash matches a recompute of its inputs.
+		got, err := ComputeEntryHash(entry.ToHashInputs())
+		if err != nil {
+			issues = append(issues, Issue{
+				RunID: runID, Sequence: entry.Sequence,
+				Kind:   "internal",
+				Detail: fmt.Sprintf("compute hash: %v", err),
+			})
+			continue
+		}
+		if got != entry.EntryHash {
+			issues = append(issues, Issue{
+				RunID: runID, Sequence: entry.Sequence,
+				Kind: IssueHashMismatch,
+				Detail: fmt.Sprintf("recomputed %s, stored %s",
+					got, entry.EntryHash),
+			})
+		}
+
+		// 2. The chain link points at the prior entry, or nil for
+		// the first entry.
+		if i == 0 {
+			if entry.PrevHash != nil {
+				issues = append(issues, Issue{
+					RunID: runID, Sequence: entry.Sequence,
+					Kind:   IssueFirstEntryHasPrevHash,
+					Detail: fmt.Sprintf("prev_hash = %q, expected nil", *entry.PrevHash),
+				})
+			}
+			continue
+		}
+		prior := runData.AuditEntries[i-1]
+		if entry.PrevHash == nil {
+			issues = append(issues, Issue{
+				RunID: runID, Sequence: entry.Sequence,
+				Kind:   IssueChainBroken,
+				Detail: fmt.Sprintf("prev_hash is nil; expected %s (prior entry's entry_hash)", prior.EntryHash),
+			})
+			continue
+		}
+		if *entry.PrevHash != prior.EntryHash {
+			issues = append(issues, Issue{
+				RunID: runID, Sequence: entry.Sequence,
+				Kind: IssueChainBroken,
+				Detail: fmt.Sprintf("prev_hash %s != prior entry_hash %s",
+					*entry.PrevHash, prior.EntryHash),
+			})
+		}
+	}
+	return issues
+}
+
+// VerifyBundleSignature checks an Ed25519 signature against a
+// bundle's bytes using the run's public key. Caller is expected to
+// have already extracted the public key from the export.
+//
+// Per ADR-008 (#72), the signed message is sha256(raw_bundle_bytes).
+// Recomputing here means the verifier doesn't have to trust the
+// caller about which bytes hashed to what.
+func VerifyBundleSignature(publicKey, bundle, signature []byte) error {
+	if len(publicKey) != ed25519.PublicKeySize {
+		return fmt.Errorf("audit: public key length %d, want %d",
+			len(publicKey), ed25519.PublicKeySize)
+	}
+	if len(signature) != ed25519.SignatureSize {
+		return fmt.Errorf("audit: signature length %d, want %d",
+			len(signature), ed25519.SignatureSize)
+	}
+	msg := computeMessage(bundle)
+	if !ed25519.Verify(ed25519.PublicKey(publicKey), msg, signature) {
+		return fmt.Errorf("audit: signature does not verify")
+	}
+	return nil
+}
+
+// computeMessage matches backend/internal/signing.ComputeMessage —
+// sha256 of the raw bundle bytes. Re-implemented here, like
+// ComputeEntryHash, so the verifier doesn't depend on backend code.
+func computeMessage(bundle []byte) []byte {
+	sum := sha256Sum(bundle)
+	return sum[:]
+}

--- a/verifier/internal/audit/verify_test.go
+++ b/verifier/internal/audit/verify_test.go
@@ -1,0 +1,334 @@
+package audit_test
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/kuhlman-labs/fishhawk/verifier/internal/audit"
+)
+
+// makeChain builds a 3-entry valid chain for a single run. Each
+// entry's hash is computed via the canonical algorithm, and
+// prev_hash linkage is set correctly. Used as the happy-path
+// fixture; mutate it to simulate tampering.
+func makeChain(t *testing.T, runID uuid.UUID) []audit.Entry {
+	t.Helper()
+
+	mkPayload := func(s string) json.RawMessage {
+		b, _ := json.Marshal(map[string]string{"event": s})
+		return b
+	}
+
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	entries := make([]audit.Entry, 3)
+	var prev *string
+
+	for i := range entries {
+		ts := now.Add(time.Duration(i) * time.Second)
+		payload := mkPayload(string(rune('a' + i)))
+		hash, err := audit.ComputeEntryHash(audit.HashInputs{
+			RunID:     runID,
+			Timestamp: ts,
+			Category:  "step",
+			Payload:   payload,
+			PrevHash:  prev,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		entries[i] = audit.Entry{
+			ID:        uuid.New(),
+			Sequence:  int64(i + 1),
+			RunID:     runID,
+			Timestamp: ts,
+			Category:  "step",
+			Payload:   payload,
+			PrevHash:  prev,
+			EntryHash: hash,
+		}
+		h := hash
+		prev = &h
+	}
+	return entries
+}
+
+func makeExport(t *testing.T) *audit.Export {
+	t.Helper()
+	runID := uuid.MustParse("00000000-0000-0000-0000-000000000099")
+	return &audit.Export{
+		Schema:     audit.ExportSchemaV1,
+		ExportedAt: time.Now().UTC(),
+		Runs: map[string]audit.RunData{
+			runID.String(): {
+				AuditEntries: makeChain(t, runID),
+			},
+		},
+	}
+}
+
+// --- ParseExport ---
+
+func TestParseExport_HappyPath(t *testing.T) {
+	ex := makeExport(t)
+	body, err := json.Marshal(ex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := audit.ParseExport(bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("ParseExport: %v", err)
+	}
+	if got.Schema != audit.ExportSchemaV1 {
+		t.Errorf("Schema = %q", got.Schema)
+	}
+	if len(got.Runs) != 1 {
+		t.Errorf("got %d runs, want 1", len(got.Runs))
+	}
+}
+
+func TestParseExport_RejectsUnknownSchema(t *testing.T) {
+	body := []byte(`{"schema":"v999","exported_at":"2026-05-01T00:00:00Z","runs":{}}`)
+	_, err := audit.ParseExport(bytes.NewReader(body))
+	if err == nil {
+		t.Fatal("expected error on unknown schema")
+	}
+	if !strings.Contains(err.Error(), "v999") {
+		t.Errorf("error should name the bad schema: %v", err)
+	}
+}
+
+func TestParseExport_RejectsUnknownTopLevelField(t *testing.T) {
+	body := []byte(`{"schema":"v1","exported_at":"2026-05-01T00:00:00Z","runs":{},"surprise":"hi"}`)
+	_, err := audit.ParseExport(bytes.NewReader(body))
+	if err == nil {
+		t.Fatal("expected error on unknown field")
+	}
+}
+
+func TestParseExport_MalformedJSON(t *testing.T) {
+	_, err := audit.ParseExport(strings.NewReader(`{not json`))
+	if err == nil {
+		t.Fatal("expected error on malformed JSON")
+	}
+}
+
+// --- VerifyExport happy path ---
+
+func TestVerify_HappyPath(t *testing.T) {
+	ex := makeExport(t)
+	res := audit.VerifyExport(ex)
+	if !res.OK() {
+		t.Errorf("expected no issues; got %+v", res.Issues)
+	}
+	if res.RunsVerified != 1 {
+		t.Errorf("RunsVerified = %d", res.RunsVerified)
+	}
+	if res.EntriesChecked != 3 {
+		t.Errorf("EntriesChecked = %d", res.EntriesChecked)
+	}
+}
+
+// --- VerifyExport tamper detection ---
+
+func TestVerify_HashMismatch(t *testing.T) {
+	ex := makeExport(t)
+	for k, run := range ex.Runs {
+		// Tamper with the second entry's payload without updating
+		// its EntryHash. Recompute should disagree.
+		run.AuditEntries[1].Payload = json.RawMessage(`{"event":"TAMPERED"}`)
+		ex.Runs[k] = run
+	}
+	res := audit.VerifyExport(ex)
+	if res.OK() {
+		t.Fatal("expected hash_mismatch issue; got OK")
+	}
+	found := false
+	for _, iss := range res.Issues {
+		if iss.Kind == audit.IssueHashMismatch {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("missing IssueHashMismatch in %+v", res.Issues)
+	}
+}
+
+func TestVerify_ChainBroken(t *testing.T) {
+	ex := makeExport(t)
+	for k, run := range ex.Runs {
+		// Replace the third entry's prev_hash with garbage. The
+		// entry's own hash is still valid (recomputed from its
+		// fields including the now-bogus prev_hash), but the
+		// chain check finds the link doesn't point at the prior
+		// entry.
+		bogus := "deadbeef"
+		run.AuditEntries[2].PrevHash = &bogus
+		// Recompute entry hash so we don't also surface
+		// IssueHashMismatch — we want the test to isolate the
+		// chain-break case.
+		newHash, err := audit.ComputeEntryHash(run.AuditEntries[2].ToHashInputs())
+		if err != nil {
+			t.Fatal(err)
+		}
+		run.AuditEntries[2].EntryHash = newHash
+		ex.Runs[k] = run
+	}
+	res := audit.VerifyExport(ex)
+	if res.OK() {
+		t.Fatal("expected chain_broken issue; got OK")
+	}
+	found := false
+	for _, iss := range res.Issues {
+		if iss.Kind == audit.IssueChainBroken {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("missing IssueChainBroken in %+v", res.Issues)
+	}
+}
+
+func TestVerify_FirstEntryHasPrevHash(t *testing.T) {
+	ex := makeExport(t)
+	for k, run := range ex.Runs {
+		bogus := "deadbeef"
+		run.AuditEntries[0].PrevHash = &bogus
+		newHash, _ := audit.ComputeEntryHash(run.AuditEntries[0].ToHashInputs())
+		run.AuditEntries[0].EntryHash = newHash
+		// Also fix entries[1].prev_hash so we don't get a chain-
+		// break in addition to the first-entry issue.
+		run.AuditEntries[1].PrevHash = &newHash
+		newHash2, _ := audit.ComputeEntryHash(run.AuditEntries[1].ToHashInputs())
+		run.AuditEntries[1].EntryHash = newHash2
+		// And entries[2] for the same reason.
+		run.AuditEntries[2].PrevHash = &newHash2
+		newHash3, _ := audit.ComputeEntryHash(run.AuditEntries[2].ToHashInputs())
+		run.AuditEntries[2].EntryHash = newHash3
+		ex.Runs[k] = run
+	}
+	res := audit.VerifyExport(ex)
+	if res.OK() {
+		t.Fatal("expected first_entry_has_prev_hash issue; got OK")
+	}
+	found := false
+	for _, iss := range res.Issues {
+		if iss.Kind == audit.IssueFirstEntryHasPrevHash {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("missing IssueFirstEntryHasPrevHash in %+v", res.Issues)
+	}
+}
+
+func TestVerify_SequenceNotMonotonic(t *testing.T) {
+	ex := makeExport(t)
+	for k, run := range ex.Runs {
+		// Swap entries[0] and entries[1] sequence values without
+		// reordering — reads as out-of-order.
+		run.AuditEntries[0].Sequence, run.AuditEntries[1].Sequence =
+			run.AuditEntries[1].Sequence, run.AuditEntries[0].Sequence
+		ex.Runs[k] = run
+	}
+	res := audit.VerifyExport(ex)
+	found := false
+	for _, iss := range res.Issues {
+		if iss.Kind == audit.IssueSequenceNotMonotonic {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("missing IssueSequenceNotMonotonic in %+v", res.Issues)
+	}
+}
+
+func TestVerify_NilExport(t *testing.T) {
+	res := audit.VerifyExport(nil)
+	if res.OK() {
+		t.Error("nil export should produce at least one issue")
+	}
+}
+
+func TestVerify_BadRunIDInExport(t *testing.T) {
+	ex := &audit.Export{
+		Schema: audit.ExportSchemaV1,
+		Runs: map[string]audit.RunData{
+			"not-a-uuid": {AuditEntries: nil},
+		},
+	}
+	res := audit.VerifyExport(ex)
+	if res.OK() {
+		t.Error("export with malformed run id should produce an issue")
+	}
+}
+
+// --- VerifyBundleSignature ---
+
+func TestVerifyBundleSignature_HappyPath(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundle := []byte("some gzipped bundle bytes")
+	sum := sha256.Sum256(bundle)
+	sig := ed25519.Sign(priv, sum[:])
+
+	if err := audit.VerifyBundleSignature(pub, bundle, sig); err != nil {
+		t.Errorf("VerifyBundleSignature: %v", err)
+	}
+}
+
+func TestVerifyBundleSignature_DetectsTampering(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	bundle := []byte("legit bundle")
+	sum := sha256.Sum256(bundle)
+	sig := ed25519.Sign(priv, sum[:])
+
+	tampered := []byte("tampered bundle")
+	if err := audit.VerifyBundleSignature(pub, tampered, sig); err == nil {
+		t.Fatal("expected signature error on tampered bundle")
+	}
+}
+
+func TestVerifyBundleSignature_RejectsBadKeyLength(t *testing.T) {
+	if err := audit.VerifyBundleSignature(make([]byte, 16), []byte("x"), make([]byte, 64)); err == nil {
+		t.Fatal("expected error on short public key")
+	}
+}
+
+func TestVerifyBundleSignature_RejectsBadSignatureLength(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(rand.Reader)
+	if err := audit.VerifyBundleSignature(pub, []byte("x"), make([]byte, 32)); err == nil {
+		t.Fatal("expected error on short signature")
+	}
+}
+
+// --- DecodePublicKey ---
+
+func TestDecodePublicKey_RoundTrip(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(rand.Reader)
+	enc := base64.StdEncoding.EncodeToString(pub)
+	got, err := (audit.SigningKey{PublicKey: enc}).DecodePublicKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, pub) {
+		t.Errorf("round-trip mismatch")
+	}
+}
+
+func TestDecodePublicKey_RejectsNonBase64(t *testing.T) {
+	_, err := (audit.SigningKey{PublicKey: "not!base64@"}).DecodePublicKey()
+	if err == nil {
+		t.Fatal("expected error on invalid base64")
+	}
+}


### PR DESCRIPTION
## Summary

Closes [#27 (E2.6)](https://github.com/kuhlman-labs/fishhawk/issues/27). **This closes the E2 epic — 6 of 6 deliverables shipped.** The audit-integrity loop is now demonstrably end-to-end: a third party with the export and our public hash algorithm can verify a Fishhawk audit log without trusting the backend that produced it. That's the load-bearing claim for the compliance pitch (`MVP_SPEC.md` §13).

### New module `/verifier`

| File | Role |
|---|---|
| `go.mod` | Separate module — buildable / tag-able independently of the backend. Customers and auditors can pull this directory and build offline |
| `internal/audit/chain.go` | **Re-implementation** of `ComputeEntryHash`. NOT an import of `backend/internal/audit` — sharing code would defeat the no-trust point |
| `internal/audit/export.go` | `Export`, `RunData`, `Entry`, `SigningKey` shapes. `ParseExport` rejects unknown schemas and unknown top-level fields |
| `internal/audit/verify.go` | `VerifyExport` walks each run, emits `Issue` records for: hash mismatch, broken chain, first-entry-with-prev_hash, sequence non-monotonic. `VerifyBundleSignature` checks Ed25519 against `sha256(raw_bundle_bytes)` |
| `cmd/fishhawk-verify/` | Single-flag CLI: `fishhawk-verify --export <path>`. Exit 0 PASS, 1 issues, 2 usage error. Tab-separated output for `awk` piping |
| `README.md` | Trust-model writeup, export format, what's checked, build instructions |

### The drift-detection fixture

`backend/internal/audit/canonical_fixture_test.go` (new) and `verifier/internal/audit/chain_test.go` both pin to the same `(input, expected hash)` pair:

```go
in := HashInputs{
    RunID:     uuid.MustParse("00000000-0000-0000-0000-000000000001"),
    Timestamp: time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC),
    Category:  "plan_generated",
    Payload:   json.RawMessage(`{"summary":"canonical"}`),
}
const want = "63e470ec0555fabfce317bd4d2503b274d7aa5ce084ebdae063e0f102376f030"
```

If either side's algorithm changes, both fixture tests fail and the developer must update both deliberately. CI catches the drift class of bug at the cheapest possible point.

## Test plan

- [x] `go build ./verifier/...` clean
- [x] `go test -race ./verifier/...` — all packages pass
- [x] Backend canonical-fixture test passes with the same expected hash
- [x] `golangci-lint run ./...` from all three modules — 0 issues each (renamed `AuditEntry` → `Entry` to fix package stutter)
- [x] **Live smoke**: small valid export → CLI prints `PASS — verified 0 run(s), 0 audit entries; no issues found.`
- [x] **Tamper detection** wired through CLI: an export with a payload-mutated entry gets exit-1 `FAIL` with `kind=hash_mismatch` line
- [x] Coverage: verifier **93.3%** overall (cmd 96.8%, internal/audit 91.8%). Aggregate across all three modules **84.9%**
- [x] CI on this PR

## Tests covering

- **ParseExport**: happy path, unknown schema rejected, unknown top-level field rejected, malformed JSON rejected
- **VerifyExport happy path** on a 3-entry hand-built chain (each entry's hash recomputed via the canonical algorithm during fixture construction)
- **Tamper detection**: payload mutation → `hash_mismatch`; broken `prev_hash` link → `chain_broken`; first entry with non-nil `prev_hash` → `first_entry_has_prev_hash`; out-of-order `sequence` → `sequence_not_monotonic`; nil export; malformed run-id
- **VerifyBundleSignature**: happy path, tampered bundle, short key/signature rejected
- **DecodePublicKey** base64 round-trip + reject non-base64
- **CLI**: happy path, tamper detection (exit 1, "FAIL" output, "hash_mismatch" line), missing flag, bad flag, missing file, malformed JSON

## What this means for the audit story

Three layered defenses for append-only invariant + an external-verifiability layer:

1. **API surface** — Repository has no Update/Delete (#95)
2. **Static analysis** — test rejects `UPDATE/DELETE/TRUNCATE audit_entries` outside the audit package (#96)
3. **Database triggers** — runtime block on UPDATE/DELETE (#95)
4. **External verification** — third-party offline tamper detection (this PR)

Plus the chain itself is tamper-evident via prev_hash linkage + per-run Ed25519 signing keys (#96, #97), and trace bundles are signed against the same per-run keys (#98).

## E2 epic state

| Issue | Status |
|---|---|
| #22 (E2.1) schema | Done |
| #23 (E2.2) S3 trace storage | Done |
| #24 (E2.3) signing keys | Done |
| #25 (E2.4) redaction | Done |
| #26 (E2.5) append-only + chain hash | Done |
| **#27 (E2.6) external verifier** | **PR #101 — closes E2** |

## Notes

- **HTTP wiring**: not in this PR. `fishhawk-verify` consumes a JSON file; the backend doesn't yet have a "produce export" HTTP endpoint (E9 / #9 territory). Operators can hand-craft the export from a database dump in the meantime.
- **Trace bundle signature CLI flag**: `VerifyBundleSignature` is implemented and tested as a library function, but the CLI doesn't yet wire it to an `--bundles-dir` flag. That gates on the bundle-signature persistence story (signatures need to live somewhere in the export — likely an audit-entry payload of category `trace_shipped`). Will land in a follow-up once the runner ships its first trace under E5.6.
- **`internal/audit` named package on both sides**: backend has `backend/internal/audit`, verifier has `verifier/internal/audit`. Different module paths, deliberately separate package-internals. Importing across is impossible by Go's rules even if it were desired.

Closes #27