### PR TITLE
Add signing-key issuance endpoint (POST /v0/runs/{id}/signing-key)

### DIFF
--- a/backend/cmd/fishhawkd/serve.go
+++ b/backend/cmd/fishhawkd/serve.go
@@ -15,6 +15,7 @@ import (
 
 	runpkg "github.com/kuhlman-labs/fishhawk/backend/internal/run"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/server"
+	"github.com/kuhlman-labs/fishhawk/backend/internal/signing"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/version"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/webhook"
 )
@@ -52,9 +53,10 @@ func runServe(args []string, logSink io.Writer) int {
 		}
 		defer pool.Close()
 		cfg.RunRepo = runpkg.NewPostgresRepository(pool)
-		logger.Info("run repository configured", slog.String("driver", "postgres"))
+		cfg.SigningRepo = signing.NewPostgresRepository(pool)
+		logger.Info("run + signing repositories configured", slog.String("driver", "postgres"))
 	} else {
-		logger.Warn("FISHHAWKD_DATABASE_URL not set; /v0/runs endpoints will respond 503")
+		logger.Warn("FISHHAWKD_DATABASE_URL not set; /v0/runs and /v0/runs/{id}/signing-key endpoints will respond 503")
 	}
 
 	// Webhook receiver wiring. Secret + delivery store both need

--- a/backend/internal/server/handlers.go
+++ b/backend/internal/server/handlers.go
@@ -15,6 +15,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /healthz", s.handleHealth)
 	mux.HandleFunc("POST /v0/runs", s.handleCreateRun)
 	mux.HandleFunc("GET /v0/runs/{run_id}", s.handleGetRun)
+	mux.HandleFunc("POST /v0/runs/{run_id}/signing-key", s.handleIssueSigningKey)
 	mux.HandleFunc("POST /webhooks/github", s.handleWebhook)
 }
 

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/kuhlman-labs/fishhawk/backend/internal/run"
+	"github.com/kuhlman-labs/fishhawk/backend/internal/signing"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/webhook"
 )
 
@@ -37,6 +38,11 @@ type Config struct {
 	// Tests inject in-memory fakes; production wires the Postgres
 	// adapter (run.NewPostgresRepository).
 	RunRepo run.Repository
+
+	// SigningRepo issues + persists per-run Ed25519 keys for the
+	// trace bundle signing flow. Wired by the
+	// /v0/runs/{id}/signing-key handler; nil leaves it 503.
+	SigningRepo signing.Repository
 
 	// GitHubWebhookSecret is the shared secret GitHub uses to
 	// HMAC-sign webhook deliveries. Empty disables the

--- a/backend/internal/server/signing.go
+++ b/backend/internal/server/signing.go
@@ -1,0 +1,111 @@
+package server
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/kuhlman-labs/fishhawk/backend/internal/signing"
+)
+
+// signingKeyResponse mirrors the 201 body in
+// docs/api/v0.openapi.yaml for `POST /v0/runs/{id}/signing-key`.
+// The private key is returned exactly once and is never persisted
+// server-side; clients must capture it on this response.
+type signingKeyResponse struct {
+	RunID      uuid.UUID `json:"run_id"`
+	PublicKey  string    `json:"public_key"`  // base64-encoded 32-byte ed25519 public
+	PrivateKey string    `json:"private_key"` // base64-encoded 64-byte ed25519 private
+	IssuedAt   time.Time `json:"issued_at"`
+	ExpiresAt  time.Time `json:"expires_at"`
+}
+
+// signingKeyRequest mirrors the OpenAPI request body. Both the body
+// and ttl_seconds are optional; when omitted the handler falls back
+// to signing.DefaultTTL.
+type signingKeyRequest struct {
+	TTLSeconds *int `json:"ttl_seconds,omitempty"`
+}
+
+// minTTLSeconds and maxTTLSeconds bracket the request-side cap per
+// the OpenAPI schema. The signing layer accepts any positive ttl;
+// the handler is the gate against silly values from clients.
+const (
+	minTTLSeconds = 60
+	maxTTLSeconds = 3600
+)
+
+// handleIssueSigningKey implements POST /v0/runs/{run_id}/signing-key.
+//
+// AUTH NOTE: per the OpenAPI contract this endpoint requires a
+// GitHub Actions OIDC token. v0 self-execution ships without OIDC
+// verification — the security boundary is currently "the run_id is
+// a UUIDv7 the caller had to learn from the dispatch path." Proper
+// OIDC verification (JWKS fetch, JWT verify, claim binding to
+// repository + workflow) is tracked separately; until it lands,
+// callers can sign for any run_id they know.
+func (s *Server) handleIssueSigningKey(w http.ResponseWriter, r *http.Request) {
+	if s.cfg.SigningRepo == nil {
+		s.writeError(w, r, http.StatusServiceUnavailable, "signing_repo_unconfigured",
+			"signing-key endpoint requires a configured repository", nil)
+		return
+	}
+
+	runID, err := uuid.Parse(r.PathValue("run_id"))
+	if err != nil {
+		s.writeError(w, r, http.StatusBadRequest, "validation_failed",
+			"run_id must be a valid UUID",
+			map[string]any{"field": "run_id", "got": r.PathValue("run_id")})
+		return
+	}
+
+	// Body is optional. An empty / missing body uses the default
+	// TTL; a present body must parse cleanly.
+	ttl := signing.DefaultTTL
+	if r.ContentLength != 0 {
+		var req signingKeyRequest
+		dec := json.NewDecoder(r.Body)
+		dec.DisallowUnknownFields()
+		if err := dec.Decode(&req); err != nil {
+			s.writeError(w, r, http.StatusBadRequest, "validation_failed",
+				"request body is not valid JSON or contains unknown fields",
+				map[string]any{"error": err.Error()})
+			return
+		}
+		if req.TTLSeconds != nil {
+			if *req.TTLSeconds < minTTLSeconds || *req.TTLSeconds > maxTTLSeconds {
+				s.writeError(w, r, http.StatusBadRequest, "validation_failed",
+					"ttl_seconds out of range",
+					map[string]any{"field": "ttl_seconds", "min": minTTLSeconds, "max": maxTTLSeconds, "got": *req.TTLSeconds})
+				return
+			}
+			ttl = time.Duration(*req.TTLSeconds) * time.Second
+		}
+	}
+
+	issued, err := s.cfg.SigningRepo.Issue(r.Context(), runID, ttl)
+	if err != nil {
+		switch {
+		case errors.Is(err, signing.ErrAlreadyIssued):
+			s.writeError(w, r, http.StatusConflict, "signing_key_already_issued",
+				"a signing key has already been issued for this run",
+				map[string]any{"run_id": runID.String()})
+		default:
+			s.writeError(w, r, http.StatusInternalServerError, "internal_error",
+				"issue signing key failed", map[string]any{"error": err.Error()})
+		}
+		return
+	}
+
+	s.writeJSON(w, r, http.StatusCreated, signingKeyResponse{
+		RunID:      issued.RunID,
+		PublicKey:  base64.StdEncoding.EncodeToString(issued.PublicKey),
+		PrivateKey: base64.StdEncoding.EncodeToString(issued.PrivateKey),
+		IssuedAt:   issued.IssuedAt,
+		ExpiresAt:  issued.ExpiresAt,
+	})
+}

--- a/backend/internal/server/signing_test.go
+++ b/backend/internal/server/signing_test.go
@@ -1,0 +1,283 @@
+package server
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/kuhlman-labs/fishhawk/backend/internal/signing"
+)
+
+// fakeSigningRepo is the in-memory signing.Repository for handler
+// tests. Issue stores the public half and a stable issued/expires
+// pair so assertions can compare timestamps deterministically.
+type fakeSigningRepo struct {
+	mu         sync.Mutex
+	keys       map[uuid.UUID]*signing.Key
+	issueErr   error
+	now        func() time.Time
+	defaultErr error
+}
+
+func newFakeSigningRepo() *fakeSigningRepo {
+	t0 := time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC)
+	return &fakeSigningRepo{
+		keys: map[uuid.UUID]*signing.Key{},
+		now:  func() time.Time { return t0 },
+	}
+}
+
+func (f *fakeSigningRepo) Issue(_ context.Context, runID uuid.UUID, ttl time.Duration) (*signing.IssuedKey, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.issueErr != nil {
+		return nil, f.issueErr
+	}
+	if _, ok := f.keys[runID]; ok {
+		return nil, signing.ErrAlreadyIssued
+	}
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+	now := f.now()
+	f.keys[runID] = &signing.Key{
+		RunID:     runID,
+		PublicKey: pub,
+		IssuedAt:  now,
+		ExpiresAt: now.Add(ttl),
+	}
+	return &signing.IssuedKey{
+		RunID:      runID,
+		PublicKey:  pub,
+		PrivateKey: priv,
+		IssuedAt:   now,
+		ExpiresAt:  now.Add(ttl),
+	}, nil
+}
+
+func (f *fakeSigningRepo) Get(_ context.Context, runID uuid.UUID) (*signing.Key, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.defaultErr != nil {
+		return nil, f.defaultErr
+	}
+	k, ok := f.keys[runID]
+	if !ok {
+		return nil, signing.ErrNotFound
+	}
+	return k, nil
+}
+
+func (f *fakeSigningRepo) Verify(_ context.Context, _ uuid.UUID, _ []byte, _ []byte) error {
+	return errors.New("fakeSigningRepo: Verify not implemented")
+}
+
+func newSigningServer(t *testing.T, repo signing.Repository) *Server {
+	t.Helper()
+	return New(Config{Addr: "127.0.0.1:0", SigningRepo: repo})
+}
+
+func issueRequest(t *testing.T, s *Server, runID uuid.UUID, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	var rdr *strings.Reader
+	if body != nil {
+		raw, _ := json.Marshal(body)
+		rdr = strings.NewReader(string(raw))
+	}
+	url := fmt.Sprintf("/v0/runs/%s/signing-key", runID)
+	var req *http.Request
+	if rdr != nil {
+		req = httptest.NewRequest(http.MethodPost, url, rdr)
+		req.Header.Set("Content-Type", "application/json")
+	} else {
+		req = httptest.NewRequest(http.MethodPost, url, nil)
+	}
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	return w
+}
+
+func TestIssueSigningKey_HappyPath_DefaultTTL(t *testing.T) {
+	repo := newFakeSigningRepo()
+	s := newSigningServer(t, repo)
+	runID := uuid.New()
+
+	w := issueRequest(t, s, runID, nil)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201:\n%s", w.Code, w.Body.String())
+	}
+
+	var got signingKeyResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.RunID != runID {
+		t.Errorf("RunID = %s, want %s", got.RunID, runID)
+	}
+	pub, err := base64.StdEncoding.DecodeString(got.PublicKey)
+	if err != nil {
+		t.Errorf("PublicKey not valid base64: %v", err)
+	}
+	if len(pub) != ed25519.PublicKeySize {
+		t.Errorf("PublicKey len = %d, want %d", len(pub), ed25519.PublicKeySize)
+	}
+	priv, err := base64.StdEncoding.DecodeString(got.PrivateKey)
+	if err != nil {
+		t.Errorf("PrivateKey not valid base64: %v", err)
+	}
+	if len(priv) != ed25519.PrivateKeySize {
+		t.Errorf("PrivateKey len = %d, want %d", len(priv), ed25519.PrivateKeySize)
+	}
+	// Default TTL = 30 minutes per signing.DefaultTTL.
+	if got.ExpiresAt.Sub(got.IssuedAt) != signing.DefaultTTL {
+		t.Errorf("expiry window = %v, want %v", got.ExpiresAt.Sub(got.IssuedAt), signing.DefaultTTL)
+	}
+}
+
+func TestIssueSigningKey_CustomTTL(t *testing.T) {
+	repo := newFakeSigningRepo()
+	s := newSigningServer(t, repo)
+	runID := uuid.New()
+
+	w := issueRequest(t, s, runID, map[string]int{"ttl_seconds": 600})
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201:\n%s", w.Code, w.Body.String())
+	}
+	var got signingKeyResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &got)
+	if got.ExpiresAt.Sub(got.IssuedAt) != 10*time.Minute {
+		t.Errorf("expiry window = %v, want 10m", got.ExpiresAt.Sub(got.IssuedAt))
+	}
+}
+
+func TestIssueSigningKey_TTLOutOfRange(t *testing.T) {
+	cases := []struct {
+		name string
+		ttl  int
+	}{
+		{"under min", minTTLSeconds - 1},
+		{"over max", maxTTLSeconds + 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := newFakeSigningRepo()
+			s := newSigningServer(t, repo)
+			w := issueRequest(t, s, uuid.New(), map[string]int{"ttl_seconds": tc.ttl})
+			if w.Code != http.StatusBadRequest {
+				t.Errorf("status = %d, want 400", w.Code)
+			}
+			if !strings.Contains(w.Body.String(), `"validation_failed"`) {
+				t.Errorf("body missing validation_failed: %s", w.Body.String())
+			}
+		})
+	}
+}
+
+func TestIssueSigningKey_BadUUID(t *testing.T) {
+	s := newSigningServer(t, newFakeSigningRepo())
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v0/runs/not-a-uuid/signing-key", nil)
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestIssueSigningKey_BadJSONBody(t *testing.T) {
+	s := newSigningServer(t, newFakeSigningRepo())
+	url := fmt.Sprintf("/v0/runs/%s/signing-key", uuid.New())
+	req := httptest.NewRequest(http.MethodPost, url, strings.NewReader("{not json"))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestIssueSigningKey_UnknownField(t *testing.T) {
+	s := newSigningServer(t, newFakeSigningRepo())
+	w := issueRequest(t, s, uuid.New(), map[string]any{"ttl_seconds": 600, "extra": true})
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 on unknown field", w.Code)
+	}
+}
+
+func TestIssueSigningKey_AlreadyIssued(t *testing.T) {
+	repo := newFakeSigningRepo()
+	s := newSigningServer(t, repo)
+	runID := uuid.New()
+
+	if w := issueRequest(t, s, runID, nil); w.Code != http.StatusCreated {
+		t.Fatalf("first issue: status = %d", w.Code)
+	}
+	w := issueRequest(t, s, runID, nil)
+	if w.Code != http.StatusConflict {
+		t.Errorf("second issue: status = %d, want 409", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), `"signing_key_already_issued"`) {
+		t.Errorf("body missing code: %s", w.Body.String())
+	}
+}
+
+func TestIssueSigningKey_RepoError(t *testing.T) {
+	repo := newFakeSigningRepo()
+	repo.issueErr = errors.New("disk full")
+	s := newSigningServer(t, repo)
+	w := issueRequest(t, s, uuid.New(), nil)
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), `"internal_error"`) {
+		t.Errorf("body missing internal_error: %s", w.Body.String())
+	}
+}
+
+func TestIssueSigningKey_NilRepoConfigured(t *testing.T) {
+	s := New(Config{Addr: "127.0.0.1:0"})
+	w := issueRequest(t, s, uuid.New(), nil)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "signing_repo_unconfigured") {
+		t.Errorf("body missing code: %s", w.Body.String())
+	}
+}
+
+func TestIssueSigningKey_PrivateKeySigsVerifyAgainstPublic(t *testing.T) {
+	// End-to-end: a caller can take the returned (public, private)
+	// pair and verify a signature with each half. Catches a class
+	// of bugs where, e.g., we accidentally swapped halves in the
+	// response.
+	repo := newFakeSigningRepo()
+	s := newSigningServer(t, repo)
+	runID := uuid.New()
+
+	w := issueRequest(t, s, runID, nil)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var resp signingKeyResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	pub, _ := base64.StdEncoding.DecodeString(resp.PublicKey)
+	priv, _ := base64.StdEncoding.DecodeString(resp.PrivateKey)
+
+	msg := []byte("hello fishhawk")
+	sig := ed25519.Sign(priv, msg)
+	if !ed25519.Verify(pub, msg, sig) {
+		t.Error("signature did not verify against returned public key")
+	}
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,6 +159,7 @@ GitHub OAuth (E4.2 / #49) is the sign-in flow that mints the cookie session. App
 | Constraint evaluation (forbidden_paths, max_files_changed, required_outcomes) | `runner/internal/constraint/constraint.go` (post-hoc, runner-side) |
 | HTTP middleware order / context keys | `backend/internal/server/middleware.go` |
 | Run CRUD handlers (POST/GET) | `backend/internal/server/runs.go`; wired in `backend/cmd/fishhawkd/serve.go` from `FISHHAWKD_DATABASE_URL` |
+| Signing-key issuance handler | `backend/internal/server/signing.go` wraps `signing.Repository.Issue`; OIDC auth pending (#112) |
 | GitHub webhook receiver | `backend/internal/webhook/` (HMAC + dedup) and `backend/internal/server/webhook.go`; secret from `FISHHAWKD_GITHUB_WEBHOOK_SECRET` |
 | How a new Go module gets added | `CLAUDE.md` "Adding a Go module" |
 


### PR DESCRIPTION
## Summary

`POST /v0/runs/{run_id}/signing-key` now exists. The handler wraps `signing.Repository.Issue` from E2.3 (#24) — backend mints a fresh Ed25519 keypair, persists the public half, returns both halves to the caller exactly once. This is the last backend piece the runner needs before E5.6 (signed trace shipping) can land.

Per ADR-008 (#72) the public half is the externally-verifiable record; the private half is never persisted server-side.

- `backend/internal/server/signing.go` — `handleIssueSigningKey`. Optional body with `ttl_seconds` (60–3600s) overrides `signing.DefaultTTL` (30m). 409 `signing_key_already_issued` maps to `signing.ErrAlreadyIssued`.
- `Server.Config` grows `SigningRepo`. nil leaves the endpoint at 503 (`signing_repo_unconfigured`), same honest-gap pattern as `RunRepo`.
- `backend/cmd/fishhawkd/serve.go`: the signing repo is wired alongside the run repo when `FISHHAWKD_DATABASE_URL` is set; both share the pgxpool.

## Test plan

- [x] `go test -race ./backend/...` — 11 new server tests pass alongside existing suites
- [x] `golangci-lint run ./backend/...` — 0 issues
- [x] Coverage: handler 100%, server pkg 93.5%, aggregate (excl. `/db/`) 86.4%
- [x] End-to-end verify: returned `(public, private)` pair actually round-trips an Ed25519 signature
- [x] CI passes

## Notes

**OIDC auth deferred** — filed as **#112 (E3.10)** per the CLAUDE.md deferred-issue policy. Until #112 lands the endpoint accepts any caller; the practical security boundary is "the run_id is a UUIDv7 the caller had to learn from the dispatch path." For v0 self-execution that's acceptable; before any external customer the OIDC path is mandatory.

**Why the IssuedKey is returned base64.** `ed25519.PublicKey` and `ed25519.PrivateKey` are `[]byte` aliases; JSON-encoding raw bytes works but base64 is the explicit choice in `docs/api/v0.openapi.yaml`'s contract. End-to-end test confirms a client decoding the response can sign + verify.

**Spec status.** Of 19 endpoints in `docs/api/v0.openapi.yaml`: `/healthz`, `POST /v0/runs`, `GET /v0/runs/{run_id}`, `POST /v0/runs/{run_id}/signing-key`, and `POST /webhooks/github` now have implementations. Next-likely (per Day 21 critical path): `POST /v0/runs/{run_id}/trace` (signature verify + bundle store + audit append) — that handler closes the runner→backend audit-trail loop end-to-end and unblocks E5.6.

**Docs updated** per the new policy: `docs/ARCHITECTURE.md` "Where to look" table now points to the signing handler with #112 cross-reference.
