### PR TITLE
Add Claude Code invocation harness (E5.2)

### DIFF
--- a/runner/README.md
+++ b/runner/README.md
@@ -10,14 +10,15 @@ This directory is its own Go module (`github.com/kuhlman-labs/fishhawk/runner`) 
 
 - `action.yml` — composite action manifest. Defines inputs, sets up the Go toolchain, invokes the binary.
 - `cmd/fishhawk-runner/` — the binary entrypoint. Flag parsing in `flags.go`, dispatch in `main.go`.
+- `internal/agent/` — the agent abstraction (`Invoker`, `Invocation`, `Result`, `Event`).
+- `internal/agent/claudecode/` — adapter for Anthropic's Claude Code CLI.
 - `internal/version/` — build-version package; set via `-ldflags` at release time.
 
 ## Status
 
-E5.1 (#52) — module scaffold. The binary parses its inputs, emits a single JSON startup log line, and exits 0. Customers pinning `v0.1` see a no-op success until later issues land:
+E5.1 (#52) shipped the scaffold. E5.2 (#29) wires the Claude Code invocation harness: when `prompt-file` is supplied, the runner invokes Claude Code with `--print --output-format stream-json`, captures each event, and emits the trace as JSON Lines on stdout. Trace bundling and signed upload land later:
 
-- E5.2 (#29) — Claude Code invocation harness
-- E5.3 (#30) — full trace capture + bundling
+- E5.3 (#30) — full trace capture + bundling (replaces stdout JSONL with `*.jsonl.gz` + manifest/trailer)
 - E5.4 (#31) — plan validation against `standard_v1` (reuses `backend/internal/plan`)
 - E5.5 (#53) — post-hoc constraint enforcement on stage output
 - E5.6 (#32) — signed trace shipping to backend (uses `backend/internal/signing` + `backend/internal/tracestore`)
@@ -25,12 +26,18 @@ E5.1 (#52) — module scaffold. The binary parses its inputs, emits a single JSO
 
 ## Inputs (action.yml)
 
-| Input | Description |
-|---|---|
-| `run-id` | Workflow run identifier (UUID, supplied by backend dispatch). |
-| `backend-url` | Fishhawk backend URL the runner ships its trace bundle to. |
-| `workflow` | Workflow ID matching a key under `workflows:` in `.fishhawk/workflows.yaml`. |
-| `stage` | Stage ID within the workflow (e.g. `plan`, `implement`, `review`). |
+| Input | Required | Description |
+|---|---|---|
+| `run-id` | yes | Workflow run identifier (UUID, supplied by backend dispatch). |
+| `backend-url` | yes | Fishhawk backend URL the runner ships its trace bundle to. |
+| `workflow` | yes | Workflow ID matching a key under `workflows:` in `.fishhawk/workflows.yaml`. |
+| `stage` | yes | Stage ID within the workflow (e.g. `plan`, `implement`, `review`). |
+| `prompt-file` | no | Path to a file containing the constructed prompt. When unset the runner exits 0 without invoking the agent — useful for exercising the dispatch path before E5.2+ are wired upstream. |
+| `working-dir` | no | Agent working directory; defaults to the runner's CWD. |
+| `max-tokens` | no | Hard cap on agent tokens (input + output); 0 means no cap. |
+| `timeout` | no | Wall-clock cap on the agent invocation, e.g. `15m`. Default 15m. |
+
+The Claude Code API key is supplied via the `ANTHROPIC_API_KEY` environment variable, which customers populate from their GitHub Secrets. v0.x will replace this with a Fishhawk-issued ephemeral key (MVP_SPEC §5.3).
 
 ## Build and test
 
@@ -48,13 +55,25 @@ Or from this directory directly:
 
 The same binary the action runs can be invoked locally for development:
 
+    # Dispatch-path probe (no agent invocation)
     go run ./cmd/fishhawk-runner \
       --run-id 11111111-2222-3333-4444-555555555555 \
       --backend-url http://localhost:8080 \
       --workflow feature_change \
       --stage plan
 
-Today this just emits a JSON log line and exits. As E5.2+ land, the same invocation will run the configured agent end-to-end.
+    # With the Claude Code harness (E5.2+)
+    echo "Summarize the README" > /tmp/prompt.txt
+    ANTHROPIC_API_KEY=sk-... go run ./cmd/fishhawk-runner \
+      --run-id 11111111-2222-3333-4444-555555555555 \
+      --backend-url http://localhost:8080 \
+      --workflow feature_change \
+      --stage plan \
+      --prompt-file /tmp/prompt.txt \
+      --max-tokens 50000 \
+      --timeout 5m
+
+When `--prompt-file` is set the runner emits one JSON event per stdout line; the structured runner log lines (`runner_started`, `runner_completed`) go to stderr.
 
 ## See also
 

--- a/runner/action.yml
+++ b/runner/action.yml
@@ -10,11 +10,13 @@ branding:
 # and pass the inputs below. The composite action checks out a Go
 # toolchain and invokes ./cmd/fishhawk-runner from this directory.
 #
-# E5.1 (#52) ships the scaffold: the Go binary parses its inputs and
-# exits 0. The agent invocation, trace capture, signing, and trace
-# shipping arrive in E5.2–E5.6. Customers pinning v0.1 see a no-op
-# success until those land — useful for exercising the dispatch
-# path early.
+# E5.1 (#52) shipped the scaffold; E5.2 (#29) added the Claude Code
+# invocation harness. With prompt-file unset the runner still
+# exits 0 after the startup log line, preserving the v0.1
+# dispatch-path probe. With prompt-file set, the runner invokes
+# Claude Code, captures the trace, and emits it as JSON Lines on
+# stdout. Trace bundling (E5.3) and signed shipping to the backend
+# (E5.6) replace stdout emission later.
 
 inputs:
   run-id:
@@ -29,6 +31,26 @@ inputs:
   stage:
     description: 'Stage ID within the workflow (e.g. plan, implement, review).'
     required: true
+  prompt-file:
+    description: 'Path to a UTF-8 file containing the prompt. When unset, the runner exits 0 without invoking the agent.'
+    required: false
+    default: ''
+  working-dir:
+    description: "Agent CWD; defaults to the runner's CWD."
+    required: false
+    default: ''
+  max-tokens:
+    description: 'Hard cap on agent tokens (input + output). 0 means no cap.'
+    required: false
+    default: '0'
+  timeout:
+    description: 'Wall-clock cap on the agent invocation (Go duration string, e.g. 15m).'
+    required: false
+    default: '15m'
+  anthropic-api-key:
+    description: 'API key forwarded to Claude Code as ANTHROPIC_API_KEY. Customers populate this from a GitHub Secret.'
+    required: false
+    default: ''
 
 runs:
   using: 'composite'
@@ -42,9 +64,15 @@ runs:
     - name: Run fishhawk-runner
       shell: bash
       working-directory: ${{ github.action_path }}
+      env:
+        ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
       run: |
         go run ./cmd/fishhawk-runner \
           --run-id "${{ inputs.run-id }}" \
           --backend-url "${{ inputs.backend-url }}" \
           --workflow "${{ inputs.workflow }}" \
-          --stage "${{ inputs.stage }}"
+          --stage "${{ inputs.stage }}" \
+          --prompt-file "${{ inputs.prompt-file }}" \
+          --working-dir "${{ inputs.working-dir }}" \
+          --max-tokens "${{ inputs.max-tokens }}" \
+          --timeout "${{ inputs.timeout }}"

--- a/runner/cmd/fishhawk-runner/flags.go
+++ b/runner/cmd/fishhawk-runner/flags.go
@@ -4,18 +4,29 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/kuhlman-labs/fishhawk/runner/internal/version"
 )
 
-// config is the parsed CLI input that future stages will consume.
-// Every field has a corresponding flag; the action.yml inputs map
-// 1:1 onto these.
+// config is the parsed CLI input. Every field has a corresponding
+// flag; the action.yml inputs map 1:1 onto the required flags.
+//
+// E5.2 added the agent-invocation flags (promptFile, workingDir,
+// budget). They're optional in the scaffold sense — if promptFile
+// is empty, the runner emits a startup line and exits 0, preserving
+// the v0.1 dispatch-path probe. Once a prompt is supplied, the
+// runner actually invokes Claude Code.
 type config struct {
 	runID      string
 	backendURL string
 	workflow   string
 	stage      string
+
+	promptFile string
+	workingDir string
+	maxTokens  int
+	timeout    time.Duration
 }
 
 // parseFlags reads args and populates a config. Returns a usage
@@ -35,6 +46,16 @@ func parseFlags(args []string, w io.Writer) (config, error) {
 	fs.StringVar(&cfg.backendURL, "backend-url", "", "Fishhawk backend URL")
 	fs.StringVar(&cfg.workflow, "workflow", "", "workflow ID matching .fishhawk/workflows.yaml")
 	fs.StringVar(&cfg.stage, "stage", "", "stage ID within the workflow")
+
+	fs.StringVar(&cfg.promptFile, "prompt-file", "",
+		"path to a UTF-8 file containing the prompt; when empty the runner exits 0 without invoking the agent")
+	fs.StringVar(&cfg.workingDir, "working-dir", "",
+		"agent CWD; defaults to the runner's CWD")
+	fs.IntVar(&cfg.maxTokens, "max-tokens", 0,
+		"hard cap on agent tokens (input + output); 0 means no cap")
+	fs.DurationVar(&cfg.timeout, "timeout", 15*time.Minute,
+		"wall-clock cap on agent invocation")
+
 	if err := fs.Parse(args); err != nil {
 		return cfg, err
 	}

--- a/runner/cmd/fishhawk-runner/main.go
+++ b/runner/cmd/fishhawk-runner/main.go
@@ -1,26 +1,28 @@
 // Command fishhawk-runner runs an agent under a Fishhawk workflow
 // stage and ships the trace.
 //
-// E5.1 (https://github.com/kuhlman-labs/fishhawk/issues/52) is just
-// the scaffold: flag parsing, version, structured logging, exit
-// codes. Real work lands in:
+// E5.1 (#52) shipped the scaffold. E5.2 (#29) wires the Claude Code
+// invocation harness: when --prompt-file is supplied, the runner
+// invokes Claude Code, captures the trace, and emits it as JSON
+// Lines on stdout. Trace bundling (E5.3 / #30) and shipping to the
+// backend (E5.6 / #32) replace the stdout emission later.
 //
-//   - E5.2 (#29) — Claude Code invocation harness
-//   - E5.3 (#30) — full trace capture + bundling
-//   - E5.4 (#31) — plan validation against standard_v1
-//   - E5.5 (#53) — post-hoc constraint enforcement
-//   - E5.6 (#32) — signed trace shipping to backend
-//
-// The current binary parses its inputs, prints a single startup
-// log line acknowledging them, and exits 0. Customers pinning
-// `kuhlman-labs/fishhawk/runner@v0.1` will see this as a no-op
-// until E5.2 lands.
+// Without --prompt-file the binary parses its inputs, prints a
+// single startup log line, and exits 0. Customers pinning
+// `kuhlman-labs/fishhawk/runner@v0.1` see this no-op until the
+// downstream stages of E5 land.
 package main
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
+
+	"github.com/kuhlman-labs/fishhawk/runner/internal/agent"
+	"github.com/kuhlman-labs/fishhawk/runner/internal/agent/claudecode"
 )
 
 const (
@@ -29,12 +31,25 @@ const (
 	exitUsage   = 2
 )
 
+// newInvoker is the seam tests use to swap the real Claude Code
+// adapter for a fake. Production wiring is the only assignment in
+// non-test code; tests reassign and restore it via t.Cleanup.
+var newInvoker = func(apiKey string) agent.Invoker {
+	return claudecode.New(apiKey)
+}
+
 func main() {
 	os.Exit(run(os.Args[1:], os.Stderr))
 }
 
 // run is split out so tests can drive it without exiting the test
 // process. Returns the intended process exit code.
+//
+// logSink receives the structured startup log line and any failure
+// notes; trace events (when the harness runs) go to os.Stdout so
+// they can be piped or captured separately. This split lets a
+// caller redirect stderr for diagnostics while keeping the trace
+// stream clean.
 func run(args []string, logSink io.Writer) int {
 	cfg, err := parseFlags(args, logSink)
 	if err != nil {
@@ -44,16 +59,97 @@ func run(args []string, logSink io.Writer) int {
 
 	logStartup(logSink, cfg)
 
-	// E5.2 onward replaces this no-op with the agent invocation,
-	// trace capture, signing, and shipping. Returning 0 here lets
-	// customers pin the runner at v0.1 and exercise the dispatch
-	// path end-to-end before the runner does real work.
+	if cfg.promptFile == "" {
+		// Scaffold mode preserved: --prompt-file unset means
+		// "exercise the dispatch path; do not invoke the agent."
+		return exitOK
+	}
+
+	prompt, err := os.ReadFile(cfg.promptFile)
+	if err != nil {
+		_, _ = fmt.Fprintf(logSink,
+			`{"event":"runner_failed","reason":"read_prompt","detail":%q}`+"\n", err.Error())
+		return exitUsage
+	}
+
+	inv := agent.Invocation{
+		RunID:      cfg.runID,
+		Stage:      cfg.stage,
+		Prompt:     string(prompt),
+		WorkingDir: cfg.workingDir,
+		Budget: agent.Budget{
+			MaxTokens: cfg.maxTokens,
+			Timeout:   cfg.timeout,
+		},
+	}
+
+	invoker := newInvoker(os.Getenv("ANTHROPIC_API_KEY"))
+	res, invokeErr := invoker.Invoke(context.Background(), inv)
+
+	emitEvents(os.Stdout, res.Events)
+	logCompletion(logSink, res, invokeErr)
+
+	if !res.OK {
+		return exitFailure
+	}
 	return exitOK
 }
 
 func logStartup(w io.Writer, cfg config) {
 	_, _ = fmt.Fprintf(w,
-		`{"event":"runner_started","run_id":%q,"workflow":%q,"stage":%q,"backend_url":%q,"version":%q}`+"\n",
-		cfg.runID, cfg.workflow, cfg.stage, cfg.backendURL, runnerVersion(),
+		`{"event":"runner_started","run_id":%q,"workflow":%q,"stage":%q,"backend_url":%q,"version":%q,"prompt_file":%q}`+"\n",
+		cfg.runID, cfg.workflow, cfg.stage, cfg.backendURL, runnerVersion(), cfg.promptFile,
 	)
+}
+
+// logCompletion writes a single structured line summarizing the
+// invocation outcome. Mirrors the failure categories from
+// MVP_SPEC §6 so log scrapers can switch on `category`.
+func logCompletion(w io.Writer, res agent.Result, err error) {
+	if res.OK {
+		_, _ = fmt.Fprintf(w,
+			`{"event":"runner_completed","outcome":"ok","tokens_used":%d}`+"\n",
+			res.TokensUsed)
+		return
+	}
+	reason := res.FailureReason
+	if reason == "" && err != nil {
+		reason = err.Error()
+	}
+	category := res.FailureCategory
+	if category == "" {
+		category = "A"
+	}
+	_, _ = fmt.Fprintf(w,
+		`{"event":"runner_completed","outcome":"failed","category":%q,"reason":%q,"tokens_used":%d,"err_class":%q}`+"\n",
+		category, reason, res.TokensUsed, classifyErr(err))
+}
+
+// classifyErr returns a stable short label for the wrapped agent
+// error so log consumers don't have to substring-match prose.
+func classifyErr(err error) string {
+	switch {
+	case err == nil:
+		return ""
+	case errors.Is(err, agent.ErrTimeout):
+		return "timeout"
+	case errors.Is(err, agent.ErrBudgetExceeded):
+		return "budget_exceeded"
+	case errors.Is(err, agent.ErrBinaryNotFound):
+		return "binary_not_found"
+	case errors.Is(err, agent.ErrAgentFailed):
+		return "agent_failed"
+	default:
+		return "other"
+	}
+}
+
+// emitEvents writes one JSON object per line. This is the
+// placeholder transport — E5.3 / #30 replaces it with the
+// JSONL.gz bundle format and E5.6 / #32 with the signed upload.
+func emitEvents(w io.Writer, events []agent.Event) {
+	enc := json.NewEncoder(w)
+	for _, ev := range events {
+		_ = enc.Encode(ev)
+	}
 }

--- a/runner/cmd/fishhawk-runner/main_test.go
+++ b/runner/cmd/fishhawk-runner/main_test.go
@@ -1,10 +1,44 @@
 package main
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/kuhlman-labs/fishhawk/runner/internal/agent"
 )
+
+// fakeInvoker lets tests drive run() without spawning a child
+// process. Returning (canned, returnErr) keeps the seam tiny.
+type fakeInvoker struct {
+	canned    agent.Result
+	returnErr error
+	gotAPIKey string
+}
+
+func (f *fakeInvoker) Invoke(ctx context.Context, inv agent.Invocation) (agent.Result, error) {
+	return f.canned, f.returnErr
+}
+
+// withFakeInvoker swaps the package's newInvoker for one that
+// records the API key and returns canned results. Cleanup restores
+// the original constructor.
+func withFakeInvoker(t *testing.T, fake *fakeInvoker) {
+	t.Helper()
+	orig := newInvoker
+	newInvoker = func(apiKey string) agent.Invoker {
+		fake.gotAPIKey = apiKey
+		return fake
+	}
+	t.Cleanup(func() { newInvoker = orig })
+}
 
 // TestRun_HappyPath exercises the no-op success path: every
 // required flag set, run() returns 0 and writes a startup log line.
@@ -62,5 +96,253 @@ func TestRun_HelpExitsUsage(t *testing.T) {
 func TestRunnerVersion_NonEmpty(t *testing.T) {
 	if runnerVersion() == "" {
 		t.Fatal("runnerVersion() should never be empty")
+	}
+}
+
+func TestRun_PromptFileMissing(t *testing.T) {
+	var out strings.Builder
+	got := run([]string{
+		"--run-id", "11111111-2222-3333-4444-555555555555",
+		"--backend-url", "https://api.fishhawk.test",
+		"--workflow", "feature_change",
+		"--stage", "plan",
+		"--prompt-file", "/no/such/path/anywhere.txt",
+	}, &out)
+	if got != exitUsage {
+		t.Errorf("run = %d, want %d", got, exitUsage)
+	}
+	if !strings.Contains(out.String(), `"event":"runner_failed"`) {
+		t.Errorf("missing runner_failed log line: %s", out.String())
+	}
+	if !strings.Contains(out.String(), `"reason":"read_prompt"`) {
+		t.Errorf("missing read_prompt reason: %s", out.String())
+	}
+}
+
+func TestClassifyErr(t *testing.T) {
+	cases := []struct {
+		err  error
+		want string
+	}{
+		{nil, ""},
+		{agent.ErrTimeout, "timeout"},
+		{fmt.Errorf("wrapped: %w", agent.ErrTimeout), "timeout"},
+		{agent.ErrBudgetExceeded, "budget_exceeded"},
+		{agent.ErrBinaryNotFound, "binary_not_found"},
+		{agent.ErrAgentFailed, "agent_failed"},
+		{fmt.Errorf("wrapped: %w", agent.ErrAgentFailed), "agent_failed"},
+		{errors.New("anything else"), "other"},
+	}
+	for _, tc := range cases {
+		var name string
+		if tc.err == nil {
+			name = "nil"
+		} else {
+			name = tc.err.Error()
+		}
+		t.Run(name, func(t *testing.T) {
+			if got := classifyErr(tc.err); got != tc.want {
+				t.Errorf("classifyErr(%v) = %q, want %q", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLogCompletion_OK(t *testing.T) {
+	var w strings.Builder
+	logCompletion(&w, agent.Result{OK: true, TokensUsed: 250}, nil)
+	out := w.String()
+	if !strings.Contains(out, `"outcome":"ok"`) {
+		t.Errorf("missing outcome ok: %s", out)
+	}
+	if !strings.Contains(out, `"tokens_used":250`) {
+		t.Errorf("missing tokens_used: %s", out)
+	}
+}
+
+func TestLogCompletion_Failure(t *testing.T) {
+	var w strings.Builder
+	logCompletion(&w, agent.Result{
+		OK:              false,
+		FailureCategory: "A",
+		FailureReason:   "agent timeout after 100ms",
+		TokensUsed:      0,
+	}, agent.ErrTimeout)
+	out := w.String()
+	for _, want := range []string{
+		`"outcome":"failed"`,
+		`"category":"A"`,
+		`"reason":"agent timeout after 100ms"`,
+		`"err_class":"timeout"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %s in: %s", want, out)
+		}
+	}
+}
+
+func TestRun_PromptInvokesAgentAndEmitsEvents(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "prompt.txt")
+	if err := os.WriteFile(path, []byte("do the thing"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test-1234")
+
+	fake := &fakeInvoker{
+		canned: agent.Result{
+			OK:         true,
+			TokensUsed: 250,
+			Events: []agent.Event{
+				{Kind: "invocation_start", Payload: agent.MakePayload(map[string]string{"a": "b"})},
+				{Kind: "result", Payload: agent.MakePayload(map[string]int{"n": 1})},
+				{Kind: "invocation_end"},
+			},
+		},
+	}
+	withFakeInvoker(t, fake)
+
+	// Capture stdout — emitEvents writes there.
+	stdoutR, stdoutW, _ := os.Pipe()
+	origStdout := os.Stdout
+	os.Stdout = stdoutW
+	t.Cleanup(func() { os.Stdout = origStdout })
+
+	var stderr strings.Builder
+	got := run([]string{
+		"--run-id", "11111111-2222-3333-4444-555555555555",
+		"--backend-url", "https://api.fishhawk.test",
+		"--workflow", "feature_change",
+		"--stage", "plan",
+		"--prompt-file", path,
+		"--max-tokens", "1000",
+		"--timeout", "30s",
+	}, &stderr)
+
+	_ = stdoutW.Close()
+	stdoutBytes, _ := io.ReadAll(stdoutR)
+
+	if got != exitOK {
+		t.Errorf("run = %d, want %d", got, exitOK)
+	}
+	if fake.gotAPIKey != "sk-test-1234" {
+		t.Errorf("invoker gotAPIKey = %q, want sk-test-1234", fake.gotAPIKey)
+	}
+
+	// Three events should have been emitted as JSON Lines on stdout.
+	lines := bytes.Split(bytes.TrimRight(stdoutBytes, "\n"), []byte("\n"))
+	if len(lines) != 3 {
+		t.Fatalf("emitted %d JSONL lines, want 3:\n%s", len(lines), stdoutBytes)
+	}
+	for i, line := range lines {
+		var ev agent.Event
+		if err := json.Unmarshal(line, &ev); err != nil {
+			t.Errorf("line %d not JSON: %v: %s", i, err, line)
+		}
+	}
+
+	// The completion log line should report ok and the token count.
+	if !strings.Contains(stderr.String(), `"outcome":"ok"`) {
+		t.Errorf("missing ok outcome in stderr: %s", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), `"tokens_used":250`) {
+		t.Errorf("missing tokens_used in stderr: %s", stderr.String())
+	}
+}
+
+func TestRun_AgentFailureMapsToExit1(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "prompt.txt")
+	if err := os.WriteFile(path, []byte("p"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("ANTHROPIC_API_KEY", "")
+
+	fake := &fakeInvoker{
+		canned: agent.Result{
+			OK:              false,
+			FailureCategory: "A",
+			FailureReason:   "agent timeout after 30s",
+			Events: []agent.Event{
+				{Kind: "invocation_start"},
+				{Kind: "invocation_end"},
+			},
+		},
+		returnErr: agent.ErrTimeout,
+	}
+	withFakeInvoker(t, fake)
+
+	// Discard stdout to keep test output clean.
+	stdoutR, stdoutW, _ := os.Pipe()
+	origStdout := os.Stdout
+	os.Stdout = stdoutW
+	t.Cleanup(func() { os.Stdout = origStdout })
+
+	var stderr strings.Builder
+	got := run([]string{
+		"--run-id", "11111111-2222-3333-4444-555555555555",
+		"--backend-url", "https://api.fishhawk.test",
+		"--workflow", "feature_change",
+		"--stage", "plan",
+		"--prompt-file", path,
+	}, &stderr)
+
+	_ = stdoutW.Close()
+	_, _ = io.ReadAll(stdoutR)
+
+	if got != exitFailure {
+		t.Errorf("run = %d, want %d", got, exitFailure)
+	}
+	out := stderr.String()
+	if !strings.Contains(out, `"outcome":"failed"`) {
+		t.Errorf("missing failed outcome: %s", out)
+	}
+	if !strings.Contains(out, `"category":"A"`) {
+		t.Errorf("missing category A: %s", out)
+	}
+	if !strings.Contains(out, `"err_class":"timeout"`) {
+		t.Errorf("missing err_class timeout: %s", out)
+	}
+}
+
+func TestEmitEvents_OneJSONPerLine(t *testing.T) {
+	var w bytes.Buffer
+	emitEvents(&w, []agent.Event{
+		{Kind: "a"},
+		{Kind: "b", Payload: agent.MakePayload(map[string]int{"n": 1})},
+	})
+	lines := bytes.Split(bytes.TrimRight(w.Bytes(), "\n"), []byte("\n"))
+	if len(lines) != 2 {
+		t.Fatalf("got %d lines, want 2:\n%s", len(lines), w.String())
+	}
+	for _, line := range lines {
+		var ev agent.Event
+		if err := json.Unmarshal(line, &ev); err != nil {
+			t.Errorf("line not JSON: %v: %s", err, line)
+		}
+	}
+}
+
+func TestNewInvoker_DefaultIsClaudeCode(t *testing.T) {
+	// Sanity check: production wiring constructs a non-nil invoker.
+	// Regression guard for someone removing the default assignment.
+	inv := newInvoker("k")
+	if inv == nil {
+		t.Fatal("newInvoker returned nil")
+	}
+}
+
+func TestLogCompletion_FailureFallsBackToErrText(t *testing.T) {
+	// FailureReason empty → reason should fall back to err.Error().
+	var w strings.Builder
+	logCompletion(&w, agent.Result{OK: false}, errors.New("boom"))
+	out := w.String()
+	if !strings.Contains(out, `"reason":"boom"`) {
+		t.Errorf("missing reason fallback: %s", out)
+	}
+	// FailureCategory empty → should default to "A".
+	if !strings.Contains(out, `"category":"A"`) {
+		t.Errorf("missing default category A: %s", out)
 	}
 }

--- a/runner/internal/agent/agent.go
+++ b/runner/internal/agent/agent.go
@@ -1,0 +1,118 @@
+// Package agent defines the abstraction the runner uses to invoke a
+// coding agent (Claude Code in v0; pluggable for v1+) and capture
+// its execution as an ordered stream of trace events.
+//
+// The runner is agent-agnostic: it speaks this package's Invoker
+// interface and never imports Claude Code internals directly. The
+// concrete adapter for Claude Code lives in
+// runner/internal/agent/claudecode.
+//
+// Trace event vocabulary aligns with docs/ARCHITECTURE.md §5.3. The
+// bundling step (E5.3) consumes Result.Events to produce the signed
+// trace bundle that ships to the backend.
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+)
+
+// Invocation is everything an Invoker needs for a single stage run.
+// The runner constructs this from the workflow spec, the stage
+// definition, and the resolved inputs (issue body, prior-stage
+// artifact, etc.).
+type Invocation struct {
+	// RunID and Stage are carried through so trace events can be
+	// tagged and correlated server-side.
+	RunID string
+	Stage string
+
+	// Prompt is the constructed text the runner hands the agent.
+	// Construction lives outside this package — by the time the
+	// Invoker sees the prompt, every variable is already
+	// substituted.
+	Prompt string
+
+	// WorkingDir is the customer's checked-out repo. The agent runs
+	// with this as its CWD; relative paths in tool calls resolve
+	// here. The agent must NOT escape this directory; enforcement
+	// is via OS sandboxing in v0.x, not v0.
+	WorkingDir string
+
+	// Budget bounds the agent's resource consumption. Zero values
+	// mean "no limit from this layer" — the runner sets sensible
+	// defaults; the workflow spec can override them per stage.
+	Budget Budget
+}
+
+// Budget caps an agent invocation. Per MVP_SPEC §4.2 (`budget`
+// block) v0 budgets are advisory. The harness enforces them anyway:
+// a hard cap is more useful than a polite warning when it's burning
+// money.
+type Budget struct {
+	// MaxTokens is the cap on total tokens (input + output)
+	// reported by the agent. The harness terminates the agent
+	// when it exceeds the cap.
+	MaxTokens int
+
+	// Timeout is the wall-clock cap on the invocation.
+	Timeout time.Duration
+}
+
+// Result is what the harness produces for a single Invoke call.
+// OK distinguishes clean completion from any kind of failure;
+// FailureCategory maps to MVP_SPEC §6 (always 'A' — agent failure —
+// for anything originating in this package).
+type Result struct {
+	OK              bool
+	FailureCategory string
+	FailureReason   string
+
+	// Events is the captured trace, in order. The first event is
+	// always kind=invocation_start; the last is invocation_end.
+	// Bundling (E5.3) wraps these with manifest/trailer events.
+	Events []Event
+
+	// TokensUsed is the agent-reported token total when known
+	// (Claude Code emits a final result event with usage). Zero
+	// when the agent didn't report or didn't get that far.
+	TokensUsed int
+}
+
+// Event is one entry in the captured trace. Kind is the discriminant
+// for Payload's shape; bundling treats Payload as opaque bytes so
+// we can evolve event schemas independently of the trace format.
+type Event struct {
+	Kind      string          `json:"kind"`
+	Timestamp time.Time       `json:"ts"`
+	Payload   json.RawMessage `json:"payload,omitempty"`
+}
+
+// Invoker runs an agent and produces a Result. Implementations are
+// agent-specific; the runner wires whichever Invoker matches the
+// workflow stage's `executor.agent` value.
+type Invoker interface {
+	Invoke(ctx context.Context, inv Invocation) (Result, error)
+}
+
+// Errors callers may want to switch on. All concrete failures wrap
+// one of these.
+var (
+	ErrAgentFailed    = errors.New("agent: agent failed")
+	ErrBudgetExceeded = errors.New("agent: budget exceeded")
+	ErrTimeout        = errors.New("agent: timeout")
+	ErrBinaryNotFound = errors.New("agent: binary not found")
+)
+
+// MakePayload marshals v to a json.RawMessage or panics. Helper for
+// adapters; payloads are constructed from typed Go values whose
+// shapes we control, so a marshal failure is a programmer error.
+func MakePayload(v any) json.RawMessage {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic("agent: payload marshal: " + err.Error())
+	}
+	return b
+}

--- a/runner/internal/agent/agent_test.go
+++ b/runner/internal/agent/agent_test.go
@@ -1,0 +1,50 @@
+package agent
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+func TestMakePayload_RoundTrips(t *testing.T) {
+	p := MakePayload(map[string]any{"k": "v", "n": 7})
+	var got map[string]any
+	if err := json.Unmarshal(p, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got["k"] != "v" {
+		t.Errorf(`got["k"] = %v, want "v"`, got["k"])
+	}
+	// JSON numbers decode to float64; check via formatted equal.
+	if n, ok := got["n"].(float64); !ok || n != 7 {
+		t.Errorf(`got["n"] = %v, want 7`, got["n"])
+	}
+}
+
+func TestMakePayload_PanicsOnUnmarshalable(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic on unmarshalable input")
+		}
+	}()
+	// Channels can't be marshaled — any panic is fine.
+	MakePayload(make(chan int))
+}
+
+func TestErrors_AreDistinct(t *testing.T) {
+	pairs := []struct {
+		a, b error
+	}{
+		{ErrAgentFailed, ErrBudgetExceeded},
+		{ErrAgentFailed, ErrTimeout},
+		{ErrAgentFailed, ErrBinaryNotFound},
+		{ErrBudgetExceeded, ErrTimeout},
+		{ErrBudgetExceeded, ErrBinaryNotFound},
+		{ErrTimeout, ErrBinaryNotFound},
+	}
+	for _, p := range pairs {
+		if errors.Is(p.a, p.b) {
+			t.Errorf("errors.Is(%v, %v) = true, want false", p.a, p.b)
+		}
+	}
+}

--- a/runner/internal/agent/claudecode/claudecode.go
+++ b/runner/internal/agent/claudecode/claudecode.go
@@ -1,0 +1,305 @@
+// Package claudecode adapts Anthropic's Claude Code CLI to the
+// runner's agent.Invoker interface.
+//
+// In v0 the customer supplies the API key via GitHub Secrets
+// (MVP_SPEC §5.3); the runner forwards it as the
+// ANTHROPIC_API_KEY env var on the child. Centralized issuance
+// (Fishhawk-managed ephemeral keys) is a v0.x story, not v0.
+//
+// The adapter spawns `claude --print --output-format stream-json -p
+// <prompt>` and reads one JSON event per line from stdout. Each
+// line becomes an agent.Event; if the line carries a `usage` block
+// we update the running token total and enforce the budget. A
+// non-zero exit, a context cancellation, or a budget breach all map
+// to MVP_SPEC §6 category-A failures — never silent successes.
+package claudecode
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/kuhlman-labs/fishhawk/runner/internal/agent"
+)
+
+// DefaultBinary is the executable name resolved against PATH when
+// Invoker.Binary is empty.
+const DefaultBinary = "claude"
+
+// Invoker is the agent.Invoker implementation for Claude Code.
+type Invoker struct {
+	// Binary is the executable name or absolute path. Empty means
+	// DefaultBinary.
+	Binary string
+
+	// APIKey is forwarded as ANTHROPIC_API_KEY to the child. Empty
+	// means the runner did not receive a key and the child is
+	// expected to fail; that's reported as a category-A failure
+	// like any other agent error rather than crashing the runner.
+	APIKey string
+
+	// Cmd builds the *exec.Cmd. Defaults to exec.CommandContext;
+	// overridable by tests to redirect to a fake binary.
+	Cmd func(ctx context.Context, name string, args ...string) *exec.Cmd
+
+	// Now returns the current time. Defaults to time.Now;
+	// overridable for deterministic event timestamps in tests.
+	Now func() time.Time
+}
+
+// New returns an Invoker configured to use the system `claude`
+// binary with the given API key.
+func New(apiKey string) *Invoker {
+	return &Invoker{APIKey: apiKey}
+}
+
+// Invoke runs Claude Code under the given Invocation and returns
+// the captured trace. The returned error is non-nil only on agent
+// failure — Result.OK is the canonical success signal so callers
+// can treat the Result as the source of truth even on error.
+func (i *Invoker) Invoke(ctx context.Context, inv agent.Invocation) (agent.Result, error) {
+	binary := i.Binary
+	if binary == "" {
+		binary = DefaultBinary
+	}
+	cmdFn := i.Cmd
+	if cmdFn == nil {
+		cmdFn = exec.CommandContext
+	}
+	now := i.now
+
+	if inv.Budget.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, inv.Budget.Timeout)
+		defer cancel()
+	}
+
+	res := agent.Result{
+		Events: []agent.Event{
+			{
+				Kind:      "invocation_start",
+				Timestamp: now(),
+				Payload: agent.MakePayload(map[string]string{
+					"agent":  "claude-code",
+					"run_id": inv.RunID,
+					"stage":  inv.Stage,
+				}),
+			},
+		},
+	}
+
+	args := []string{"--print", "--output-format", "stream-json", "-p", inv.Prompt}
+	cmd := cmdFn(ctx, binary, args...)
+	cmd.Dir = inv.WorkingDir
+	// Compose env so a Cmd builder (e.g. tests) can pre-set
+	// vars on cmd.Env and we layer the API key on top. nil means
+	// "child will inherit our env", so seed with os.Environ() in
+	// that case to keep PATH, HOME, etc. for the agent process.
+	if cmd.Env == nil {
+		cmd.Env = os.Environ()
+	}
+	if i.APIKey != "" {
+		cmd.Env = append(cmd.Env, "ANTHROPIC_API_KEY="+i.APIKey)
+	}
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return res, fmt.Errorf("claudecode: stdout pipe: %w", err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return res, fmt.Errorf("claudecode: stderr pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		// Distinguish "binary missing" from other start errors so
+		// callers can surface a precise error to the operator.
+		if isBinaryMissing(err) {
+			return failureResult(res, now(), "A",
+				fmt.Sprintf("agent binary not found: %s", binary),
+				"binary_not_found",
+			), agent.ErrBinaryNotFound
+		}
+		return res, fmt.Errorf("claudecode: start: %w", err)
+	}
+
+	// Drain stderr concurrently to avoid deadlock if the child
+	// writes more than the pipe buffer can hold.
+	var stderrBuf bytes.Buffer
+	stderrDone := make(chan struct{})
+	go func() {
+		defer close(stderrDone)
+		_, _ = io.Copy(&stderrBuf, stderr)
+	}()
+
+	tokensUsed := 0
+	budgetHit := false
+
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := append([]byte(nil), scanner.Bytes()...)
+		ev, used, ok := parseLine(line, now())
+		res.Events = append(res.Events, ev)
+		if ok && used > 0 {
+			tokensUsed = used
+			if inv.Budget.MaxTokens > 0 && tokensUsed > inv.Budget.MaxTokens {
+				budgetHit = true
+				_ = cmd.Process.Kill()
+				break
+			}
+		}
+	}
+	scanErr := scanner.Err()
+
+	// Drain remaining stdout if we killed mid-stream.
+	_, _ = io.Copy(io.Discard, stdout)
+	<-stderrDone
+
+	if stderrBuf.Len() > 0 {
+		res.Events = append(res.Events, agent.Event{
+			Kind:      "stderr",
+			Timestamp: now(),
+			Payload: agent.MakePayload(map[string]string{
+				"text": stderrBuf.String(),
+			}),
+		})
+	}
+
+	waitErr := cmd.Wait()
+	res.TokensUsed = tokensUsed
+
+	switch {
+	case budgetHit:
+		return failureResult(res, now(), "A",
+			fmt.Sprintf("token budget exceeded: used %d, max %d", tokensUsed, inv.Budget.MaxTokens),
+			"budget_exceeded",
+		), agent.ErrBudgetExceeded
+
+	case errors.Is(ctx.Err(), context.DeadlineExceeded):
+		return failureResult(res, now(), "A",
+			fmt.Sprintf("agent timeout after %s", inv.Budget.Timeout),
+			"timeout",
+		), agent.ErrTimeout
+
+	case waitErr != nil:
+		return failureResult(res, now(), "A",
+			fmt.Sprintf("agent exited with error: %v", waitErr),
+			"agent_error",
+		), fmt.Errorf("%w: %v", agent.ErrAgentFailed, waitErr)
+
+	case scanErr != nil:
+		return failureResult(res, now(), "A",
+			fmt.Sprintf("trace stream read error: %v", scanErr),
+			"stream_error",
+		), fmt.Errorf("%w: %v", agent.ErrAgentFailed, scanErr)
+	}
+
+	res.OK = true
+	res.Events = append(res.Events, agent.Event{
+		Kind:      "invocation_end",
+		Timestamp: now(),
+		Payload:   agent.MakePayload(map[string]any{"outcome": "ok", "tokens_used": tokensUsed}),
+	})
+	return res, nil
+}
+
+func (i *Invoker) now() time.Time {
+	if i.Now != nil {
+		return i.Now()
+	}
+	return time.Now().UTC()
+}
+
+// failureResult appends an invocation_end with the failure metadata
+// and stamps the top-level failure fields. Centralized so every
+// failure path produces the same shape.
+func failureResult(res agent.Result, ts time.Time, category, reason, outcome string) agent.Result {
+	res.OK = false
+	res.FailureCategory = category
+	res.FailureReason = reason
+	res.Events = append(res.Events, agent.Event{
+		Kind:      "invocation_end",
+		Timestamp: ts,
+		Payload: agent.MakePayload(map[string]string{
+			"outcome": outcome,
+			"reason":  reason,
+		}),
+	})
+	return res
+}
+
+// parseLine turns one JSON line from Claude Code's stream-json
+// output into an agent.Event. The kind is taken from the line's
+// `type` field when present; unknown / non-JSON lines become
+// kind=raw so we never silently drop trace bytes.
+//
+// Returns (event, tokensUsed, hasUsage). hasUsage is true when the
+// line carried a `usage.input_tokens` + `usage.output_tokens`
+// block we could parse; tokensUsed is the SUM of those two.
+func parseLine(line []byte, ts time.Time) (agent.Event, int, bool) {
+	trimmed := bytes.TrimSpace(line)
+	if len(trimmed) == 0 {
+		return agent.Event{Kind: "raw", Timestamp: ts}, 0, false
+	}
+
+	// Probe the kind without unmarshaling the whole payload.
+	var meta struct {
+		Type    string `json:"type"`
+		Subtype string `json:"subtype"`
+		Usage   *struct {
+			InputTokens  int `json:"input_tokens"`
+			OutputTokens int `json:"output_tokens"`
+		} `json:"usage"`
+	}
+	if err := json.Unmarshal(trimmed, &meta); err != nil {
+		// Non-JSON line — capture verbatim so the trace is still
+		// honest about what the child wrote.
+		return agent.Event{
+			Kind:      "raw",
+			Timestamp: ts,
+			Payload:   agent.MakePayload(map[string]string{"text": string(trimmed)}),
+		}, 0, false
+	}
+
+	kind := meta.Type
+	if kind == "" {
+		kind = "raw"
+	} else if meta.Subtype != "" {
+		kind = kind + "." + meta.Subtype
+	}
+
+	used := 0
+	hasUsage := false
+	if meta.Usage != nil {
+		used = meta.Usage.InputTokens + meta.Usage.OutputTokens
+		hasUsage = used > 0
+	}
+
+	return agent.Event{
+		Kind:      kind,
+		Timestamp: ts,
+		Payload:   json.RawMessage(trimmed),
+	}, used, hasUsage
+}
+
+// isBinaryMissing reports whether err means the binary itself is
+// not on disk / not on PATH, as opposed to a runtime failure.
+// exec.ErrNotFound is the canonical case but the underlying syscall
+// error message varies by platform; matching the substring is a
+// pragmatic fallback.
+func isBinaryMissing(err error) bool {
+	if errors.Is(err, exec.ErrNotFound) {
+		return true
+	}
+	return strings.Contains(err.Error(), "executable file not found") ||
+		strings.Contains(err.Error(), "no such file or directory")
+}

--- a/runner/internal/agent/claudecode/claudecode_test.go
+++ b/runner/internal/agent/claudecode/claudecode_test.go
@@ -1,0 +1,296 @@
+package claudecode
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kuhlman-labs/fishhawk/runner/internal/agent"
+)
+
+// TestHelperProcess is the test-helper-process pattern from the Go
+// stdlib: when invoked with GO_HELPER_PROCESS=1 set in env, this
+// test pretends to be a `claude` binary and emits a canned
+// stream-json transcript driven by additional env vars. The real
+// tests then run the test binary itself with these env vars in
+// place of the missing claude binary.
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_HELPER_PROCESS") != "1" {
+		return
+	}
+	defer os.Exit(0)
+
+	switch os.Getenv("HELPER_MODE") {
+	case "happy":
+		// Three event lines, last one carries usage so the
+		// harness can populate Result.TokensUsed.
+		fmt.Println(`{"type":"system","subtype":"init"}`)
+		fmt.Println(`{"type":"assistant","content":"hello"}`)
+		fmt.Println(`{"type":"result","usage":{"input_tokens":42,"output_tokens":58}}`)
+	case "budget":
+		// Each line reports cumulative usage; the third trips a
+		// caller-set 100-token budget.
+		fmt.Println(`{"type":"system","subtype":"init"}`)
+		fmt.Println(`{"type":"assistant","usage":{"input_tokens":40,"output_tokens":40}}`)
+		fmt.Println(`{"type":"assistant","usage":{"input_tokens":80,"output_tokens":80}}`)
+		// Sleep to allow the harness time to kill us; if we exit
+		// cleanly the test still validates that budget was hit.
+		time.Sleep(200 * time.Millisecond)
+	case "error":
+		fmt.Println(`{"type":"system","subtype":"init"}`)
+		fmt.Fprintln(os.Stderr, "agent: model rate-limited")
+		os.Exit(1)
+	case "raw_line":
+		// Non-JSON output should not crash the harness; it must
+		// still appear in the trace as kind=raw.
+		fmt.Println(`not even close to JSON`)
+		fmt.Println(`{"type":"result","usage":{"input_tokens":1,"output_tokens":1}}`)
+	case "timeout":
+		// Sleep longer than the test's configured timeout.
+		time.Sleep(2 * time.Second)
+	case "echo_env":
+		// Echo a single env var so we can assert the harness
+		// wired API key forwarding correctly.
+		fmt.Printf(`{"type":"env","key":"ANTHROPIC_API_KEY","value":%q}`+"\n",
+			os.Getenv("ANTHROPIC_API_KEY"))
+		fmt.Println(`{"type":"result","usage":{"input_tokens":1,"output_tokens":1}}`)
+	default:
+		fmt.Fprintln(os.Stderr, "unknown HELPER_MODE")
+		os.Exit(2)
+	}
+}
+
+// helperCommand returns a Cmd-builder that re-execs the test
+// binary as the `claude` stand-in, passing through HELPER_MODE.
+func helperCommand(mode string) func(ctx context.Context, name string, args ...string) *exec.Cmd {
+	return func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+		c := exec.CommandContext(ctx, os.Args[0], "-test.run=TestHelperProcess")
+		c.Env = append(os.Environ(),
+			"GO_HELPER_PROCESS=1",
+			"HELPER_MODE="+mode,
+		)
+		return c
+	}
+}
+
+// frozenNow returns a Now() that ticks deterministically so tests
+// can assert event ordering without fighting wall-clock jitter.
+func frozenNow() func() time.Time {
+	t := time.Date(2026, 5, 2, 9, 30, 0, 0, time.UTC)
+	return func() time.Time {
+		t = t.Add(time.Millisecond)
+		return t
+	}
+}
+
+func TestInvoke_HappyPath(t *testing.T) {
+	inv := &Invoker{
+		Cmd: helperCommand("happy"),
+		Now: frozenNow(),
+	}
+	res, err := inv.Invoke(context.Background(), agent.Invocation{
+		RunID:  "11111111-2222-3333-4444-555555555555",
+		Stage:  "plan",
+		Prompt: "do the thing",
+	})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if !res.OK {
+		t.Errorf("OK = false; FailureReason = %q", res.FailureReason)
+	}
+	if res.TokensUsed != 100 {
+		t.Errorf("TokensUsed = %d, want 100", res.TokensUsed)
+	}
+	// invocation_start, system.init, assistant, result, invocation_end → 5
+	if got, want := len(res.Events), 5; got != want {
+		t.Fatalf("Events = %d, want %d:\n%+v", got, want, res.Events)
+	}
+	if res.Events[0].Kind != "invocation_start" {
+		t.Errorf("Events[0].Kind = %q, want invocation_start", res.Events[0].Kind)
+	}
+	if res.Events[1].Kind != "system.init" {
+		t.Errorf("Events[1].Kind = %q, want system.init", res.Events[1].Kind)
+	}
+	if res.Events[len(res.Events)-1].Kind != "invocation_end" {
+		t.Errorf("last event kind = %q, want invocation_end", res.Events[len(res.Events)-1].Kind)
+	}
+}
+
+func TestInvoke_BudgetExceeded(t *testing.T) {
+	inv := &Invoker{
+		Cmd: helperCommand("budget"),
+		Now: frozenNow(),
+	}
+	res, err := inv.Invoke(context.Background(), agent.Invocation{
+		Budget: agent.Budget{MaxTokens: 100},
+	})
+	if !errors.Is(err, agent.ErrBudgetExceeded) {
+		t.Fatalf("err = %v, want ErrBudgetExceeded", err)
+	}
+	if res.OK {
+		t.Error("OK = true on budget exceeded")
+	}
+	if res.FailureCategory != "A" {
+		t.Errorf("FailureCategory = %q, want A", res.FailureCategory)
+	}
+	if !strings.Contains(res.FailureReason, "budget exceeded") {
+		t.Errorf("FailureReason = %q", res.FailureReason)
+	}
+	if res.TokensUsed < 100 {
+		t.Errorf("TokensUsed = %d, want >= 100", res.TokensUsed)
+	}
+}
+
+func TestInvoke_AgentError(t *testing.T) {
+	inv := &Invoker{
+		Cmd: helperCommand("error"),
+		Now: frozenNow(),
+	}
+	res, err := inv.Invoke(context.Background(), agent.Invocation{})
+	if !errors.Is(err, agent.ErrAgentFailed) {
+		t.Fatalf("err = %v, want wrapping ErrAgentFailed", err)
+	}
+	if res.OK {
+		t.Error("OK = true on agent error")
+	}
+	if res.FailureCategory != "A" {
+		t.Errorf("FailureCategory = %q, want A", res.FailureCategory)
+	}
+	// stderr from the helper must surface as a kind=stderr event.
+	var sawStderr bool
+	for _, ev := range res.Events {
+		if ev.Kind == "stderr" {
+			sawStderr = true
+			if !strings.Contains(string(ev.Payload), "rate-limited") {
+				t.Errorf("stderr event payload missing message: %s", ev.Payload)
+			}
+		}
+	}
+	if !sawStderr {
+		t.Error("no kind=stderr event captured")
+	}
+}
+
+func TestInvoke_RawLine(t *testing.T) {
+	inv := &Invoker{
+		Cmd: helperCommand("raw_line"),
+		Now: frozenNow(),
+	}
+	res, err := inv.Invoke(context.Background(), agent.Invocation{})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	var sawRaw bool
+	for _, ev := range res.Events {
+		if ev.Kind == "raw" {
+			sawRaw = true
+			if !strings.Contains(string(ev.Payload), "not even close") {
+				t.Errorf("raw event payload missing text: %s", ev.Payload)
+			}
+		}
+	}
+	if !sawRaw {
+		t.Error("no kind=raw event captured")
+	}
+}
+
+func TestInvoke_Timeout(t *testing.T) {
+	inv := &Invoker{
+		Cmd: helperCommand("timeout"),
+		Now: frozenNow(),
+	}
+	res, err := inv.Invoke(context.Background(), agent.Invocation{
+		Budget: agent.Budget{Timeout: 100 * time.Millisecond},
+	})
+	if !errors.Is(err, agent.ErrTimeout) {
+		t.Fatalf("err = %v, want ErrTimeout", err)
+	}
+	if res.OK {
+		t.Error("OK = true on timeout")
+	}
+	if res.FailureCategory != "A" {
+		t.Errorf("FailureCategory = %q, want A", res.FailureCategory)
+	}
+}
+
+func TestInvoke_BinaryNotFound(t *testing.T) {
+	inv := &Invoker{
+		Binary: "/no/such/binary/anywhere",
+		Now:    frozenNow(),
+	}
+	res, err := inv.Invoke(context.Background(), agent.Invocation{})
+	if !errors.Is(err, agent.ErrBinaryNotFound) {
+		t.Fatalf("err = %v, want ErrBinaryNotFound", err)
+	}
+	if res.OK {
+		t.Error("OK = true on missing binary")
+	}
+	if res.FailureCategory != "A" {
+		t.Errorf("FailureCategory = %q, want A", res.FailureCategory)
+	}
+}
+
+func TestInvoke_ForwardsAPIKey(t *testing.T) {
+	inv := &Invoker{
+		APIKey: "sk-test-1234",
+		Cmd:    helperCommand("echo_env"),
+		Now:    frozenNow(),
+	}
+	res, err := inv.Invoke(context.Background(), agent.Invocation{})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if !res.OK {
+		t.Fatalf("OK = false: %s", res.FailureReason)
+	}
+	var found bool
+	for _, ev := range res.Events {
+		if ev.Kind != "env" {
+			continue
+		}
+		found = true
+		if !strings.Contains(string(ev.Payload), "sk-test-1234") {
+			t.Errorf("env event missing API key value: %s", ev.Payload)
+		}
+	}
+	if !found {
+		t.Error("no kind=env event captured")
+	}
+}
+
+func TestInvoke_StartsWithInvocationStart(t *testing.T) {
+	// Run a no-op helper just to assert event-shape invariants the
+	// other tests would also catch but make implicit.
+	inv := &Invoker{Cmd: helperCommand("happy"), Now: frozenNow()}
+	res, _ := inv.Invoke(context.Background(), agent.Invocation{
+		RunID: "rid", Stage: "plan",
+	})
+	if len(res.Events) == 0 {
+		t.Fatal("no events captured")
+	}
+	first := res.Events[0]
+	if first.Kind != "invocation_start" {
+		t.Errorf("first event kind = %q, want invocation_start", first.Kind)
+	}
+	if !strings.Contains(string(first.Payload), `"run_id":"rid"`) {
+		t.Errorf("invocation_start payload missing run_id: %s", first.Payload)
+	}
+}
+
+func TestNew_DefaultsBinary(t *testing.T) {
+	// Ensures the public constructor doesn't accidentally hard-code
+	// a different default than DefaultBinary.
+	inv := New("k")
+	if inv.Binary != "" {
+		t.Errorf("Binary = %q, want empty (resolved at Invoke time)", inv.Binary)
+	}
+	if inv.APIKey != "k" {
+		t.Errorf("APIKey = %q, want k", inv.APIKey)
+	}
+}


### PR DESCRIPTION
## Summary

Wires the runner's agent invocation layer — the keystone for the Day 21 self-execution milestone. With this in, the runner can actually invoke Claude Code, capture its trace, and surface failure modes in the shape MVP_SPEC §6 requires.

- `runner/internal/agent/` — agent-agnostic abstraction (`Invoker`, `Invocation`, `Budget`, `Result`, `Event`, errors). v1+ pluggability for Cursor, Copilot, etc. comes for free.
- `runner/internal/agent/claudecode/` — Claude Code adapter. Spawns `claude --print --output-format stream-json -p <prompt>`, parses one JSON event per output line, honors timeout + token budget, treats every failure as a category-A failure per MVP_SPEC §6.
- `runner/cmd/fishhawk-runner/` — new flags `--prompt-file`, `--working-dir`, `--max-tokens`, `--timeout`. Without `--prompt-file` the runner still no-ops (preserves the v0.1 dispatch-path probe). With it, the runner invokes Claude Code and emits the trace as JSON Lines on stdout. E5.3 / #30 will replace stdout JSONL with the bundled `*.jsonl.gz` format; E5.6 / #32 with signed upload.
- `action.yml` — new optional inputs (`prompt-file`, `working-dir`, `max-tokens`, `timeout`, `anthropic-api-key`). The API key forwards as `ANTHROPIC_API_KEY` to the child; per MVP_SPEC §5.3 customers populate it from their GitHub Secrets in v0.

## Test plan

- [x] `go test -race ./runner/...` — all 4 packages pass
- [x] `golangci-lint run ./runner/...` — 0 issues
- [x] `python3 scripts/check-coverage.py --threshold 80 --exclude '/db/'` — 86.2% aggregate (was 86.x before this PR)
- [x] Per-package coverage: `internal/agent` 100%, `internal/agent/claudecode` 91.3%, `cmd/fishhawk-runner` 94.2%
- [x] CI passes on all jobs

## Notes

**Test approach.** The Claude Code adapter is tested via the standard Go test-helper-process pattern: a `TestHelperProcess` function in `claudecode_test.go` re-execs the test binary as a stand-in for `claude`, driven by an env var that selects which canned transcript to emit. No dependency on a real `claude` binary on the build machine, full control over edge cases (budget, timeout, agent error, malformed line, missing binary, API key forwarding).

**One subtle bug surfaced and fixed during development.** The Invoker initially overwrote `cmd.Env` instead of appending, which clobbered the test helper's `GO_HELPER_PROCESS` / `HELPER_MODE` env vars. The fix: only seed `cmd.Env` from `os.Environ()` when the Cmd builder hasn't already set it, then append the API key. This also gives production a clean compose model where future Cmd builders (e.g. for sandboxed execution) can pre-set the env without the Invoker fighting them.

**Failure handling.** Every non-OK path produces a Result with `OK: false`, `FailureCategory: "A"`, a precise `FailureReason`, and an `invocation_end` event. Callers can switch on `agent.ErrTimeout` / `ErrBudgetExceeded` / `ErrBinaryNotFound` / `ErrAgentFailed` via `errors.Is`. The runner's `runner_completed` stderr line carries an `err_class` field that maps these onto stable short labels for log scrapers.

**What's deferred.** Concrete trace bundling (E5.3) takes the captured `[]Event` and produces the signed `*.jsonl.gz` per ARCHITECTURE.md §5.3. Until then, stdout JSON Lines is the transport. Plan-artifact validation (E5.4), constraint enforcement (E5.5), signed upload (E5.6), and signed releases (E5.7) round out the runner per the E5 epic.

Closes #29
