### PR TITLE
Add plan validation to the runner (E5.4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,8 @@ jobs:
                   backend/internal/spec/schemas/workflow-v0.schema.json
           diff -u docs/spec/plan-standard-v1.schema.json \
                   backend/internal/plan/schemas/plan-standard-v1.schema.json
+          diff -u docs/spec/plan-standard-v1.schema.json \
+                  runner/internal/plan/schemas/plan-standard-v1.schema.json
 
       - name: Install golangci-lint
         if: steps.have-modules.outputs.yes == 'true'

--- a/runner/README.md
+++ b/runner/README.md
@@ -13,13 +13,13 @@ This directory is its own Go module (`github.com/kuhlman-labs/fishhawk/runner`) 
 - `internal/agent/` — the agent abstraction (`Invoker`, `Invocation`, `Result`, `Event`).
 - `internal/agent/claudecode/` — adapter for Anthropic's Claude Code CLI.
 - `internal/bundle/` — `*.jsonl.gz` trace bundle pack/unpack per ADR-007 (#71).
+- `internal/plan/` — plan-artifact validator against `standard_v1` (E1.5 schema; embedded copy under `schemas/`).
 - `internal/version/` — build-version package; set via `-ldflags` at release time.
 
 ## Status
 
-E5.1 (#52) shipped the scaffold. E5.2 (#29) wired the Claude Code invocation harness. E5.3 (#30) added trace bundling: when `--prompt-file` and `--bundle-out` are supplied together, the runner invokes Claude Code, packs the captured events into the ADR-007 `*.jsonl.gz` format (manifest first, trailer last with content hash), and writes the gzipped bundle to disk. Without `--bundle-out` the runner falls back to JSONL on stdout for ad-hoc inspection. Signed upload lands in E5.6.
+E5.1 (#52) shipped the scaffold. E5.2 (#29) wired the Claude Code invocation harness. E5.3 (#30) added trace bundling. E5.4 (#31) added plan-artifact validation: when `--plan-out` points at a file the agent writes its plan to, the runner validates it against `standard_v1` after the agent succeeds. A validation failure demotes the run to category-B (constraint/policy violation, MVP_SPEC §6) and the bundle records a `policy_event` with the outcome.
 
-- E5.4 (#31) — plan validation against `standard_v1` (reuses `backend/internal/plan`)
 - E5.5 (#53) — post-hoc constraint enforcement on stage output
 - E5.6 (#32) — signed trace shipping to backend (uses `backend/internal/signing` + `backend/internal/tracestore`)
 - E5.7 (#54) — versioned, signed releases of `fishhawk/runner` with SBOM
@@ -37,6 +37,7 @@ E5.1 (#52) shipped the scaffold. E5.2 (#29) wired the Claude Code invocation har
 | `max-tokens` | no | Hard cap on agent tokens (input + output); 0 means no cap. |
 | `timeout` | no | Wall-clock cap on the agent invocation, e.g. `15m`. Default 15m. |
 | `bundle-out` | no | Path to write the gzipped trace bundle. When set the runner produces an ADR-007 `*.jsonl.gz` artifact instead of JSONL on stdout. |
+| `plan-out` | no | Path the agent writes its plan artifact to. When set, the runner validates the file against `standard_v1` after a successful agent invocation; a malformed plan demotes the run to category-B failure. |
 
 The Claude Code API key is supplied via the `ANTHROPIC_API_KEY` environment variable, which customers populate from their GitHub Secrets. v0.x will replace this with a Fishhawk-issued ephemeral key (MVP_SPEC §5.3).
 

--- a/runner/action.yml
+++ b/runner/action.yml
@@ -55,6 +55,10 @@ inputs:
     description: 'Path to write the gzipped trace bundle (ADR-007 *.jsonl.gz). When unset, events go to stdout as JSONL.'
     required: false
     default: ''
+  plan-out:
+    description: 'Path the agent writes its plan artifact to. When set, the runner validates against standard_v1 after a successful agent invocation.'
+    required: false
+    default: ''
 
 runs:
   using: 'composite'
@@ -80,4 +84,5 @@ runs:
           --working-dir "${{ inputs.working-dir }}" \
           --max-tokens "${{ inputs.max-tokens }}" \
           --timeout "${{ inputs.timeout }}" \
-          --bundle-out "${{ inputs.bundle-out }}"
+          --bundle-out "${{ inputs.bundle-out }}" \
+          --plan-out "${{ inputs.plan-out }}"

--- a/runner/cmd/fishhawk-runner/flags.go
+++ b/runner/cmd/fishhawk-runner/flags.go
@@ -28,6 +28,7 @@ type config struct {
 	maxTokens  int
 	timeout    time.Duration
 	bundleOut  string
+	planOut    string
 }
 
 // parseFlags reads args and populates a config. Returns a usage
@@ -58,6 +59,8 @@ func parseFlags(args []string, w io.Writer) (config, error) {
 		"wall-clock cap on agent invocation")
 	fs.StringVar(&cfg.bundleOut, "bundle-out", "",
 		"path to write the gzipped trace bundle (ADR-007); when empty, events go to stdout as JSONL")
+	fs.StringVar(&cfg.planOut, "plan-out", "",
+		"path the agent writes its plan artifact to; when set, the runner validates it against standard_v1 after a successful agent invocation")
 
 	if err := fs.Parse(args); err != nil {
 		return cfg, err

--- a/runner/cmd/fishhawk-runner/main.go
+++ b/runner/cmd/fishhawk-runner/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/kuhlman-labs/fishhawk/runner/internal/agent"
 	"github.com/kuhlman-labs/fishhawk/runner/internal/agent/claudecode"
 	"github.com/kuhlman-labs/fishhawk/runner/internal/bundle"
+	"github.com/kuhlman-labs/fishhawk/runner/internal/plan"
 )
 
 const (
@@ -87,6 +88,23 @@ func run(args []string, logSink io.Writer) int {
 
 	invoker := newInvoker(os.Getenv("ANTHROPIC_API_KEY"))
 	res, invokeErr := invoker.Invoke(context.Background(), inv)
+
+	// Plan validation runs only if the agent itself succeeded —
+	// no point re-stating "your plan is malformed" when the
+	// agent already failed. A plan-validation failure overrides
+	// res.OK and demotes the run to category-B (constraint /
+	// policy violation per MVP_SPEC §6).
+	if res.OK && cfg.planOut != "" {
+		if ev, demote := validatePlan(cfg.planOut); demote != nil {
+			res.Events = append(res.Events, ev)
+			res.OK = false
+			res.FailureCategory = "B"
+			res.FailureReason = demote.Error()
+			invokeErr = demote
+		} else {
+			res.Events = append(res.Events, ev)
+		}
+	}
 
 	if cfg.bundleOut != "" {
 		if err := writeBundle(cfg, res); err != nil {
@@ -184,9 +202,36 @@ func classifyErr(err error) string {
 	}
 }
 
+// validatePlan reads the plan artifact at path and validates it
+// against the standard_v1 schema. The first return is a policy_event
+// suitable for the trace bundle: kind=policy_event, payload describes
+// the validation outcome. The second return is non-nil ONLY on
+// validation failure — it carries the reason for callers wiring up
+// category-B failure handling per MVP_SPEC §6.
+func validatePlan(path string) (agent.Event, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return agent.Event{
+			Kind:    "policy_event",
+			Payload: agent.MakePayload(map[string]string{"check": "plan_validation", "outcome": "missing", "path": path, "error": err.Error()}),
+		}, fmt.Errorf("plan: read %s: %w", path, err)
+	}
+	if vErr := plan.Validate(data); vErr != nil {
+		return agent.Event{
+			Kind:    "policy_event",
+			Payload: agent.MakePayload(map[string]string{"check": "plan_validation", "outcome": "invalid", "path": path, "error": vErr.Error()}),
+		}, vErr
+	}
+	return agent.Event{
+		Kind:    "policy_event",
+		Payload: agent.MakePayload(map[string]string{"check": "plan_validation", "outcome": "valid", "path": path}),
+	}, nil
+}
+
 // emitEvents writes one JSON object per line. This is the
-// placeholder transport — E5.3 / #30 replaces it with the
-// JSONL.gz bundle format and E5.6 / #32 with the signed upload.
+// placeholder transport — E5.3 / #30 replaced it with the
+// JSONL.gz bundle format when --bundle-out is set; E5.6 / #32
+// adds the signed upload.
 func emitEvents(w io.Writer, events []agent.Event) {
 	enc := json.NewEncoder(w)
 	for _, ev := range events {

--- a/runner/cmd/fishhawk-runner/main_test.go
+++ b/runner/cmd/fishhawk-runner/main_test.go
@@ -406,6 +406,155 @@ func TestRun_BundleWriteFailureSurfacesAsExitFailure(t *testing.T) {
 	}
 }
 
+// validPlanJSON returns a minimal standard_v1 plan that the
+// validator accepts. Inline rather than reading a fixture so the
+// test is self-contained.
+func validPlanJSON() string {
+	return `{
+  "plan_version": "standard_v1",
+  "ticket_reference": {"type":"github_issue","url":"https://github.com/x/y/issues/1","id":"x/y#1"},
+  "generated_by": {"agent":"claude-code","model":"claude-opus-4-7","version":"build-1","timestamp":"2026-05-02T10:00:00Z"},
+  "summary": "Add a thing.",
+  "scope": {"files": [{"path":"a.go","operation":"create"}], "estimated_lines_changed": 10},
+  "approach": [{"step":1,"description":"Do."}],
+  "verification": {"test_strategy":"go test","rollback_plan":"revert PR"}
+}`
+}
+
+func TestRun_PlanValidationOK(t *testing.T) {
+	dir := t.TempDir()
+	promptPath := filepath.Join(dir, "prompt.txt")
+	planPath := filepath.Join(dir, "plan.json")
+	bundlePath := filepath.Join(dir, "trace.jsonl.gz")
+	if err := os.WriteFile(promptPath, []byte("p"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(planPath, []byte(validPlanJSON()), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	withFakeInvoker(t, &fakeInvoker{
+		canned: agent.Result{
+			OK:     true,
+			Events: []agent.Event{{Kind: "system.init"}},
+		},
+	})
+
+	var stderr strings.Builder
+	got := run([]string{
+		"--run-id", "rid", "--backend-url", "u", "--workflow", "w", "--stage", "s",
+		"--prompt-file", promptPath, "--plan-out", planPath, "--bundle-out", bundlePath,
+	}, &stderr)
+	if got != exitOK {
+		t.Fatalf("run = %d, want %d:\n%s", got, exitOK, stderr.String())
+	}
+	// Bundle should now contain the system.init plus a policy_event
+	// with outcome=valid.
+	data, err := os.ReadFile(bundlePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, events, _, err := openBundleForTest(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sawValid bool
+	for _, ev := range events {
+		if ev.Kind == "policy_event" && strings.Contains(string(ev.Data), `"outcome":"valid"`) {
+			sawValid = true
+		}
+	}
+	if !sawValid {
+		t.Errorf("missing policy_event outcome=valid in bundle:\n%+v", events)
+	}
+}
+
+func TestRun_PlanValidationInvalid_DemotesToCategoryB(t *testing.T) {
+	dir := t.TempDir()
+	promptPath := filepath.Join(dir, "prompt.txt")
+	planPath := filepath.Join(dir, "plan.json")
+	if err := os.WriteFile(promptPath, []byte("p"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Drop required field "summary" — schema rejects.
+	bad := strings.Replace(validPlanJSON(), `"summary": "Add a thing.",`, "", 1)
+	if err := os.WriteFile(planPath, []byte(bad), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	withFakeInvoker(t, &fakeInvoker{canned: agent.Result{OK: true}})
+
+	var stderr strings.Builder
+	got := run([]string{
+		"--run-id", "rid", "--backend-url", "u", "--workflow", "w", "--stage", "s",
+		"--prompt-file", promptPath, "--plan-out", planPath,
+	}, &stderr)
+	if got != exitFailure {
+		t.Errorf("run = %d, want exitFailure", got)
+	}
+	out := stderr.String()
+	if !strings.Contains(out, `"category":"B"`) {
+		t.Errorf("missing category B (plan validation should demote): %s", out)
+	}
+	if !strings.Contains(out, `"outcome":"failed"`) {
+		t.Errorf("missing failed outcome: %s", out)
+	}
+}
+
+func TestRun_PlanFileMissing_DemotesToCategoryB(t *testing.T) {
+	dir := t.TempDir()
+	promptPath := filepath.Join(dir, "prompt.txt")
+	if err := os.WriteFile(promptPath, []byte("p"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	withFakeInvoker(t, &fakeInvoker{canned: agent.Result{OK: true}})
+
+	var stderr strings.Builder
+	got := run([]string{
+		"--run-id", "rid", "--backend-url", "u", "--workflow", "w", "--stage", "s",
+		"--prompt-file", promptPath,
+		"--plan-out", filepath.Join(dir, "nonexistent.json"),
+	}, &stderr)
+	if got != exitFailure {
+		t.Errorf("run = %d, want exitFailure", got)
+	}
+	if !strings.Contains(stderr.String(), `"category":"B"`) {
+		t.Errorf("missing category B: %s", stderr.String())
+	}
+}
+
+func TestRun_PlanValidationSkippedOnAgentFailure(t *testing.T) {
+	// If the agent already failed (category A), don't run plan
+	// validation — there's no plan to validate, and the failure
+	// classification must remain A.
+	dir := t.TempDir()
+	promptPath := filepath.Join(dir, "prompt.txt")
+	if err := os.WriteFile(promptPath, []byte("p"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	withFakeInvoker(t, &fakeInvoker{
+		canned: agent.Result{
+			OK:              false,
+			FailureCategory: "A",
+			FailureReason:   "agent crash",
+		},
+		returnErr: agent.ErrAgentFailed,
+	})
+
+	var stderr strings.Builder
+	got := run([]string{
+		"--run-id", "rid", "--backend-url", "u", "--workflow", "w", "--stage", "s",
+		"--prompt-file", promptPath,
+		// plan-out points to a missing file — if validation ran, this
+		// would override category to B; assert it doesn't.
+		"--plan-out", filepath.Join(dir, "nope.json"),
+	}, &stderr)
+	if got != exitFailure {
+		t.Errorf("run = %d, want exitFailure", got)
+	}
+	if !strings.Contains(stderr.String(), `"category":"A"`) {
+		t.Errorf("expected category A preserved: %s", stderr.String())
+	}
+}
+
 func TestEmitEvents_OneJSONPerLine(t *testing.T) {
 	var w bytes.Buffer
 	emitEvents(&w, []agent.Event{

--- a/runner/go.mod
+++ b/runner/go.mod
@@ -1,3 +1,8 @@
 module github.com/kuhlman-labs/fishhawk/runner
 
 go 1.25
+
+require (
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
+	golang.org/x/text v0.14.0 // indirect
+)

--- a/runner/go.sum
+++ b/runner/go.sum
@@ -1,0 +1,4 @@
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
+golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
+golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=

--- a/runner/internal/plan/plan.go
+++ b/runner/internal/plan/plan.go
@@ -1,0 +1,146 @@
+// Package plan validates plan artifacts against the standard_v1
+// JSON Schema. The runner uses this after an agent invocation to
+// reject malformed plans before they're bundled into a trace and
+// shipped to the backend.
+//
+// The schema's canonical home is docs/spec/plan-standard-v1.schema.json;
+// the embedded copy under schemas/ keeps this package self-contained
+// at runtime, with the CI's schema-sync guard ensuring the two stay
+// in lockstep. Same approach used by backend/internal/plan — see
+// CLAUDE.md "Canonical references".
+//
+// This package intentionally exposes only Validate (pass/fail). The
+// typed *Plan struct + decoder live on the backend side; the runner
+// only needs to enforce that the artifact is structurally sound
+// before declaring the stage successful (MVP_SPEC §5.2 step 4).
+package plan
+
+import (
+	"bytes"
+	"embed"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+//go:embed schemas/plan-standard-v1.schema.json
+var schemaFS embed.FS
+
+// compiledSchema is the JSON Schema used by Validate. Compiled once
+// at package init; if the embedded schema is malformed we want to
+// crash loudly at process start, not on the first call.
+var compiledSchema = mustCompileSchema()
+
+func mustCompileSchema() *jsonschema.Schema {
+	const path = "schemas/plan-standard-v1.schema.json"
+	data, err := schemaFS.ReadFile(path)
+	if err != nil {
+		panic(fmt.Sprintf("plan: read embedded schema %s: %v", path, err))
+	}
+	var raw any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		panic(fmt.Sprintf("plan: parse embedded schema %s: %v", path, err))
+	}
+	c := jsonschema.NewCompiler()
+	if err := c.AddResource("plan-standard-v1.schema.json", raw); err != nil {
+		panic(fmt.Sprintf("plan: register embedded schema %s: %v", path, err))
+	}
+	s, err := c.Compile("plan-standard-v1.schema.json")
+	if err != nil {
+		panic(fmt.Sprintf("plan: compile embedded schema %s: %v", path, err))
+	}
+	return s
+}
+
+// ParseError is returned for malformed-JSON inputs.
+type ParseError struct {
+	Msg   string
+	Cause error
+}
+
+func (e *ParseError) Error() string { return "plan: " + e.Msg }
+func (e *ParseError) Unwrap() error { return e.Cause }
+
+// SchemaError is returned for schema violations. Path is a JSON
+// Pointer into the input document; Message is the leaf-level
+// failure message from the validator, the most actionable line for
+// surfacing to the user.
+type SchemaError struct {
+	Path    string
+	Message string
+}
+
+func (e *SchemaError) Error() string {
+	if e.Path == "" || e.Path == "/" {
+		return "plan: schema violation: " + e.Message
+	}
+	return fmt.Sprintf("plan: schema violation at %s: %s", e.Path, e.Message)
+}
+
+// Validate validates plan bytes against the standard_v1 schema. The
+// returned error is *ParseError (malformed JSON) or *SchemaError
+// (schema violation). Use errors.As to distinguish.
+func Validate(data []byte) error {
+	if len(bytes.TrimSpace(data)) == 0 {
+		return &ParseError{Msg: "empty document"}
+	}
+	var raw any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return &ParseError{Msg: err.Error(), Cause: err}
+	}
+	if err := compiledSchema.Validate(raw); err != nil {
+		var verr *jsonschema.ValidationError
+		if errors.As(err, &verr) {
+			return schemaErrorFrom(verr)
+		}
+		return &SchemaError{Path: "/", Message: err.Error()}
+	}
+	return nil
+}
+
+// schemaErrorFrom collapses a jsonschema.ValidationError tree to
+// the most actionable leaf. Mirrors the helper in
+// backend/internal/plan; kept independent so each side stays
+// self-contained.
+func schemaErrorFrom(verr *jsonschema.ValidationError) *SchemaError {
+	leaf := deepestLeaf(verr)
+	loc := leaf.InstanceLocation
+	if len(loc) == 0 {
+		loc = []string{""}
+	}
+	return &SchemaError{
+		Path:    "/" + joinPointer(loc),
+		Message: kindMessage(leaf),
+	}
+}
+
+func kindMessage(v *jsonschema.ValidationError) string {
+	full := v.Error()
+	if idx := strings.LastIndex(full, ": "); idx >= 0 {
+		return full[idx+2:]
+	}
+	return full
+}
+
+func deepestLeaf(v *jsonschema.ValidationError) *jsonschema.ValidationError {
+	for _, c := range v.Causes {
+		if len(c.InstanceLocation) >= len(v.InstanceLocation) {
+			return deepestLeaf(c)
+		}
+	}
+	return v
+}
+
+func joinPointer(parts []string) string {
+	if len(parts) == 0 {
+		return ""
+	}
+	out := parts[0]
+	for _, p := range parts[1:] {
+		out += "/" + p
+	}
+	return out
+}

--- a/runner/internal/plan/plan_test.go
+++ b/runner/internal/plan/plan_test.go
@@ -1,0 +1,103 @@
+package plan
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+)
+
+func mustRead(t *testing.T, path string) []byte {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return b
+}
+
+func TestValidate_Valid(t *testing.T) {
+	data := mustRead(t, "testdata/valid/example.json")
+	if err := Validate(data); err != nil {
+		t.Errorf("Validate: unexpected error: %v", err)
+	}
+}
+
+func TestValidate_EmptyDocument(t *testing.T) {
+	var perr *ParseError
+	if err := Validate(nil); !errors.As(err, &perr) {
+		t.Fatalf("err = %v, want *ParseError", err)
+	}
+	if err := Validate([]byte("   ")); !errors.As(err, &perr) {
+		t.Fatalf("whitespace err = %v, want *ParseError", err)
+	}
+}
+
+func TestValidate_MalformedJSON(t *testing.T) {
+	var perr *ParseError
+	err := Validate([]byte("{ not json"))
+	if !errors.As(err, &perr) {
+		t.Fatalf("err = %v, want *ParseError", err)
+	}
+	if perr.Cause == nil {
+		t.Error("expected ParseError.Cause to be set")
+	}
+}
+
+func TestValidate_MissingRequired(t *testing.T) {
+	// Drop the `summary` field — schema requires it.
+	src := mustRead(t, "testdata/valid/example.json")
+	tampered := strings.Replace(string(src), `"summary":`, `"summary_renamed":`, 1)
+	var serr *SchemaError
+	err := Validate([]byte(tampered))
+	if !errors.As(err, &serr) {
+		t.Fatalf("err = %v, want *SchemaError", err)
+	}
+	if !strings.Contains(serr.Error(), "schema violation") {
+		t.Errorf("error message missing 'schema violation': %v", serr)
+	}
+}
+
+func TestValidate_BadEnum(t *testing.T) {
+	// scope.files[].operation only accepts a closed set; "demolish"
+	// is not a member.
+	src := mustRead(t, "testdata/valid/example.json")
+	tampered := strings.Replace(string(src), `"operation": "create"`, `"operation": "demolish"`, 1)
+	var serr *SchemaError
+	err := Validate([]byte(tampered))
+	if !errors.As(err, &serr) {
+		t.Fatalf("err = %v, want *SchemaError", err)
+	}
+	if serr.Path == "" {
+		t.Errorf("SchemaError.Path is empty: %+v", serr)
+	}
+}
+
+func TestValidate_BadVersion(t *testing.T) {
+	// plan_version is constrained to "standard_v1".
+	src := mustRead(t, "testdata/valid/example.json")
+	tampered := strings.Replace(string(src), `"standard_v1"`, `"standard_v2"`, 1)
+	if err := Validate([]byte(tampered)); err == nil {
+		t.Fatal("expected version error")
+	}
+}
+
+func TestSchemaErrorFormatting(t *testing.T) {
+	// Branch coverage for the no-path error fallback.
+	se := &SchemaError{Path: "", Message: "bad"}
+	if !strings.Contains(se.Error(), "bad") {
+		t.Errorf("SchemaError.Error missing message: %s", se.Error())
+	}
+	se2 := &SchemaError{Path: "/scope/files/0/operation", Message: "not in enum"}
+	if !strings.Contains(se2.Error(), "/scope/files/0/operation") {
+		t.Errorf("SchemaError.Error missing path: %s", se2.Error())
+	}
+}
+
+func TestParseErrorUnwrap(t *testing.T) {
+	cause := errors.New("underlying")
+	pe := &ParseError{Msg: "wrapped", Cause: cause}
+	if errors.Unwrap(pe) != cause {
+		t.Errorf("Unwrap returned %v, want %v", errors.Unwrap(pe), cause)
+	}
+}

--- a/runner/internal/plan/schemas/plan-standard-v1.schema.json
+++ b/runner/internal/plan/schemas/plan-standard-v1.schema.json
@@ -1,0 +1,168 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://fishhawk.dev/spec/plan-standard-v1.schema.json",
+  "title": "Fishhawk plan artifact (standard_v1)",
+  "description": "The plan-stage output produced by the agent and validated by the runner before the stage is considered successful. Frozen at Day 21 of the v0 build per MVP_SPEC.md §8 — old plans in the audit log remain readable forever; never break this schema in place. Future versions land as standard_v2, etc.",
+
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "plan_version",
+    "ticket_reference",
+    "generated_by",
+    "summary",
+    "scope",
+    "approach",
+    "verification"
+  ],
+
+  "properties": {
+    "plan_version": {
+      "type": "string",
+      "enum": ["standard_v1"],
+      "description": "Schema version the document was authored against."
+    },
+    "ticket_reference": { "$ref": "#/$defs/ticket-reference" },
+    "generated_by":     { "$ref": "#/$defs/generated-by" },
+    "summary": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human-readable description of the change. Rendered as the lead paragraph in the issue comment."
+    },
+    "scope":              { "$ref": "#/$defs/scope" },
+    "approach": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/approach-step" },
+      "description": "Ordered steps the agent intends to take."
+    },
+    "verification":       { "$ref": "#/$defs/verification" },
+    "risks_and_assumptions": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "description": "Optional. Things the agent flagged as uncertain or assumed; surfaces in the review UI."
+    }
+  },
+
+  "$defs": {
+    "ticket-reference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "url", "id"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["github_issue"],
+          "description": "v0 closed set; v0.x adds linear_ticket and jira_ticket."
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Canonical URL of the originating ticket."
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Stable identifier — e.g. \"kuhlman-labs/fishhawk#1247\"."
+        }
+      }
+    },
+
+    "generated-by": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["agent", "model", "timestamp"],
+      "properties": {
+        "agent": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Agent identifier matching the workflow spec's executor.agent."
+        },
+        "model": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Specific model used (e.g. claude-opus-4-7)."
+        },
+        "version": {
+          "type": "string",
+          "description": "Optional. Model version or build SHA when agent reports it."
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "RFC 3339 timestamp of generation. The runner wall-clock at agent invocation."
+        }
+      }
+    },
+
+    "scope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["files"],
+      "properties": {
+        "files": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/scope-file" },
+          "description": "Files the agent intends to create, modify, or delete."
+        },
+        "estimated_lines_changed": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Rough estimate. Used by reviewers to gauge change size; not enforced."
+        }
+      }
+    },
+
+    "scope-file": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "operation"],
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Repo-relative path."
+        },
+        "operation": {
+          "type": "string",
+          "enum": ["create", "modify", "delete"]
+        }
+      }
+    },
+
+    "approach-step": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["step", "description"],
+      "properties": {
+        "step": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+
+    "verification": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["test_strategy", "rollback_plan"],
+      "properties": {
+        "test_strategy": {
+          "type": "string",
+          "minLength": 1,
+          "description": "How the change will be tested. Free-form prose; reviewers expect concrete tests, not just \"add tests\"."
+        },
+        "rollback_plan": {
+          "type": "string",
+          "minLength": 1,
+          "description": "How a regression would be undone. \"Revert PR\" is a valid answer for purely-additive changes; data migrations need more."
+        }
+      }
+    }
+  }
+}

--- a/runner/internal/plan/testdata/valid/example.json
+++ b/runner/internal/plan/testdata/valid/example.json
@@ -1,0 +1,34 @@
+{
+  "plan_version": "standard_v1",
+  "ticket_reference": {
+    "type": "github_issue",
+    "url": "https://github.com/kuhlman-labs/fishhawk/issues/1247",
+    "id": "kuhlman-labs/fishhawk#1247"
+  },
+  "generated_by": {
+    "agent": "claude-code",
+    "model": "claude-opus-4-7",
+    "version": "build-abc123",
+    "timestamp": "2026-04-30T14:22:11Z"
+  },
+  "summary": "Add a bulk export endpoint for the audit log.",
+  "scope": {
+    "files": [
+      { "path": "backend/internal/api/audit_export.go", "operation": "create" },
+      { "path": "backend/internal/api/router.go", "operation": "modify" }
+    ],
+    "estimated_lines_changed": 280
+  },
+  "approach": [
+    { "step": 1, "description": "Add GET /v0/audit/export with --from and --to query parameters." },
+    { "step": 2, "description": "Stream JSON Lines from audit_entries with cursor-based pagination." }
+  ],
+  "verification": {
+    "test_strategy": "Integration test under backend/internal/api/audit_export_test.go uses testcontainers Postgres, seeds entries, asserts pagination cursor stability.",
+    "rollback_plan": "Revert the PR. The endpoint is purely additive; no data migration to roll back."
+  },
+  "risks_and_assumptions": [
+    "Assumes (created_at, entry_id) is the natural sort order.",
+    "Risk: very large date ranges; mitigated by per-page limit of 1000 rows."
+  ]
+}


### PR DESCRIPTION
## Summary

Closes the loop on plan-stage success per `MVP_SPEC.md §5.2 step 4`: an agent that produced a malformed plan no longer ships a "successful" bundle to the backend; it fails as category-B (constraint/policy violation, §6) with the precise schema violation captured in the trace as a `policy_event`.

- `runner/internal/plan/` — embedded copy of `docs/spec/plan-standard-v1.schema.json` + `Validate(data) → *ParseError | *SchemaError | nil`. Mirrors `backend/internal/plan` rather than imports it (the runner is its own Go module). Schema-sync CI now diffs three copies of the canonical schema.
- `runner/cmd/fishhawk-runner` — new `--plan-out` flag pointing at the file the agent writes its plan to. After a successful agent invocation, the runner reads + validates. Success appends a `policy_event` with `outcome=valid`; failure appends `outcome=invalid|missing` and demotes the result (OK=false, FailureCategory="B", exit 1).
- Plan validation **only** runs when the agent itself succeeded — keeps category classification honest (`A` stays `A`).
- `action.yml` exposes the new `plan-out` input.

## Test plan

- [x] `go test -race ./runner/...` — 6 packages pass
- [x] `golangci-lint run ./...` across all 3 modules — 0 issues
- [x] `diff -u docs/spec/plan-standard-v1.schema.json runner/internal/plan/schemas/...` — in sync
- [x] Aggregate coverage 86.1% (excl. `/db/`); plan package 83.7%
- [x] 5 new run() cases: valid plan, invalid plan demotes to category B, missing plan file demotes to B, agent-failed leaves category A intact, valid plan emits `policy_event` into the bundle
- [x] CI passes

## Notes

**Why mirror, not import?** The runner is its own Go module (`runner/go.mod`); `backend/internal/...` is unreachable from outside the backend module. Same situation as the verifier with `backend/internal/audit`. For audit-grade code (chain hashing) we mirror with a canonical fixture test for drift detection per ADR-008. For schema-only code like this one, the CI schema-sync diff is the simpler equivalent — a producer drift on either side fails the gate.

**Validation classification.** Plan validation produces a category-B failure, not A. A is "the agent failed"; B is "the agent succeeded but the output violated policy." A malformed plan is the latter — the agent ran fine, it just emitted something the schema rejects.

**Bundle contract.** Plan-validation outcomes land as `kind=policy_event` events in the trace bundle. ARCHITECTURE.md §5.3 lists `policy_event` as a valid mid-bundle event kind, so this slots in without a format change. The full transition log is preserved even on demotion: agent's events first, then the validation policy_event, then the bundle's trailer.

**Not in scope.** This PR doesn't define how the agent gets told *where* to write the plan — that's prompt-construction logic that lives in the workflow-stage runner orchestration (E3.3 backend dispatch) and beyond. The flag is the seam; the prompt template wiring is the next deliverable.

Closes #31
