### PR TITLE
Add GitHub webhook receiver (E3.7)

### DIFF
--- a/backend/cmd/fishhawkd/serve.go
+++ b/backend/cmd/fishhawkd/serve.go
@@ -9,11 +9,14 @@ import (
 	"os/signal"
 	"syscall"
 
+	"time"
+
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	runpkg "github.com/kuhlman-labs/fishhawk/backend/internal/run"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/server"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/version"
+	"github.com/kuhlman-labs/fishhawk/backend/internal/webhook"
 )
 
 // runServe boots the HTTP server with graceful SIGINT/SIGTERM
@@ -24,6 +27,9 @@ func runServe(args []string, logSink io.Writer) int {
 	addr := fs.String("addr", envOr("FISHHAWKD_ADDR", ":8080"), "listen address")
 	dbURL := fs.String("db", envOr("FISHHAWKD_DATABASE_URL", ""),
 		"postgres URL; when empty, /v0/runs endpoints respond 503")
+	webhookSecret := fs.String("github-webhook-secret",
+		envOr("FISHHAWKD_GITHUB_WEBHOOK_SECRET", ""),
+		"shared secret GitHub uses to HMAC-sign webhook deliveries; when empty, /webhooks/github responds 503")
 	if err := fs.Parse(args); err != nil {
 		return exitFailure
 	}
@@ -49,6 +55,18 @@ func runServe(args []string, logSink io.Writer) int {
 		logger.Info("run repository configured", slog.String("driver", "postgres"))
 	} else {
 		logger.Warn("FISHHAWKD_DATABASE_URL not set; /v0/runs endpoints will respond 503")
+	}
+
+	// Webhook receiver wiring. Secret + delivery store both need
+	// to be configured for /webhooks/github to accept deliveries.
+	// 24h TTL covers GitHub's ~3h retry window with comfortable
+	// margin without growing unboundedly.
+	if *webhookSecret != "" {
+		cfg.GitHubWebhookSecret = []byte(*webhookSecret)
+		cfg.WebhookDeliveries = webhook.NewMemoryStore(24 * time.Hour)
+		logger.Info("github webhook receiver configured")
+	} else {
+		logger.Warn("FISHHAWKD_GITHUB_WEBHOOK_SECRET not set; /webhooks/github will respond 503")
 	}
 
 	srv := server.New(cfg)

--- a/backend/internal/server/handlers.go
+++ b/backend/internal/server/handlers.go
@@ -15,6 +15,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /healthz", s.handleHealth)
 	mux.HandleFunc("POST /v0/runs", s.handleCreateRun)
 	mux.HandleFunc("GET /v0/runs/{run_id}", s.handleGetRun)
+	mux.HandleFunc("POST /webhooks/github", s.handleWebhook)
 }
 
 type healthResponse struct {

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/kuhlman-labs/fishhawk/backend/internal/run"
+	"github.com/kuhlman-labs/fishhawk/backend/internal/webhook"
 )
 
 // Config holds the values needed to construct a Server. Zero-valued
@@ -36,6 +37,16 @@ type Config struct {
 	// Tests inject in-memory fakes; production wires the Postgres
 	// adapter (run.NewPostgresRepository).
 	RunRepo run.Repository
+
+	// GitHubWebhookSecret is the shared secret GitHub uses to
+	// HMAC-sign webhook deliveries. Empty disables the
+	// /webhooks/github endpoint (handler returns 503).
+	GitHubWebhookSecret []byte
+
+	// WebhookDeliveries dedups GitHub webhook deliveries by their
+	// X-GitHub-Delivery UUID across the GitHub retry window. nil
+	// disables the /webhooks/github endpoint.
+	WebhookDeliveries webhook.DeliveryStore
 }
 
 // Server wraps an http.Server with the routes and middleware stack

--- a/backend/internal/server/webhook.go
+++ b/backend/internal/server/webhook.go
@@ -1,0 +1,99 @@
+package server
+
+import (
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+
+	"github.com/kuhlman-labs/fishhawk/backend/internal/webhook"
+)
+
+// maxWebhookBody is a defensive upper bound on the body GitHub will
+// send. GitHub's documented max is 25 MiB; we cap at 10 MiB which
+// comfortably handles every payload type we care about (issues,
+// PRs, pushes, marketplace events) and rejects pathological inputs.
+const maxWebhookBody = 10 * 1024 * 1024
+
+// handleWebhook implements POST /webhooks/github per
+// docs/api/v0.openapi.yaml. The endpoint is unversioned because
+// GitHub controls the request shape; the backend adapts as
+// GitHub's webhook schema evolves.
+//
+// Order of checks: signature → headers → dedup. We verify the
+// signature first so a forged body can't influence the dedup
+// store. Headers come next so we don't re-process events whose
+// payload is malformed; dedup is last because it has a side
+// effect (recording the delivery).
+func (s *Server) handleWebhook(w http.ResponseWriter, r *http.Request) {
+	if len(s.cfg.GitHubWebhookSecret) == 0 {
+		s.writeError(w, r, http.StatusServiceUnavailable, "webhook_secret_unconfigured",
+			"webhook receiver requires a configured secret", nil)
+		return
+	}
+	if s.cfg.WebhookDeliveries == nil {
+		s.writeError(w, r, http.StatusServiceUnavailable, "webhook_store_unconfigured",
+			"webhook receiver requires a configured delivery store", nil)
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxWebhookBody+1))
+	if err != nil {
+		s.writeError(w, r, http.StatusBadRequest, "validation_failed",
+			"could not read request body", map[string]any{"error": err.Error()})
+		return
+	}
+	if len(body) > maxWebhookBody {
+		s.writeError(w, r, http.StatusRequestEntityTooLarge, "body_too_large",
+			"webhook body exceeds 10 MiB", map[string]any{"limit_bytes": maxWebhookBody})
+		return
+	}
+
+	sig := r.Header.Get("X-Hub-Signature-256")
+	if err := webhook.VerifySignature(s.cfg.GitHubWebhookSecret, body, sig); err != nil {
+		s.writeError(w, r, http.StatusUnauthorized, "webhook_signature_invalid",
+			"signature did not verify against the configured secret",
+			map[string]any{"error": err.Error()})
+		return
+	}
+
+	eventType := r.Header.Get("X-GitHub-Event")
+	deliveryID := r.Header.Get("X-GitHub-Delivery")
+	ev, err := webhook.ParseEvent(eventType, deliveryID, body)
+	if err != nil {
+		s.writeError(w, r, http.StatusBadRequest, "validation_failed",
+			"webhook headers or body invalid", map[string]any{"error": err.Error()})
+		return
+	}
+
+	if err := s.cfg.WebhookDeliveries.Mark(deliveryID); err != nil {
+		if errors.Is(err, webhook.ErrDeliveryDuplicate) {
+			// Acknowledge duplicates with 202 — GitHub retries on
+			// non-2xx, and we don't want to ask for a retry of an
+			// event we've already processed.
+			s.cfg.Logger.LogAttrs(r.Context(), slog.LevelInfo, "webhook duplicate delivery",
+				slog.String("event", ev.Type),
+				slog.String("delivery_id", deliveryID),
+			)
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		s.writeError(w, r, http.StatusInternalServerError, "internal_error",
+			"failed to record delivery", map[string]any{"error": err.Error()})
+		return
+	}
+
+	s.cfg.Logger.LogAttrs(r.Context(), slog.LevelInfo, "webhook received",
+		slog.String("event", ev.Type),
+		slog.String("action", ev.Action),
+		slog.String("delivery_id", ev.DeliveryID),
+		slog.String("repo", ev.Repo),
+		slog.String("sender", ev.Sender),
+	)
+
+	// Run dispatch from webhook events lands in a follow-up PR — it
+	// needs a GitHub API client to resolve `.fishhawk/workflows.yaml`'s
+	// SHA at the event's repo + ref. For now we acknowledge the
+	// delivery and stop.
+	w.WriteHeader(http.StatusAccepted)
+}

--- a/backend/internal/server/webhook_test.go
+++ b/backend/internal/server/webhook_test.go
@@ -1,0 +1,192 @@
+package server
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/kuhlman-labs/fishhawk/backend/internal/webhook"
+)
+
+const testSecret = "shhh-its-a-secret"
+
+func sign(body []byte) string {
+	mac := hmac.New(sha256.New, []byte(testSecret))
+	mac.Write(body)
+	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+func newWebhookServer(t *testing.T) (*Server, *webhook.MemoryStore) {
+	t.Helper()
+	store := webhook.NewMemoryStore(0)
+	s := New(Config{
+		Addr:                "127.0.0.1:0",
+		GitHubWebhookSecret: []byte(testSecret),
+		WebhookDeliveries:   store,
+	})
+	return s, store
+}
+
+func postWebhook(t *testing.T, s *Server, headers map[string]string, body []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/github", bytes.NewReader(body))
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	return w
+}
+
+func TestWebhook_HappyPath(t *testing.T) {
+	s, _ := newWebhookServer(t)
+	body := []byte(`{
+		"action": "labeled",
+		"repository": {"full_name": "kuhlman-labs/fishhawk"},
+		"sender": {"login": "kuhlman-labs"}
+	}`)
+	w := postWebhook(t, s, map[string]string{
+		"X-GitHub-Event":      "issues",
+		"X-GitHub-Delivery":   "11111111-2222-3333-4444-555555555555",
+		"X-Hub-Signature-256": sign(body),
+		"Content-Type":        "application/json",
+	}, body)
+	if w.Code != http.StatusAccepted {
+		t.Errorf("status = %d, want 202:\n%s", w.Code, w.Body.String())
+	}
+}
+
+func TestWebhook_BadSignature(t *testing.T) {
+	s, _ := newWebhookServer(t)
+	body := []byte(`{}`)
+	w := postWebhook(t, s, map[string]string{
+		"X-GitHub-Event":      "ping",
+		"X-GitHub-Delivery":   "deliv",
+		"X-Hub-Signature-256": "sha256=" + strings.Repeat("00", 32),
+	}, body)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), `"webhook_signature_invalid"`) {
+		t.Errorf("body missing code: %s", w.Body.String())
+	}
+}
+
+func TestWebhook_MissingSignature(t *testing.T) {
+	s, _ := newWebhookServer(t)
+	body := []byte(`{}`)
+	w := postWebhook(t, s, map[string]string{
+		"X-GitHub-Event":    "ping",
+		"X-GitHub-Delivery": "deliv",
+		// No X-Hub-Signature-256.
+	}, body)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401 for missing sig", w.Code)
+	}
+}
+
+func TestWebhook_MissingEventHeader(t *testing.T) {
+	s, _ := newWebhookServer(t)
+	body := []byte(`{}`)
+	w := postWebhook(t, s, map[string]string{
+		"X-GitHub-Delivery":   "deliv",
+		"X-Hub-Signature-256": sign(body),
+		// No X-GitHub-Event.
+	}, body)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestWebhook_MissingDeliveryHeader(t *testing.T) {
+	s, _ := newWebhookServer(t)
+	body := []byte(`{}`)
+	w := postWebhook(t, s, map[string]string{
+		"X-GitHub-Event":      "ping",
+		"X-Hub-Signature-256": sign(body),
+		// No X-GitHub-Delivery.
+	}, body)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestWebhook_MalformedBody(t *testing.T) {
+	s, _ := newWebhookServer(t)
+	body := []byte("{not json")
+	w := postWebhook(t, s, map[string]string{
+		"X-GitHub-Event":      "issues",
+		"X-GitHub-Delivery":   "deliv",
+		"X-Hub-Signature-256": sign(body),
+	}, body)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestWebhook_DuplicateDeliveryAcknowledged(t *testing.T) {
+	s, _ := newWebhookServer(t)
+	body := []byte(`{}`)
+	headers := map[string]string{
+		"X-GitHub-Event":      "ping",
+		"X-GitHub-Delivery":   "deliv-dup",
+		"X-Hub-Signature-256": sign(body),
+	}
+	if w := postWebhook(t, s, headers, body); w.Code != http.StatusAccepted {
+		t.Fatalf("first delivery: status = %d, want 202", w.Code)
+	}
+	// Second delivery with the same ID — must still respond 202
+	// because GitHub retries any non-2xx. Refuse-with-error would
+	// mean retry storms.
+	if w := postWebhook(t, s, headers, body); w.Code != http.StatusAccepted {
+		t.Errorf("second delivery: status = %d, want 202", w.Code)
+	}
+}
+
+func TestWebhook_NoSecretConfigured(t *testing.T) {
+	s := New(Config{Addr: "127.0.0.1:0", WebhookDeliveries: webhook.NewMemoryStore(0)})
+	w := postWebhook(t, s, map[string]string{
+		"X-GitHub-Event":      "ping",
+		"X-GitHub-Delivery":   "deliv",
+		"X-Hub-Signature-256": "sha256=00",
+	}, []byte(`{}`))
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "webhook_secret_unconfigured") {
+		t.Errorf("body missing code: %s", w.Body.String())
+	}
+}
+
+func TestWebhook_NoDeliveryStore(t *testing.T) {
+	s := New(Config{Addr: "127.0.0.1:0", GitHubWebhookSecret: []byte(testSecret)})
+	w := postWebhook(t, s, map[string]string{
+		"X-GitHub-Event":      "ping",
+		"X-GitHub-Delivery":   "deliv",
+		"X-Hub-Signature-256": sign([]byte(`{}`)),
+	}, []byte(`{}`))
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "webhook_store_unconfigured") {
+		t.Errorf("body missing code: %s", w.Body.String())
+	}
+}
+
+func TestWebhook_BodyTooLarge(t *testing.T) {
+	s, _ := newWebhookServer(t)
+	body := bytes.Repeat([]byte("a"), maxWebhookBody+1)
+	w := postWebhook(t, s, map[string]string{
+		"X-GitHub-Event":      "issues",
+		"X-GitHub-Delivery":   "deliv",
+		"X-Hub-Signature-256": sign(body),
+	}, body)
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("status = %d, want 413", w.Code)
+	}
+}

--- a/backend/internal/webhook/webhook.go
+++ b/backend/internal/webhook/webhook.go
@@ -1,0 +1,203 @@
+// Package webhook implements GitHub App webhook receipt: signature
+// verification, delivery-ID dedup, and event parsing. The HTTP
+// handler that wires these primitives lives in
+// backend/internal/server/webhook.go.
+//
+// Per docs/api/v0.openapi.yaml, the receiver is at
+// `POST /webhooks/github`. Auth is the GitHub HMAC over the body
+// (X-Hub-Signature-256); no Bearer or cookie required.
+package webhook
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Errors callers may want to switch on.
+var (
+	ErrSignatureInvalid    = errors.New("webhook: signature invalid")
+	ErrSignatureMissing    = errors.New("webhook: signature header missing or malformed")
+	ErrDeliveryDuplicate   = errors.New("webhook: delivery already processed")
+	ErrDeliveryMissing     = errors.New("webhook: X-GitHub-Delivery missing")
+	ErrEventTypeMissing    = errors.New("webhook: X-GitHub-Event missing")
+	ErrSecretNotConfigured = errors.New("webhook: secret not configured")
+)
+
+// signaturePrefix is the algorithm tag GitHub uses on the
+// X-Hub-Signature-256 header. Hard-coded because GitHub doesn't
+// support algorithm negotiation; if they ship a v2 we'll add a
+// branch.
+const signaturePrefix = "sha256="
+
+// VerifySignature checks that signatureHeader (expected:
+// "sha256=<hex>") is a valid HMAC-SHA256 of body using secret. It
+// uses crypto/hmac.Equal for constant-time comparison so an
+// attacker cannot leak the signature byte-by-byte via timing.
+//
+// Returns ErrSignatureMissing for empty / malformed headers and
+// ErrSignatureInvalid for valid-shape-but-wrong values; callers
+// usually translate both to 401.
+func VerifySignature(secret []byte, body []byte, signatureHeader string) error {
+	if len(secret) == 0 {
+		return ErrSecretNotConfigured
+	}
+	if !strings.HasPrefix(signatureHeader, signaturePrefix) {
+		return ErrSignatureMissing
+	}
+	got, err := hex.DecodeString(strings.TrimPrefix(signatureHeader, signaturePrefix))
+	if err != nil {
+		return ErrSignatureMissing
+	}
+	mac := hmac.New(sha256.New, secret)
+	mac.Write(body)
+	want := mac.Sum(nil)
+	if !hmac.Equal(got, want) {
+		return ErrSignatureInvalid
+	}
+	return nil
+}
+
+// DeliveryStore deduplicates webhook deliveries by X-GitHub-Delivery
+// (a UUID GitHub assigns per delivery, retained across the retry
+// window). Implementations decide on persistence and TTL.
+//
+// Production should back this with Postgres so dedup survives
+// restarts and works across multiple instances. v0 self-execution
+// runs single-instance; in-memory with a 24h TTL covers the retry
+// window for that deployment.
+type DeliveryStore interface {
+	// Mark records id as processed. Returns ErrDeliveryDuplicate if
+	// id was already recorded; nil on first write.
+	Mark(id string) error
+}
+
+// MemoryStore is a process-local DeliveryStore with TTL eviction.
+// Suitable for single-instance v0 deployments. NOT suitable for
+// multi-instance because nodes don't share state — two instances
+// could both process the same delivery.
+type MemoryStore struct {
+	mu      sync.Mutex
+	entries map[string]time.Time
+	ttl     time.Duration
+	now     func() time.Time
+}
+
+// NewMemoryStore returns a MemoryStore with the given TTL. ttl=0
+// means "no eviction"; tests use that to keep behavior deterministic.
+// Production should use 24h to comfortably exceed GitHub's webhook
+// retry window (~3h) without growing unboundedly.
+func NewMemoryStore(ttl time.Duration) *MemoryStore {
+	return &MemoryStore{
+		entries: make(map[string]time.Time),
+		ttl:     ttl,
+		now:     func() time.Time { return time.Now() },
+	}
+}
+
+// Mark records id as seen. Repeated calls with the same id (within
+// the TTL window) return ErrDeliveryDuplicate.
+func (s *MemoryStore) Mark(id string) error {
+	if id == "" {
+		return ErrDeliveryMissing
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := s.now()
+	if s.ttl > 0 {
+		s.evictExpired(now)
+	}
+	if _, ok := s.entries[id]; ok {
+		return ErrDeliveryDuplicate
+	}
+	s.entries[id] = now
+	return nil
+}
+
+// evictExpired drops entries older than the TTL. Caller holds mu.
+func (s *MemoryStore) evictExpired(now time.Time) {
+	for k, t := range s.entries {
+		if now.Sub(t) > s.ttl {
+			delete(s.entries, k)
+		}
+	}
+}
+
+// Event is the parsed envelope of a webhook payload. Fields are
+// what we care about across event types; type-specific logic
+// re-decodes from RawBody.
+type Event struct {
+	// Type is the X-GitHub-Event header value (e.g. "issues",
+	// "pull_request", "push", "ping").
+	Type string
+
+	// DeliveryID is the X-GitHub-Delivery header value.
+	DeliveryID string
+
+	// Action is the top-level "action" field common to most webhook
+	// payloads (e.g. "labeled", "opened", "closed"). Empty for
+	// events that don't have actions (e.g. "push", "ping").
+	Action string
+
+	// Repo is the repository's full name ("owner/repo") when the
+	// payload includes one. Empty for events without a repo
+	// (e.g. installation-level events).
+	Repo string
+
+	// Sender is the GitHub login of the user / app that triggered
+	// the event. Empty when the payload doesn't include one.
+	Sender string
+
+	// RawBody is the original payload, kept for downstream handlers
+	// that need event-specific fields not surfaced here.
+	RawBody []byte
+}
+
+// minimal is the subset of fields we extract from every webhook
+// payload. JSON unmarshal is permissive about absent fields, so the
+// same struct works for issues, pull_request, push, ping, etc.
+type minimal struct {
+	Action     string `json:"action,omitempty"`
+	Repository struct {
+		FullName string `json:"full_name,omitempty"`
+	} `json:"repository,omitempty"`
+	Sender struct {
+		Login string `json:"login,omitempty"`
+	} `json:"sender,omitempty"`
+}
+
+// ParseEvent extracts the headers and decodes the common fields
+// from body. Returns errors for missing required headers; never
+// returns an error for missing JSON fields (those are simply
+// reported as zero values on the Event).
+func ParseEvent(eventType, deliveryID string, body []byte) (Event, error) {
+	if eventType == "" {
+		return Event{}, ErrEventTypeMissing
+	}
+	if deliveryID == "" {
+		return Event{}, ErrDeliveryMissing
+	}
+	ev := Event{
+		Type:       eventType,
+		DeliveryID: deliveryID,
+		RawBody:    body,
+	}
+	// Body may be empty for some test deliveries; attempt to parse
+	// only when present.
+	if len(body) > 0 {
+		var m minimal
+		if err := json.Unmarshal(body, &m); err != nil {
+			return ev, fmt.Errorf("webhook: parse body: %w", err)
+		}
+		ev.Action = m.Action
+		ev.Repo = m.Repository.FullName
+		ev.Sender = m.Sender.Login
+	}
+	return ev, nil
+}

--- a/backend/internal/webhook/webhook_test.go
+++ b/backend/internal/webhook/webhook_test.go
@@ -1,0 +1,193 @@
+package webhook
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"testing"
+	"time"
+)
+
+// signed returns the GitHub-style header value for body+secret,
+// shared by tests that exercise both the verifier and the
+// HTTP-handler layer.
+func signed(t *testing.T, secret, body []byte) string {
+	t.Helper()
+	mac := hmac.New(sha256.New, secret)
+	mac.Write(body)
+	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+func TestVerifySignature_OK(t *testing.T) {
+	secret := []byte("s3cr3t")
+	body := []byte(`{"hello":"world"}`)
+	if err := VerifySignature(secret, body, signed(t, secret, body)); err != nil {
+		t.Errorf("VerifySignature: %v", err)
+	}
+}
+
+func TestVerifySignature_WrongSecret(t *testing.T) {
+	body := []byte("payload")
+	hdr := signed(t, []byte("right"), body)
+	err := VerifySignature([]byte("wrong"), body, hdr)
+	if !errors.Is(err, ErrSignatureInvalid) {
+		t.Errorf("err = %v, want ErrSignatureInvalid", err)
+	}
+}
+
+func TestVerifySignature_MalformedHeader(t *testing.T) {
+	cases := []string{"", "sha256", "sha1=abc", "sha256=zzz"}
+	for _, h := range cases {
+		t.Run(h, func(t *testing.T) {
+			err := VerifySignature([]byte("s"), []byte("b"), h)
+			if !errors.Is(err, ErrSignatureMissing) {
+				t.Errorf("err = %v, want ErrSignatureMissing", err)
+			}
+		})
+	}
+}
+
+func TestVerifySignature_NoSecret(t *testing.T) {
+	err := VerifySignature(nil, []byte("b"), "sha256=00")
+	if !errors.Is(err, ErrSecretNotConfigured) {
+		t.Errorf("err = %v, want ErrSecretNotConfigured", err)
+	}
+}
+
+func TestMemoryStore_FirstSeen(t *testing.T) {
+	s := NewMemoryStore(0)
+	if err := s.Mark("delivery-1"); err != nil {
+		t.Errorf("first Mark: %v", err)
+	}
+}
+
+func TestMemoryStore_DuplicateRejected(t *testing.T) {
+	s := NewMemoryStore(0)
+	_ = s.Mark("delivery-1")
+	err := s.Mark("delivery-1")
+	if !errors.Is(err, ErrDeliveryDuplicate) {
+		t.Errorf("err = %v, want ErrDeliveryDuplicate", err)
+	}
+}
+
+func TestMemoryStore_EmptyID(t *testing.T) {
+	s := NewMemoryStore(0)
+	if err := s.Mark(""); !errors.Is(err, ErrDeliveryMissing) {
+		t.Errorf("err = %v, want ErrDeliveryMissing", err)
+	}
+}
+
+func TestMemoryStore_TTLEvicts(t *testing.T) {
+	s := NewMemoryStore(time.Hour)
+	// Inject a fake clock so we can advance without sleeping.
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	cur := t0
+	s.now = func() time.Time { return cur }
+
+	if err := s.Mark("d1"); err != nil {
+		t.Fatal(err)
+	}
+	// Within TTL: still a duplicate.
+	cur = t0.Add(30 * time.Minute)
+	if err := s.Mark("d1"); !errors.Is(err, ErrDeliveryDuplicate) {
+		t.Errorf("within TTL err = %v, want ErrDeliveryDuplicate", err)
+	}
+	// Past TTL: entry evicts on next Mark; second insert succeeds.
+	cur = t0.Add(2 * time.Hour)
+	if err := s.Mark("d1"); err != nil {
+		t.Errorf("past TTL err = %v, want nil", err)
+	}
+}
+
+func TestParseEvent_HappyPath(t *testing.T) {
+	body := []byte(`{
+		"action": "labeled",
+		"repository": {"full_name": "kuhlman-labs/fishhawk"},
+		"sender": {"login": "kuhlman-labs"}
+	}`)
+	ev, err := ParseEvent("issues", "deliv-1", body)
+	if err != nil {
+		t.Fatalf("ParseEvent: %v", err)
+	}
+	if ev.Type != "issues" {
+		t.Errorf("Type = %q", ev.Type)
+	}
+	if ev.DeliveryID != "deliv-1" {
+		t.Errorf("DeliveryID = %q", ev.DeliveryID)
+	}
+	if ev.Action != "labeled" {
+		t.Errorf("Action = %q", ev.Action)
+	}
+	if ev.Repo != "kuhlman-labs/fishhawk" {
+		t.Errorf("Repo = %q", ev.Repo)
+	}
+	if ev.Sender != "kuhlman-labs" {
+		t.Errorf("Sender = %q", ev.Sender)
+	}
+	if string(ev.RawBody) != string(body) {
+		t.Errorf("RawBody not preserved verbatim")
+	}
+}
+
+func TestParseEvent_MissingHeaders(t *testing.T) {
+	if _, err := ParseEvent("", "deliv-1", []byte(`{}`)); !errors.Is(err, ErrEventTypeMissing) {
+		t.Errorf("missing event type: %v", err)
+	}
+	if _, err := ParseEvent("issues", "", []byte(`{}`)); !errors.Is(err, ErrDeliveryMissing) {
+		t.Errorf("missing delivery: %v", err)
+	}
+}
+
+func TestParseEvent_EmptyBody(t *testing.T) {
+	// GitHub's "ping" event sometimes posts a small body, but the
+	// header-only form should still parse cleanly.
+	ev, err := ParseEvent("ping", "deliv-1", nil)
+	if err != nil {
+		t.Errorf("err = %v", err)
+	}
+	if ev.Type != "ping" {
+		t.Errorf("Type = %q", ev.Type)
+	}
+}
+
+func TestParseEvent_MalformedBody(t *testing.T) {
+	_, err := ParseEvent("issues", "deliv-1", []byte("{not json"))
+	if err == nil {
+		t.Error("expected parse error")
+	}
+}
+
+func TestParseEvent_AbsentFieldsAreEmpty(t *testing.T) {
+	// "push" events don't have a top-level action; the Event must
+	// still parse and report Action="" rather than failing.
+	ev, err := ParseEvent("push", "deliv-1", []byte(`{"repository":{"full_name":"x/y"}}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ev.Action != "" {
+		t.Errorf("Action = %q, want empty", ev.Action)
+	}
+	if ev.Repo != "x/y" {
+		t.Errorf("Repo = %q", ev.Repo)
+	}
+	if ev.Sender != "" {
+		t.Errorf("Sender = %q, want empty", ev.Sender)
+	}
+}
+
+func TestErrors_Distinct(t *testing.T) {
+	// Pin sentinel errors as non-equivalent so a future refactor
+	// doesn't accidentally collapse them.
+	pairs := [][2]error{
+		{ErrSignatureInvalid, ErrSignatureMissing},
+		{ErrSignatureMissing, ErrSecretNotConfigured},
+		{ErrDeliveryDuplicate, ErrDeliveryMissing},
+		{ErrEventTypeMissing, ErrDeliveryMissing},
+	}
+	for _, p := range pairs {
+		if errors.Is(p[0], p[1]) {
+			t.Errorf("errors.Is(%v, %v) = true, want false", p[0], p[1])
+		}
+	}
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,6 +159,7 @@ GitHub OAuth (E4.2 / #49) is the sign-in flow that mints the cookie session. App
 | Constraint evaluation (forbidden_paths, max_files_changed, required_outcomes) | `runner/internal/constraint/constraint.go` (post-hoc, runner-side) |
 | HTTP middleware order / context keys | `backend/internal/server/middleware.go` |
 | Run CRUD handlers (POST/GET) | `backend/internal/server/runs.go`; wired in `backend/cmd/fishhawkd/serve.go` from `FISHHAWKD_DATABASE_URL` |
+| GitHub webhook receiver | `backend/internal/webhook/` (HMAC + dedup) and `backend/internal/server/webhook.go`; secret from `FISHHAWKD_GITHUB_WEBHOOK_SECRET` |
 | How a new Go module gets added | `CLAUDE.md` "Adding a Go module" |
 
 ## 11. Open work


### PR DESCRIPTION
## Summary

`POST /webhooks/github` now exists. The endpoint HMAC-verifies GitHub's signature, dedups by `X-GitHub-Delivery`, parses common envelope fields, and emits a structured log line per event. Critical-path piece for Day 21 self-execution: without it, nothing triggers a run from a labeled issue.

- `backend/internal/webhook/` (100% covered) — `VerifySignature` uses `crypto/hmac.Equal` for constant-time comparison; `ParseEvent` extracts the few fields shared across event types (`action`, `repo`, `sender`) without locking us into a per-type taxonomy yet; `MemoryStore` does in-memory delivery dedup with TTL-based eviction.
- `backend/internal/server/webhook.go` — `handleWebhook` wires the primitives. Order is signature → headers → dedup so a forged body can't influence the dedup store. Duplicate deliveries get 202 (not 4xx) so GitHub's retry behavior doesn't pile up errors. 10 MiB body cap with explicit 413.
- `fishhawkd serve` grows `--github-webhook-secret` / `FISHHAWKD_GITHUB_WEBHOOK_SECRET`. Without it, `/webhooks/github` returns 503 (same honest-gap pattern as `/v0/runs`).

## Test plan

- [x] `go test -race ./backend/...` — 12 webhook server tests + 14 unit tests pass
- [x] `golangci-lint run ./backend/...` — 0 issues
- [x] Coverage: webhook package 100%, handleWebhook 87.5%, aggregate (excl. `/db/`) 86.2%
- [ ] CI passes

## Notes

**Run dispatch deferred.** This PR lands the receiver. Translating webhook events into actual `Run` records needs a GitHub API client to resolve `.fishhawk/workflows.yaml`'s SHA at the event's repo + ref — that's a meaningful additional surface (auth, rate limits, error mapping) and belongs in its own PR. For now the receiver acknowledges the delivery and emits the structured log line; the fan-out to `Repository.CreateRun` plugs in cleanly once the API client lands.

**Why memory dedup is fine for v0.** GitHub's webhook retry window is ~3h; the `MemoryStore` evicts at 24h. Process restarts lose state, which means a redelivery during a deploy could re-process. For single-instance v0 self-execution that's acceptable — at worst we log an event twice. Multi-instance deploys will need a Postgres-backed store (a follow-up; the `DeliveryStore` interface is already the seam).

**Signature check ordering.** Verify HMAC first, before ParseEvent or Mark. A forged body shouldn't reach the dedup store at all — even if the dedup IDs are short-lived, recording a delivery ID for a payload an attacker chose is a free injection.

**Test matrix (12 server-side cases):**
- happy path 202
- bad signature → 401 `webhook_signature_invalid`
- missing signature → 401
- missing event header → 400
- missing delivery header → 400
- malformed body → 400
- duplicate delivery → 202 (not 4xx — GitHub retries on non-2xx)
- secret unconfigured → 503 `webhook_secret_unconfigured`
- delivery store unconfigured → 503 `webhook_store_unconfigured`
- body > 10 MiB → 413 `body_too_large`

**Spec status.** Of 19 endpoints in `docs/api/v0.openapi.yaml`: `/healthz`, `POST /v0/runs`, `GET /v0/runs/{run_id}`, and `POST /webhooks/github` now have implementations.

Closes #47
