### PR TITLE
Add run CRUD handlers (POST + GET /v0/runs)

### DIFF
--- a/backend/cmd/fishhawkd/serve.go
+++ b/backend/cmd/fishhawkd/serve.go
@@ -9,6 +9,9 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	runpkg "github.com/kuhlman-labs/fishhawk/backend/internal/run"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/server"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/version"
 )
@@ -19,12 +22,36 @@ func runServe(args []string, logSink io.Writer) int {
 	fs := flag.NewFlagSet("fishhawkd serve", flag.ContinueOnError)
 	fs.SetOutput(logSink)
 	addr := fs.String("addr", envOr("FISHHAWKD_ADDR", ":8080"), "listen address")
+	dbURL := fs.String("db", envOr("FISHHAWKD_DATABASE_URL", ""),
+		"postgres URL; when empty, /v0/runs endpoints respond 503")
 	if err := fs.Parse(args); err != nil {
 		return exitFailure
 	}
 
 	logger := newLogger(logSink)
-	srv := server.New(server.Config{Addr: *addr, Logger: logger})
+
+	cfg := server.Config{Addr: *addr, Logger: logger}
+
+	// Wire the run repository when a DB URL is supplied. Without
+	// one the server still boots — /healthz works and any
+	// repository-dependent handler returns 503 — so operators can
+	// smoke-test a deploy before pointing it at production data.
+	var pool *pgxpool.Pool
+	if *dbURL != "" {
+		var err error
+		pool, err = pgxpool.New(context.Background(), *dbURL)
+		if err != nil {
+			logger.Error("db pool create failed", slog.String("error", err.Error()))
+			return exitFailure
+		}
+		defer pool.Close()
+		cfg.RunRepo = runpkg.NewPostgresRepository(pool)
+		logger.Info("run repository configured", slog.String("driver", "postgres"))
+	} else {
+		logger.Warn("FISHHAWKD_DATABASE_URL not set; /v0/runs endpoints will respond 503")
+	}
+
+	srv := server.New(cfg)
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()

--- a/backend/internal/server/errors.go
+++ b/backend/internal/server/errors.go
@@ -1,0 +1,62 @@
+package server
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+)
+
+// errorEnvelope is the JSON shape every non-2xx response uses, per
+// docs/api/v0.openapi.yaml's `Error` schema. The `code` field is
+// the stable, machine-readable identifier; clients switch on it.
+// `message` is human-readable and may change between versions.
+// `details` is structured per-code; the keys ARE part of the
+// contract for that specific code.
+type errorEnvelope struct {
+	Error errorBody `json:"error"`
+}
+
+type errorBody struct {
+	Code    string         `json:"code"`
+	Message string         `json:"message"`
+	Details map[string]any `json:"details,omitempty"`
+}
+
+// writeError renders an error envelope to w with the given status.
+// The logger surfaces 5xx errors at LevelError and 4xx at LevelInfo
+// so misuse vs. server faults are easy to filter in production.
+func (s *Server) writeError(w http.ResponseWriter, r *http.Request, status int, code, msg string, details map[string]any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	body := errorEnvelope{Error: errorBody{Code: code, Message: msg, Details: details}}
+	if err := json.NewEncoder(w).Encode(body); err != nil {
+		s.cfg.Logger.LogAttrs(r.Context(), slog.LevelError, "encode error response",
+			slog.String("error", err.Error()),
+		)
+	}
+
+	level := slog.LevelInfo
+	if status >= 500 {
+		level = slog.LevelError
+	}
+	s.cfg.Logger.LogAttrs(r.Context(), level, "http error response",
+		slog.Int("status", status),
+		slog.String("code", code),
+		slog.String("message", msg),
+		slog.String("path", r.URL.Path),
+		slog.String("method", r.Method),
+	)
+}
+
+// writeJSON renders v as the response body with the given status.
+// Centralized so every handler uses the same content-type and
+// JSON-encoder configuration.
+func (s *Server) writeJSON(w http.ResponseWriter, r *http.Request, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		s.cfg.Logger.LogAttrs(r.Context(), slog.LevelError, "encode response",
+			slog.String("error", err.Error()),
+		)
+	}
+}

--- a/backend/internal/server/handlers.go
+++ b/backend/internal/server/handlers.go
@@ -9,10 +9,12 @@ import (
 )
 
 // registerRoutes wires every endpoint onto mux. Method-aware patterns
-// require Go 1.22+ ServeMux. Add new routes here as the API surface
-// grows under E3.6 (#46); for v0 the surface is just liveness.
+// require Go 1.22+ ServeMux. Add new routes here as handlers land
+// per docs/api/v0.openapi.yaml.
 func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /healthz", s.handleHealth)
+	mux.HandleFunc("POST /v0/runs", s.handleCreateRun)
+	mux.HandleFunc("GET /v0/runs/{run_id}", s.handleGetRun)
 }
 
 type healthResponse struct {

--- a/backend/internal/server/runs.go
+++ b/backend/internal/server/runs.go
@@ -1,0 +1,154 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/kuhlman-labs/fishhawk/backend/internal/run"
+)
+
+// runResponse is the JSON shape POST /v0/runs and GET /v0/runs/{id}
+// return. Field names + types match docs/api/v0.openapi.yaml's
+// `Run` schema exactly so there's never a translation step between
+// the OpenAPI doc and the wire format.
+type runResponse struct {
+	ID            uuid.UUID `json:"id"`
+	Repo          string    `json:"repo"`
+	WorkflowID    string    `json:"workflow_id"`
+	WorkflowSHA   string    `json:"workflow_sha"`
+	TriggerSource string    `json:"trigger_source"`
+	TriggerRef    *string   `json:"trigger_ref"`
+	State         string    `json:"state"`
+	CreatedAt     time.Time `json:"created_at"`
+	UpdatedAt     time.Time `json:"updated_at"`
+}
+
+func toRunResponse(r *run.Run) runResponse {
+	return runResponse{
+		ID:            r.ID,
+		Repo:          r.Repo,
+		WorkflowID:    r.WorkflowID,
+		WorkflowSHA:   r.WorkflowSHA,
+		TriggerSource: string(r.TriggerSource),
+		TriggerRef:    r.TriggerRef,
+		State:         string(r.State),
+		CreatedAt:     r.CreatedAt,
+		UpdatedAt:     r.UpdatedAt,
+	}
+}
+
+// createRunRequest mirrors POST /v0/runs's request body in
+// v0.openapi.yaml. All four required fields must be present and
+// non-empty; trigger_ref is optional.
+type createRunRequest struct {
+	Repo          string  `json:"repo"`
+	WorkflowID    string  `json:"workflow_id"`
+	WorkflowSHA   string  `json:"workflow_sha"`
+	TriggerSource string  `json:"trigger_source"`
+	TriggerRef    *string `json:"trigger_ref,omitempty"`
+}
+
+// validTriggerSources is the closed set per the workflow-spec and
+// OpenAPI surface. New sources land in v0.x and require an explicit
+// schema bump (see MVP_SPEC §7.1).
+var validTriggerSources = map[string]struct{}{
+	string(run.TriggerGitHubIssue): {},
+	string(run.TriggerCLI):         {},
+	string(run.TriggerUI):          {},
+}
+
+// handleCreateRun implements POST /v0/runs. Validates the request
+// body, calls into the run repository, and returns the canonical
+// Run JSON. The state machine starts every new run in
+// run.StatePending.
+func (s *Server) handleCreateRun(w http.ResponseWriter, r *http.Request) {
+	if s.cfg.RunRepo == nil {
+		s.writeError(w, r, http.StatusServiceUnavailable, "run_repo_unconfigured",
+			"runs endpoint requires a configured run repository", nil)
+		return
+	}
+
+	var req createRunRequest
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&req); err != nil {
+		s.writeError(w, r, http.StatusBadRequest, "validation_failed",
+			"request body is not valid JSON or contains unknown fields",
+			map[string]any{"error": err.Error()})
+		return
+	}
+
+	if req.Repo == "" {
+		s.writeError(w, r, http.StatusBadRequest, "validation_failed",
+			"repo is required", map[string]any{"field": "repo"})
+		return
+	}
+	if req.WorkflowID == "" {
+		s.writeError(w, r, http.StatusBadRequest, "validation_failed",
+			"workflow_id is required", map[string]any{"field": "workflow_id"})
+		return
+	}
+	if req.WorkflowSHA == "" {
+		s.writeError(w, r, http.StatusBadRequest, "validation_failed",
+			"workflow_sha is required", map[string]any{"field": "workflow_sha"})
+		return
+	}
+	if _, ok := validTriggerSources[req.TriggerSource]; !ok {
+		s.writeError(w, r, http.StatusBadRequest, "validation_failed",
+			"trigger_source must be one of github_issue, cli, ui",
+			map[string]any{"field": "trigger_source", "got": req.TriggerSource})
+		return
+	}
+
+	created, err := s.cfg.RunRepo.CreateRun(r.Context(), run.CreateRunParams{
+		Repo:          req.Repo,
+		WorkflowID:    req.WorkflowID,
+		WorkflowSHA:   req.WorkflowSHA,
+		TriggerSource: run.TriggerSource(req.TriggerSource),
+		TriggerRef:    req.TriggerRef,
+	})
+	if err != nil {
+		s.writeError(w, r, http.StatusInternalServerError, "internal_error",
+			"create run failed", map[string]any{"error": err.Error()})
+		return
+	}
+
+	s.writeJSON(w, r, http.StatusCreated, toRunResponse(created))
+}
+
+// handleGetRun implements GET /v0/runs/{run_id}. Returns 404 with
+// the run_not_found code if the ID doesn't resolve, and 400 if the
+// path parameter isn't a valid UUID.
+func (s *Server) handleGetRun(w http.ResponseWriter, r *http.Request) {
+	if s.cfg.RunRepo == nil {
+		s.writeError(w, r, http.StatusServiceUnavailable, "run_repo_unconfigured",
+			"runs endpoint requires a configured run repository", nil)
+		return
+	}
+
+	runID, err := uuid.Parse(r.PathValue("run_id"))
+	if err != nil {
+		s.writeError(w, r, http.StatusBadRequest, "validation_failed",
+			"run_id must be a valid UUID",
+			map[string]any{"field": "run_id", "got": r.PathValue("run_id")})
+		return
+	}
+
+	got, err := s.cfg.RunRepo.GetRun(r.Context(), runID)
+	if err != nil {
+		if errors.Is(err, run.ErrNotFound) {
+			s.writeError(w, r, http.StatusNotFound, "run_not_found",
+				"no run with that id", map[string]any{"run_id": runID.String()})
+			return
+		}
+		s.writeError(w, r, http.StatusInternalServerError, "internal_error",
+			"get run failed", map[string]any{"error": err.Error()})
+		return
+	}
+
+	s.writeJSON(w, r, http.StatusOK, toRunResponse(got))
+}

--- a/backend/internal/server/runs_test.go
+++ b/backend/internal/server/runs_test.go
@@ -1,0 +1,389 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/kuhlman-labs/fishhawk/backend/internal/run"
+)
+
+// fakeRepo is a minimum in-memory implementation of run.Repository
+// for handler tests. The Postgres adapter is exercised separately
+// in backend/internal/run/postgres_test.go via testcontainers, so
+// this fake only needs to satisfy the contract well enough that
+// the handler logic gets coverage.
+type fakeRepo struct {
+	mu   sync.Mutex
+	runs map[uuid.UUID]*run.Run
+
+	// createErr / getErr let tests inject failures without
+	// instrumenting fakeRepo's internals.
+	createErr error
+	getErr    error
+}
+
+func newFakeRepo() *fakeRepo {
+	return &fakeRepo{runs: map[uuid.UUID]*run.Run{}}
+}
+
+func (f *fakeRepo) CreateRun(_ context.Context, p run.CreateRunParams) (*run.Run, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.createErr != nil {
+		return nil, f.createErr
+	}
+	now := time.Now().UTC()
+	r := &run.Run{
+		ID:            uuid.New(),
+		Repo:          p.Repo,
+		WorkflowID:    p.WorkflowID,
+		WorkflowSHA:   p.WorkflowSHA,
+		TriggerSource: p.TriggerSource,
+		TriggerRef:    p.TriggerRef,
+		State:         run.StatePending,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+	f.runs[r.ID] = r
+	return r, nil
+}
+
+func (f *fakeRepo) GetRun(_ context.Context, id uuid.UUID) (*run.Run, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	r, ok := f.runs[id]
+	if !ok {
+		return nil, run.ErrNotFound
+	}
+	return r, nil
+}
+
+// The remaining methods aren't exercised by these handler tests but
+// must exist so fakeRepo satisfies run.Repository. Returning
+// "not implemented" errors makes any accidental call obvious.
+func (f *fakeRepo) TransitionRun(_ context.Context, _ uuid.UUID, _ run.State) (*run.Run, error) {
+	return nil, errors.New("fakeRepo: TransitionRun not implemented")
+}
+func (f *fakeRepo) CreateStage(_ context.Context, _ run.CreateStageParams) (*run.Stage, error) {
+	return nil, errors.New("fakeRepo: CreateStage not implemented")
+}
+func (f *fakeRepo) GetStage(_ context.Context, _ uuid.UUID) (*run.Stage, error) {
+	return nil, errors.New("fakeRepo: GetStage not implemented")
+}
+func (f *fakeRepo) ListStagesForRun(_ context.Context, _ uuid.UUID) ([]*run.Stage, error) {
+	return nil, errors.New("fakeRepo: ListStagesForRun not implemented")
+}
+func (f *fakeRepo) TransitionStage(_ context.Context, _ uuid.UUID, _ run.StageState, _ *run.StageCompletion) (*run.Stage, error) {
+	return nil, errors.New("fakeRepo: TransitionStage not implemented")
+}
+
+// newServer builds a Server wired to repo, with the Handler() exposed
+// so tests can call it via httptest.NewRecorder.
+func newServer(t *testing.T, repo run.Repository) *Server {
+	t.Helper()
+	return New(Config{Addr: "127.0.0.1:0", RunRepo: repo})
+}
+
+func TestCreateRun_HappyPath(t *testing.T) {
+	repo := newFakeRepo()
+	s := newServer(t, repo)
+
+	body := `{
+		"repo": "kuhlman-labs/fishhawk",
+		"workflow_id": "feature_change",
+		"workflow_sha": "abc123",
+		"trigger_source": "cli"
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/v0/runs", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201:\n%s", w.Code, w.Body.String())
+	}
+
+	var got runResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if got.Repo != "kuhlman-labs/fishhawk" {
+		t.Errorf("Repo = %q", got.Repo)
+	}
+	if got.State != string(run.StatePending) {
+		t.Errorf("State = %q, want pending", got.State)
+	}
+	if got.TriggerSource != "cli" {
+		t.Errorf("TriggerSource = %q", got.TriggerSource)
+	}
+	if got.ID == uuid.Nil {
+		t.Error("ID is zero")
+	}
+}
+
+func TestCreateRun_OptionalTriggerRef(t *testing.T) {
+	repo := newFakeRepo()
+	s := newServer(t, repo)
+
+	body := `{
+		"repo": "x/y",
+		"workflow_id": "w",
+		"workflow_sha": "abc",
+		"trigger_source": "github_issue",
+		"trigger_ref": "issue:1247"
+	}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v0/runs", strings.NewReader(body))
+	s.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201:\n%s", w.Code, w.Body.String())
+	}
+	var got runResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &got)
+	if got.TriggerRef == nil || *got.TriggerRef != "issue:1247" {
+		t.Errorf("TriggerRef = %v, want issue:1247", got.TriggerRef)
+	}
+}
+
+func TestCreateRun_BadJSON(t *testing.T) {
+	s := newServer(t, newFakeRepo())
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v0/runs", strings.NewReader("{not json"))
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), `"validation_failed"`) {
+		t.Errorf("body missing code: %s", w.Body.String())
+	}
+}
+
+func TestCreateRun_UnknownField(t *testing.T) {
+	s := newServer(t, newFakeRepo())
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v0/runs",
+		strings.NewReader(`{"repo":"r","workflow_id":"w","workflow_sha":"s","trigger_source":"cli","extra":"x"}`))
+	s.Handler().ServeHTTP(w, req)
+	// DisallowUnknownFields → 400.
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 on unknown field", w.Code)
+	}
+}
+
+func TestCreateRun_MissingRequiredFields(t *testing.T) {
+	cases := []struct {
+		name      string
+		body      string
+		wantField string
+	}{
+		{"no repo", `{"workflow_id":"w","workflow_sha":"s","trigger_source":"cli"}`, "repo"},
+		{"no workflow_id", `{"repo":"r","workflow_sha":"s","trigger_source":"cli"}`, "workflow_id"},
+		{"no workflow_sha", `{"repo":"r","workflow_id":"w","trigger_source":"cli"}`, "workflow_sha"},
+	}
+	s := newServer(t, newFakeRepo())
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/v0/runs", strings.NewReader(tc.body))
+			s.Handler().ServeHTTP(w, req)
+			if w.Code != http.StatusBadRequest {
+				t.Errorf("status = %d, want 400", w.Code)
+			}
+			if !strings.Contains(w.Body.String(), tc.wantField) {
+				t.Errorf("body missing field name %q: %s", tc.wantField, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestCreateRun_BadTriggerSource(t *testing.T) {
+	s := newServer(t, newFakeRepo())
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v0/runs",
+		strings.NewReader(`{"repo":"r","workflow_id":"w","workflow_sha":"s","trigger_source":"bogus"}`))
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestCreateRun_RepoError(t *testing.T) {
+	repo := newFakeRepo()
+	repo.createErr = errors.New("disk full")
+	s := newServer(t, repo)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v0/runs",
+		strings.NewReader(`{"repo":"r","workflow_id":"w","workflow_sha":"s","trigger_source":"cli"}`))
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), `"internal_error"`) {
+		t.Errorf("body missing internal_error code: %s", w.Body.String())
+	}
+}
+
+func TestCreateRun_NilRepoConfigured(t *testing.T) {
+	s := New(Config{Addr: "127.0.0.1:0"}) // no RunRepo
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v0/runs",
+		strings.NewReader(`{"repo":"r","workflow_id":"w","workflow_sha":"s","trigger_source":"cli"}`))
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", w.Code)
+	}
+}
+
+func TestGetRun_HappyPath(t *testing.T) {
+	repo := newFakeRepo()
+	s := newServer(t, repo)
+
+	// Pre-seed a run by calling the repo directly.
+	got, _ := repo.CreateRun(context.Background(), run.CreateRunParams{
+		Repo: "x/y", WorkflowID: "w", WorkflowSHA: "s",
+		TriggerSource: run.TriggerCLI,
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/v0/runs/%s", got.ID), nil)
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200:\n%s", w.Code, w.Body.String())
+	}
+	var resp runResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.ID != got.ID {
+		t.Errorf("ID = %s, want %s", resp.ID, got.ID)
+	}
+}
+
+func TestGetRun_NotFound(t *testing.T) {
+	s := newServer(t, newFakeRepo())
+	id := uuid.New()
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/v0/runs/%s", id), nil)
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), `"run_not_found"`) {
+		t.Errorf("body missing run_not_found code: %s", w.Body.String())
+	}
+}
+
+func TestGetRun_BadUUID(t *testing.T) {
+	s := newServer(t, newFakeRepo())
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v0/runs/not-a-uuid", nil)
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestGetRun_RepoError(t *testing.T) {
+	repo := newFakeRepo()
+	repo.getErr = errors.New("connection lost")
+	s := newServer(t, repo)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/v0/runs/%s", uuid.New()), nil)
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", w.Code)
+	}
+}
+
+func TestGetRun_NilRepoConfigured(t *testing.T) {
+	s := New(Config{Addr: "127.0.0.1:0"})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/v0/runs/%s", uuid.New()), nil)
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", w.Code)
+	}
+}
+
+func TestErrorEnvelope_Shape(t *testing.T) {
+	// Decoding a known 400 confirms the envelope matches OpenAPI's
+	// error schema verbatim. If the field names drift, clients
+	// switching on `error.code` break.
+	s := newServer(t, newFakeRepo())
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v0/runs", strings.NewReader("{not json"))
+	s.Handler().ServeHTTP(w, req)
+	body, _ := io.ReadAll(w.Body)
+	var env errorEnvelope
+	if err := json.Unmarshal(body, &env); err != nil {
+		t.Fatalf("decode envelope: %v", err)
+	}
+	if env.Error.Code == "" || env.Error.Message == "" {
+		t.Errorf("error envelope missing code/message: %+v", env)
+	}
+}
+
+// requestPath is a tiny helper for round-tripping a raw body through
+// the server and asserting status + decoded JSON.
+func requestPath(t *testing.T, s *Server, method, path string, body any) (*httptest.ResponseRecorder, []byte) {
+	t.Helper()
+	var rdr io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		rdr = bytes.NewReader(b)
+	}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(method, path, rdr)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	s.Handler().ServeHTTP(w, req)
+	return w, w.Body.Bytes()
+}
+
+func TestRoundTrip_CreateThenGet(t *testing.T) {
+	s := newServer(t, newFakeRepo())
+
+	w, body := requestPath(t, s, http.MethodPost, "/v0/runs", map[string]any{
+		"repo":           "x/y",
+		"workflow_id":    "w",
+		"workflow_sha":   "abc",
+		"trigger_source": "ui",
+	})
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create status = %d:\n%s", w.Code, body)
+	}
+	var created runResponse
+	if err := json.Unmarshal(body, &created); err != nil {
+		t.Fatal(err)
+	}
+
+	w2, body2 := requestPath(t, s, http.MethodGet, "/v0/runs/"+created.ID.String(), nil)
+	if w2.Code != http.StatusOK {
+		t.Fatalf("get status = %d:\n%s", w2.Code, body2)
+	}
+	var fetched runResponse
+	if err := json.Unmarshal(body2, &fetched); err != nil {
+		t.Fatal(err)
+	}
+	if fetched.ID != created.ID {
+		t.Errorf("ID round-trip mismatch: %s vs %s", fetched.ID, created.ID)
+	}
+}

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -13,6 +13,8 @@ import (
 	"log/slog"
 	"net/http"
 	"time"
+
+	"github.com/kuhlman-labs/fishhawk/backend/internal/run"
 )
 
 // Config holds the values needed to construct a Server. Zero-valued
@@ -28,6 +30,12 @@ type Config struct {
 	// ShutdownTimeout caps Shutdown's wait for in-flight requests to
 	// drain before forcing closure.
 	ShutdownTimeout time.Duration
+
+	// RunRepo persists workflow runs and stages. Wired by the
+	// /v0/runs handlers; nil leaves those handlers returning 503.
+	// Tests inject in-memory fakes; production wires the Postgres
+	// adapter (run.NewPostgresRepository).
+	RunRepo run.Repository
 }
 
 // Server wraps an http.Server with the routes and middleware stack

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,6 +158,7 @@ GitHub OAuth (E4.2 / #49) is the sign-in flow that mints the cookie session. App
 | Trace bundle wire format (`*.jsonl.gz`) | `runner/internal/bundle/bundle.go` (pack + open) — implements ADR-007 (#71) |
 | Constraint evaluation (forbidden_paths, max_files_changed, required_outcomes) | `runner/internal/constraint/constraint.go` (post-hoc, runner-side) |
 | HTTP middleware order / context keys | `backend/internal/server/middleware.go` |
+| Run CRUD handlers (POST/GET) | `backend/internal/server/runs.go`; wired in `backend/cmd/fishhawkd/serve.go` from `FISHHAWKD_DATABASE_URL` |
 | How a new Go module gets added | `CLAUDE.md` "Adding a Go module" |
 
 ## 11. Open work


### PR DESCRIPTION
## Summary

First handler PR off the OpenAPI contract landed in #102. The run state machine, repository, and Postgres adapter were already in place from E3.3 — this PR wires them to HTTP.

- `backend/internal/server/runs.go` — `handleCreateRun` validates the body, calls `Repository.CreateRun`, returns the canonical `Run` shape from `docs/api/v0.openapi.yaml`. `handleGetRun` resolves UUID, returns 404 → `run_not_found` / 400 → bad UUID.
- `backend/internal/server/errors.go` — `errorEnvelope` helpers that always emit the `{error: {code, message, details?}}` shape from the OpenAPI `Error` schema. Centralized so every non-2xx response is structurally identical.
- `Server.Config` grows a `RunRepo run.Repository` field. nil leaves the runs endpoints returning 503 (`run_repo_unconfigured`) — honest about the gap rather than 500-ing on a nil deref.
- `backend/cmd/fishhawkd/serve.go` now wires a `pgxpool.Pool` via `FISHHAWKD_DATABASE_URL` (`--db`). Without one, the server still boots, `/healthz` works, and only `/v0/runs` degrades.

## Test plan

- [x] `go test -race ./backend/...` — 13 server tests pass; existing testcontainers tests for run/audit/signing/tracestore still pass
- [x] `golangci-lint run ./backend/...` — 0 issues
- [x] Coverage: server package 93.5% (`handleCreateRun` + `handleGetRun` both 100%); aggregate (excl. `/db/`) 86.0%
- [x] CI passes

## Notes

**Test approach.** Handler tests use an in-memory `fakeRepo` that satisfies `run.Repository` enough for the create + get path (other methods return "not implemented" errors so accidental calls are obvious). The Postgres adapter is integration-tested separately under `backend/internal/run/postgres_test.go` via testcontainers. This split keeps server tests fast (~1s) while the contract-level test stays in the right place.

**Test coverage matrix.** 13 cases:

| Case | Expected |
|---|---|
| happy path POST + GET round-trip | 201 / 200 |
| POST with optional `trigger_ref` | 201, ref preserved |
| POST malformed JSON | 400 `validation_failed` |
| POST unknown field | 400 (DisallowUnknownFields) |
| POST missing each of repo / workflow_id / workflow_sha | 400 with field name |
| POST bad `trigger_source` enum | 400 |
| POST repo error | 500 `internal_error` |
| POST when `RunRepo` nil | 503 `run_repo_unconfigured` |
| GET 404 | 404 `run_not_found` |
| GET bad UUID | 400 |
| GET repo error | 500 |
| GET when `RunRepo` nil | 503 |
| Error envelope shape | `{error: {code, message}}` |

**Spec status.** Of the 19 endpoints in `docs/api/v0.openapi.yaml`: `/healthz`, `POST /v0/runs`, and `GET /v0/runs/{run_id}` now have implementations. The rest still return 404 from the mux. Follow-up PRs land them incrementally — natural next handlers are `POST /v0/runs/{id}/cancel` and `GET /v0/runs/{id}/stages`, both small reuses of the same Repository.

**Auth deferred.** Per the OpenAPI default security scheme (`sessionCookie OR bearerToken`), these endpoints should require auth. The `authStub` middleware is in place but issues `Identity{Subject: "anonymous"}` for everyone until E4 lands real auth. Adding the auth check here would just gate everyone uniformly; better to add it once cookie + bearer issuance exist.

**Production wiring.** `fishhawkd serve --db postgres://…` (or `FISHHAWKD_DATABASE_URL=...`) constructs the `pgxpool.Pool`, wraps it as the `run.Repository`, and passes it to `server.Config`. Without `--db`, the server logs a warning at startup, boots anyway, and `/v0/runs` returns 503 — useful for smoke-testing a deploy before pointing it at production data.
