### PR TITLE
Add trace upload endpoint (POST /v0/runs/{id}/trace)

### DIFF
--- a/backend/cmd/fishhawkd/serve.go
+++ b/backend/cmd/fishhawkd/serve.go
@@ -11,11 +11,16 @@ import (
 
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/kuhlman-labs/fishhawk/backend/internal/audit"
 	runpkg "github.com/kuhlman-labs/fishhawk/backend/internal/run"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/server"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/signing"
+	"github.com/kuhlman-labs/fishhawk/backend/internal/tracestore"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/version"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/webhook"
 )
@@ -31,6 +36,12 @@ func runServe(args []string, logSink io.Writer) int {
 	webhookSecret := fs.String("github-webhook-secret",
 		envOr("FISHHAWKD_GITHUB_WEBHOOK_SECRET", ""),
 		"shared secret GitHub uses to HMAC-sign webhook deliveries; when empty, /webhooks/github responds 503")
+	s3Bucket := fs.String("s3-bucket", envOr("FISHHAWKD_S3_BUCKET", ""),
+		"S3 bucket for trace bundle storage; when empty, /v0/runs/{id}/trace responds 503")
+	s3Region := fs.String("s3-region", envOr("FISHHAWKD_S3_REGION", "us-east-1"),
+		"AWS region for the trace bundle bucket")
+	s3Endpoint := fs.String("s3-endpoint", envOr("FISHHAWKD_S3_ENDPOINT", ""),
+		"override the S3 endpoint (e.g. http://minio:9000 in dev); empty uses the AWS default")
 	if err := fs.Parse(args); err != nil {
 		return exitFailure
 	}
@@ -54,9 +65,35 @@ func runServe(args []string, logSink io.Writer) int {
 		defer pool.Close()
 		cfg.RunRepo = runpkg.NewPostgresRepository(pool)
 		cfg.SigningRepo = signing.NewPostgresRepository(pool)
-		logger.Info("run + signing repositories configured", slog.String("driver", "postgres"))
+		cfg.AuditRepo = audit.NewPostgresRepository(pool)
+		logger.Info("run + signing + audit repositories configured", slog.String("driver", "postgres"))
 	} else {
 		logger.Warn("FISHHAWKD_DATABASE_URL not set; /v0/runs and /v0/runs/{id}/signing-key endpoints will respond 503")
+	}
+
+	// Trace storage wiring. The S3 client uses path-style requests
+	// so the same code works against AWS S3 and MinIO. An empty
+	// bucket leaves /v0/runs/{id}/trace at 503.
+	if *s3Bucket != "" {
+		awsCfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+			awsconfig.WithRegion(*s3Region))
+		if err != nil {
+			logger.Error("aws config failed", slog.String("error", err.Error()))
+			return exitFailure
+		}
+		client := s3.NewFromConfig(awsCfg, func(o *s3.Options) {
+			if *s3Endpoint != "" {
+				o.BaseEndpoint = aws.String(*s3Endpoint)
+			}
+			o.UsePathStyle = true
+		})
+		cfg.TraceStore = tracestore.NewS3Storage(client, *s3Bucket)
+		logger.Info("trace store configured",
+			slog.String("bucket", *s3Bucket),
+			slog.String("region", *s3Region),
+			slog.String("endpoint", *s3Endpoint))
+	} else {
+		logger.Warn("FISHHAWKD_S3_BUCKET not set; /v0/runs/{id}/trace will respond 503")
 	}
 
 	// Webhook receiver wiring. Secret + delivery store both need

--- a/backend/internal/server/handlers.go
+++ b/backend/internal/server/handlers.go
@@ -16,6 +16,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /v0/runs", s.handleCreateRun)
 	mux.HandleFunc("GET /v0/runs/{run_id}", s.handleGetRun)
 	mux.HandleFunc("POST /v0/runs/{run_id}/signing-key", s.handleIssueSigningKey)
+	mux.HandleFunc("POST /v0/runs/{run_id}/trace", s.handleShipTrace)
 	mux.HandleFunc("POST /webhooks/github", s.handleWebhook)
 }
 

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -14,8 +14,10 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/kuhlman-labs/fishhawk/backend/internal/audit"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/run"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/signing"
+	"github.com/kuhlman-labs/fishhawk/backend/internal/tracestore"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/webhook"
 )
 
@@ -43,6 +45,15 @@ type Config struct {
 	// trace bundle signing flow. Wired by the
 	// /v0/runs/{id}/signing-key handler; nil leaves it 503.
 	SigningRepo signing.Repository
+
+	// TraceStore persists agent trace bundles to S3 / MinIO. Wired
+	// by the /v0/runs/{id}/trace handler; nil leaves it 503.
+	TraceStore tracestore.Storage
+
+	// AuditRepo writes the audit log entries that pair with every
+	// state change. Wired by the trace-upload handler; nil leaves
+	// it 503.
+	AuditRepo audit.Repository
 
 	// GitHubWebhookSecret is the shared secret GitHub uses to
 	// HMAC-sign webhook deliveries. Empty disables the

--- a/backend/internal/server/trace.go
+++ b/backend/internal/server/trace.go
@@ -1,0 +1,179 @@
+package server
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/kuhlman-labs/fishhawk/backend/internal/audit"
+	"github.com/kuhlman-labs/fishhawk/backend/internal/signing"
+	"github.com/kuhlman-labs/fishhawk/backend/internal/tracestore"
+)
+
+// maxTraceBundleBytes mirrors the runner's bundle.MaxBundleBytes so
+// the runner and backend agree on the gzipped payload ceiling. v0
+// trace volumes are bounded by token budgets; this is the
+// belt-and-suspenders cap that protects backend storage from a
+// runaway agent.
+const maxTraceBundleBytes = 64 * 1024 * 1024
+
+// traceUploadResponse is the 202 body in docs/api/v0.openapi.yaml
+// for `POST /v0/runs/{run_id}/trace`. Returns the (run, stage,
+// variant, content_hash) tuple so the runner can confirm the
+// backend stored the same bytes it sent and stash the hash for
+// later cross-reference.
+type traceUploadResponse struct {
+	RunID       uuid.UUID `json:"run_id"`
+	StageID     uuid.UUID `json:"stage_id"`
+	Variant     string    `json:"variant"`
+	ContentHash string    `json:"content_hash"`
+}
+
+// handleShipTrace implements POST /v0/runs/{run_id}/trace.
+//
+// Auth is the Ed25519 signature itself: the runner produced the
+// signature with the per-run private key (issued by the
+// signing-key endpoint); the backend looks up the stored public
+// half and verifies. A forged or expired signature → 401, no
+// audit log entry, no bundle stored.
+//
+// On success the handler writes a kind=trace_uploaded audit
+// entry via AppendChained — the chain hash links the upload event
+// to the run's prior audit history, so a tampered or replayed
+// trace can't slip into an unrelated run's chain.
+func (s *Server) handleShipTrace(w http.ResponseWriter, r *http.Request) {
+	if s.cfg.SigningRepo == nil || s.cfg.TraceStore == nil || s.cfg.AuditRepo == nil {
+		s.writeError(w, r, http.StatusServiceUnavailable, "trace_upload_unconfigured",
+			"trace upload requires signing, tracestore, and audit to be configured", nil)
+		return
+	}
+
+	runID, err := uuid.Parse(r.PathValue("run_id"))
+	if err != nil {
+		s.writeError(w, r, http.StatusBadRequest, "validation_failed",
+			"run_id must be a valid UUID",
+			map[string]any{"field": "run_id", "got": r.PathValue("run_id")})
+		return
+	}
+
+	stageID, err := uuid.Parse(r.URL.Query().Get("stage_id"))
+	if err != nil {
+		s.writeError(w, r, http.StatusBadRequest, "validation_failed",
+			"stage_id query parameter must be a valid UUID",
+			map[string]any{"field": "stage_id", "got": r.URL.Query().Get("stage_id")})
+		return
+	}
+
+	variant := tracestore.Variant(r.URL.Query().Get("variant"))
+	if !variant.Valid() {
+		s.writeError(w, r, http.StatusBadRequest, "validation_failed",
+			"variant must be raw or redacted",
+			map[string]any{"field": "variant", "got": string(variant)})
+		return
+	}
+
+	sigHeader := r.Header.Get("X-Fishhawk-Signature")
+	if sigHeader == "" {
+		s.writeError(w, r, http.StatusUnauthorized, "signature_missing",
+			"X-Fishhawk-Signature header is required", nil)
+		return
+	}
+	signature, err := hex.DecodeString(sigHeader)
+	if err != nil {
+		s.writeError(w, r, http.StatusUnauthorized, "signature_invalid",
+			"X-Fishhawk-Signature is not valid hex",
+			map[string]any{"error": err.Error()})
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxTraceBundleBytes+1))
+	if err != nil {
+		s.writeError(w, r, http.StatusBadRequest, "validation_failed",
+			"could not read request body", map[string]any{"error": err.Error()})
+		return
+	}
+	if len(body) > maxTraceBundleBytes {
+		s.writeError(w, r, http.StatusRequestEntityTooLarge, "body_too_large",
+			"trace bundle exceeds size cap",
+			map[string]any{"limit_bytes": maxTraceBundleBytes})
+		return
+	}
+
+	message := signing.ComputeMessage(body)
+	if err := s.cfg.SigningRepo.Verify(r.Context(), runID, message, signature); err != nil {
+		switch {
+		case errors.Is(err, signing.ErrNotFound):
+			s.writeError(w, r, http.StatusNotFound, "signing_key_not_found",
+				"no signing key issued for this run", map[string]any{"run_id": runID.String()})
+		case errors.Is(err, signing.ErrExpired):
+			s.writeError(w, r, http.StatusUnauthorized, "signing_key_expired",
+				"signing key TTL has passed", map[string]any{"run_id": runID.String()})
+		case errors.Is(err, signing.ErrSignatureInvalid):
+			s.writeError(w, r, http.StatusUnauthorized, "signature_invalid",
+				"signature does not match the run's stored public key", nil)
+		default:
+			s.writeError(w, r, http.StatusInternalServerError, "internal_error",
+				"signature verification failed", map[string]any{"error": err.Error()})
+		}
+		return
+	}
+
+	contentHash := sha256Hex(body)
+	ref := tracestore.BundleRef{
+		RunID:       runID,
+		Variant:     variant,
+		ContentHash: contentHash,
+	}
+	if err := s.cfg.TraceStore.Put(r.Context(), ref, bytes.NewReader(body)); err != nil {
+		s.writeError(w, r, http.StatusInternalServerError, "internal_error",
+			"store trace bundle failed", map[string]any{"error": err.Error()})
+		return
+	}
+
+	// Audit: append a chained entry tying the upload to this run's
+	// prior history. AppendChained holds a row-lock on runs so two
+	// concurrent uploads can't fork the chain.
+	auditPayload, _ := json.Marshal(map[string]any{
+		"run_id":       runID.String(),
+		"stage_id":     stageID.String(),
+		"variant":      string(variant),
+		"content_hash": contentHash,
+		"size_bytes":   len(body),
+	})
+	systemKind := audit.ActorKind("system")
+	if _, err := s.cfg.AuditRepo.AppendChained(r.Context(), audit.ChainAppendParams{
+		RunID:     runID,
+		StageID:   &stageID,
+		Timestamp: time.Now().UTC(),
+		Category:  "trace_uploaded",
+		ActorKind: &systemKind,
+		Payload:   auditPayload,
+	}); err != nil {
+		// Bundle is already stored; failing here would leave us
+		// with a stored bundle and no audit record. We surface
+		// 500 so the runner retries (idempotent at the storage
+		// layer) and the audit row eventually lands.
+		s.writeError(w, r, http.StatusInternalServerError, "internal_error",
+			"append audit entry failed", map[string]any{"error": err.Error()})
+		return
+	}
+
+	s.writeJSON(w, r, http.StatusAccepted, traceUploadResponse{
+		RunID:       runID,
+		StageID:     stageID,
+		Variant:     string(variant),
+		ContentHash: contentHash,
+	})
+}
+
+func sha256Hex(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}

--- a/backend/internal/server/trace_test.go
+++ b/backend/internal/server/trace_test.go
@@ -1,0 +1,423 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/kuhlman-labs/fishhawk/backend/internal/audit"
+	"github.com/kuhlman-labs/fishhawk/backend/internal/signing"
+	"github.com/kuhlman-labs/fishhawk/backend/internal/tracestore"
+)
+
+// signingFake is a richer fake than newFakeSigningRepo so the trace
+// tests can drive Verify with controlled (key, message, signature)
+// triples. We hold the raw bytes of the issued private key so a
+// test can sign messages and feed them through the handler.
+type signingFake struct {
+	mu   sync.Mutex
+	keys map[uuid.UUID]ed25519.PrivateKey
+
+	// verifyErr forces Verify to return a chosen error regardless
+	// of the supplied signature, useful for the expired / not-found
+	// branches.
+	verifyErr error
+}
+
+func newSigningFake() *signingFake {
+	return &signingFake{keys: map[uuid.UUID]ed25519.PrivateKey{}}
+}
+
+func (f *signingFake) issue(t *testing.T, runID uuid.UUID) (ed25519.PrivateKey, ed25519.PublicKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.mu.Lock()
+	f.keys[runID] = priv
+	f.mu.Unlock()
+	return priv, pub
+}
+
+func (f *signingFake) Issue(_ context.Context, _ uuid.UUID, _ time.Duration) (*signing.IssuedKey, error) {
+	return nil, errors.New("signingFake: Issue not used in trace tests")
+}
+
+func (f *signingFake) Get(_ context.Context, _ uuid.UUID) (*signing.Key, error) {
+	return nil, errors.New("signingFake: Get not used in trace tests")
+}
+
+func (f *signingFake) Verify(_ context.Context, runID uuid.UUID, message, signature []byte) error {
+	if f.verifyErr != nil {
+		return f.verifyErr
+	}
+	f.mu.Lock()
+	priv, ok := f.keys[runID]
+	f.mu.Unlock()
+	if !ok {
+		return signing.ErrNotFound
+	}
+	if !ed25519.Verify(priv.Public().(ed25519.PublicKey), message, signature) {
+		return signing.ErrSignatureInvalid
+	}
+	return nil
+}
+
+// traceStoreFake records the last Put so tests can assert what was
+// stored without standing up MinIO. tracestore.Storage has more
+// methods than we need here; the unused ones return errors so an
+// accidental call is loud.
+type traceStoreFake struct {
+	mu     sync.Mutex
+	last   *tracestore.BundleRef
+	body   []byte
+	putErr error
+}
+
+func newTraceStoreFake() *traceStoreFake { return &traceStoreFake{} }
+
+func (s *traceStoreFake) Put(_ context.Context, ref tracestore.BundleRef, body io.Reader) error {
+	if s.putErr != nil {
+		return s.putErr
+	}
+	b, err := io.ReadAll(body)
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	rc := ref
+	s.last = &rc
+	s.body = b
+	return nil
+}
+
+func (s *traceStoreFake) Get(_ context.Context, _ tracestore.BundleRef) (io.ReadCloser, error) {
+	return nil, errors.New("traceStoreFake: Get not used")
+}
+func (s *traceStoreFake) Stat(_ context.Context, _ tracestore.BundleRef) (tracestore.Stat, error) {
+	return tracestore.Stat{}, errors.New("traceStoreFake: Stat not used")
+}
+func (s *traceStoreFake) List(_ context.Context, _ uuid.UUID) ([]tracestore.BundleRef, error) {
+	return nil, errors.New("traceStoreFake: List not used")
+}
+
+// auditFake captures appended entries so tests can assert what got
+// logged. AppendChained is the only method exercised by the trace
+// handler.
+type auditFake struct {
+	mu        sync.Mutex
+	appended  []audit.ChainAppendParams
+	appendErr error
+}
+
+func newAuditFake() *auditFake { return &auditFake{} }
+
+func (a *auditFake) Append(_ context.Context, _ audit.AppendParams) (*audit.Entry, error) {
+	return nil, errors.New("auditFake: Append not used")
+}
+func (a *auditFake) AppendChained(_ context.Context, p audit.ChainAppendParams) (*audit.Entry, error) {
+	if a.appendErr != nil {
+		return nil, a.appendErr
+	}
+	a.mu.Lock()
+	a.appended = append(a.appended, p)
+	a.mu.Unlock()
+	return &audit.Entry{ID: uuid.New(), RunID: p.RunID}, nil
+}
+func (a *auditFake) Get(_ context.Context, _ uuid.UUID) (*audit.Entry, error) {
+	return nil, errors.New("auditFake: Get not used")
+}
+func (a *auditFake) ListForRun(_ context.Context, _ uuid.UUID) ([]*audit.Entry, error) {
+	return nil, errors.New("auditFake: ListForRun not used")
+}
+func (a *auditFake) LastForRun(_ context.Context, _ uuid.UUID) (*audit.Entry, error) {
+	return nil, errors.New("auditFake: LastForRun not used")
+}
+func (a *auditFake) ListForRunByCategory(_ context.Context, _ uuid.UUID, _ string) ([]*audit.Entry, error) {
+	return nil, errors.New("auditFake: ListForRunByCategory not used")
+}
+
+// newTraceServer wires all three repos for the trace handler.
+func newTraceServer(t *testing.T) (*Server, *signingFake, *traceStoreFake, *auditFake) {
+	t.Helper()
+	sf := newSigningFake()
+	ts := newTraceStoreFake()
+	au := newAuditFake()
+	s := New(Config{
+		Addr:        "127.0.0.1:0",
+		SigningRepo: sf,
+		TraceStore:  ts,
+		AuditRepo:   au,
+	})
+	return s, sf, ts, au
+}
+
+// shipRequest builds a POST /v0/runs/{id}/trace request signed by
+// `priv`. Returns the recorded response.
+func shipRequest(t *testing.T, s *Server, runID, stageID uuid.UUID, variant string, priv ed25519.PrivateKey, body []byte, sigOverride string) *httptest.ResponseRecorder {
+	t.Helper()
+	url := fmt.Sprintf("/v0/runs/%s/trace?stage_id=%s&variant=%s", runID, stageID, variant)
+	req := httptest.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	if sigOverride != "" {
+		req.Header.Set("X-Fishhawk-Signature", sigOverride)
+	} else if priv != nil {
+		sig := ed25519.Sign(priv, signing.ComputeMessage(body))
+		req.Header.Set("X-Fishhawk-Signature", hex.EncodeToString(sig))
+	}
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	return w
+}
+
+func TestShipTrace_HappyPath(t *testing.T) {
+	s, sf, ts, au := newTraceServer(t)
+	runID := uuid.New()
+	stageID := uuid.New()
+	priv, _ := sf.issue(t, runID)
+	bundle := []byte("fake-gzipped-bundle-bytes")
+
+	w := shipRequest(t, s, runID, stageID, "raw", priv, bundle, "")
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202:\n%s", w.Code, w.Body.String())
+	}
+
+	var resp traceUploadResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.RunID != runID || resp.StageID != stageID || resp.Variant != "raw" {
+		t.Errorf("response mismatch: %+v", resp)
+	}
+	if len(resp.ContentHash) != 64 {
+		t.Errorf("ContentHash len = %d, want 64", len(resp.ContentHash))
+	}
+
+	// Tracestore: stored at the ref with matching content_hash.
+	if ts.last == nil {
+		t.Fatal("tracestore.Put was not called")
+	}
+	if ts.last.RunID != runID || ts.last.Variant != tracestore.VariantRaw || ts.last.ContentHash != resp.ContentHash {
+		t.Errorf("ref mismatch: got %+v", ts.last)
+	}
+	if !bytes.Equal(ts.body, bundle) {
+		t.Errorf("body bytes not stored verbatim")
+	}
+
+	// Audit: one trace_uploaded entry tied to the run.
+	au.mu.Lock()
+	defer au.mu.Unlock()
+	if len(au.appended) != 1 {
+		t.Fatalf("audit appended %d, want 1", len(au.appended))
+	}
+	ent := au.appended[0]
+	if ent.RunID != runID {
+		t.Errorf("audit RunID = %s", ent.RunID)
+	}
+	if ent.Category != "trace_uploaded" {
+		t.Errorf("audit Category = %q", ent.Category)
+	}
+	if ent.StageID == nil || *ent.StageID != stageID {
+		t.Errorf("audit StageID = %v", ent.StageID)
+	}
+	// Payload should mention the content_hash so the audit log can be
+	// cross-referenced to the stored bundle.
+	if !bytes.Contains(ent.Payload, []byte(resp.ContentHash)) {
+		t.Errorf("audit payload missing content_hash: %s", ent.Payload)
+	}
+}
+
+func TestShipTrace_BadUUID(t *testing.T) {
+	s, _, _, _ := newTraceServer(t)
+	req := httptest.NewRequest(http.MethodPost,
+		"/v0/runs/not-a-uuid/trace?stage_id="+uuid.New().String()+"&variant=raw",
+		strings.NewReader(""))
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestShipTrace_MissingStageID(t *testing.T) {
+	s, _, _, _ := newTraceServer(t)
+	req := httptest.NewRequest(http.MethodPost,
+		fmt.Sprintf("/v0/runs/%s/trace?variant=raw", uuid.New()),
+		strings.NewReader(""))
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 for missing stage_id", w.Code)
+	}
+}
+
+func TestShipTrace_BadVariant(t *testing.T) {
+	s, _, _, _ := newTraceServer(t)
+	req := httptest.NewRequest(http.MethodPost,
+		fmt.Sprintf("/v0/runs/%s/trace?stage_id=%s&variant=other", uuid.New(), uuid.New()),
+		strings.NewReader(""))
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 for bad variant", w.Code)
+	}
+}
+
+func TestShipTrace_MissingSignature(t *testing.T) {
+	s, sf, _, _ := newTraceServer(t)
+	runID := uuid.New()
+	sf.issue(t, runID)
+	req := httptest.NewRequest(http.MethodPost,
+		fmt.Sprintf("/v0/runs/%s/trace?stage_id=%s&variant=raw", runID, uuid.New()),
+		strings.NewReader("body"))
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), `"signature_missing"`) {
+		t.Errorf("body missing signature_missing: %s", w.Body.String())
+	}
+}
+
+func TestShipTrace_BadHexSignature(t *testing.T) {
+	s, sf, _, _ := newTraceServer(t)
+	runID := uuid.New()
+	priv, _ := sf.issue(t, runID)
+	w := shipRequest(t, s, runID, uuid.New(), "raw", priv, []byte("body"), "not-hex")
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), `"signature_invalid"`) {
+		t.Errorf("body missing signature_invalid: %s", w.Body.String())
+	}
+}
+
+func TestShipTrace_WrongSignature(t *testing.T) {
+	s, sf, _, _ := newTraceServer(t)
+	runID := uuid.New()
+	sf.issue(t, runID)
+
+	// Sign with a DIFFERENT key (a totally separate keypair).
+	_, otherPriv, _ := ed25519.GenerateKey(rand.Reader)
+	w := shipRequest(t, s, runID, uuid.New(), "raw", otherPriv, []byte("body"), "")
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", w.Code)
+	}
+}
+
+func TestShipTrace_NoSigningKeyForRun(t *testing.T) {
+	s, _, _, _ := newTraceServer(t)
+	// No issue() called → key not in fake's map → ErrNotFound.
+	body := []byte("body")
+	_, priv, _ := ed25519.GenerateKey(rand.Reader)
+	w := shipRequest(t, s, uuid.New(), uuid.New(), "raw", priv, body, "")
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), `"signing_key_not_found"`) {
+		t.Errorf("body missing signing_key_not_found: %s", w.Body.String())
+	}
+}
+
+func TestShipTrace_ExpiredKey(t *testing.T) {
+	s, sf, _, _ := newTraceServer(t)
+	sf.verifyErr = signing.ErrExpired
+	runID := uuid.New()
+	body := []byte("b")
+	_, priv, _ := ed25519.GenerateKey(rand.Reader)
+	w := shipRequest(t, s, runID, uuid.New(), "raw", priv, body, "")
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401 for expired key", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), `"signing_key_expired"`) {
+		t.Errorf("body missing signing_key_expired: %s", w.Body.String())
+	}
+}
+
+func TestShipTrace_BodyTooLarge(t *testing.T) {
+	s, sf, _, _ := newTraceServer(t)
+	runID := uuid.New()
+	priv, _ := sf.issue(t, runID)
+	big := bytes.Repeat([]byte{0}, maxTraceBundleBytes+1)
+	w := shipRequest(t, s, runID, uuid.New(), "raw", priv, big, "")
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("status = %d, want 413", w.Code)
+	}
+}
+
+func TestShipTrace_TraceStoreError(t *testing.T) {
+	s, sf, ts, _ := newTraceServer(t)
+	ts.putErr = errors.New("s3 down")
+	runID := uuid.New()
+	priv, _ := sf.issue(t, runID)
+	w := shipRequest(t, s, runID, uuid.New(), "raw", priv, []byte("b"), "")
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", w.Code)
+	}
+}
+
+func TestShipTrace_AuditAppendError(t *testing.T) {
+	// The bundle has been stored already; failing here surfaces 500
+	// so the runner retries.
+	s, sf, _, au := newTraceServer(t)
+	au.appendErr = errors.New("db down")
+	runID := uuid.New()
+	priv, _ := sf.issue(t, runID)
+	w := shipRequest(t, s, runID, uuid.New(), "raw", priv, []byte("b"), "")
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", w.Code)
+	}
+}
+
+func TestShipTrace_NilDepsConfigured(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  Config
+	}{
+		{"missing signing", Config{Addr: "127.0.0.1:0", TraceStore: newTraceStoreFake(), AuditRepo: newAuditFake()}},
+		{"missing tracestore", Config{Addr: "127.0.0.1:0", SigningRepo: newSigningFake(), AuditRepo: newAuditFake()}},
+		{"missing audit", Config{Addr: "127.0.0.1:0", SigningRepo: newSigningFake(), TraceStore: newTraceStoreFake()}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := New(tc.cfg)
+			req := httptest.NewRequest(http.MethodPost,
+				fmt.Sprintf("/v0/runs/%s/trace?stage_id=%s&variant=raw", uuid.New(), uuid.New()),
+				strings.NewReader(""))
+			w := httptest.NewRecorder()
+			s.Handler().ServeHTTP(w, req)
+			if w.Code != http.StatusServiceUnavailable {
+				t.Errorf("status = %d, want 503", w.Code)
+			}
+		})
+	}
+}
+
+func TestShipTrace_RedactedVariant(t *testing.T) {
+	s, sf, ts, _ := newTraceServer(t)
+	runID := uuid.New()
+	priv, _ := sf.issue(t, runID)
+	w := shipRequest(t, s, runID, uuid.New(), "redacted", priv, []byte("b"), "")
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202", w.Code)
+	}
+	if ts.last == nil || ts.last.Variant != tracestore.VariantRedacted {
+		t.Errorf("variant not preserved in BundleRef: %+v", ts.last)
+	}
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -160,6 +160,7 @@ GitHub OAuth (E4.2 / #49) is the sign-in flow that mints the cookie session. App
 | HTTP middleware order / context keys | `backend/internal/server/middleware.go` |
 | Run CRUD handlers (POST/GET) | `backend/internal/server/runs.go`; wired in `backend/cmd/fishhawkd/serve.go` from `FISHHAWKD_DATABASE_URL` |
 | Signing-key issuance handler | `backend/internal/server/signing.go` wraps `signing.Repository.Issue`; OIDC auth pending (#112) |
+| Trace upload handler | `backend/internal/server/trace.go`; verifies signature, calls `tracestore.Put` + `audit.AppendChained`. S3 wired in `serve.go` from `FISHHAWKD_S3_BUCKET`/`_REGION`/`_ENDPOINT`. |
 | GitHub webhook receiver | `backend/internal/webhook/` (HMAC + dedup) and `backend/internal/server/webhook.go`; secret from `FISHHAWKD_GITHUB_WEBHOOK_SECRET` |
 | How a new Go module gets added | `CLAUDE.md` "Adding a Go module" |
 


### PR DESCRIPTION
## Summary

`POST /v0/runs/{run_id}/trace` now exists. Closes the runner→backend audit-trail loop: with this in, the runner-side E5.6 (signed trace shipping) can land — bundle the events with `runner/internal/bundle`, sign `sha256(bytes)`, POST.

Handler does four things in order:
1. Parse path/query (`run_id`, `stage_id`, `variant`) + `X-Fishhawk-Signature` header.
2. Verify signature against the run's stored public key via `signing.Repository.Verify` (looks up + checks expiry).
3. Store the gzipped bundle via `tracestore.Storage.Put` under the canonical key `{run_id}/{variant}/{sha256}.jsonl.gz`.
4. Append a chained `audit_entry` (`category=trace_uploaded`) so the run's chain hash captures this event.

Auth IS the signature itself per the OpenAPI spec — no Bearer, cookie, or OIDC. A forged signature returns 401 before anything touches the trace store or audit log.

`Server.Config` grows `TraceStore` + `AuditRepo`. nil values keep the endpoint at 503 (`trace_upload_unconfigured`).

`fishhawkd serve` grows `--s3-bucket` / `--s3-region` / `--s3-endpoint` (envs `FISHHAWKD_S3_*`). With S3 + DB both configured the endpoint is fully live; with either missing it's an honest 503. The S3 client uses path-style requests so the same code works against AWS S3 and MinIO in dev.

## Test plan

- [x] `go test -race ./backend/...` — 14 new server tests pass alongside existing suites
- [x] `golangci-lint run ./backend/...` — 0 issues
- [x] Coverage: handler 93.9%, server pkg 93.6%, aggregate (excl `/db/`) 86.0%
- [x] CI passes

## Notes

**Test approach.** `signingFake` holds the issued private keys so each test signs its own body and the handler's verify path runs end-to-end with real Ed25519 math. `traceStoreFake` records the last `Put` so we can assert the `BundleRef` and stored bytes. `auditFake` records `AppendChained` calls so we can assert the audit entry's RunID, StageID, Category, and that the payload mentions the `content_hash`.

**14-case matrix:**

| Case | Expected |
|---|---|
| happy path raw + redacted | 202, body stored verbatim, audit entry written |
| bad UUID in path | 400 `validation_failed` |
| missing `stage_id` query | 400 |
| bad `variant` query | 400 |
| missing signature header | 401 `signature_missing` |
| non-hex signature | 401 `signature_invalid` |
| signature with wrong key | 401 `signature_invalid` |
| no signing key issued for run | 404 `signing_key_not_found` |
| expired signing key | 401 `signing_key_expired` |
| body > 64 MiB | 413 `body_too_large` |
| tracestore.Put error | 500 `internal_error` |
| audit.AppendChained error | 500 (bundle stored; runner retries — Put is idempotent) |
| nil signing repo | 503 `trace_upload_unconfigured` |
| nil tracestore | 503 |
| nil audit repo | 503 |

**Bundle-stored-but-audit-failed.** If the audit append fails after the trace has been stored, we return 500 so the runner retries. `tracestore.Put` is idempotent at the storage layer (content-addressed key + identical bytes = no-op), and `audit.AppendChained` is the source of truth for "the audit log saw this." The cost of a retry is negligible compared to a missing audit entry.

**No follow-up issues to file.** This endpoint's auth is the signature itself, not OIDC, so there's no deferred-auth gap to track. (Compare with #112 from PR #113 — different story.)

**Spec status.** 6 of 19 endpoints in `docs/api/v0.openapi.yaml` now have implementations: `/healthz`, `POST /v0/runs`, `GET /v0/runs/{run_id}`, `POST /v0/runs/{run_id}/signing-key`, `POST /v0/runs/{run_id}/trace`, `POST /webhooks/github`. The runner→backend audit-grade story is now end-to-end demonstrable end-to-end pending E5.6's runner-side wiring.
