### PR TITLE
Add post-hoc constraint enforcement to the runner (E5.5)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -156,6 +156,7 @@ GitHub OAuth (E4.2 / #49) is the sign-in flow that mints the cookie session. App
 | Plan artifact structure | `docs/spec/plan-standard-v1.md` + `docs/spec/plan-standard-v1.schema.json` |
 | HTTP API contract (endpoints, auth, errors) | `docs/api/v0.openapi.yaml` (source of truth) + `docs/api/v0.md` (companion) |
 | Trace bundle wire format (`*.jsonl.gz`) | `runner/internal/bundle/bundle.go` (pack + open) — implements ADR-007 (#71) |
+| Constraint evaluation (forbidden_paths, max_files_changed, required_outcomes) | `runner/internal/constraint/constraint.go` (post-hoc, runner-side) |
 | HTTP middleware order / context keys | `backend/internal/server/middleware.go` |
 | How a new Go module gets added | `CLAUDE.md` "Adding a Go module" |
 

--- a/runner/README.md
+++ b/runner/README.md
@@ -14,13 +14,14 @@ This directory is its own Go module (`github.com/kuhlman-labs/fishhawk/runner`) 
 - `internal/agent/claudecode/` — adapter for Anthropic's Claude Code CLI.
 - `internal/bundle/` — `*.jsonl.gz` trace bundle pack/unpack per ADR-007 (#71).
 - `internal/plan/` — plan-artifact validator against `standard_v1` (E1.5 schema; embedded copy under `schemas/`).
+- `internal/constraint/` — workflow-spec constraint evaluator (`forbidden_paths`, `allowed_paths`, `max_files_changed`, `required_outcomes`).
+- `internal/gitdiff/` — thin shim around `git diff --name-status -z` producing a `constraint.Diff`.
 - `internal/version/` — build-version package; set via `-ldflags` at release time.
 
 ## Status
 
-E5.1 (#52) shipped the scaffold. E5.2 (#29) wired the Claude Code invocation harness. E5.3 (#30) added trace bundling. E5.4 (#31) added plan-artifact validation: when `--plan-out` points at a file the agent writes its plan to, the runner validates it against `standard_v1` after the agent succeeds. A validation failure demotes the run to category-B (constraint/policy violation, MVP_SPEC §6) and the bundle records a `policy_event` with the outcome.
+E5.1 (#52) shipped the scaffold. E5.2 (#29) wired the Claude Code invocation harness. E5.3 (#30) added trace bundling. E5.4 (#31) added plan-artifact validation. E5.5 (#53) added post-hoc constraint enforcement: with `--constraints-file` and `--check-base-ref`, the runner runs `git diff --name-status -z` against the base ref and evaluates `forbidden_paths` / `allowed_paths` / `max_files_changed` / `required_outcomes` against the diff. Any violation demotes the run to category-B and emits one `policy_event` per violation into the bundle.
 
-- E5.5 (#53) — post-hoc constraint enforcement on stage output
 - E5.6 (#32) — signed trace shipping to backend (uses `backend/internal/signing` + `backend/internal/tracestore`)
 - E5.7 (#54) — versioned, signed releases of `fishhawk/runner` with SBOM
 
@@ -38,6 +39,8 @@ E5.1 (#52) shipped the scaffold. E5.2 (#29) wired the Claude Code invocation har
 | `timeout` | no | Wall-clock cap on the agent invocation, e.g. `15m`. Default 15m. |
 | `bundle-out` | no | Path to write the gzipped trace bundle. When set the runner produces an ADR-007 `*.jsonl.gz` artifact instead of JSONL on stdout. |
 | `plan-out` | no | Path the agent writes its plan artifact to. When set, the runner validates the file against `standard_v1` after a successful agent invocation; a malformed plan demotes the run to category-B failure. |
+| `constraints-file` | no | Path to a JSON file with the stage's constraints (`forbidden_paths`, `allowed_paths`, `max_files_changed`, `required_outcomes`, `ci_green`). |
+| `check-base-ref` | no | Git ref to diff against for constraint evaluation. Constraints run only when both `constraints-file` and `check-base-ref` are set. |
 
 The Claude Code API key is supplied via the `ANTHROPIC_API_KEY` environment variable, which customers populate from their GitHub Secrets. v0.x will replace this with a Fishhawk-issued ephemeral key (MVP_SPEC §5.3).
 

--- a/runner/action.yml
+++ b/runner/action.yml
@@ -59,6 +59,14 @@ inputs:
     description: 'Path the agent writes its plan artifact to. When set, the runner validates against standard_v1 after a successful agent invocation.'
     required: false
     default: ''
+  constraints-file:
+    description: 'Path to a JSON file describing the stage constraints (forbidden_paths, allowed_paths, max_files_changed, required_outcomes).'
+    required: false
+    default: ''
+  check-base-ref:
+    description: 'Git ref to diff against for constraint evaluation (e.g. origin/main). Constraints run only when both constraints-file and check-base-ref are set.'
+    required: false
+    default: ''
 
 runs:
   using: 'composite'
@@ -85,4 +93,6 @@ runs:
           --max-tokens "${{ inputs.max-tokens }}" \
           --timeout "${{ inputs.timeout }}" \
           --bundle-out "${{ inputs.bundle-out }}" \
-          --plan-out "${{ inputs.plan-out }}"
+          --plan-out "${{ inputs.plan-out }}" \
+          --constraints-file "${{ inputs.constraints-file }}" \
+          --check-base-ref "${{ inputs.check-base-ref }}"

--- a/runner/cmd/fishhawk-runner/flags.go
+++ b/runner/cmd/fishhawk-runner/flags.go
@@ -23,12 +23,14 @@ type config struct {
 	workflow   string
 	stage      string
 
-	promptFile string
-	workingDir string
-	maxTokens  int
-	timeout    time.Duration
-	bundleOut  string
-	planOut    string
+	promptFile      string
+	workingDir      string
+	maxTokens       int
+	timeout         time.Duration
+	bundleOut       string
+	planOut         string
+	constraintsFile string
+	checkBaseRef    string
 }
 
 // parseFlags reads args and populates a config. Returns a usage
@@ -61,6 +63,10 @@ func parseFlags(args []string, w io.Writer) (config, error) {
 		"path to write the gzipped trace bundle (ADR-007); when empty, events go to stdout as JSONL")
 	fs.StringVar(&cfg.planOut, "plan-out", "",
 		"path the agent writes its plan artifact to; when set, the runner validates it against standard_v1 after a successful agent invocation")
+	fs.StringVar(&cfg.constraintsFile, "constraints-file", "",
+		"path to a JSON file describing the stage's constraints (forbidden_paths, allowed_paths, max_files_changed, required_outcomes); requires --check-base-ref to be useful")
+	fs.StringVar(&cfg.checkBaseRef, "check-base-ref", "",
+		"git ref to diff against for constraint evaluation (e.g. origin/main); when set together with --constraints-file the runner enforces post-hoc")
 
 	if err := fs.Parse(args); err != nil {
 		return cfg, err

--- a/runner/cmd/fishhawk-runner/main.go
+++ b/runner/cmd/fishhawk-runner/main.go
@@ -21,10 +21,13 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/kuhlman-labs/fishhawk/runner/internal/agent"
 	"github.com/kuhlman-labs/fishhawk/runner/internal/agent/claudecode"
 	"github.com/kuhlman-labs/fishhawk/runner/internal/bundle"
+	"github.com/kuhlman-labs/fishhawk/runner/internal/constraint"
+	"github.com/kuhlman-labs/fishhawk/runner/internal/gitdiff"
 	"github.com/kuhlman-labs/fishhawk/runner/internal/plan"
 )
 
@@ -103,6 +106,21 @@ func run(args []string, logSink io.Writer) int {
 			invokeErr = demote
 		} else {
 			res.Events = append(res.Events, ev)
+		}
+	}
+
+	// Constraint evaluation: same demotion rules as plan
+	// validation. Only runs if everything before it succeeded so
+	// we don't double-stamp a category-A failure as B.
+	if res.OK && cfg.constraintsFile != "" && cfg.checkBaseRef != "" {
+		if evs, demote := enforceConstraints(cfg); demote != nil {
+			res.Events = append(res.Events, evs...)
+			res.OK = false
+			res.FailureCategory = "B"
+			res.FailureReason = demote.Error()
+			invokeErr = demote
+		} else {
+			res.Events = append(res.Events, evs...)
 		}
 	}
 
@@ -200,6 +218,77 @@ func classifyErr(err error) string {
 	default:
 		return "other"
 	}
+}
+
+// enforceConstraints runs `git diff --name-status` against the
+// configured base ref and evaluates the constraints from the JSON
+// file. Returns one or more policy_event events for the bundle
+// plus a non-nil error iff any constraint was violated. The
+// caller demotes the run to category-B on a non-nil error.
+//
+// On infra failures (file read, git error) we still demote to
+// category-B because from the workflow author's perspective "the
+// runner couldn't verify your constraints" is a constraint-stage
+// failure, not an agent failure.
+func enforceConstraints(cfg config) ([]agent.Event, error) {
+	raw, err := os.ReadFile(cfg.constraintsFile)
+	if err != nil {
+		return []agent.Event{{
+			Kind:    "policy_event",
+			Payload: agent.MakePayload(map[string]string{"check": "constraints", "outcome": "config_unreadable", "error": err.Error()}),
+		}}, fmt.Errorf("constraints: read %s: %w", cfg.constraintsFile, err)
+	}
+	var c constraint.Constraints
+	if err := json.Unmarshal(raw, &c); err != nil {
+		return []agent.Event{{
+			Kind:    "policy_event",
+			Payload: agent.MakePayload(map[string]string{"check": "constraints", "outcome": "config_invalid", "error": err.Error()}),
+		}}, fmt.Errorf("constraints: parse %s: %w", cfg.constraintsFile, err)
+	}
+
+	repoDir := cfg.workingDir
+	if repoDir == "" {
+		repoDir = "."
+	}
+	d, err := (&gitdiff.Runner{}).Run(context.Background(), cfg.checkBaseRef, repoDir)
+	if err != nil {
+		return []agent.Event{{
+			Kind:    "policy_event",
+			Payload: agent.MakePayload(map[string]string{"check": "constraints", "outcome": "diff_failed", "error": err.Error()}),
+		}}, fmt.Errorf("constraints: %w", err)
+	}
+
+	violations := constraint.Evaluate(d, c)
+	if len(violations) == 0 {
+		return []agent.Event{{
+			Kind: "policy_event",
+			Payload: agent.MakePayload(map[string]any{
+				"check":         "constraints",
+				"outcome":       "valid",
+				"files_checked": len(d.ChangedFiles),
+			}),
+		}}, nil
+	}
+
+	// One policy_event per violation keeps the bundle structured —
+	// audit consumers can group / filter by Constraint without
+	// parsing free-text.
+	var evs []agent.Event
+	var summary []string
+	for _, v := range violations {
+		evs = append(evs, agent.Event{
+			Kind: "policy_event",
+			Payload: agent.MakePayload(map[string]any{
+				"check":      "constraints",
+				"outcome":    "violation",
+				"constraint": v.Constraint,
+				"detail":     v.Detail,
+				"files":      v.Files,
+			}),
+		})
+		summary = append(summary, v.String())
+	}
+	return evs, fmt.Errorf("constraint violations: %s", strings.Join(summary, "; "))
 }
 
 // validatePlan reads the plan artifact at path and validates it

--- a/runner/cmd/fishhawk-runner/main_test.go
+++ b/runner/cmd/fishhawk-runner/main_test.go
@@ -555,6 +555,109 @@ func TestRun_PlanValidationSkippedOnAgentFailure(t *testing.T) {
 	}
 }
 
+func TestRun_ConstraintsConfigUnreadable_DemotesToB(t *testing.T) {
+	dir := t.TempDir()
+	promptPath := filepath.Join(dir, "prompt.txt")
+	if err := os.WriteFile(promptPath, []byte("p"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	withFakeInvoker(t, &fakeInvoker{canned: agent.Result{OK: true}})
+
+	var stderr strings.Builder
+	got := run([]string{
+		"--run-id", "rid", "--backend-url", "u", "--workflow", "w", "--stage", "s",
+		"--prompt-file", promptPath,
+		"--constraints-file", filepath.Join(dir, "no-such.json"),
+		"--check-base-ref", "main",
+	}, &stderr)
+	if got != exitFailure {
+		t.Fatalf("run = %d, want exitFailure", got)
+	}
+	if !strings.Contains(stderr.String(), `"category":"B"`) {
+		t.Errorf("missing category B: %s", stderr.String())
+	}
+}
+
+func TestRun_ConstraintsConfigInvalidJSON_DemotesToB(t *testing.T) {
+	dir := t.TempDir()
+	promptPath := filepath.Join(dir, "prompt.txt")
+	configPath := filepath.Join(dir, "constraints.json")
+	if err := os.WriteFile(promptPath, []byte("p"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configPath, []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	withFakeInvoker(t, &fakeInvoker{canned: agent.Result{OK: true}})
+
+	var stderr strings.Builder
+	got := run([]string{
+		"--run-id", "rid", "--backend-url", "u", "--workflow", "w", "--stage", "s",
+		"--prompt-file", promptPath,
+		"--constraints-file", configPath,
+		"--check-base-ref", "main",
+	}, &stderr)
+	if got != exitFailure {
+		t.Errorf("run = %d, want exitFailure", got)
+	}
+	if !strings.Contains(stderr.String(), `"category":"B"`) {
+		t.Errorf("missing category B: %s", stderr.String())
+	}
+}
+
+func TestRun_ConstraintsRequiresBothFlags(t *testing.T) {
+	// --constraints-file alone (no --check-base-ref) should NOT
+	// trigger constraint evaluation. Use a path that would error
+	// if read; if we still exit OK, the wiring is correct.
+	dir := t.TempDir()
+	promptPath := filepath.Join(dir, "prompt.txt")
+	if err := os.WriteFile(promptPath, []byte("p"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	withFakeInvoker(t, &fakeInvoker{canned: agent.Result{OK: true}})
+
+	var stderr strings.Builder
+	got := run([]string{
+		"--run-id", "rid", "--backend-url", "u", "--workflow", "w", "--stage", "s",
+		"--prompt-file", promptPath,
+		"--constraints-file", filepath.Join(dir, "no-such.json"),
+		// --check-base-ref intentionally absent.
+	}, &stderr)
+	if got != exitOK {
+		t.Errorf("run = %d, want exitOK (constraints should be skipped without --check-base-ref)", got)
+	}
+}
+
+func TestRun_ConstraintsSkippedOnAgentFailure(t *testing.T) {
+	// If the agent failed, constraint evaluation must not run —
+	// keep failure category A.
+	dir := t.TempDir()
+	promptPath := filepath.Join(dir, "prompt.txt")
+	if err := os.WriteFile(promptPath, []byte("p"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	withFakeInvoker(t, &fakeInvoker{
+		canned: agent.Result{
+			OK: false, FailureCategory: "A", FailureReason: "agent crash",
+		},
+		returnErr: agent.ErrAgentFailed,
+	})
+
+	var stderr strings.Builder
+	got := run([]string{
+		"--run-id", "rid", "--backend-url", "u", "--workflow", "w", "--stage", "s",
+		"--prompt-file", promptPath,
+		"--constraints-file", filepath.Join(dir, "no-such.json"),
+		"--check-base-ref", "main",
+	}, &stderr)
+	if got != exitFailure {
+		t.Fatalf("run = %d, want exitFailure", got)
+	}
+	if !strings.Contains(stderr.String(), `"category":"A"`) {
+		t.Errorf("expected category A preserved: %s", stderr.String())
+	}
+}
+
 func TestEmitEvents_OneJSONPerLine(t *testing.T) {
 	var w bytes.Buffer
 	emitEvents(&w, []agent.Event{

--- a/runner/go.mod
+++ b/runner/go.mod
@@ -3,6 +3,7 @@ module github.com/kuhlman-labs/fishhawk/runner
 go 1.25
 
 require (
+	github.com/bmatcuk/doublestar/v4 v4.10.0 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	golang.org/x/text v0.14.0 // indirect
 )

--- a/runner/go.sum
+++ b/runner/go.sum
@@ -1,3 +1,5 @@
+github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=
+github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=

--- a/runner/internal/constraint/constraint.go
+++ b/runner/internal/constraint/constraint.go
@@ -1,0 +1,315 @@
+// Package constraint evaluates the closed set of workflow-spec
+// constraints (forbidden_paths, allowed_paths, max_files_changed,
+// required_outcomes) against a stage's actual output. Returns a
+// list of violations; one or more violations means the stage failed
+// as category-B (constraint / policy violation) per MVP_SPEC §6.
+//
+// Designed to be agent-agnostic: the input is a Diff (list of
+// changed files with status) and a Constraints struct. The runner
+// produces the Diff via `git diff --name-status` after the agent
+// has finished writing files; the backend will use the same
+// package on ingest to re-verify what the runner reported.
+//
+// Glob semantics follow gitignore-style: `**` matches any number
+// of path segments, `*` matches within a segment, leading `/` is
+// implicit (paths are repo-relative). Implementation delegates to
+// github.com/bmatcuk/doublestar/v4, which is the de-facto Go
+// matcher for this style.
+package constraint
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/bmatcuk/doublestar/v4"
+)
+
+// Status is the per-file change kind. The values mirror the single
+// letter `git diff --name-status` emits, so a thin parser can build
+// a Diff without translation.
+type Status string
+
+// Status letter values mirroring `git diff --name-status` output;
+// see git-diff(1) for the full meaning of each.
+const (
+	StatusAdded    Status = "A"
+	StatusModified Status = "M"
+	StatusDeleted  Status = "D"
+	StatusRenamed  Status = "R"
+	StatusCopied   Status = "C"
+	StatusTypeChg  Status = "T"
+)
+
+// ChangedFile is one row of a stage's diff. Path is repo-relative
+// and uses forward slashes regardless of platform.
+type ChangedFile struct {
+	Path   string
+	Status Status
+}
+
+// Diff is the input to Evaluate: every file the agent touched in
+// the stage, in any order. Empty Diff means the agent produced no
+// changes (which is itself a constraint check for some stages).
+type Diff struct {
+	ChangedFiles []ChangedFile
+}
+
+// Constraints is the parsed shape of the workflow-spec stage's
+// `constraints` block. Zero values mean "this constraint isn't
+// configured" — Evaluate skips them.
+type Constraints struct {
+	// ForbiddenPaths: any changed file matching ANY pattern is a
+	// violation. Patterns are gitignore-style globs.
+	ForbiddenPaths []string
+	// AllowedPaths: every changed file MUST match at least one
+	// pattern. A file matching none is a violation.
+	AllowedPaths []string
+	// MaxFilesChanged: 0 means "no limit"; otherwise the diff's
+	// file count must be <= this value.
+	MaxFilesChanged int
+	// RequiredOutcomes: closed set per the schema —
+	// "tests_added_or_updated", "ci_green".
+	RequiredOutcomes []string
+	// CIGreen is what an upstream signal said about the customer
+	// CI's outcome. Required only if RequiredOutcomes contains
+	// "ci_green"; nil when the runner doesn't have a CI signal
+	// available (the backend re-checks once CI completes).
+	CIGreen *bool
+}
+
+// Violation is one constraint failure. Constraint names match the
+// workflow-spec keys so log scrapers and the audit log can index
+// on them. Detail is human-readable; Files lists the offending
+// paths when relevant.
+type Violation struct {
+	Constraint string
+	Detail     string
+	Files      []string
+}
+
+func (v Violation) String() string {
+	if len(v.Files) == 0 {
+		return fmt.Sprintf("%s: %s", v.Constraint, v.Detail)
+	}
+	return fmt.Sprintf("%s: %s [%s]", v.Constraint, v.Detail, strings.Join(v.Files, ", "))
+}
+
+// Evaluate runs every configured constraint against the diff and
+// returns the list of violations in deterministic order (by
+// constraint name, then by file). An empty slice means the diff
+// satisfies every constraint.
+//
+// Bad glob patterns produce a Violation with Constraint =
+// "<original>" and Detail = "invalid pattern" rather than crashing;
+// the runner's policy-event for the bundle should surface these so
+// the workflow-spec author sees the typo without reading runner
+// stderr.
+func Evaluate(diff Diff, c Constraints) []Violation {
+	var out []Violation
+
+	if len(c.ForbiddenPaths) > 0 {
+		out = append(out, checkForbidden(diff, c.ForbiddenPaths)...)
+	}
+	if len(c.AllowedPaths) > 0 {
+		out = append(out, checkAllowed(diff, c.AllowedPaths)...)
+	}
+	if c.MaxFilesChanged > 0 {
+		out = append(out, checkMaxFiles(diff, c.MaxFilesChanged)...)
+	}
+	if len(c.RequiredOutcomes) > 0 {
+		out = append(out, checkRequiredOutcomes(diff, c.RequiredOutcomes, c.CIGreen)...)
+	}
+
+	return out
+}
+
+func checkForbidden(diff Diff, patterns []string) []Violation {
+	var v []Violation
+	for _, pat := range patterns {
+		hit := matchAny(diff, pat)
+		if len(hit.invalid) > 0 {
+			v = append(v, Violation{
+				Constraint: "forbidden_paths",
+				Detail:     fmt.Sprintf("invalid pattern %q", pat),
+			})
+			continue
+		}
+		if len(hit.matched) > 0 {
+			v = append(v, Violation{
+				Constraint: "forbidden_paths",
+				Detail:     fmt.Sprintf("pattern %q matched", pat),
+				Files:      hit.matched,
+			})
+		}
+	}
+	return v
+}
+
+func checkAllowed(diff Diff, patterns []string) []Violation {
+	// A file is allowed if ANY pattern matches. The violation list
+	// names every file that matched none.
+	var bad []string
+	var hadInvalid bool
+	for _, f := range diff.ChangedFiles {
+		matched := false
+		for _, pat := range patterns {
+			ok, err := doublestar.PathMatch(pat, f.Path)
+			if err != nil {
+				hadInvalid = true
+				continue
+			}
+			if ok {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			bad = append(bad, f.Path)
+		}
+	}
+	var out []Violation
+	if hadInvalid {
+		out = append(out, Violation{
+			Constraint: "allowed_paths",
+			Detail:     "one or more patterns invalid",
+		})
+	}
+	if len(bad) > 0 {
+		out = append(out, Violation{
+			Constraint: "allowed_paths",
+			Detail:     "files outside allowed patterns",
+			Files:      bad,
+		})
+	}
+	return out
+}
+
+func checkMaxFiles(diff Diff, max int) []Violation {
+	if len(diff.ChangedFiles) <= max {
+		return nil
+	}
+	return []Violation{{
+		Constraint: "max_files_changed",
+		Detail:     fmt.Sprintf("changed %d files; limit %d", len(diff.ChangedFiles), max),
+	}}
+}
+
+func checkRequiredOutcomes(diff Diff, outcomes []string, ciGreen *bool) []Violation {
+	var v []Violation
+	for _, o := range outcomes {
+		switch o {
+		case "tests_added_or_updated":
+			if !diffTouchesTests(diff) {
+				v = append(v, Violation{
+					Constraint: "required_outcomes",
+					Detail:     "no test files added or updated",
+				})
+			}
+		case "ci_green":
+			// The runner can only check ci_green when an upstream
+			// signal was provided. When CIGreen is nil, the runner
+			// records that as 'unknown' and lets the backend
+			// re-check post-hoc once CI completes — silence here
+			// would falsely pass the constraint.
+			if ciGreen == nil {
+				v = append(v, Violation{
+					Constraint: "required_outcomes",
+					Detail:     "ci_green required but no signal available; backend will re-check",
+				})
+			} else if !*ciGreen {
+				v = append(v, Violation{
+					Constraint: "required_outcomes",
+					Detail:     "ci is not green",
+				})
+			}
+		default:
+			// The schema enum bounds this; defense-in-depth
+			// catches drift between schema and code.
+			v = append(v, Violation{
+				Constraint: "required_outcomes",
+				Detail:     fmt.Sprintf("unknown outcome %q", o),
+			})
+		}
+	}
+	return v
+}
+
+// diffTouchesTests reports whether any added or modified file in
+// the diff looks like a test by path convention. Closed set of
+// patterns covering the languages v0 customers most commonly use;
+// extend per-language as needs surface.
+func diffTouchesTests(diff Diff) bool {
+	for _, f := range diff.ChangedFiles {
+		if f.Status == StatusDeleted {
+			continue
+		}
+		if isTestPath(f.Path) {
+			return true
+		}
+	}
+	return false
+}
+
+// isTestPath returns true for paths that match a recognized test
+// convention. Kept as a single function so the heuristic set lives
+// in one place; new frameworks add a clause here.
+func isTestPath(p string) bool {
+	low := strings.ToLower(p)
+	switch {
+	case strings.HasSuffix(low, "_test.go"): // Go
+		return true
+	case strings.HasSuffix(low, ".test.ts"),
+		strings.HasSuffix(low, ".test.tsx"),
+		strings.HasSuffix(low, ".test.js"),
+		strings.HasSuffix(low, ".test.jsx"),
+		strings.HasSuffix(low, ".spec.ts"),
+		strings.HasSuffix(low, ".spec.tsx"),
+		strings.HasSuffix(low, ".spec.js"),
+		strings.HasSuffix(low, ".spec.jsx"): // JS / TS
+		return true
+	case strings.HasPrefix(low, "tests/") ||
+		strings.Contains(low, "/tests/") ||
+		strings.HasPrefix(low, "test/") ||
+		strings.Contains(low, "/test/"): // Python / Rust / C++ test directories
+		return true
+	case strings.HasSuffix(low, "_test.py"),
+		strings.HasPrefix(filepathBase(low), "test_"): // Python
+		return true
+	case strings.Contains(low, "/spec/"): // Ruby / Elixir
+		return true
+	}
+	return false
+}
+
+// filepathBase trims directory components from p without importing
+// path/filepath (keeps platform-independence). Equivalent to
+// path.Base for forward-slash inputs.
+func filepathBase(p string) string {
+	if i := strings.LastIndex(p, "/"); i >= 0 {
+		return p[i+1:]
+	}
+	return p
+}
+
+// matchResult collects the per-pattern outcome of a forbidden-paths
+// check: matched is the list of diff paths the pattern flagged,
+// invalid records whether the pattern itself failed to compile.
+type matchResult struct {
+	matched []string
+	invalid []string
+}
+
+func matchAny(diff Diff, pattern string) matchResult {
+	var r matchResult
+	for _, f := range diff.ChangedFiles {
+		ok, err := doublestar.PathMatch(pattern, f.Path)
+		if err != nil {
+			r.invalid = append(r.invalid, f.Path)
+			continue
+		}
+		if ok {
+			r.matched = append(r.matched, f.Path)
+		}
+	}
+	return r
+}

--- a/runner/internal/constraint/constraint_test.go
+++ b/runner/internal/constraint/constraint_test.go
@@ -1,0 +1,240 @@
+package constraint
+
+import (
+	"strings"
+	"testing"
+)
+
+func diff(files ...string) Diff {
+	d := Diff{}
+	for _, f := range files {
+		// Default to modified status; tests that need other
+		// statuses build the slice manually.
+		d.ChangedFiles = append(d.ChangedFiles, ChangedFile{Path: f, Status: StatusModified})
+	}
+	return d
+}
+
+func TestEvaluate_Empty_NoConstraintsConfigured(t *testing.T) {
+	v := Evaluate(diff("a.go"), Constraints{})
+	if len(v) != 0 {
+		t.Errorf("expected no violations, got %+v", v)
+	}
+}
+
+func TestForbiddenPaths_Hit(t *testing.T) {
+	d := diff("backend/main.go", "infra/terraform.tf")
+	v := Evaluate(d, Constraints{ForbiddenPaths: []string{"infra/**"}})
+	if len(v) != 1 {
+		t.Fatalf("got %d violations, want 1: %+v", len(v), v)
+	}
+	if v[0].Constraint != "forbidden_paths" {
+		t.Errorf("Constraint = %q", v[0].Constraint)
+	}
+	if len(v[0].Files) != 1 || v[0].Files[0] != "infra/terraform.tf" {
+		t.Errorf("Files = %v, want [infra/terraform.tf]", v[0].Files)
+	}
+}
+
+func TestForbiddenPaths_NoHit(t *testing.T) {
+	d := diff("backend/main.go", "frontend/app.tsx")
+	v := Evaluate(d, Constraints{ForbiddenPaths: []string{"infra/**", ".github/workflows/**"}})
+	if len(v) != 0 {
+		t.Errorf("expected no violations, got %+v", v)
+	}
+}
+
+func TestForbiddenPaths_InvalidPattern(t *testing.T) {
+	d := diff("a.go")
+	// `[` opens a character class that's never closed → invalid.
+	v := Evaluate(d, Constraints{ForbiddenPaths: []string{"[bad"}})
+	if len(v) != 1 || !strings.Contains(v[0].Detail, "invalid") {
+		t.Errorf("expected invalid-pattern violation, got %+v", v)
+	}
+}
+
+func TestAllowedPaths_AllAllowed(t *testing.T) {
+	d := diff("backend/main.go", "backend/internal/server/handlers.go")
+	v := Evaluate(d, Constraints{AllowedPaths: []string{"backend/**"}})
+	if len(v) != 0 {
+		t.Errorf("expected no violations, got %+v", v)
+	}
+}
+
+func TestAllowedPaths_OutsideAllowed(t *testing.T) {
+	d := diff("backend/main.go", "frontend/app.tsx")
+	v := Evaluate(d, Constraints{AllowedPaths: []string{"backend/**"}})
+	if len(v) != 1 {
+		t.Fatalf("got %d violations, want 1: %+v", len(v), v)
+	}
+	if len(v[0].Files) != 1 || v[0].Files[0] != "frontend/app.tsx" {
+		t.Errorf("Files = %v", v[0].Files)
+	}
+}
+
+func TestAllowedPaths_InvalidPattern(t *testing.T) {
+	d := diff("a.go")
+	v := Evaluate(d, Constraints{AllowedPaths: []string{"[bad"}})
+	// Two violations: invalid-pattern note + the file matching nothing.
+	if len(v) != 2 {
+		t.Fatalf("got %d violations, want 2: %+v", len(v), v)
+	}
+	if !strings.Contains(v[0].Detail, "invalid") {
+		t.Errorf("first violation = %+v, want invalid", v[0])
+	}
+}
+
+func TestMaxFilesChanged_Under(t *testing.T) {
+	d := diff("a.go", "b.go", "c.go")
+	v := Evaluate(d, Constraints{MaxFilesChanged: 5})
+	if len(v) != 0 {
+		t.Errorf("expected no violations, got %+v", v)
+	}
+}
+
+func TestMaxFilesChanged_Equal(t *testing.T) {
+	d := diff("a.go", "b.go", "c.go")
+	v := Evaluate(d, Constraints{MaxFilesChanged: 3})
+	if len(v) != 0 {
+		t.Errorf("equal-to-limit should pass, got %+v", v)
+	}
+}
+
+func TestMaxFilesChanged_Over(t *testing.T) {
+	d := diff("a.go", "b.go", "c.go", "d.go")
+	v := Evaluate(d, Constraints{MaxFilesChanged: 3})
+	if len(v) != 1 {
+		t.Fatalf("got %d violations, want 1: %+v", len(v), v)
+	}
+	if !strings.Contains(v[0].Detail, "limit 3") {
+		t.Errorf("Detail = %q", v[0].Detail)
+	}
+}
+
+func TestRequiredOutcomes_TestsAddedOrUpdated_Pass(t *testing.T) {
+	cases := []string{
+		"backend/internal/server/handlers_test.go",
+		"frontend/app.test.tsx",
+		"tests/integration/api.py",
+		"backend/internal/server/test/fixtures.go",
+		"src/foo/spec/bar.rb",
+		"py/test_thing.py",
+	}
+	for _, p := range cases {
+		t.Run(p, func(t *testing.T) {
+			v := Evaluate(diff(p), Constraints{RequiredOutcomes: []string{"tests_added_or_updated"}})
+			if len(v) != 0 {
+				t.Errorf("expected pass, got %+v", v)
+			}
+		})
+	}
+}
+
+func TestRequiredOutcomes_TestsAddedOrUpdated_Fail(t *testing.T) {
+	d := diff("backend/main.go", "frontend/app.tsx")
+	v := Evaluate(d, Constraints{RequiredOutcomes: []string{"tests_added_or_updated"}})
+	if len(v) != 1 || !strings.Contains(v[0].Detail, "no test files") {
+		t.Errorf("expected tests-not-added violation, got %+v", v)
+	}
+}
+
+func TestRequiredOutcomes_DeletedTestFileDoesntCount(t *testing.T) {
+	// A pure-deletion of a test file shouldn't satisfy
+	// "tests added or updated" — that's the opposite of what we
+	// want.
+	d := Diff{ChangedFiles: []ChangedFile{
+		{Path: "x_test.go", Status: StatusDeleted},
+		{Path: "x.go", Status: StatusModified},
+	}}
+	v := Evaluate(d, Constraints{RequiredOutcomes: []string{"tests_added_or_updated"}})
+	if len(v) != 1 {
+		t.Errorf("expected violation when only test was deleted, got %+v", v)
+	}
+}
+
+func TestRequiredOutcomes_CIGreen_NoSignal(t *testing.T) {
+	// When CIGreen is nil, the runner can't verify; recording the
+	// gap honestly is the spec-mandated behavior (MVP_SPEC §6
+	// "honesty about gaps beats fictional completeness").
+	d := diff("a.go")
+	v := Evaluate(d, Constraints{RequiredOutcomes: []string{"ci_green"}})
+	if len(v) != 1 || !strings.Contains(v[0].Detail, "no signal") {
+		t.Errorf("expected no-signal violation, got %+v", v)
+	}
+}
+
+func TestRequiredOutcomes_CIGreen_True(t *testing.T) {
+	green := true
+	d := diff("a.go")
+	v := Evaluate(d, Constraints{
+		RequiredOutcomes: []string{"ci_green"},
+		CIGreen:          &green,
+	})
+	if len(v) != 0 {
+		t.Errorf("expected no violations, got %+v", v)
+	}
+}
+
+func TestRequiredOutcomes_CIGreen_False(t *testing.T) {
+	green := false
+	d := diff("a.go")
+	v := Evaluate(d, Constraints{
+		RequiredOutcomes: []string{"ci_green"},
+		CIGreen:          &green,
+	})
+	if len(v) != 1 || !strings.Contains(v[0].Detail, "not green") {
+		t.Errorf("expected ci-not-green violation, got %+v", v)
+	}
+}
+
+func TestRequiredOutcomes_UnknownOutcome(t *testing.T) {
+	v := Evaluate(diff("a.go"), Constraints{RequiredOutcomes: []string{"sky_is_blue"}})
+	if len(v) != 1 || !strings.Contains(v[0].Detail, "unknown outcome") {
+		t.Errorf("expected unknown-outcome violation, got %+v", v)
+	}
+}
+
+func TestEvaluate_MultipleConstraints(t *testing.T) {
+	// The classic feature_change implement stage from MVP_SPEC §4.2.
+	d := diff(
+		"backend/internal/server/handlers.go",
+		"backend/internal/server/handlers_test.go",
+		"infra/main.tf", // forbidden
+	)
+	v := Evaluate(d, Constraints{
+		ForbiddenPaths:   []string{"infra/**", ".github/workflows/**", "security/**", ".fishhawk/**"},
+		MaxFilesChanged:  30,
+		RequiredOutcomes: []string{"tests_added_or_updated"},
+	})
+	if len(v) != 1 {
+		t.Fatalf("expected exactly 1 violation (forbidden_paths), got %+v", v)
+	}
+	if v[0].Constraint != "forbidden_paths" {
+		t.Errorf("Constraint = %q, want forbidden_paths", v[0].Constraint)
+	}
+}
+
+func TestViolation_String(t *testing.T) {
+	v := Violation{Constraint: "k", Detail: "d"}
+	if got := v.String(); got != "k: d" {
+		t.Errorf("String() = %q", got)
+	}
+	v2 := Violation{Constraint: "k", Detail: "d", Files: []string{"x", "y"}}
+	if got := v2.String(); got != "k: d [x, y]" {
+		t.Errorf("String() with files = %q", got)
+	}
+}
+
+func TestStatusConstants(t *testing.T) {
+	// Pin to the git --name-status letters; CI parsers depend on
+	// these matching upstream's output.
+	pairs := map[Status]string{
+		StatusAdded: "A", StatusModified: "M", StatusDeleted: "D",
+		StatusRenamed: "R", StatusCopied: "C", StatusTypeChg: "T",
+	}
+	for s, want := range pairs {
+		if string(s) != want {
+			t.Errorf("Status %q = %q, want %q", s, string(s), want)
+		}
+	}
+}

--- a/runner/internal/gitdiff/gitdiff.go
+++ b/runner/internal/gitdiff/gitdiff.go
@@ -1,0 +1,162 @@
+// Package gitdiff produces a constraint.Diff from a git working
+// tree by running `git diff --name-status <baseRef>...HEAD`. It's
+// a thin shim around os/exec so the constraint package itself
+// stays pure and testable without touching real git state.
+//
+// The runner calls this after the agent finishes editing files
+// (typically: agent commits to a branch, runner runs gitdiff
+// against the merge-base with the workflow base ref, evaluates
+// constraints).
+package gitdiff
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/kuhlman-labs/fishhawk/runner/internal/constraint"
+)
+
+// Runner executes `git` to produce a Diff. Cmd defaults to
+// exec.CommandContext but is overridable for tests so we can drive
+// the parser without a real git working tree.
+type Runner struct {
+	// Binary is the git executable path. Empty defaults to "git".
+	Binary string
+
+	// Cmd builds the *exec.Cmd. nil defaults to exec.CommandContext.
+	Cmd func(ctx context.Context, name string, args ...string) *exec.Cmd
+}
+
+// Run executes the diff command and parses the output.
+//
+// baseRef is the ref the stage's changes should be measured
+// against (typically the workflow base branch); repoDir is the
+// git working directory the agent edited.
+//
+// The form `<base>...HEAD` (three-dot) gives the diff at the
+// merge base, which is what the workflow author intends — changes
+// the stage actually introduced, not unrelated commits on the base
+// branch.
+func (r *Runner) Run(ctx context.Context, baseRef, repoDir string) (constraint.Diff, error) {
+	if baseRef == "" {
+		return constraint.Diff{}, fmt.Errorf("gitdiff: baseRef required")
+	}
+	if repoDir == "" {
+		return constraint.Diff{}, fmt.Errorf("gitdiff: repoDir required")
+	}
+
+	binary := r.Binary
+	if binary == "" {
+		binary = "git"
+	}
+	cmdFn := r.Cmd
+	if cmdFn == nil {
+		cmdFn = exec.CommandContext
+	}
+
+	args := []string{"diff", "--name-status", "-z", fmt.Sprintf("%s...HEAD", baseRef)}
+	cmd := cmdFn(ctx, binary, args...)
+	cmd.Dir = repoDir
+
+	out, err := cmd.Output()
+	if err != nil {
+		// Surface stderr if available so a typo in baseRef or a
+		// missing repoDir produces an actionable error rather
+		// than a generic exit-status message.
+		if ee, ok := err.(*exec.ExitError); ok && len(ee.Stderr) > 0 {
+			return constraint.Diff{}, fmt.Errorf("gitdiff: %v: %s",
+				err, strings.TrimSpace(string(ee.Stderr)))
+		}
+		return constraint.Diff{}, fmt.Errorf("gitdiff: %w", err)
+	}
+
+	diff, perr := Parse(out)
+	if perr != nil {
+		return constraint.Diff{}, fmt.Errorf("gitdiff: parse: %w", perr)
+	}
+	return diff, nil
+}
+
+// Parse interprets the NUL-separated output of `git diff
+// --name-status -z`. Each entry is (status, path) for ordinary
+// changes; renames and copies have a third field (oldPath).
+//
+// We use the -z (NUL-terminated) form to dodge filenames with
+// special characters; the same parser handles the renamed/copied
+// case by consuming three fields when status is R or C.
+func Parse(raw []byte) (constraint.Diff, error) {
+	var d constraint.Diff
+	if len(raw) == 0 {
+		return d, nil
+	}
+
+	// Build a token list; a NUL-terminated stream yields N tokens
+	// where consecutive NULs would imply an empty token. -z output
+	// from git always emits a status, then a path, then for R/C a
+	// further oldPath. We don't see consecutive NULs in practice;
+	// guard with a bounded loop anyway.
+	scanner := bufio.NewScanner(strings.NewReader(string(raw)))
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	scanner.Split(splitNULs)
+
+	for scanner.Scan() {
+		status := scanner.Text()
+		if status == "" {
+			continue
+		}
+		// Status field for renames is "R<score>" (e.g. R100);
+		// strip the trailing digits for the comparison below but
+		// preserve the leading letter as the canonical status.
+		statusLetter := status[:1]
+
+		if !scanner.Scan() {
+			return constraint.Diff{}, fmt.Errorf("missing path after status %q", status)
+		}
+		path := scanner.Text()
+
+		if statusLetter == "R" || statusLetter == "C" {
+			// Old path follows; we record the new path (the
+			// destination) since constraints look at the resulting
+			// tree.
+			if !scanner.Scan() {
+				return constraint.Diff{},
+					fmt.Errorf("missing destination path after rename/copy from %q", path)
+			}
+			newPath := scanner.Text()
+			d.ChangedFiles = append(d.ChangedFiles, constraint.ChangedFile{
+				Path:   newPath,
+				Status: constraint.Status(statusLetter),
+			})
+			continue
+		}
+
+		d.ChangedFiles = append(d.ChangedFiles, constraint.ChangedFile{
+			Path:   path,
+			Status: constraint.Status(statusLetter),
+		})
+	}
+	if err := scanner.Err(); err != nil {
+		return constraint.Diff{}, fmt.Errorf("scan: %w", err)
+	}
+	return d, nil
+}
+
+// splitNULs is a bufio.SplitFunc that splits on NUL bytes. The
+// stdlib doesn't ship one; this keeps the parser dependency-free.
+func splitNULs(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	if atEOF && len(data) == 0 {
+		return 0, nil, nil
+	}
+	for i, b := range data {
+		if b == 0 {
+			return i + 1, data[:i], nil
+		}
+	}
+	if atEOF {
+		return len(data), data, nil
+	}
+	return 0, nil, nil // request more data
+}

--- a/runner/internal/gitdiff/gitdiff_test.go
+++ b/runner/internal/gitdiff/gitdiff_test.go
@@ -1,0 +1,218 @@
+package gitdiff
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/kuhlman-labs/fishhawk/runner/internal/constraint"
+)
+
+func TestParse_Empty(t *testing.T) {
+	d, err := Parse(nil)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(d.ChangedFiles) != 0 {
+		t.Errorf("expected empty diff, got %+v", d)
+	}
+}
+
+func TestParse_SimpleAddedModifiedDeleted(t *testing.T) {
+	// Simulated `git diff --name-status -z` output: each field is
+	// NUL-terminated.
+	raw := []byte("M\x00backend/main.go\x00A\x00new.go\x00D\x00gone.go\x00")
+	d, err := Parse(raw)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(d.ChangedFiles) != 3 {
+		t.Fatalf("got %d files, want 3: %+v", len(d.ChangedFiles), d.ChangedFiles)
+	}
+	want := []constraint.ChangedFile{
+		{Path: "backend/main.go", Status: constraint.StatusModified},
+		{Path: "new.go", Status: constraint.StatusAdded},
+		{Path: "gone.go", Status: constraint.StatusDeleted},
+	}
+	for i, w := range want {
+		if d.ChangedFiles[i] != w {
+			t.Errorf("file %d = %+v, want %+v", i, d.ChangedFiles[i], w)
+		}
+	}
+}
+
+func TestParse_RenameAndCopy(t *testing.T) {
+	// R100 = pure rename. C75 = copy with 75% similarity. The
+	// destination path goes second; we record the destination.
+	raw := []byte("R100\x00old.go\x00new.go\x00C75\x00source.go\x00dest.go\x00")
+	d, err := Parse(raw)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(d.ChangedFiles) != 2 {
+		t.Fatalf("got %d files, want 2: %+v", len(d.ChangedFiles), d.ChangedFiles)
+	}
+	if d.ChangedFiles[0].Path != "new.go" || d.ChangedFiles[0].Status != constraint.StatusRenamed {
+		t.Errorf("rename: got %+v", d.ChangedFiles[0])
+	}
+	if d.ChangedFiles[1].Path != "dest.go" || d.ChangedFiles[1].Status != constraint.StatusCopied {
+		t.Errorf("copy: got %+v", d.ChangedFiles[1])
+	}
+}
+
+func TestParse_PathWithSpecialChars(t *testing.T) {
+	// -z form preserves filenames with newlines / quotes / spaces
+	// without escaping. Test that a path containing a tab survives.
+	raw := []byte("M\x00path with\ttab.go\x00")
+	d, err := Parse(raw)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(d.ChangedFiles) != 1 || d.ChangedFiles[0].Path != "path with\ttab.go" {
+		t.Errorf("got %+v, want path preserved verbatim", d.ChangedFiles)
+	}
+}
+
+func TestParse_MissingPath(t *testing.T) {
+	// A stream that ends after a status with no following path is
+	// malformed; the parser should reject rather than silently
+	// drop.
+	raw := []byte("M\x00")
+	_, err := Parse(raw)
+	if err == nil {
+		t.Fatal("expected error for status with no path")
+	}
+}
+
+func TestParse_RenameMissingDestination(t *testing.T) {
+	raw := []byte("R100\x00old.go\x00")
+	_, err := Parse(raw)
+	if err == nil {
+		t.Fatal("expected error for rename with no destination")
+	}
+}
+
+// fakeCmd returns a Cmd builder that re-execs the test binary
+// pretending to be `git`. The helper test below emits canned -z
+// output driven by HELPER_MODE.
+func fakeCmd(mode string) func(ctx context.Context, name string, args ...string) *exec.Cmd {
+	return func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+		c := exec.CommandContext(ctx, os.Args[0], "-test.run=TestHelperProcess")
+		c.Env = append(os.Environ(),
+			"GO_HELPER_PROCESS=1",
+			"HELPER_MODE="+mode,
+		)
+		return c
+	}
+}
+
+// TestHelperProcess stands in for the `git` binary in tests.
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_HELPER_PROCESS") != "1" {
+		return
+	}
+	defer os.Exit(0)
+
+	switch os.Getenv("HELPER_MODE") {
+	case "ok":
+		fmt.Print("M\x00a.go\x00A\x00b.go\x00")
+	case "error":
+		fmt.Fprintln(os.Stderr, "fatal: ambiguous argument 'no-such-ref'")
+		os.Exit(128)
+	case "ok_empty":
+		// No output — clean diff.
+	default:
+		fmt.Fprintln(os.Stderr, "unknown HELPER_MODE")
+		os.Exit(2)
+	}
+}
+
+func TestRun_OK(t *testing.T) {
+	r := &Runner{Cmd: fakeCmd("ok")}
+	d, err := r.Run(context.Background(), "main", t.TempDir())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(d.ChangedFiles) != 2 {
+		t.Errorf("got %d files, want 2", len(d.ChangedFiles))
+	}
+}
+
+func TestRun_Error_SurfacesStderr(t *testing.T) {
+	r := &Runner{Cmd: fakeCmd("error")}
+	_, err := r.Run(context.Background(), "no-such-ref", t.TempDir())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "ambiguous argument") {
+		t.Errorf("err = %v, want stderr-derived message", err)
+	}
+}
+
+func TestRun_Empty(t *testing.T) {
+	r := &Runner{Cmd: fakeCmd("ok_empty")}
+	d, err := r.Run(context.Background(), "main", t.TempDir())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(d.ChangedFiles) != 0 {
+		t.Errorf("expected empty diff, got %+v", d)
+	}
+}
+
+func TestRun_RequiredArgs(t *testing.T) {
+	r := &Runner{}
+	if _, err := r.Run(context.Background(), "", "/x"); err == nil {
+		t.Error("expected baseRef required")
+	}
+	if _, err := r.Run(context.Background(), "main", ""); err == nil {
+		t.Error("expected repoDir required")
+	}
+}
+
+func TestSplitNULs(t *testing.T) {
+	// Direct exercise of the splitter so we cover the request-more
+	// branch.
+	advance, token, err := splitNULs([]byte("ab"), false)
+	if err != nil || advance != 0 || token != nil {
+		t.Errorf("partial input: got (%d, %q, %v), want (0, nil, nil)", advance, token, err)
+	}
+	advance, token, err = splitNULs([]byte("ab\x00cd"), false)
+	if err != nil || advance != 3 || string(token) != "ab" {
+		t.Errorf("found NUL: got (%d, %q, %v)", advance, token, err)
+	}
+	advance, token, err = splitNULs([]byte("ab"), true)
+	if err != nil || advance != 2 || string(token) != "ab" {
+		t.Errorf("EOF: got (%d, %q, %v)", advance, token, err)
+	}
+	// EOF with no data should yield (0, nil, nil).
+	advance, token, err = splitNULs(nil, true)
+	if err != nil || advance != 0 || token != nil {
+		t.Errorf("EOF empty: got (%d, %q, %v)", advance, token, err)
+	}
+}
+
+// errExitWithoutStderr ensures the *exec.ExitError-without-stderr
+// path is exercised. When git fails but emits no stderr (rare but
+// possible in mocked cases), the wrapped error still carries the
+// exit message.
+func TestRun_ExitErrorWithoutStderr(t *testing.T) {
+	// Use exec.CommandContext to exec /bin/false (or equivalent).
+	// false always exits 1 with no output — perfect proxy.
+	r := &Runner{
+		Cmd: func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+			return exec.CommandContext(ctx, "false")
+		},
+	}
+	_, err := r.Run(context.Background(), "main", t.TempDir())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, err) { // smoke: just make sure non-nil
+		t.Errorf("err = %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Implements `MVP_SPEC.md §4.2`'s constraint block on the runner side. After the agent finishes (and after plan validation passes), the runner runs `git diff --name-status -z <base>...HEAD`, evaluates the parsed diff against the configured constraints, and demotes the run to category-B (constraint/policy violation, §6) on any violation.

- `runner/internal/constraint/` (100% covered) — pure evaluator over a `Diff` + `Constraints`. Glob matching via `doublestar` (gitignore semantics, supports `**`). Closed set: `forbidden_paths`, `allowed_paths`, `max_files_changed`, `required_outcomes` ∈ {`tests_added_or_updated`, `ci_green`}.
- `runner/internal/gitdiff/` (92.6%) — thin shim around `exec.CommandContext("git", ...)`. The `-z` form preserves paths with whitespace verbatim; renames/copies parse the three-field form and record the destination.
- `runner/cmd/fishhawk-runner` — new `--constraints-file` (JSON shape matching `constraint.Constraints`) and `--check-base-ref` flags. Constraint evaluation runs only when **both** are set AND the agent + plan validation succeeded.
- `action.yml` exposes the two new inputs.

## Test plan

- [x] `go test -race ./runner/...` — 8 packages pass
- [x] `golangci-lint run ./...` across all 3 modules — 0 issues
- [x] Aggregate coverage 86.3% (excl. `/db/`); constraint 100%, gitdiff 92.6%
- [x] 4 new run() cases: config unreadable, config invalid JSON, requires both flags, skipped on agent failure
- [x] 19 constraint cases covering each constraint kind, invalid patterns, the test-path heuristic across Go / TS / JS / Python / Rust / Ruby, and the `ci_green` no-signal honesty rule
- [x] CI passes

## Notes

**Why a JSON file instead of inline flags?** The constraint set is a multi-typed structured object — flag-flattening it (`--forbidden-paths a,b --allowed-paths c,d --max-files 30 --required-outcomes ci_green,tests_added_or_updated --ci-green=true`) produces a fragile interface every consumer reformats. The backend dispatcher will write a temp file with the constraints from the workflow spec; one flag in, one path. Same shape as the way `--prompt-file` works.

**`ci_green` honesty rule.** The runner can't observe customer CI at the time of the post-hoc check — the PR isn't even open yet. When `RequiredOutcomes` includes `ci_green` and `CIGreen` is nil, `Evaluate` returns a violation with detail "no signal available; backend will re-check". Per MVP_SPEC §6: "honesty about gaps beats fictional completeness." The backend's ingest re-runs constraints once CI completes and either clears or confirms.

**Failure-category invariant preserved.** Constraint evaluation only runs when `res.OK == true`. An agent crash stays category-A; a malformed plan stays category-B (plan validation got there first); a constraint violation is the third gate. The `enforceConstraints` helper handles infra failures (config unreadable, git error) the same way — those map to category-B because from the workflow author's perspective "the runner couldn't verify your constraints" is a constraint-stage failure, not an agent failure.

**`tests_added_or_updated` heuristic.** Path conventions across Go (`*_test.go`), JS/TS (`.test.tsx`, `.spec.ts`), Python (`test_*.py`, `_test.py`, `tests/`), and Ruby (`spec/`). Deletions don't count — removing the only test file shouldn't satisfy "tests added or updated". New languages add a clause to `isTestPath`; the function lives in one place by design.

Closes #53
