### PR TITLE
Document docs-in-same-PR + deferred-issue rules in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,13 +58,19 @@ python3 scripts/check-coverage.py --threshold 80 --exclude internal/run/db backe
 
 ## Git flow
 
-**Issue → feature branch → PR → close issue → update relevant issues.**
+**Issue → feature branch → PR → docs + follow-ups → close issue → update relevant issues.**
 
 1. Pick a child issue from Project #7. If a blocking ADR is open, resolve it first.
 2. Branch from `origin/main`: `<issue-slug>-<desc>`, e.g. `e3.1-backend-skeleton`.
 3. Commit with `git commit -s` (DCO is mandatory; PRs without sign-off are rejected). Imperative-mood title, no conventional-commits prefix. Use HEREDOC for multi-line messages.
-4. Open PR — body uses `## Summary` / `## Test plan` / optional `## Notes` / `Closes #<issue>`. Match #80, #81.
-5. After merge, walk the dependents:
+4. **Update docs in the same PR**, before opening:
+   - New package / HTTP route / env var / flag → `docs/ARCHITECTURE.md` "Where to look" table; operator-facing inputs also → component `README.md`.
+   - Spec or schema change → `docs/spec/<x>.md` + every embedded copy (CI's schema-sync diff fails otherwise).
+   - HTTP API change → `docs/api/v0.openapi.yaml` (source of truth) + `docs/api/v0.md`.
+   - Voice/naming → `BRAND_FOUNDATIONS.md`. New trap / build workflow → `CLAUDE.md`. Autonomy convention → `METHODOLOGY.md`.
+5. **File issues for deferred work** before the PR opens. Any TODO, "follow-up PR", "deferred to E…", or obvious operability gap gets a tracking issue: title `[E<parent>.<n>]` (or `[ADR-NNN]`), same `area:*/autonomy:*/phase:*/type:*` labels as siblings, add to Project #7 with `Status=Backlog`, link from the parent epic's Children list, and reference from the PR body's `## Notes` so the deferral is reviewable.
+6. Open PR — body uses `## Summary` / `## Test plan` / optional `## Notes` / `Closes #<issue>`. Match #80, #81.
+7. After merge, walk the dependents:
    - Verify parent epic's task list checked off.
    - Update sibling issues if scope shifted (e.g., a CI fix bundled here means another sibling no longer needs it).
    - If an ADR was resolved, edit its body's Decision section and close.


### PR DESCRIPTION
## Summary

Two recurring failure modes for agent-driven PRs show up otherwise:

1. **Cross-component changes ship without their docs.** The next session opens `ARCHITECTURE.md`, sees no entry for the new route/package/env var, and either re-discovers the surface or designs around code that already exists.
2. **Deferred work disappears.** PRs say "follow-up PR will…" or leave a TODO; with no tracking issue, the deferral is invisible on the project board. (E3.8 / #109 and E3.9 / #110, just filed for PR #108, are the case in point.)

Two new steps in the git flow:

- **Step 4 — update docs in the same PR.** Per-surface table: ARCHITECTURE.md "Where to look" for new packages/routes/env vars, plus component README; spec+embedded copies for schema changes (CI's diff catches drift); OpenAPI for HTTP API changes; brand/methodology/CLAUDE for voice/policy.
- **Step 5 — file issues for deferred work before opening the PR.** Title format `[E<parent>.<n>]`, sibling labels, Project #7 Status=Backlog (per the existing trap), parent epic's Children list, cross-reference from PR `## Notes`.

Header summary gains "docs + follow-ups" so the new steps surface in a table-of-contents grep.

## Test plan

- [x] Word count check: CLAUDE.md grew from ~890 → 934 words (+44, second tighten pass after a verbose first draft)
- [x] Markdown renders: GitHub view shows ordered list intact
- [x] CI passes (no Go/TS/OpenAPI changes; expects only path-filter Detect to run)

## Notes

The flow now has 7 numbered steps; step 7 (post-merge dependent walk) is unchanged. The doc-surface bullet list under step 4 is intentionally compact — one line per surface — to keep total token cost reasonable for a file in every prompt.

No issue closed by this PR; it's a governance change that codifies what we already started doing manually (filed #109 and #110 explicitly for PR #108).
