### PR TITLE
Add trace bundle pack/unpack (E5.3)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -155,6 +155,7 @@ GitHub OAuth (E4.2 / #49) is the sign-in flow that mints the cookie session. App
 | Workflow spec grammar | `docs/spec/workflow-v0.md` + `docs/spec/workflow-v0.schema.json` |
 | Plan artifact structure | `docs/spec/plan-standard-v1.md` + `docs/spec/plan-standard-v1.schema.json` |
 | HTTP API contract (endpoints, auth, errors) | `docs/api/v0.openapi.yaml` (source of truth) + `docs/api/v0.md` (companion) |
+| Trace bundle wire format (`*.jsonl.gz`) | `runner/internal/bundle/bundle.go` (pack + open) — implements ADR-007 (#71) |
 | HTTP middleware order / context keys | `backend/internal/server/middleware.go` |
 | How a new Go module gets added | `CLAUDE.md` "Adding a Go module" |
 

--- a/runner/README.md
+++ b/runner/README.md
@@ -12,13 +12,13 @@ This directory is its own Go module (`github.com/kuhlman-labs/fishhawk/runner`) 
 - `cmd/fishhawk-runner/` — the binary entrypoint. Flag parsing in `flags.go`, dispatch in `main.go`.
 - `internal/agent/` — the agent abstraction (`Invoker`, `Invocation`, `Result`, `Event`).
 - `internal/agent/claudecode/` — adapter for Anthropic's Claude Code CLI.
+- `internal/bundle/` — `*.jsonl.gz` trace bundle pack/unpack per ADR-007 (#71).
 - `internal/version/` — build-version package; set via `-ldflags` at release time.
 
 ## Status
 
-E5.1 (#52) shipped the scaffold. E5.2 (#29) wires the Claude Code invocation harness: when `prompt-file` is supplied, the runner invokes Claude Code with `--print --output-format stream-json`, captures each event, and emits the trace as JSON Lines on stdout. Trace bundling and signed upload land later:
+E5.1 (#52) shipped the scaffold. E5.2 (#29) wired the Claude Code invocation harness. E5.3 (#30) added trace bundling: when `--prompt-file` and `--bundle-out` are supplied together, the runner invokes Claude Code, packs the captured events into the ADR-007 `*.jsonl.gz` format (manifest first, trailer last with content hash), and writes the gzipped bundle to disk. Without `--bundle-out` the runner falls back to JSONL on stdout for ad-hoc inspection. Signed upload lands in E5.6.
 
-- E5.3 (#30) — full trace capture + bundling (replaces stdout JSONL with `*.jsonl.gz` + manifest/trailer)
 - E5.4 (#31) — plan validation against `standard_v1` (reuses `backend/internal/plan`)
 - E5.5 (#53) — post-hoc constraint enforcement on stage output
 - E5.6 (#32) — signed trace shipping to backend (uses `backend/internal/signing` + `backend/internal/tracestore`)
@@ -36,6 +36,7 @@ E5.1 (#52) shipped the scaffold. E5.2 (#29) wires the Claude Code invocation har
 | `working-dir` | no | Agent working directory; defaults to the runner's CWD. |
 | `max-tokens` | no | Hard cap on agent tokens (input + output); 0 means no cap. |
 | `timeout` | no | Wall-clock cap on the agent invocation, e.g. `15m`. Default 15m. |
+| `bundle-out` | no | Path to write the gzipped trace bundle. When set the runner produces an ADR-007 `*.jsonl.gz` artifact instead of JSONL on stdout. |
 
 The Claude Code API key is supplied via the `ANTHROPIC_API_KEY` environment variable, which customers populate from their GitHub Secrets. v0.x will replace this with a Fishhawk-issued ephemeral key (MVP_SPEC §5.3).
 
@@ -62,7 +63,7 @@ The same binary the action runs can be invoked locally for development:
       --workflow feature_change \
       --stage plan
 
-    # With the Claude Code harness (E5.2+)
+    # With the Claude Code harness (E5.2+) and bundled output (E5.3+)
     echo "Summarize the README" > /tmp/prompt.txt
     ANTHROPIC_API_KEY=sk-... go run ./cmd/fishhawk-runner \
       --run-id 11111111-2222-3333-4444-555555555555 \
@@ -71,9 +72,13 @@ The same binary the action runs can be invoked locally for development:
       --stage plan \
       --prompt-file /tmp/prompt.txt \
       --max-tokens 50000 \
-      --timeout 5m
+      --timeout 5m \
+      --bundle-out /tmp/trace.jsonl.gz
 
-When `--prompt-file` is set the runner emits one JSON event per stdout line; the structured runner log lines (`runner_started`, `runner_completed`) go to stderr.
+    # Inspect the bundle: manifest first, trailer last (with content hash).
+    gunzip -c /tmp/trace.jsonl.gz | jq -c .
+
+When `--prompt-file` is set the runner invokes Claude Code; the structured runner log lines (`runner_started`, `runner_completed`) go to stderr. With `--bundle-out`, captured events are packed into `*.jsonl.gz` per ADR-007. Without it, events fall back to JSONL on stdout.
 
 ## See also
 

--- a/runner/action.yml
+++ b/runner/action.yml
@@ -51,6 +51,10 @@ inputs:
     description: 'API key forwarded to Claude Code as ANTHROPIC_API_KEY. Customers populate this from a GitHub Secret.'
     required: false
     default: ''
+  bundle-out:
+    description: 'Path to write the gzipped trace bundle (ADR-007 *.jsonl.gz). When unset, events go to stdout as JSONL.'
+    required: false
+    default: ''
 
 runs:
   using: 'composite'
@@ -75,4 +79,5 @@ runs:
           --prompt-file "${{ inputs.prompt-file }}" \
           --working-dir "${{ inputs.working-dir }}" \
           --max-tokens "${{ inputs.max-tokens }}" \
-          --timeout "${{ inputs.timeout }}"
+          --timeout "${{ inputs.timeout }}" \
+          --bundle-out "${{ inputs.bundle-out }}"

--- a/runner/cmd/fishhawk-runner/flags.go
+++ b/runner/cmd/fishhawk-runner/flags.go
@@ -27,6 +27,7 @@ type config struct {
 	workingDir string
 	maxTokens  int
 	timeout    time.Duration
+	bundleOut  string
 }
 
 // parseFlags reads args and populates a config. Returns a usage
@@ -55,6 +56,8 @@ func parseFlags(args []string, w io.Writer) (config, error) {
 		"hard cap on agent tokens (input + output); 0 means no cap")
 	fs.DurationVar(&cfg.timeout, "timeout", 15*time.Minute,
 		"wall-clock cap on agent invocation")
+	fs.StringVar(&cfg.bundleOut, "bundle-out", "",
+		"path to write the gzipped trace bundle (ADR-007); when empty, events go to stdout as JSONL")
 
 	if err := fs.Parse(args); err != nil {
 		return cfg, err

--- a/runner/cmd/fishhawk-runner/main.go
+++ b/runner/cmd/fishhawk-runner/main.go
@@ -1,11 +1,12 @@
 // Command fishhawk-runner runs an agent under a Fishhawk workflow
 // stage and ships the trace.
 //
-// E5.1 (#52) shipped the scaffold. E5.2 (#29) wires the Claude Code
-// invocation harness: when --prompt-file is supplied, the runner
-// invokes Claude Code, captures the trace, and emits it as JSON
-// Lines on stdout. Trace bundling (E5.3 / #30) and shipping to the
-// backend (E5.6 / #32) replace the stdout emission later.
+// E5.1 (#52) shipped the scaffold. E5.2 (#29) wired the Claude Code
+// invocation harness. E5.3 (#30) added trace bundling: when
+// --prompt-file and --bundle-out are supplied together, the runner
+// invokes the agent, packs the captured events into the *.jsonl.gz
+// wire format from ADR-007, and writes the bundle to disk. Signed
+// upload to the backend lands in E5.6 (#32).
 //
 // Without --prompt-file the binary parses its inputs, prints a
 // single startup log line, and exits 0. Customers pinning
@@ -23,6 +24,7 @@ import (
 
 	"github.com/kuhlman-labs/fishhawk/runner/internal/agent"
 	"github.com/kuhlman-labs/fishhawk/runner/internal/agent/claudecode"
+	"github.com/kuhlman-labs/fishhawk/runner/internal/bundle"
 )
 
 const (
@@ -86,13 +88,51 @@ func run(args []string, logSink io.Writer) int {
 	invoker := newInvoker(os.Getenv("ANTHROPIC_API_KEY"))
 	res, invokeErr := invoker.Invoke(context.Background(), inv)
 
-	emitEvents(os.Stdout, res.Events)
+	if cfg.bundleOut != "" {
+		if err := writeBundle(cfg, res); err != nil {
+			_, _ = fmt.Fprintf(logSink,
+				`{"event":"runner_failed","reason":"bundle_write","detail":%q}`+"\n", err.Error())
+			logCompletion(logSink, res, invokeErr)
+			return exitFailure
+		}
+	} else {
+		// No bundle path configured — fall back to JSONL on stdout
+		// so callers exercising --prompt-file alone can still
+		// inspect the captured trace. E5.6 will replace this with
+		// signed upload to the backend.
+		emitEvents(os.Stdout, res.Events)
+	}
+
 	logCompletion(logSink, res, invokeErr)
 
 	if !res.OK {
 		return exitFailure
 	}
 	return exitOK
+}
+
+// writeBundle packs the captured events into the ADR-007 wire
+// format and writes the gzipped bytes to cfg.bundleOut. Returns the
+// storage hash via a side channel — for now we just log it in
+// logCompletion when a bundle was written; E5.6 will hand it to the
+// signing layer + backend upload.
+func writeBundle(cfg config, res agent.Result) error {
+	data, _, err := bundle.PackBytes(bundle.PackInputs{
+		RunID:   cfg.runID,
+		StageID: cfg.stage, // stage UUID not yet plumbed; v0.x replaces with cfg.stageID
+		Agent:   "claude-code",
+	}, res.Events)
+	if err != nil {
+		return fmt.Errorf("pack: %w", err)
+	}
+	// 0o600 — bundle may carry redacted credentials in raw events
+	// until E2.4 redaction is wired upstream of the bundler. The
+	// runner's filesystem is ephemeral, but defense in depth is
+	// cheap.
+	if err := os.WriteFile(cfg.bundleOut, data, 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", cfg.bundleOut, err)
+	}
+	return nil
 }
 
 func logStartup(w io.Writer, cfg config) {

--- a/runner/cmd/fishhawk-runner/main_test.go
+++ b/runner/cmd/fishhawk-runner/main_test.go
@@ -13,7 +13,17 @@ import (
 	"testing"
 
 	"github.com/kuhlman-labs/fishhawk/runner/internal/agent"
+	"github.com/kuhlman-labs/fishhawk/runner/internal/bundle"
 )
+
+// openBundleForTest is a thin wrapper around bundle.Open so the
+// table-driven test reads cleanly. We round-trip in tests because
+// the runner is the producer; the canonical verifier path lives in
+// /verifier (and it intentionally re-implements bundle parsing
+// rather than importing this code, per ADR-008's no-trust model).
+func openBundleForTest(data []byte) (bundle.ManifestData, []bundle.Line, bundle.TrailerData, error) {
+	return bundle.Open(bytes.NewReader(data))
+}
 
 // fakeInvoker lets tests drive run() without spawning a child
 // process. Returning (canned, returnErr) keeps the seam tiny.
@@ -303,6 +313,96 @@ func TestRun_AgentFailureMapsToExit1(t *testing.T) {
 	}
 	if !strings.Contains(out, `"err_class":"timeout"`) {
 		t.Errorf("missing err_class timeout: %s", out)
+	}
+}
+
+func TestRun_PromptWithBundleOut_WritesGzipFile(t *testing.T) {
+	dir := t.TempDir()
+	promptPath := filepath.Join(dir, "prompt.txt")
+	bundlePath := filepath.Join(dir, "trace.jsonl.gz")
+	if err := os.WriteFile(promptPath, []byte("p"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	fake := &fakeInvoker{
+		canned: agent.Result{
+			OK:         true,
+			TokensUsed: 7,
+			Events: []agent.Event{
+				{Kind: "system.init", Payload: agent.MakePayload(map[string]string{"a": "b"})},
+				{Kind: "result", Payload: agent.MakePayload(map[string]int{"n": 1})},
+			},
+		},
+	}
+	withFakeInvoker(t, fake)
+
+	var stderr strings.Builder
+	got := run([]string{
+		"--run-id", "11111111-2222-3333-4444-555555555555",
+		"--backend-url", "https://api.fishhawk.test",
+		"--workflow", "feature_change",
+		"--stage", "plan",
+		"--prompt-file", promptPath,
+		"--bundle-out", bundlePath,
+	}, &stderr)
+	if got != exitOK {
+		t.Fatalf("run = %d, want %d:\n%s", got, exitOK, stderr.String())
+	}
+	info, err := os.Stat(bundlePath)
+	if err != nil {
+		t.Fatalf("bundle not written: %v", err)
+	}
+	if info.Size() == 0 {
+		t.Fatal("bundle is empty")
+	}
+
+	// Sanity-check that the file is a valid bundle. We import
+	// internal/bundle here just to round-trip-verify; in
+	// production the backend re-implements verification under
+	// the audit-grade no-trust constraint (see verifier/).
+	data, err := os.ReadFile(bundlePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest, events, trailer, err := openBundleForTest(data)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if manifest.RunID != "11111111-2222-3333-4444-555555555555" {
+		t.Errorf("manifest RunID = %q", manifest.RunID)
+	}
+	if len(events) != 2 {
+		t.Errorf("events = %d, want 2", len(events))
+	}
+	if trailer.EventCount != 2 {
+		t.Errorf("trailer EventCount = %d, want 2", trailer.EventCount)
+	}
+}
+
+func TestRun_BundleWriteFailureSurfacesAsExitFailure(t *testing.T) {
+	dir := t.TempDir()
+	promptPath := filepath.Join(dir, "prompt.txt")
+	if err := os.WriteFile(promptPath, []byte("p"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	withFakeInvoker(t, &fakeInvoker{canned: agent.Result{OK: true}})
+
+	var stderr strings.Builder
+	got := run([]string{
+		"--run-id", "rid",
+		"--backend-url", "https://x",
+		"--workflow", "w",
+		"--stage", "s",
+		"--prompt-file", promptPath,
+		// Path under a non-existent parent directory.
+		"--bundle-out", filepath.Join(dir, "no-such-subdir", "trace.jsonl.gz"),
+	}, &stderr)
+	if got != exitFailure {
+		t.Errorf("run = %d, want %d", got, exitFailure)
+	}
+	if !strings.Contains(stderr.String(), `"reason":"bundle_write"`) {
+		t.Errorf("missing bundle_write reason: %s", stderr.String())
 	}
 }
 

--- a/runner/internal/bundle/bundle.go
+++ b/runner/internal/bundle/bundle.go
@@ -1,0 +1,326 @@
+// Package bundle packages a runner's captured trace events into the
+// signed *.jsonl.gz wire format defined by ADR-007 (#71). The
+// resulting artifact is what the runner uploads to the backend's
+// `POST /v0/runs/{id}/trace` endpoint per docs/api/v0.openapi.yaml.
+//
+// Bundle layout (per ADR-007):
+//
+//   - One JSON object per line, UTF-8.
+//   - Each line: {seq, ts, kind, data}. seq is monotonic from 1.
+//   - First line: kind="manifest", data carries bundle_schema,
+//     run_id, stage_id, agent identity.
+//   - Middle lines: one per captured agent.Event.
+//   - Last line: kind="trailer", data carries event_count and a
+//     sha256 of all preceding lines (truncation detector).
+//   - The whole stream is gzipped at the default level (6).
+//
+// Storage / signing identity is the sha256 of the gzipped bytes
+// (ARCHITECTURE.md §5.2 layout `{run_id}/<variant>/<sha256>.jsonl.gz`).
+// That hash is computed by the caller from Pack's output.
+//
+// The trailer's content hash covers everything BEFORE the trailer
+// line. It's an integrity check that runs purely on the JSONL
+// payload and stays meaningful even if a downstream tool re-gzips
+// or strips compression.
+package bundle
+
+import (
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/kuhlman-labs/fishhawk/runner/internal/agent"
+)
+
+// SchemaV1 is the only supported bundle schema. v2+ stays additive
+// within v1; breaking changes bump the major.
+const SchemaV1 = "v1"
+
+// MaxBundleBytes caps the gzipped output size. v0 trace volumes are
+// already bounded by per-stage token budgets, so a hard ceiling
+// here just protects backend storage from a runaway agent.
+const MaxBundleBytes = 64 * 1024 * 1024 // 64 MiB
+
+// ManifestData is the payload of the first line of every bundle.
+// Fields align with ADR-007's manifest record.
+type ManifestData struct {
+	BundleSchema string    `json:"bundle_schema"`
+	RunID        string    `json:"run_id"`
+	StageID      string    `json:"stage_id"`
+	Agent        string    `json:"agent"`
+	Model        string    `json:"model,omitempty"`
+	GeneratedAt  time.Time `json:"generated_at"`
+}
+
+// TrailerData is the payload of the last line of every bundle. The
+// ContentHash covers all preceding lines' raw bytes (with
+// terminators) and is the floor on integrity inside the gzip layer.
+type TrailerData struct {
+	EventCount  int    `json:"event_count"`
+	ContentHash string `json:"content_hash"`
+}
+
+// Line is the on-the-wire envelope. Every JSONL line in a bundle
+// decodes to one of these regardless of kind.
+type Line struct {
+	Seq       int             `json:"seq"`
+	Timestamp time.Time       `json:"ts"`
+	Kind      string          `json:"kind"`
+	Data      json.RawMessage `json:"data,omitempty"`
+}
+
+// PackInputs collects the few non-event fields Pack needs. Keeping
+// this in a struct (rather than positional args) makes call sites
+// readable and lets us add fields without churning callers.
+type PackInputs struct {
+	RunID   string
+	StageID string
+	Agent   string // e.g. "claude-code"
+	Model   string // optional; "" omits the field
+
+	// Now returns the manifest's GeneratedAt timestamp. Default
+	// time.Now; overridable for deterministic tests.
+	Now func() time.Time
+}
+
+// Errors callers may want to switch on.
+var (
+	ErrEmptyRunID    = errors.New("bundle: RunID required")
+	ErrEmptyStageID  = errors.New("bundle: StageID required")
+	ErrEmptyAgent    = errors.New("bundle: Agent required")
+	ErrTooLarge      = errors.New("bundle: exceeds MaxBundleBytes")
+	ErrBadTrailer    = errors.New("bundle: trailer missing or malformed")
+	ErrHashMismatch  = errors.New("bundle: content hash does not match trailer")
+	ErrSchemaUnknown = errors.New("bundle: unsupported bundle schema")
+)
+
+// Pack writes a complete trace bundle to w: manifest, events,
+// trailer, all gzipped. Returns the number of bytes written
+// (gzipped) so callers can reason about size before uploading.
+//
+// Events appear in the order received; their Kind / Timestamp /
+// Payload feed straight into the wire envelope. agent.Event's
+// Kind="" defaults to "raw" so we don't emit empty-kind lines.
+func Pack(w io.Writer, in PackInputs, events []agent.Event) (int, error) {
+	if in.RunID == "" {
+		return 0, ErrEmptyRunID
+	}
+	if in.StageID == "" {
+		return 0, ErrEmptyStageID
+	}
+	if in.Agent == "" {
+		return 0, ErrEmptyAgent
+	}
+	now := in.Now
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+
+	// Build the raw JSONL stream first, then gzip into a counting
+	// writer. Hashing the pre-gzip bytes is required for the
+	// trailer; building in memory keeps the streaming code simple
+	// and the size cap enforceable.
+	var raw bytes.Buffer
+	manifestPayload, err := json.Marshal(ManifestData{
+		BundleSchema: SchemaV1,
+		RunID:        in.RunID,
+		StageID:      in.StageID,
+		Agent:        in.Agent,
+		Model:        in.Model,
+		GeneratedAt:  now(),
+	})
+	if err != nil {
+		return 0, fmt.Errorf("bundle: marshal manifest: %w", err)
+	}
+	if err := writeLine(&raw, Line{
+		Seq: 1, Timestamp: now(), Kind: "manifest",
+		Data: manifestPayload,
+	}); err != nil {
+		return 0, err
+	}
+
+	for i, ev := range events {
+		kind := ev.Kind
+		if kind == "" {
+			kind = "raw"
+		}
+		ts := ev.Timestamp
+		if ts.IsZero() {
+			ts = now()
+		}
+		if err := writeLine(&raw, Line{
+			Seq: i + 2, Timestamp: ts, Kind: kind, Data: ev.Payload,
+		}); err != nil {
+			return 0, err
+		}
+	}
+
+	// Hash everything written so far — the trailer's content hash
+	// covers all preceding lines verbatim.
+	contentHash := sha256.Sum256(raw.Bytes())
+
+	trailerPayload, err := json.Marshal(TrailerData{
+		EventCount:  len(events),
+		ContentHash: hex.EncodeToString(contentHash[:]),
+	})
+	if err != nil {
+		return 0, fmt.Errorf("bundle: marshal trailer: %w", err)
+	}
+	if err := writeLine(&raw, Line{
+		Seq: len(events) + 2, Timestamp: now(), Kind: "trailer",
+		Data: trailerPayload,
+	}); err != nil {
+		return 0, err
+	}
+
+	// Gzip in-memory so we can enforce the size cap before handing
+	// bytes to the caller's writer (which may be a network stream).
+	var gz bytes.Buffer
+	zw, err := gzip.NewWriterLevel(&gz, gzip.DefaultCompression)
+	if err != nil {
+		return 0, fmt.Errorf("bundle: gzip writer: %w", err)
+	}
+	if _, err := zw.Write(raw.Bytes()); err != nil {
+		return 0, fmt.Errorf("bundle: gzip write: %w", err)
+	}
+	if err := zw.Close(); err != nil {
+		return 0, fmt.Errorf("bundle: gzip close: %w", err)
+	}
+	if gz.Len() > MaxBundleBytes {
+		return 0, fmt.Errorf("%w: gzipped %d bytes > %d", ErrTooLarge, gz.Len(), MaxBundleBytes)
+	}
+	n, err := w.Write(gz.Bytes())
+	if err != nil {
+		return n, fmt.Errorf("bundle: write: %w", err)
+	}
+	return n, nil
+}
+
+// PackBytes is the convenience form: returns the gzipped bundle as
+// a byte slice plus the storage hash (sha256 of those bytes). The
+// storage hash is the upload key per ARCHITECTURE.md §5.2 and the
+// signing input the runner feeds to backend/internal/signing.
+func PackBytes(in PackInputs, events []agent.Event) (data []byte, storageHash string, err error) {
+	var buf bytes.Buffer
+	if _, err := Pack(&buf, in, events); err != nil {
+		return nil, "", err
+	}
+	sum := sha256.Sum256(buf.Bytes())
+	return buf.Bytes(), hex.EncodeToString(sum[:]), nil
+}
+
+// Open decompresses r and returns the parsed bundle: manifest,
+// trace lines (events between manifest and trailer), and the
+// trailer. It also re-computes the content hash and returns
+// ErrHashMismatch if the trailer's value disagrees, so callers
+// can rely on the bundle's integrity once Open returns nil error.
+//
+// Decoding stops on EOF or io.ErrUnexpectedEOF; partial bundles
+// produce ErrBadTrailer rather than silent success.
+func Open(r io.Reader) (manifest ManifestData, events []Line, trailer TrailerData, err error) {
+	zr, err := gzip.NewReader(r)
+	if err != nil {
+		return manifest, nil, trailer, fmt.Errorf("bundle: gzip reader: %w", err)
+	}
+	defer func() { _ = zr.Close() }()
+
+	raw, err := io.ReadAll(zr)
+	if err != nil {
+		return manifest, nil, trailer, fmt.Errorf("bundle: read: %w", err)
+	}
+
+	// Split on '\n' but keep terminators — the content hash covers
+	// each line's '\n' as written.
+	var lines []Line
+	var lineBytes [][]byte
+	start := 0
+	for i, b := range raw {
+		if b != '\n' {
+			continue
+		}
+		lineBytes = append(lineBytes, raw[start:i+1])
+		var ln Line
+		if err := json.Unmarshal(raw[start:i], &ln); err != nil {
+			return manifest, nil, trailer,
+				fmt.Errorf("bundle: parse line %d: %w", len(lines)+1, err)
+		}
+		lines = append(lines, ln)
+		start = i + 1
+	}
+
+	if len(lines) < 2 {
+		return manifest, nil, trailer, ErrBadTrailer
+	}
+
+	first := lines[0]
+	if first.Kind != "manifest" {
+		return manifest, nil, trailer,
+			fmt.Errorf("%w: first line kind=%q, want manifest", ErrBadTrailer, first.Kind)
+	}
+	if err := json.Unmarshal(first.Data, &manifest); err != nil {
+		return manifest, nil, trailer, fmt.Errorf("bundle: parse manifest: %w", err)
+	}
+	if manifest.BundleSchema != SchemaV1 {
+		return manifest, nil, trailer,
+			fmt.Errorf("%w: %q", ErrSchemaUnknown, manifest.BundleSchema)
+	}
+
+	last := lines[len(lines)-1]
+	if last.Kind != "trailer" {
+		return manifest, nil, trailer,
+			fmt.Errorf("%w: last line kind=%q, want trailer", ErrBadTrailer, last.Kind)
+	}
+	if err := json.Unmarshal(last.Data, &trailer); err != nil {
+		return manifest, nil, trailer, fmt.Errorf("bundle: parse trailer: %w", err)
+	}
+
+	// Content hash covers everything except the trailer line's bytes.
+	preceding := concat(lineBytes[:len(lineBytes)-1])
+	got := sha256.Sum256(preceding)
+	if hex.EncodeToString(got[:]) != trailer.ContentHash {
+		return manifest, nil, trailer, ErrHashMismatch
+	}
+	if trailer.EventCount != len(lines)-2 {
+		return manifest, nil, trailer,
+			fmt.Errorf("%w: trailer event_count=%d, observed=%d",
+				ErrBadTrailer, trailer.EventCount, len(lines)-2)
+	}
+
+	events = lines[1 : len(lines)-1]
+	return manifest, events, trailer, nil
+}
+
+// writeLine emits one JSON line followed by '\n'. Centralized so
+// every line uses the same encoder configuration and we never
+// accidentally end up with a missing terminator.
+func writeLine(w io.Writer, ln Line) error {
+	body, err := json.Marshal(ln)
+	if err != nil {
+		return fmt.Errorf("bundle: marshal line: %w", err)
+	}
+	if _, err := w.Write(body); err != nil {
+		return fmt.Errorf("bundle: write line: %w", err)
+	}
+	if _, err := w.Write([]byte{'\n'}); err != nil {
+		return fmt.Errorf("bundle: write newline: %w", err)
+	}
+	return nil
+}
+
+func concat(bs [][]byte) []byte {
+	n := 0
+	for _, b := range bs {
+		n += len(b)
+	}
+	out := make([]byte, 0, n)
+	for _, b := range bs {
+		out = append(out, b...)
+	}
+	return out
+}

--- a/runner/internal/bundle/bundle_test.go
+++ b/runner/internal/bundle/bundle_test.go
@@ -1,0 +1,460 @@
+package bundle
+
+import (
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kuhlman-labs/fishhawk/runner/internal/agent"
+)
+
+// frozenNow returns a deterministic clock so manifest /
+// per-line timestamps are stable across runs.
+func frozenNow() func() time.Time {
+	t := time.Date(2026, 5, 2, 9, 30, 0, 0, time.UTC)
+	return func() time.Time {
+		t = t.Add(time.Second)
+		return t
+	}
+}
+
+func sampleEvents() []agent.Event {
+	return []agent.Event{
+		{
+			Kind:      "system.init",
+			Timestamp: time.Date(2026, 5, 2, 9, 31, 0, 0, time.UTC),
+			Payload:   agent.MakePayload(map[string]string{"agent": "claude-code"}),
+		},
+		{
+			Kind:      "tool_call",
+			Timestamp: time.Date(2026, 5, 2, 9, 31, 5, 0, time.UTC),
+			Payload:   agent.MakePayload(map[string]string{"name": "bash"}),
+		},
+		{
+			Kind:      "result",
+			Timestamp: time.Date(2026, 5, 2, 9, 31, 10, 0, time.UTC),
+			Payload:   agent.MakePayload(map[string]int{"input_tokens": 50, "output_tokens": 75}),
+		},
+	}
+}
+
+func TestPack_RoundTrip(t *testing.T) {
+	in := PackInputs{
+		RunID:   "11111111-2222-3333-4444-555555555555",
+		StageID: "22222222-3333-4444-5555-666666666666",
+		Agent:   "claude-code",
+		Model:   "claude-opus-4-7",
+		Now:     frozenNow(),
+	}
+	events := sampleEvents()
+
+	data, hash, err := PackBytes(in, events)
+	if err != nil {
+		t.Fatalf("PackBytes: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("PackBytes returned empty data")
+	}
+	if len(hash) != 64 {
+		t.Errorf("storage hash len = %d, want 64 (hex sha256)", len(hash))
+	}
+
+	manifest, gotEvents, trailer, err := Open(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if manifest.BundleSchema != SchemaV1 {
+		t.Errorf("manifest schema = %q, want %q", manifest.BundleSchema, SchemaV1)
+	}
+	if manifest.RunID != in.RunID {
+		t.Errorf("manifest RunID = %q, want %q", manifest.RunID, in.RunID)
+	}
+	if manifest.StageID != in.StageID {
+		t.Errorf("manifest StageID = %q, want %q", manifest.StageID, in.StageID)
+	}
+	if manifest.Agent != "claude-code" {
+		t.Errorf("manifest Agent = %q", manifest.Agent)
+	}
+	if manifest.Model != "claude-opus-4-7" {
+		t.Errorf("manifest Model = %q", manifest.Model)
+	}
+	if len(gotEvents) != len(events) {
+		t.Fatalf("got %d events, want %d", len(gotEvents), len(events))
+	}
+	for i, ev := range gotEvents {
+		if ev.Kind != events[i].Kind {
+			t.Errorf("events[%d].Kind = %q, want %q", i, ev.Kind, events[i].Kind)
+		}
+		if ev.Seq != i+2 { // manifest is seq 1
+			t.Errorf("events[%d].Seq = %d, want %d", i, ev.Seq, i+2)
+		}
+	}
+	if trailer.EventCount != len(events) {
+		t.Errorf("trailer EventCount = %d, want %d", trailer.EventCount, len(events))
+	}
+	if len(trailer.ContentHash) != 64 {
+		t.Errorf("trailer content_hash len = %d, want 64", len(trailer.ContentHash))
+	}
+}
+
+func TestPack_StorageHashIsDeterministic(t *testing.T) {
+	// Same inputs + same Now produce byte-identical output and
+	// thus the same storage hash. Required for content-addressed
+	// dedup at the backend (ARCHITECTURE.md §5.2).
+	in := PackInputs{
+		RunID: "r", StageID: "s", Agent: "claude-code", Now: frozenNow(),
+	}
+	events := sampleEvents()
+
+	d1, h1, err := PackBytes(in, events)
+	if err != nil {
+		t.Fatal(err)
+	}
+	d2, h2, err := PackBytes(PackInputs{
+		RunID: "r", StageID: "s", Agent: "claude-code", Now: frozenNow(),
+	}, events)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(d1, d2) {
+		t.Error("identical inputs produced different bytes")
+	}
+	if h1 != h2 {
+		t.Errorf("storage hash mismatch: %q vs %q", h1, h2)
+	}
+}
+
+func TestPack_DetectsTampering(t *testing.T) {
+	in := PackInputs{
+		RunID: "r", StageID: "s", Agent: "claude-code", Now: frozenNow(),
+	}
+	data, _, err := PackBytes(in, sampleEvents())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Decompress, mutate one event line in the middle, recompress
+	// (so gzip integrity stays intact), then Open should reject.
+	zr, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, _ := readAll(t, zr)
+	tampered := bytes.Replace(raw, []byte(`"name":"bash"`), []byte(`"name":"DROP"`), 1)
+	if bytes.Equal(raw, tampered) {
+		t.Fatal("test setup: expected substring not found in raw bundle")
+	}
+
+	var rebuilt bytes.Buffer
+	zw := gzip.NewWriter(&rebuilt)
+	if _, err := zw.Write(tampered); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, _, err = Open(&rebuilt)
+	if !errors.Is(err, ErrHashMismatch) {
+		t.Errorf("Open after tamper: err = %v, want ErrHashMismatch", err)
+	}
+}
+
+func TestPack_EmptyEvents(t *testing.T) {
+	// A bundle with zero captured events still pairs manifest +
+	// trailer; trailer.EventCount = 0 and the content hash covers
+	// just the manifest line.
+	in := PackInputs{
+		RunID: "r", StageID: "s", Agent: "claude-code", Now: frozenNow(),
+	}
+	data, _, err := PackBytes(in, nil)
+	if err != nil {
+		t.Fatalf("PackBytes: %v", err)
+	}
+	manifest, events, trailer, err := Open(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if manifest.BundleSchema != SchemaV1 {
+		t.Errorf("schema = %q", manifest.BundleSchema)
+	}
+	if len(events) != 0 {
+		t.Errorf("got %d events, want 0", len(events))
+	}
+	if trailer.EventCount != 0 {
+		t.Errorf("trailer EventCount = %d, want 0", trailer.EventCount)
+	}
+}
+
+func TestPack_RequiredFields(t *testing.T) {
+	cases := []struct {
+		name string
+		in   PackInputs
+		want error
+	}{
+		{"empty run id", PackInputs{StageID: "s", Agent: "a"}, ErrEmptyRunID},
+		{"empty stage id", PackInputs{RunID: "r", Agent: "a"}, ErrEmptyStageID},
+		{"empty agent", PackInputs{RunID: "r", StageID: "s"}, ErrEmptyAgent},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := PackBytes(tc.in, nil)
+			if !errors.Is(err, tc.want) {
+				t.Errorf("err = %v, want %v", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestPack_DefaultsKindToRaw(t *testing.T) {
+	in := PackInputs{
+		RunID: "r", StageID: "s", Agent: "claude-code", Now: frozenNow(),
+	}
+	events := []agent.Event{{Kind: "", Payload: agent.MakePayload(map[string]string{"x": "y"})}}
+	data, _, err := PackBytes(in, events)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, got, _, err := Open(bytes.NewReader(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Kind != "raw" {
+		t.Errorf("expected one event with kind=raw, got %+v", got)
+	}
+}
+
+func TestOpen_BadGzip(t *testing.T) {
+	_, _, _, err := Open(strings.NewReader("not gzip"))
+	if err == nil {
+		t.Fatal("expected error on non-gzip input")
+	}
+	if !strings.Contains(err.Error(), "gzip") {
+		t.Errorf("err = %v, want gzip error", err)
+	}
+}
+
+func TestOpen_TooShort(t *testing.T) {
+	// A bundle with only one line cannot have both manifest and
+	// trailer; Open should reject.
+	var raw bytes.Buffer
+	if err := writeLine(&raw, Line{Seq: 1, Kind: "manifest", Data: json.RawMessage(`{}`)}); err != nil {
+		t.Fatal(err)
+	}
+	var gz bytes.Buffer
+	zw := gzip.NewWriter(&gz)
+	_, _ = zw.Write(raw.Bytes())
+	_ = zw.Close()
+
+	_, _, _, err := Open(&gz)
+	if !errors.Is(err, ErrBadTrailer) {
+		t.Errorf("err = %v, want ErrBadTrailer", err)
+	}
+}
+
+func TestOpen_UnknownSchema(t *testing.T) {
+	// Manually construct a bundle whose manifest has a future
+	// schema version; Open must reject explicitly.
+	manifestPayload, _ := json.Marshal(ManifestData{
+		BundleSchema: "v2",
+		RunID:        "r", StageID: "s", Agent: "x",
+		GeneratedAt: time.Now().UTC(),
+	})
+	var raw bytes.Buffer
+	_ = writeLine(&raw, Line{Seq: 1, Kind: "manifest", Data: manifestPayload})
+	hash := sha256.Sum256(raw.Bytes())
+	trailerPayload, _ := json.Marshal(TrailerData{EventCount: 0, ContentHash: hex.EncodeToString(hash[:])})
+	_ = writeLine(&raw, Line{Seq: 2, Kind: "trailer", Data: trailerPayload})
+
+	var gz bytes.Buffer
+	zw := gzip.NewWriter(&gz)
+	_, _ = zw.Write(raw.Bytes())
+	_ = zw.Close()
+
+	_, _, _, err := Open(&gz)
+	if !errors.Is(err, ErrSchemaUnknown) {
+		t.Errorf("err = %v, want ErrSchemaUnknown", err)
+	}
+}
+
+func TestPack_HonorsGeneratedAt(t *testing.T) {
+	// The Now closure runs many times during Pack; the manifest's
+	// GeneratedAt must be the FIRST tick (it's emitted first).
+	t0 := time.Date(2026, 5, 2, 9, 0, 0, 0, time.UTC)
+	step := time.Second
+	cur := t0
+	now := func() time.Time {
+		out := cur
+		cur = cur.Add(step)
+		return out
+	}
+	in := PackInputs{
+		RunID: "r", StageID: "s", Agent: "claude-code", Now: now,
+	}
+	data, _, err := PackBytes(in, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest, _, _, err := Open(bytes.NewReader(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !manifest.GeneratedAt.Equal(t0) {
+		t.Errorf("GeneratedAt = %v, want %v", manifest.GeneratedAt, t0)
+	}
+}
+
+// failingWriter returns an error after a fixed byte budget so we
+// can drive Pack's write-error branch deterministically.
+type failingWriter struct {
+	budget int
+	wrote  int
+}
+
+func (w *failingWriter) Write(p []byte) (int, error) {
+	if w.wrote >= w.budget {
+		return 0, errors.New("disk full")
+	}
+	n := len(p)
+	if w.wrote+n > w.budget {
+		n = w.budget - w.wrote
+	}
+	w.wrote += n
+	return n, errors.New("disk full")
+}
+
+func TestPack_WriteError(t *testing.T) {
+	in := PackInputs{RunID: "r", StageID: "s", Agent: "x", Now: frozenNow()}
+	_, err := Pack(&failingWriter{budget: 0}, in, nil)
+	if err == nil {
+		t.Fatal("expected write error")
+	}
+	if !strings.Contains(err.Error(), "disk full") {
+		t.Errorf("err = %v, missing underlying disk full", err)
+	}
+}
+
+func TestOpen_BadJSONLine(t *testing.T) {
+	// Build a gzipped stream where one line is not JSON. Open
+	// must fail with a parse error; never silently skip.
+	var raw bytes.Buffer
+	manifestPayload, _ := json.Marshal(ManifestData{
+		BundleSchema: SchemaV1,
+		RunID:        "r", StageID: "s", Agent: "x",
+		GeneratedAt: time.Now().UTC(),
+	})
+	_ = writeLine(&raw, Line{Seq: 1, Kind: "manifest", Data: manifestPayload})
+	raw.WriteString("not json\n")
+	hash := sha256.Sum256(raw.Bytes())
+	trailerPayload, _ := json.Marshal(TrailerData{EventCount: 1, ContentHash: hex.EncodeToString(hash[:])})
+	_ = writeLine(&raw, Line{Seq: 3, Kind: "trailer", Data: trailerPayload})
+
+	var gz bytes.Buffer
+	zw := gzip.NewWriter(&gz)
+	_, _ = zw.Write(raw.Bytes())
+	_ = zw.Close()
+
+	_, _, _, err := Open(&gz)
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+	if !strings.Contains(err.Error(), "parse line") {
+		t.Errorf("err = %v, want parse line error", err)
+	}
+}
+
+func TestOpen_FirstLineNotManifest(t *testing.T) {
+	var raw bytes.Buffer
+	_ = writeLine(&raw, Line{Seq: 1, Kind: "result", Data: json.RawMessage(`{}`)})
+	hash := sha256.Sum256(raw.Bytes())
+	trailerPayload, _ := json.Marshal(TrailerData{EventCount: 0, ContentHash: hex.EncodeToString(hash[:])})
+	_ = writeLine(&raw, Line{Seq: 2, Kind: "trailer", Data: trailerPayload})
+
+	var gz bytes.Buffer
+	zw := gzip.NewWriter(&gz)
+	_, _ = zw.Write(raw.Bytes())
+	_ = zw.Close()
+
+	_, _, _, err := Open(&gz)
+	if !errors.Is(err, ErrBadTrailer) {
+		t.Errorf("err = %v, want ErrBadTrailer for missing manifest", err)
+	}
+}
+
+func TestOpen_LastLineNotTrailer(t *testing.T) {
+	var raw bytes.Buffer
+	manifestPayload, _ := json.Marshal(ManifestData{
+		BundleSchema: SchemaV1, RunID: "r", StageID: "s", Agent: "x",
+		GeneratedAt: time.Now().UTC(),
+	})
+	_ = writeLine(&raw, Line{Seq: 1, Kind: "manifest", Data: manifestPayload})
+	_ = writeLine(&raw, Line{Seq: 2, Kind: "tool_call", Data: json.RawMessage(`{"x":1}`)})
+
+	var gz bytes.Buffer
+	zw := gzip.NewWriter(&gz)
+	_, _ = zw.Write(raw.Bytes())
+	_ = zw.Close()
+
+	_, _, _, err := Open(&gz)
+	if !errors.Is(err, ErrBadTrailer) {
+		t.Errorf("err = %v, want ErrBadTrailer for missing trailer", err)
+	}
+}
+
+func TestOpen_TrailerEventCountMismatch(t *testing.T) {
+	// Build a bundle where the trailer's event_count is wrong.
+	// Open must reject — guards against silent truncation that
+	// somehow preserves the content hash (e.g. hash-collision
+	// future or buggy producer).
+	var raw bytes.Buffer
+	manifestPayload, _ := json.Marshal(ManifestData{
+		BundleSchema: SchemaV1, RunID: "r", StageID: "s", Agent: "x",
+		GeneratedAt: time.Now().UTC(),
+	})
+	_ = writeLine(&raw, Line{Seq: 1, Kind: "manifest", Data: manifestPayload})
+	_ = writeLine(&raw, Line{Seq: 2, Kind: "tool_call", Data: json.RawMessage(`{"x":1}`)})
+	hash := sha256.Sum256(raw.Bytes())
+	// Lie about the count.
+	trailerPayload, _ := json.Marshal(TrailerData{EventCount: 99, ContentHash: hex.EncodeToString(hash[:])})
+	_ = writeLine(&raw, Line{Seq: 3, Kind: "trailer", Data: trailerPayload})
+
+	var gz bytes.Buffer
+	zw := gzip.NewWriter(&gz)
+	_, _ = zw.Write(raw.Bytes())
+	_ = zw.Close()
+
+	_, _, _, err := Open(&gz)
+	if !errors.Is(err, ErrBadTrailer) {
+		t.Errorf("err = %v, want ErrBadTrailer on count mismatch", err)
+	}
+}
+
+func TestSchemaConstant(t *testing.T) {
+	// Pinning the constant prevents an accidental rename from
+	// silently invalidating every bundle in production.
+	if SchemaV1 != "v1" {
+		t.Errorf("SchemaV1 = %q, want v1", SchemaV1)
+	}
+}
+
+// readAll is a tiny io.ReadAll wrapper that fails the test on error.
+func readAll(t *testing.T, r interface {
+	Read(p []byte) (n int, err error)
+}) ([]byte, error) {
+	t.Helper()
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(readerFunc(r.Read)); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes(), nil
+}
+
+type readerFunc func(p []byte) (n int, err error)
+
+func (f readerFunc) Read(p []byte) (int, error) { return f(p) }


### PR DESCRIPTION
## Summary

Implements the `*.jsonl.gz` trace bundle wire format from ADR-007 (#71). The runner now writes the same artifact shape that backend ingest and the external verifier will consume.

- `runner/internal/bundle/` — `Pack` (manifest + events with monotonic seq + trailer with sha256 of preceding lines, all gzipped) and `Open` (round-trip parse, re-hash, reject on tampering / truncation / unknown schema).
- `PackBytes` returns the gzipped artifact plus the storage hash (sha256 of compressed bytes) used as the S3 key per `ARCHITECTURE.md §5.2` and as the signing input the runner will hand `backend/internal/signing` in E5.6.
- `runner/cmd/fishhawk-runner` — new `--bundle-out` flag. When set the runner writes the gzipped bundle to disk; when unset, falls back to JSONL on stdout (the inspection mode E5.2 introduced). Bundle write failures map to `exitFailure` with a `runner_failed` log line.
- `action.yml` exposes the new `bundle-out` input.

## Test plan

- [x] `go test -race ./runner/...` — all 5 packages pass
- [x] `golangci-lint run ./...` across all 3 modules — 0 issues
- [x] Aggregate coverage 86.0% (excl. `/db/`); bundle package 84.1%
- [x] Targeted Open tests: gzip-but-not-bundle, missing manifest, missing trailer, non-JSON line, tampered event (hash mismatch), unknown schema, mismatched `event_count`
- [x] Local end-to-end: fake invoker → Pack → write to disk → Open round-trips manifest, events, trailer
- [ ] CI passes

## Notes

**Why not import this from the verifier?** Same reason `verifier/internal/audit` re-implements `ComputeEntryHash` rather than importing `backend/internal/audit`: a compromised producer should not be able to ship a tampered parser alongside a tampered bundle. The runner-side bundle code is canonical for *production*; future verifier code will re-implement parsing and pin to this format via a canonical fixture test (the same pattern E2.6 used for the chain hash).

**`event_count` check.** The trailer carries both a content hash and an event count. The hash is the strong integrity check; the count is a cheap cross-check that catches a class of producer bugs (off-by-one truncation that somehow re-hashes correctly). `Open` rejects on either mismatch.

**Storage hash vs. trailer hash.** Two distinct hashes:
1. `TrailerData.ContentHash` — sha256 of the **uncompressed** preceding lines. Floor-of-integrity for the wire format; survives re-gzipping.
2. `PackBytes` storage hash — sha256 of the **gzipped** bytes. The S3 key + signing input.

**Deferred to E5.6.** Signed upload to backend; `backend/internal/signing` already exists, so E5.6 is plumbing — sign `storage_hash`, POST to `/v0/runs/{id}/trace` with `X-Fishhawk-Signature`.

Closes #30
