### PR TITLE
Add REST API v0 design (E3.6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
     outputs:
       go: ${{ steps.filter.outputs.go }}
       ts: ${{ steps.filter.outputs.ts }}
+      openapi: ${{ steps.filter.outputs.openapi }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v4
@@ -43,6 +44,9 @@ jobs:
               - '.eslintrc*'
               - 'eslint.config.*'
               - '.prettierrc*'
+              - '.github/workflows/ci.yml'
+            openapi:
+              - 'docs/api/**'
               - '.github/workflows/ci.yml'
 
   go:
@@ -140,13 +144,29 @@ jobs:
           echo "::notice::TypeScript pipeline lands with E7.1 (frontend scaffold, issue #37)."
           echo "Until then this job is a placeholder so the path filter is exercised."
 
+  openapi:
+    name: OpenAPI (lint)
+    needs: detect
+    if: ${{ needs.detect.outputs.openapi == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+      - name: Lint OpenAPI spec
+        run: |
+          npx -y @redocly/cli@latest lint \
+            --config docs/api/redocly.yaml \
+            docs/api/v0.openapi.yaml
+
   # Rollup gate. The repo ruleset requires only this job; it inherits
   # the result of every job listed in `needs`. Add new jobs to that
   # list and they automatically become part of the gate without
   # touching the ruleset.
   ci-pass:
     name: CI Pass
-    needs: [detect, go, ts]
+    needs: [detect, go, ts, openapi]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ Pre-alpha. Most code referenced in `docs/MVP_SPEC.md` doesn't exist yet — it's
 - `docs/BRAND_FOUNDATIONS.md` — voice, naming, positioning.
 - `docs/METHODOLOGY.md` — autonomy tiers (low/medium/high).
 - `docs/spec/` — canonical JSON Schemas + reference docs for the workflow spec (`.fishhawk/workflows.yaml`) and the plan artifact (`standard_v1`). Validate with `check-jsonschema --schemafile <schema> <yaml-or-json>`.
+- `docs/api/` — REST API surface: `v0.openapi.yaml` is source of truth, `v0.md` is the human companion. Lint with `npx -y @redocly/cli@latest lint --config docs/api/redocly.yaml docs/api/v0.openapi.yaml`.
 - `.fishhawk/workflows.yaml` — placeholder; executed by the product itself starting Day 21 (~2026-05-20).
 
 ## Documentation surfaces

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -154,6 +154,7 @@ GitHub OAuth (E4.2 / #49) is the sign-in flow that mints the cookie session. App
 | Autonomy tier of a change | `docs/METHODOLOGY.md` |
 | Workflow spec grammar | `docs/spec/workflow-v0.md` + `docs/spec/workflow-v0.schema.json` |
 | Plan artifact structure | `docs/spec/plan-standard-v1.md` + `docs/spec/plan-standard-v1.schema.json` |
+| HTTP API contract (endpoints, auth, errors) | `docs/api/v0.openapi.yaml` (source of truth) + `docs/api/v0.md` (companion) |
 | HTTP middleware order / context keys | `backend/internal/server/middleware.go` |
 | How a new Go module gets added | `CLAUDE.md` "Adding a Go module" |
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,42 @@
+# Fishhawk API documentation
+
+Two artifacts live here:
+
+| File | Purpose |
+|---|---|
+| [`v0.openapi.yaml`](./v0.openapi.yaml) | **Source of truth** — OpenAPI 3.1 spec for the v0 backend HTTP surface |
+| [`v0.md`](./v0.md) | Human-readable companion — endpoint map, auth model, caller flows, error codes |
+| [`redocly.yaml`](./redocly.yaml) | Lint configuration; disables checks that don't apply to OAuth redirect endpoints |
+
+If `v0.md` and `v0.openapi.yaml` disagree, the OpenAPI document wins. CI lints
+the OpenAPI document on changes; new endpoints land in both files in the same
+PR.
+
+## Versioning
+
+Per ADR (#46) and `MVP_SPEC.md` §5.1.1:
+
+- `/v0` is **unstable** — breaking changes allowed until v1 cuts at the end
+  of phase 4.
+- Once `/v1` ships, both prefixes coexist for one minor version cycle, then
+  `/v0` is retired.
+- Webhook ingestion (`/webhooks/github`) is unversioned because GitHub
+  controls the request shape.
+
+## Working on the API
+
+```sh
+# Lint
+npx -y @redocly/cli@latest lint --config docs/api/redocly.yaml docs/api/v0.openapi.yaml
+
+# Preview rendered docs
+npx -y @redocly/cli@latest preview-docs docs/api/v0.openapi.yaml
+```
+
+When adding an endpoint:
+
+1. Add the path to `v0.openapi.yaml` with all expected response codes.
+2. Update the endpoint map and (if non-trivial) caller flows in `v0.md`.
+3. Implement the handler in `backend/internal/server/` with a name matching
+   the `operationId`.
+4. Lint locally before pushing.

--- a/docs/api/redocly.yaml
+++ b/docs/api/redocly.yaml
@@ -1,0 +1,9 @@
+extends:
+  - recommended
+
+rules:
+  # OAuth login/callback intentionally redirect (302) and have no 2XX response.
+  # The recommended rule wants both a 2XX and a 4XX; we get 4XX from the 500/302.
+  operation-2xx-response: off
+  # Localhost dev server URL is intentional for local-loop testing.
+  no-server-example.com: off

--- a/docs/api/v0.md
+++ b/docs/api/v0.md
@@ -1,0 +1,194 @@
+# Fishhawk Backend API — v0
+
+This is the human-readable companion to [`v0.openapi.yaml`](./v0.openapi.yaml).
+The OpenAPI document is the source of truth; this file exists to give agents
+and humans a faster way to grok the surface than reading 900 lines of YAML.
+If the two disagree, the OpenAPI document wins.
+
+## Why `/v0`
+
+`/v0` is the prefix for everything the Web UI, CLI, and runner call. It is
+**unstable by design** — fields may be renamed, endpoints may move, request
+bodies may grow required fields — until the v1 cut at the end of phase 4
+(MVP_SPEC §13). Once `/v1` ships, `/v0` and `/v1` coexist for one minor
+version cycle, then `/v0` is retired.
+
+The webhook receiver (`/webhooks/github`) is **unversioned** because GitHub
+controls the request shape; the backend adapts as GitHub evolves.
+
+## Auth at a glance — ADR-005 (#69)
+
+Three security schemes for three caller classes; no other auth is supported
+in v0.
+
+| Scheme | Used by | Carrier |
+|---|---|---|
+| `sessionCookie` | Web UI (browser) | `Set-Cookie: fishhawk_session=…; HttpOnly; Secure; SameSite=Lax`; CSRF token via `X-CSRF-Token` matching `__Host-csrf` |
+| `bearerToken` | CLI, programmatic | `Authorization: Bearer <opaque>` — server-issued, scope-bound, immediately revocable |
+| `githubOIDC` | Runner action only | `Authorization: Bearer <github-oidc-jwt>` — verified against GitHub's JWKS per request, no server state |
+
+Default for all UI/CLI endpoints is `sessionCookie OR bearerToken`. Runner-
+facing endpoints override this individually; webhook ingestion uses neither
+(GitHub HMAC over the body).
+
+## Conventions
+
+- **JSON everywhere** except `POST /v0/runs/{run_id}/trace`, which uploads
+  `application/gzip` bytes and signs them via `X-Fishhawk-Signature`.
+- **Cursor pagination** for every list endpoint. Response: `{ items, next_cursor }`.
+  `next_cursor` is `null` at the end. Cursors are opaque; clients pass them back
+  unmodified.
+- **Error envelope** is `{ error: { code, message, details? } }`.
+  - `code` is snake_case, stable, machine-readable. Clients switch on it.
+  - `message` is human, may change between versions.
+  - `details` is structured per-code; the keys ARE part of the contract for
+    that code.
+- **Timestamps** are RFC 3339, always UTC, always with `Z`.
+- **IDs** are UUIDv7 strings; `format: uuid` in the schema.
+- **Idempotency** — only `POST /v0/runs` is non-idempotent in v0. The cancel
+  endpoint and approval submission are idempotent on equal inputs.
+
+## Endpoint map
+
+```
+GET    /healthz                              — liveness, public
+
+# Auth (sessionCookie or bearerToken unless noted)
+GET    /v0/auth/github/login                 — public; redirect to GitHub OAuth
+GET    /v0/auth/github/callback              — public; exchange code, set cookie
+GET    /v0/auth/me                           — current user
+POST   /v0/auth/logout                       — destroy session
+GET    /v0/tokens                            — list scoped API tokens
+POST   /v0/tokens                            — mint new token (returned ONCE)
+DELETE /v0/tokens/{token_id}                 — revoke
+
+# Runs
+GET    /v0/runs                              — list (filter by repo/workflow/state)
+POST   /v0/runs                              — create + dispatch
+GET    /v0/runs/{run_id}                     — detail
+POST   /v0/runs/{run_id}/cancel              — cancel
+GET    /v0/runs/{run_id}/stages              — stages for run
+GET    /v0/runs/{run_id}/audit               — audit entries for run
+
+# Stages, artifacts, approvals
+GET    /v0/stages/{stage_id}                 — detail
+GET    /v0/stages/{stage_id}/artifacts       — artifacts emitted by stage
+POST   /v0/stages/{stage_id}/approvals       — submit approve/reject decision
+GET    /v0/artifacts/{artifact_id}           — artifact with content
+
+# Runner-facing (githubOIDC for signing-key; signature for trace)
+POST   /v0/runs/{run_id}/signing-key         — issue per-run Ed25519 keypair
+POST   /v0/runs/{run_id}/trace               — upload signed trace bundle
+
+# Webhook ingestion (unversioned; HMAC-verified)
+POST   /webhooks/github                      — GitHub App events
+```
+
+## Resource model
+
+The handlers in `backend/internal/server` map cleanly onto the persistent
+state layered up through `backend/internal/run`, `backend/internal/audit`,
+`backend/internal/signing`, and `backend/internal/tracestore`.
+
+| Resource | Source of truth | Notes |
+|---|---|---|
+| `Run` | `runs` table; state machine in `internal/run/transition.go` | All state transitions validated against the table; FOR UPDATE lock per write |
+| `Stage` | `stages` table | One stage per workflow stage; `executor` is `{kind: agent|human, ref}` |
+| `Artifact` | `artifacts` table | Plans (`kind=plan`) validated against `docs/spec/plan-standard-v1.schema.json` |
+| `AuditEntry` | `audit_entries` table; chain in `internal/audit/chain.go` | Append-only at three layers: API surface, static-analysis test, DB triggers |
+| `SigningKey` | `signing_keys` table; ephemeral private half | One key per run; private half NEVER persisted, returned exactly once |
+| `User` / `ApiToken` | `users`, `api_tokens` tables | Tokens stored hashed; plaintext returned exactly once |
+
+## Caller flows
+
+### Web UI: review → approve a stage
+
+```
+GET  /v0/auth/me                      → User
+GET  /v0/runs?state=running           → recent runs
+GET  /v0/runs/{id}                    → run detail
+GET  /v0/runs/{id}/stages             → stage list
+GET  /v0/stages/{stage_id}/artifacts  → fetch the plan
+GET  /v0/artifacts/{plan_id}          → plan content (standard_v1)
+POST /v0/stages/{stage_id}/approvals  → { decision: "approve" }
+```
+
+### CLI: kick off a run, watch it finish
+
+```
+POST /v0/runs                              → { repo, workflow_id, workflow_sha, trigger_source: "cli" }
+GET  /v0/runs/{run_id}                     → poll until state in {succeeded, failed, cancelled}
+GET  /v0/runs/{run_id}/stages              → final stage breakdown
+```
+
+### Runner: ship a signed trace
+
+```
+POST /v0/runs/{run_id}/signing-key         (githubOIDC)        → { public_key, private_key, ... }
+# ... runner executes the agent, produces a trace bundle ...
+POST /v0/runs/{run_id}/trace?stage_id=&variant=raw              → 202
+   X-Fishhawk-Signature: <hex>                                  body: gzipped JSONL
+POST /v0/runs/{run_id}/trace?stage_id=&variant=redacted         → 202
+```
+
+The signing key's private half lives only in the runner's process memory and
+is discarded after upload. ADR-008 (#72) is the governing decision.
+
+### GitHub: webhook fires, run starts
+
+```
+POST /webhooks/github
+   X-GitHub-Event: issues, X-GitHub-Delivery: <uuid>, X-Hub-Signature-256: <hmac>
+   body: GitHub event JSON
+→ backend dedupes by delivery, dispatches a run if the event matches a
+  trigger configured in .fishhawk/workflows.yaml
+```
+
+## Common error codes
+
+These are the codes the backend currently emits. The list grows as endpoints
+are implemented; codes are additive and never repurposed.
+
+| Code | Status | Meaning |
+|---|---|---|
+| `unauthenticated` | 401 | No valid session, token, or OIDC token |
+| `forbidden` | 403 | Authenticated, but not authorized for this resource |
+| `run_not_found` | 404 | `run_id` does not exist |
+| `stage_not_found` | 404 | `stage_id` does not exist |
+| `artifact_not_found` | 404 | `artifact_id` does not exist |
+| `token_not_found` | 404 | `token_id` does not exist |
+| `invalid_state_transition` | 409 | Run/stage cannot move to the requested state from its current state |
+| `signing_key_already_issued` | 409 | A run may have only one signing key |
+| `signature_invalid` | 401 | `X-Fishhawk-Signature` did not verify against the run's public key |
+| `webhook_signature_invalid` | 401 | `X-Hub-Signature-256` did not verify |
+| `validation_failed` | 400 | Request body or query parameter failed schema validation. `details.field` names the offending field |
+| `cursor_invalid` | 400 | The pagination cursor is malformed or stale |
+
+## Testing the spec
+
+```sh
+# Lint (uses docs/api/redocly.yaml for project-specific rule overrides)
+npx -y @redocly/cli@latest lint --config docs/api/redocly.yaml docs/api/v0.openapi.yaml
+
+# Render preview
+npx -y @redocly/cli@latest preview-docs docs/api/v0.openapi.yaml
+```
+
+The lint config disables `operation-2xx-response` (the OAuth redirect
+endpoints intentionally have no 2XX response) and `no-server-example.com`
+(the localhost server URL is intentional for local-loop testing).
+
+## Where this lives in code
+
+The eventual handler implementations land in `backend/internal/server/`. Each
+operation in the OpenAPI document corresponds to one handler function whose
+name matches the `operationId`. The router is plain `net/http` `ServeMux`
+(per `docs/ARCHITECTURE.md` §3 — Go 1.22+ is required).
+
+## Cross-references
+
+- [`docs/MVP_SPEC.md`](../MVP_SPEC.md) §5.1.1 — the v0 control plane scope
+- [`docs/ARCHITECTURE.md`](../ARCHITECTURE.md) §6 — load-bearing invariants
+  (audit chain, signing-key handoff)
+- ADRs: #66 (#001 cloud), #67 (#003 storage), #69 (#005 auth), #72 (#008 signing)
+- Issue [#46](https://github.com/kuhlman-labs/fishhawk/issues/46) — E3.6 design tracker

--- a/docs/api/v0.openapi.yaml
+++ b/docs/api/v0.openapi.yaml
@@ -1,0 +1,972 @@
+openapi: 3.1.0
+info:
+  title: Fishhawk Backend API
+  version: 0.1.0
+  description: |
+    The HTTP surface that the Fishhawk backend (`fishhawkd`) exposes to its
+    three classes of caller:
+
+    1. **The Web UI and CLI** — humans driving plan review, approval, audit
+       search, and run management.
+    2. **The runner** — `kuhlman-labs/fishhawk/runner@vX.Y` running on the
+       customer's CI, requesting per-run signing keys and shipping signed
+       trace bundles.
+    3. **GitHub webhooks** — the customer's GitHub App installation pushing
+       issue / PR / check events that drive workflow dispatch.
+
+    Per ADR (#46) and `MVP_SPEC.md` §5.1.1, every customer-facing endpoint is
+    prefixed with `/v0`. The `v0` prefix is **unstable** by design — the
+    surface is allowed to change before v1. Once the v1 surface is published
+    (post-Day 21), `/v0` and `/v1` coexist for one minor version cycle to
+    let clients migrate, and `/v0` is then retired.
+
+    Webhook ingestion (`/webhooks/github`) is unversioned because GitHub
+    controls the request shape; the backend adapts as GitHub's webhook
+    schema evolves.
+
+  contact:
+    name: Fishhawk
+    url: https://github.com/kuhlman-labs/fishhawk
+  license:
+    name: Apache-2.0
+    url: https://github.com/kuhlman-labs/fishhawk/blob/main/LICENSE
+
+servers:
+  - url: https://api.fishhawk.dev
+    description: Production
+  - url: http://localhost:8080
+    description: Local dev (docker compose up)
+
+# ---------------------------------------------------------------------------
+# Security schemes — three auth models for three caller classes (ADR-005).
+# ---------------------------------------------------------------------------
+components:
+  securitySchemes:
+    sessionCookie:
+      type: apiKey
+      in: cookie
+      name: fishhawk_session
+      description: |
+        HTTP-only `Secure; SameSite=Lax` session cookie set by the OAuth
+        callback. Same-origin SPA requests are auto-included; CSRF
+        protection on state-changing endpoints requires an
+        `X-CSRF-Token` header that matches the `__Host-csrf` cookie.
+
+    bearerToken:
+      type: http
+      scheme: bearer
+      bearerFormat: opaque
+      description: |
+        Scoped server-issued token (NOT a JWT). Index into the
+        `api_tokens` table; revocation is immediate. Used by the CLI
+        and any programmatic caller.
+
+    githubOIDC:
+      type: http
+      scheme: bearer
+      bearerFormat: jwt
+      description: |
+        GitHub Actions OIDC token for runner authentication. Verified
+        by the backend against GitHub's JWKS per request; no server-
+        side state. Required by `POST /v0/runs/{run_id}/signing-key`.
+
+  # -------------------------------------------------------------------------
+  # Shared schemas. Detailed property schemas grow as endpoints are
+  # implemented — what's frozen here is the envelope shape and the
+  # canonical types every endpoint returns.
+  # -------------------------------------------------------------------------
+  schemas:
+    Error:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: object
+          required: [code, message]
+          properties:
+            code:
+              type: string
+              description: |
+                Stable, machine-readable code. Snake-case identifier;
+                clients switch on this. New codes are additive; codes
+                are never repurposed.
+              example: run_not_found
+            message:
+              type: string
+              description: |
+                Human-readable description. May change between
+                versions; clients should not parse it.
+              example: "No run with id 11111111-…"
+            details:
+              type: object
+              additionalProperties: true
+              description: |
+                Optional code-specific structured fields. The keys
+                under `details` are part of the contract for that
+                specific code.
+      examples:
+        - error:
+            code: run_not_found
+            message: No run with id 11111111-2222-3333-4444-555555555555
+
+    Pagination:
+      type: object
+      description: |
+        Cursor-based pagination envelope wrapped around list endpoints.
+        `next_cursor` is null when the caller has reached the end. The
+        cursor is opaque; clients pass it back unmodified.
+      required: [items]
+      properties:
+        items:
+          type: array
+          items: {}
+        next_cursor:
+          type: [string, "null"]
+
+    UUID:
+      type: string
+      format: uuid
+
+    Run:
+      type: object
+      description: |
+        A workflow run record. State follows the explicit transition
+        table in `backend/internal/run/transition.go`.
+      required:
+        [id, repo, workflow_id, workflow_sha, trigger_source, state,
+         created_at, updated_at]
+      properties:
+        id: { $ref: '#/components/schemas/UUID' }
+        repo:
+          type: string
+          example: kuhlman-labs/fishhawk
+        workflow_id:
+          type: string
+          example: feature_change
+          description: Matches a top-level key in `.fishhawk/workflows.yaml`.
+        workflow_sha:
+          type: string
+          description: Git SHA of `.fishhawk/workflows.yaml` at run time.
+        trigger_source:
+          type: string
+          enum: [github_issue, cli, ui]
+        trigger_ref:
+          type: [string, "null"]
+          example: "issue:1247"
+        state:
+          type: string
+          enum: [pending, running, succeeded, failed, cancelled]
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    Stage:
+      type: object
+      required:
+        [id, run_id, sequence, type, executor, state, created_at,
+         updated_at]
+      properties:
+        id: { $ref: '#/components/schemas/UUID' }
+        run_id: { $ref: '#/components/schemas/UUID' }
+        sequence:
+          type: integer
+          minimum: 0
+        type:
+          type: string
+          enum: [plan, implement, review]
+        executor:
+          type: object
+          description: Exactly one of agent or human.
+          properties:
+            kind:
+              type: string
+              enum: [agent, human]
+            ref:
+              type: string
+              example: claude-code
+        state:
+          type: string
+          enum:
+            [pending, dispatched, running, awaiting_approval, succeeded,
+             failed, cancelled]
+        started_at:
+          type: [string, "null"]
+          format: date-time
+        ended_at:
+          type: [string, "null"]
+          format: date-time
+        failure_category:
+          type: [string, "null"]
+          enum: [A, B, C, D, null]
+          description: |
+            Set on failed transitions per MVP_SPEC §6.
+            A: agent failure, B: constraint/policy, C: infrastructure,
+            D: approval timeout.
+        failure_reason:
+          type: [string, "null"]
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    Artifact:
+      type: object
+      required: [id, stage_id, kind, content_hash, created_at]
+      properties:
+        id: { $ref: '#/components/schemas/UUID' }
+        stage_id: { $ref: '#/components/schemas/UUID' }
+        kind:
+          type: string
+          enum: [plan, pull_request]
+        schema_version:
+          type: [string, "null"]
+          example: standard_v1
+        content_hash:
+          type: string
+          description: Hex sha256 of canonical content bytes.
+        content:
+          description: |
+            JSON content of the artifact. For kind=plan validated
+            against the standard_v1 schema in
+            docs/spec/plan-standard-v1.schema.json.
+        created_at:
+          type: string
+          format: date-time
+
+    AuditEntry:
+      type: object
+      description: |
+        One line in the append-only audit log. Entries form a per-run
+        chain via prev_hash → entry_hash; see backend/internal/audit
+        and verifier/internal/audit for the canonical algorithm.
+      required:
+        [id, sequence, run_id, ts, category, payload, entry_hash]
+      properties:
+        id: { $ref: '#/components/schemas/UUID' }
+        sequence:
+          type: integer
+          format: int64
+          minimum: 1
+        run_id: { $ref: '#/components/schemas/UUID' }
+        stage_id:
+          oneOf:
+            - $ref: '#/components/schemas/UUID'
+            - type: "null"
+        ts:
+          type: string
+          format: date-time
+        category:
+          type: string
+          example: plan_generated
+        actor_kind:
+          type: [string, "null"]
+          enum: [agent, user, system, null]
+        actor_subject:
+          type: [string, "null"]
+        payload:
+          description: Event-specific JSON object.
+        prev_hash:
+          type: [string, "null"]
+          description: Hex sha256 of the prior entry's entry_hash; null on the first entry of a run.
+        entry_hash:
+          type: string
+          description: Hex sha256 of the canonical hash inputs.
+
+    User:
+      type: object
+      required: [id, github_login, name]
+      properties:
+        id: { $ref: '#/components/schemas/UUID' }
+        github_login:
+          type: string
+          example: kuhlman-labs
+        name:
+          type: string
+          example: Brett Kuhlman
+        email:
+          type: [string, "null"]
+
+    ApiToken:
+      type: object
+      required: [id, scopes, created_at]
+      properties:
+        id: { $ref: '#/components/schemas/UUID' }
+        scopes:
+          type: array
+          items:
+            type: string
+        last_used_at:
+          type: [string, "null"]
+          format: date-time
+        created_at:
+          type: string
+          format: date-time
+        revoked_at:
+          type: [string, "null"]
+          format: date-time
+
+  responses:
+    BadRequest:
+      description: Request body or query parameters were invalid.
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/Error' }
+    Unauthorized:
+      description: Authentication missing or invalid.
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/Error' }
+    Forbidden:
+      description: Authenticated identity lacks permission for this operation.
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/Error' }
+    NotFound:
+      description: Referenced resource does not exist.
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/Error' }
+    Conflict:
+      description: Request conflicts with current resource state.
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/Error' }
+
+# ---------------------------------------------------------------------------
+# Default security: cookie OR bearer for all UI/CLI endpoints. Runner-
+# facing and webhook endpoints override this individually.
+# ---------------------------------------------------------------------------
+security:
+  - sessionCookie: []
+  - bearerToken: []
+
+paths:
+  # ---------------------------------------------------------------------
+  # Liveness — public, unversioned
+  # ---------------------------------------------------------------------
+  /healthz:
+    get:
+      operationId: getHealthz
+      summary: Liveness probe
+      description: |
+        Lightweight check used by load balancers, ECS health checks, and
+        local smoke tests. Returns build version so operators can confirm
+        a deploy reached the instance. Implemented in
+        `backend/internal/server/handlers.go`.
+      security: []
+      tags: [diagnostics]
+      responses:
+        '200':
+          description: Process is up.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [status, version]
+                properties:
+                  status:
+                    type: string
+                    example: ok
+                  version:
+                    type: string
+                    example: dev
+        '503':
+          description: Process is shutting down or otherwise not ready.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
+  # ---------------------------------------------------------------------
+  # Auth — sign in via GitHub OAuth, manage scoped tokens
+  # ---------------------------------------------------------------------
+  /v0/auth/github/login:
+    get:
+      operationId: githubLogin
+      summary: Begin GitHub OAuth sign-in
+      description: |
+        Redirects the browser to GitHub's OAuth authorize endpoint with a
+        backend-generated state value. The state is bound to the browser
+        via a temporary cookie and verified on callback.
+      security: []
+      tags: [auth]
+      responses:
+        '302':
+          description: Redirect to GitHub's OAuth authorize URL.
+        '500':
+          description: OAuth state could not be issued.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
+  /v0/auth/github/callback:
+    get:
+      operationId: githubCallback
+      summary: GitHub OAuth callback
+      description: |
+        Verifies the state, exchanges the code for a GitHub access token,
+        looks up or creates the user, and sets the `fishhawk_session`
+        cookie. Redirects to the SPA on success.
+      security: []
+      tags: [auth]
+      parameters:
+        - name: code
+          in: query
+          required: true
+          schema: { type: string }
+        - name: state
+          in: query
+          required: true
+          schema: { type: string }
+      responses:
+        '302':
+          description: Redirect to the SPA root with session cookie set.
+        '400': { $ref: '#/components/responses/BadRequest' }
+
+  /v0/auth/me:
+    get:
+      operationId: getMe
+      summary: Current user
+      description: Returns the authenticated user, or 401 if unauthenticated.
+      tags: [auth]
+      responses:
+        '200':
+          description: The authenticated user.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/User' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+
+  /v0/auth/logout:
+    post:
+      operationId: logout
+      summary: Sign out
+      description: Invalidates the current session.
+      tags: [auth]
+      responses:
+        '204':
+          description: Session destroyed.
+        '401': { $ref: '#/components/responses/Unauthorized' }
+
+  /v0/tokens:
+    get:
+      operationId: listTokens
+      summary: List API tokens for the current user
+      tags: [auth]
+      responses:
+        '200':
+          description: Active tokens. Token strings are NOT returned.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Pagination'
+                  - type: object
+                    properties:
+                      items:
+                        type: array
+                        items: { $ref: '#/components/schemas/ApiToken' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+    post:
+      operationId: createToken
+      summary: Mint a new scoped API token
+      description: |
+        Returns the freshly-minted token string ONCE in the response body.
+        The token is not retrievable later; if lost, revoke and re-issue.
+      tags: [auth]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [scopes]
+              properties:
+                scopes:
+                  type: array
+                  items: { type: string }
+      responses:
+        '201':
+          description: Token created. The plaintext value is in the response.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiToken'
+                  - type: object
+                    required: [token]
+                    properties:
+                      token:
+                        type: string
+                        description: |
+                          The bearer token. Store immediately — not
+                          retrievable later.
+        '401': { $ref: '#/components/responses/Unauthorized' }
+
+  /v0/tokens/{token_id}:
+    delete:
+      operationId: revokeToken
+      summary: Revoke an API token
+      tags: [auth]
+      parameters:
+        - { name: token_id, in: path, required: true, schema: { $ref: '#/components/schemas/UUID' } }
+      responses:
+        '204':
+          description: Token revoked.
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '404': { $ref: '#/components/responses/NotFound' }
+
+  # ---------------------------------------------------------------------
+  # Runs
+  # ---------------------------------------------------------------------
+  /v0/runs:
+    get:
+      operationId: listRuns
+      summary: List workflow runs
+      description: |
+        Cursor-paginated list ordered by `created_at` descending. Filter
+        parameters are additive; multiple query values AND together.
+      tags: [runs]
+      parameters:
+        - { name: repo, in: query, schema: { type: string } }
+        - { name: workflow_id, in: query, schema: { type: string } }
+        - { name: state, in: query, schema: { type: string, enum: [pending, running, succeeded, failed, cancelled] } }
+        - { name: limit, in: query, schema: { type: integer, default: 50, maximum: 200 } }
+        - { name: cursor, in: query, schema: { type: string } }
+      responses:
+        '200':
+          description: Page of runs.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Pagination'
+                  - type: object
+                    properties:
+                      items:
+                        type: array
+                        items: { $ref: '#/components/schemas/Run' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+    post:
+      operationId: createRun
+      summary: Create a workflow run
+      description: |
+        Creates a `runs` row in the `pending` state and dispatches a
+        `workflow_dispatch` event to the customer's repo. The runner
+        action picks it up and proceeds through the configured stages.
+      tags: [runs]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [repo, workflow_id, workflow_sha, trigger_source]
+              properties:
+                repo:
+                  type: string
+                  example: kuhlman-labs/fishhawk
+                workflow_id:
+                  type: string
+                  example: feature_change
+                workflow_sha:
+                  type: string
+                trigger_source:
+                  type: string
+                  enum: [github_issue, cli, ui]
+                trigger_ref:
+                  type: [string, "null"]
+      responses:
+        '201':
+          description: Run created and dispatched.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Run' }
+        '400': { $ref: '#/components/responses/BadRequest' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+
+  /v0/runs/{run_id}:
+    get:
+      operationId: getRun
+      summary: Get a run
+      tags: [runs]
+      parameters:
+        - { name: run_id, in: path, required: true, schema: { $ref: '#/components/schemas/UUID' } }
+      responses:
+        '200':
+          description: Run details.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Run' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '404': { $ref: '#/components/responses/NotFound' }
+
+  /v0/runs/{run_id}/cancel:
+    post:
+      operationId: cancelRun
+      summary: Cancel a run
+      description: |
+        Transitions the run and any non-terminal stages to `cancelled`.
+        Idempotent — calling on an already-cancelled or already-terminal
+        run returns 409 unless `state` already equals `cancelled`.
+      tags: [runs]
+      parameters:
+        - { name: run_id, in: path, required: true, schema: { $ref: '#/components/schemas/UUID' } }
+      responses:
+        '200':
+          description: Run cancelled.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Run' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '409': { $ref: '#/components/responses/Conflict' }
+
+  /v0/runs/{run_id}/stages:
+    get:
+      operationId: listRunStages
+      summary: List stages for a run
+      tags: [runs]
+      parameters:
+        - { name: run_id, in: path, required: true, schema: { $ref: '#/components/schemas/UUID' } }
+      responses:
+        '200':
+          description: Stages ordered by sequence ascending.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items]
+                properties:
+                  items:
+                    type: array
+                    items: { $ref: '#/components/schemas/Stage' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '404': { $ref: '#/components/responses/NotFound' }
+
+  /v0/runs/{run_id}/audit:
+    get:
+      operationId: listRunAudit
+      summary: List audit entries for a run
+      description: |
+        Cursor-paginated, sequence-ascending. Used by the run-detail UI
+        and (eventually) the compliance export.
+      tags: [audit]
+      parameters:
+        - { name: run_id, in: path, required: true, schema: { $ref: '#/components/schemas/UUID' } }
+        - { name: category, in: query, schema: { type: string } }
+        - { name: limit, in: query, schema: { type: integer, default: 100, maximum: 500 } }
+        - { name: cursor, in: query, schema: { type: string } }
+      responses:
+        '200':
+          description: Page of audit entries.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Pagination'
+                  - type: object
+                    properties:
+                      items:
+                        type: array
+                        items: { $ref: '#/components/schemas/AuditEntry' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '404': { $ref: '#/components/responses/NotFound' }
+
+  # ---------------------------------------------------------------------
+  # Stages, artifacts, approvals
+  # ---------------------------------------------------------------------
+  /v0/stages/{stage_id}:
+    get:
+      operationId: getStage
+      summary: Get a stage
+      tags: [stages]
+      parameters:
+        - { name: stage_id, in: path, required: true, schema: { $ref: '#/components/schemas/UUID' } }
+      responses:
+        '200':
+          description: Stage details.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Stage' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '404': { $ref: '#/components/responses/NotFound' }
+
+  /v0/stages/{stage_id}/artifacts:
+    get:
+      operationId: listStageArtifacts
+      summary: List artifacts for a stage
+      tags: [stages]
+      parameters:
+        - { name: stage_id, in: path, required: true, schema: { $ref: '#/components/schemas/UUID' } }
+      responses:
+        '200':
+          description: Artifacts, ordered by created_at ascending.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items]
+                properties:
+                  items:
+                    type: array
+                    items: { $ref: '#/components/schemas/Artifact' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '404': { $ref: '#/components/responses/NotFound' }
+
+  /v0/stages/{stage_id}/approvals:
+    post:
+      operationId: submitApproval
+      summary: Approve or reject the gate on a stage
+      description: |
+        The authenticated user must resolve to a role listed in the
+        gate's `approvers` block. Submitting an `approve` decision
+        transitions the gate to passed; `reject` fails the stage as
+        category D.
+      tags: [approvals]
+      parameters:
+        - { name: stage_id, in: path, required: true, schema: { $ref: '#/components/schemas/UUID' } }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [decision]
+              properties:
+                decision:
+                  type: string
+                  enum: [approve, reject]
+                comment:
+                  type: string
+      responses:
+        '200':
+          description: Approval recorded; stage state advanced.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Stage' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '409': { $ref: '#/components/responses/Conflict' }
+
+  /v0/artifacts/{artifact_id}:
+    get:
+      operationId: getArtifact
+      summary: Get an artifact
+      tags: [artifacts]
+      parameters:
+        - { name: artifact_id, in: path, required: true, schema: { $ref: '#/components/schemas/UUID' } }
+      responses:
+        '200':
+          description: Artifact with content.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Artifact' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '404': { $ref: '#/components/responses/NotFound' }
+
+  # ---------------------------------------------------------------------
+  # Runner-facing endpoints
+  # ---------------------------------------------------------------------
+  /v0/runs/{run_id}/signing-key:
+    post:
+      operationId: issueSigningKey
+      summary: Issue a per-run Ed25519 signing key
+      description: |
+        Called by the runner at job start. The backend mints a fresh
+        Ed25519 keypair, persists the public half in `signing_keys`,
+        and returns the private half in the response body. The private
+        key is never persisted server-side and never returned to anyone
+        else. Auth is GitHub Actions OIDC token, verified per request.
+        See ADR-008 (#72).
+      tags: [runner]
+      security:
+        - githubOIDC: []
+      parameters:
+        - { name: run_id, in: path, required: true, schema: { $ref: '#/components/schemas/UUID' } }
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                ttl_seconds:
+                  type: integer
+                  description: |
+                    Optional override for the default TTL (1800s).
+                    Backend may cap to a maximum.
+                  minimum: 60
+                  maximum: 3600
+      responses:
+        '201':
+          description: Keypair issued.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [run_id, public_key, private_key, issued_at, expires_at]
+                properties:
+                  run_id: { $ref: '#/components/schemas/UUID' }
+                  public_key:
+                    type: string
+                    description: Base64-encoded 32-byte Ed25519 public key.
+                  private_key:
+                    type: string
+                    description: |
+                      Base64-encoded 64-byte Ed25519 private key. The
+                      runner stores this in process memory only and
+                      discards it after trace upload.
+                  issued_at:
+                    type: string
+                    format: date-time
+                  expires_at:
+                    type: string
+                    format: date-time
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '404':
+          description: Run does not exist.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+        '409':
+          description: A signing key has already been issued for this run.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
+  /v0/runs/{run_id}/trace:
+    post:
+      operationId: shipTrace
+      summary: Upload a signed trace bundle
+      description: |
+        Called by the runner after a stage completes. The bundle bytes
+        (`application/gzip`, JSON Lines) are uploaded as the request body;
+        the signature comes via the `X-Fishhawk-Signature` header. The
+        backend verifies the signature against the run's stored public
+        key, stores the bundle in S3 (per ADR-003 #67), and writes the
+        corresponding audit entry. Auth is the signature itself; no
+        Bearer or cookie required.
+      tags: [runner]
+      security: []
+      parameters:
+        - { name: run_id, in: path, required: true, schema: { $ref: '#/components/schemas/UUID' } }
+        - { name: stage_id, in: query, required: true, schema: { $ref: '#/components/schemas/UUID' } }
+        - name: variant
+          in: query
+          required: true
+          schema:
+            type: string
+            enum: [raw, redacted]
+        - name: X-Fishhawk-Signature
+          in: header
+          required: true
+          schema:
+            type: string
+            description: |
+              Hex-encoded 64-byte Ed25519 signature over
+              sha256(raw_bundle_bytes).
+      requestBody:
+        required: true
+        content:
+          application/gzip:
+            schema:
+              type: string
+              format: binary
+      responses:
+        '202':
+          description: Bundle accepted, signature verified.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [run_id, stage_id, variant, content_hash]
+                properties:
+                  run_id: { $ref: '#/components/schemas/UUID' }
+                  stage_id: { $ref: '#/components/schemas/UUID' }
+                  variant: { type: string, enum: [raw, redacted] }
+                  content_hash:
+                    type: string
+                    description: Hex sha256 of the uploaded bundle bytes.
+        '400': { $ref: '#/components/responses/BadRequest' }
+        '401':
+          description: Signature invalid or no signing key for this run.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+        '404': { $ref: '#/components/responses/NotFound' }
+
+  # ---------------------------------------------------------------------
+  # Webhook ingestion (unversioned; GitHub controls request shape)
+  # ---------------------------------------------------------------------
+  /webhooks/github:
+    post:
+      operationId: receiveGithubWebhook
+      summary: GitHub App webhook receiver
+      description: |
+        Inbound from the customer's GitHub App installation. Events
+        include issues, pull requests, check runs, push, and the
+        Marketplace billing events. The backend signature-verifies via
+        the GitHub App webhook secret, deduplicates by delivery ID,
+        and translates relevant events into workflow run dispatches.
+        See E3.7 (#47).
+      tags: [webhooks]
+      security: []
+      parameters:
+        - name: X-GitHub-Event
+          in: header
+          required: true
+          schema: { type: string }
+        - name: X-GitHub-Delivery
+          in: header
+          required: true
+          schema: { type: string }
+        - name: X-Hub-Signature-256
+          in: header
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+      responses:
+        '202':
+          description: Event accepted.
+        '401':
+          description: Webhook signature invalid.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+        '400':
+          description: Malformed event.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
+tags:
+  - name: diagnostics
+    description: Liveness, readiness, build info.
+  - name: auth
+    description: GitHub OAuth flow + scoped API tokens (ADR-005).
+  - name: runs
+    description: Workflow run lifecycle.
+  - name: stages
+    description: Stage details + artifacts.
+  - name: approvals
+    description: Human-in-the-loop gate decisions.
+  - name: artifacts
+    description: Plans and pull-request references emitted by stages.
+  - name: audit
+    description: Append-only audit log read paths.
+  - name: runner
+    description: Endpoints called by the fishhawk/runner GitHub Action.
+  - name: webhooks
+    description: Inbound from GitHub App installations.


### PR DESCRIPTION
## Summary

Lands the contract for `fishhawkd`'s HTTP surface — the document the backend handlers, frontend client, CLI, and runner all consume.

- `docs/api/v0.openapi.yaml` — OpenAPI 3.1 spec, source of truth. 19 endpoints across diagnostics, auth, runs, stages, artifacts, approvals, audit, runner, and webhooks. Three security schemes (`sessionCookie`, `bearerToken`, `githubOIDC`) per ADR-005 (#69).
- `docs/api/v0.md` — human-readable companion: endpoint map, auth table, caller flows for each of the 4 client classes, error-code table.
- `docs/api/README.md` — index + working-on-the-API instructions.
- `docs/api/redocly.yaml` — lint config; disables `operation-2xx-response` (OAuth redirects don't have 2XX) and `no-server-example.com` (localhost dev URL is intentional).

CI gets a new `openapi` lint job, path-filtered on `docs/api/**`, wired into the `CI Pass` rollup so a broken spec fails the gate.

Handlers themselves (`backend/internal/server/`) are deferred to follow-up issues — this PR fixes the contract so they can be built in parallel.

## Test plan

- [x] `npx -y @redocly/cli@latest lint --config docs/api/redocly.yaml docs/api/v0.openapi.yaml` returns "valid" (2 non-blocking warnings on `/healthz` and OAuth login lacking 4XX, which is intentional)
- [x] CI `openapi` job runs green on this PR
- [x] CI `CI Pass` rollup passes

## Notes

The auth model matches ADR-005 (#69) exactly: cookie + CSRF for the SPA, opaque bearers for CLI/programmatic, GitHub OIDC for the runner.

The runner endpoints (`/v0/runs/{id}/signing-key`, `/v0/runs/{id}/trace`) match what `backend/internal/signing` and `backend/internal/tracestore` already implement — only the HTTP surface was missing.

Errors use a single envelope `{ error: { code, message, details? } }` with snake_case stable codes; the v0.md error table seeds the initial code list. New codes are additive.

`/v0` is unstable by design until the v1 cut at the end of phase 4 (MVP_SPEC §13). Webhook ingestion is unversioned because GitHub controls the request shape.

Closes #46
