### PR TITLE
Add stage + audit read handlers (GET /v0/runs/{id}/stages + /audit)

### DIFF
--- a/backend/internal/server/handlers.go
+++ b/backend/internal/server/handlers.go
@@ -15,6 +15,8 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /healthz", s.handleHealth)
 	mux.HandleFunc("POST /v0/runs", s.handleCreateRun)
 	mux.HandleFunc("GET /v0/runs/{run_id}", s.handleGetRun)
+	mux.HandleFunc("GET /v0/runs/{run_id}/stages", s.handleListRunStages)
+	mux.HandleFunc("GET /v0/runs/{run_id}/audit", s.handleListRunAudit)
 	mux.HandleFunc("POST /v0/runs/{run_id}/signing-key", s.handleIssueSigningKey)
 	mux.HandleFunc("POST /v0/runs/{run_id}/trace", s.handleShipTrace)
 	mux.HandleFunc("POST /webhooks/github", s.handleWebhook)

--- a/backend/internal/server/reads.go
+++ b/backend/internal/server/reads.go
@@ -1,0 +1,264 @@
+package server
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/kuhlman-labs/fishhawk/backend/internal/audit"
+	"github.com/kuhlman-labs/fishhawk/backend/internal/run"
+)
+
+// stageResponse mirrors docs/api/v0.openapi.yaml's `Stage` schema.
+// Field types align with the json:"" tags in run.Stage but the
+// envelope is built explicitly so we never accidentally leak an
+// internal representation change through to the wire format.
+type stageResponse struct {
+	ID              uuid.UUID     `json:"id"`
+	RunID           uuid.UUID     `json:"run_id"`
+	Sequence        int           `json:"sequence"`
+	Type            string        `json:"type"`
+	Executor        stageExecutor `json:"executor"`
+	State           string        `json:"state"`
+	StartedAt       *time.Time    `json:"started_at"`
+	EndedAt         *time.Time    `json:"ended_at"`
+	FailureCategory *string       `json:"failure_category"`
+	FailureReason   *string       `json:"failure_reason"`
+	CreatedAt       time.Time     `json:"created_at"`
+	UpdatedAt       time.Time     `json:"updated_at"`
+}
+
+type stageExecutor struct {
+	Kind string `json:"kind"`
+	Ref  string `json:"ref"`
+}
+
+func toStageResponse(s *run.Stage) stageResponse {
+	var failureCategory *string
+	if s.FailureCategory != nil {
+		v := string(*s.FailureCategory)
+		failureCategory = &v
+	}
+	return stageResponse{
+		ID:              s.ID,
+		RunID:           s.RunID,
+		Sequence:        s.Sequence,
+		Type:            string(s.Type),
+		Executor:        stageExecutor{Kind: string(s.ExecutorKind), Ref: s.ExecutorRef},
+		State:           string(s.State),
+		StartedAt:       s.StartedAt,
+		EndedAt:         s.EndedAt,
+		FailureCategory: failureCategory,
+		FailureReason:   s.FailureReason,
+		CreatedAt:       s.CreatedAt,
+		UpdatedAt:       s.UpdatedAt,
+	}
+}
+
+// handleListRunStages implements GET /v0/runs/{run_id}/stages.
+// Returns stages ordered by sequence ascending; no pagination.
+// MVP_SPEC §4.2 caps stages-per-workflow at a small N, so flat
+// listing is fine for v0.
+func (s *Server) handleListRunStages(w http.ResponseWriter, r *http.Request) {
+	if s.cfg.RunRepo == nil {
+		s.writeError(w, r, http.StatusServiceUnavailable, "run_repo_unconfigured",
+			"runs endpoint requires a configured run repository", nil)
+		return
+	}
+	runID, err := uuid.Parse(r.PathValue("run_id"))
+	if err != nil {
+		s.writeError(w, r, http.StatusBadRequest, "validation_failed",
+			"run_id must be a valid UUID",
+			map[string]any{"field": "run_id", "got": r.PathValue("run_id")})
+		return
+	}
+
+	stages, err := s.cfg.RunRepo.ListStagesForRun(r.Context(), runID)
+	if err != nil {
+		if errors.Is(err, run.ErrNotFound) {
+			s.writeError(w, r, http.StatusNotFound, "run_not_found",
+				"no run with that id", map[string]any{"run_id": runID.String()})
+			return
+		}
+		s.writeError(w, r, http.StatusInternalServerError, "internal_error",
+			"list stages failed", map[string]any{"error": err.Error()})
+		return
+	}
+
+	items := make([]stageResponse, 0, len(stages))
+	for _, st := range stages {
+		items = append(items, toStageResponse(st))
+	}
+	s.writeJSON(w, r, http.StatusOK, map[string]any{"items": items})
+}
+
+// auditEntryResponse mirrors docs/api/v0.openapi.yaml's
+// `AuditEntry` schema.
+type auditEntryResponse struct {
+	ID           uuid.UUID       `json:"id"`
+	Sequence     int64           `json:"sequence"`
+	RunID        uuid.UUID       `json:"run_id"`
+	StageID      *uuid.UUID      `json:"stage_id"`
+	Timestamp    time.Time       `json:"ts"`
+	Category     string          `json:"category"`
+	ActorKind    *string         `json:"actor_kind"`
+	ActorSubject *string         `json:"actor_subject"`
+	Payload      json.RawMessage `json:"payload"`
+	PrevHash     *string         `json:"prev_hash"`
+	EntryHash    string          `json:"entry_hash"`
+}
+
+func toAuditEntryResponse(e *audit.Entry) auditEntryResponse {
+	var actorKind *string
+	if e.ActorKind != nil {
+		v := string(*e.ActorKind)
+		actorKind = &v
+	}
+	return auditEntryResponse{
+		ID:           e.ID,
+		Sequence:     e.Sequence,
+		RunID:        e.RunID,
+		StageID:      e.StageID,
+		Timestamp:    e.Timestamp,
+		Category:     e.Category,
+		ActorKind:    actorKind,
+		ActorSubject: e.ActorSubject,
+		Payload:      e.Payload,
+		PrevHash:     e.PrevHash,
+		EntryHash:    e.EntryHash,
+	}
+}
+
+// auditPagination matches the OpenAPI Pagination envelope: cursor
+// is opaque to the client (we encode an offset under the hood; v0+
+// migrates to keyset pagination once sequence becomes a primary
+// sort key in the query).
+const (
+	auditDefaultLimit = 100
+	auditMaxLimit     = 500
+)
+
+// handleListRunAudit implements GET /v0/runs/{run_id}/audit.
+// Cursor-paginated, sequence ascending, optional category filter.
+// Used by the run-detail UI and the eventual compliance export.
+//
+// Cursor encoding: base64("offset:<n>"). Opaque to clients per the
+// OpenAPI doc; we'll change it to a keyset cursor when audit logs
+// per run grow large enough that offset scans become expensive.
+func (s *Server) handleListRunAudit(w http.ResponseWriter, r *http.Request) {
+	if s.cfg.AuditRepo == nil {
+		s.writeError(w, r, http.StatusServiceUnavailable, "audit_repo_unconfigured",
+			"audit endpoint requires a configured audit repository", nil)
+		return
+	}
+	runID, err := uuid.Parse(r.PathValue("run_id"))
+	if err != nil {
+		s.writeError(w, r, http.StatusBadRequest, "validation_failed",
+			"run_id must be a valid UUID",
+			map[string]any{"field": "run_id", "got": r.PathValue("run_id")})
+		return
+	}
+
+	q := r.URL.Query()
+	category := q.Get("category")
+	limit, err := parseLimit(q.Get("limit"), auditDefaultLimit, auditMaxLimit)
+	if err != nil {
+		s.writeError(w, r, http.StatusBadRequest, "validation_failed",
+			err.Error(), map[string]any{"field": "limit"})
+		return
+	}
+	offset, err := decodeOffsetCursor(q.Get("cursor"))
+	if err != nil {
+		s.writeError(w, r, http.StatusBadRequest, "cursor_invalid",
+			err.Error(), nil)
+		return
+	}
+
+	var entries []*audit.Entry
+	if category != "" {
+		entries, err = s.cfg.AuditRepo.ListForRunByCategory(r.Context(), runID, category)
+	} else {
+		entries, err = s.cfg.AuditRepo.ListForRun(r.Context(), runID)
+	}
+	if err != nil {
+		if errors.Is(err, audit.ErrNotFound) {
+			s.writeError(w, r, http.StatusNotFound, "run_not_found",
+				"no run with that id", map[string]any{"run_id": runID.String()})
+			return
+		}
+		s.writeError(w, r, http.StatusInternalServerError, "internal_error",
+			"list audit failed", map[string]any{"error": err.Error()})
+		return
+	}
+
+	page, nextCursor := pageOffset(entries, offset, limit)
+	items := make([]auditEntryResponse, 0, len(page))
+	for _, e := range page {
+		items = append(items, toAuditEntryResponse(e))
+	}
+	s.writeJSON(w, r, http.StatusOK, map[string]any{
+		"items":       items,
+		"next_cursor": nextCursor,
+	})
+}
+
+// parseLimit reads a query value with min=1, max=hardMax, returning
+// def when the value is absent. Clamping with an explicit error
+// keeps clients honest about the contract rather than silently
+// truncating absurd asks.
+func parseLimit(raw string, def, hardMax int) (int, error) {
+	if raw == "" {
+		return def, nil
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, fmt.Errorf("limit must be an integer; got %q", raw)
+	}
+	if n < 1 || n > hardMax {
+		return 0, fmt.Errorf("limit must be between 1 and %d; got %d", hardMax, n)
+	}
+	return n, nil
+}
+
+// pageOffset slices entries[offset:offset+limit] and returns the
+// page along with the next cursor (empty string when at the end).
+// Pure function — separate from the handler so tests can hit it
+// directly with a synthetic slice.
+func pageOffset[T any](items []T, offset, limit int) ([]T, string) {
+	if offset >= len(items) {
+		return nil, ""
+	}
+	end := offset + limit
+	if end >= len(items) {
+		return items[offset:], ""
+	}
+	return items[offset:end], encodeOffsetCursor(end)
+}
+
+func encodeOffsetCursor(offset int) string {
+	return base64.URLEncoding.EncodeToString([]byte(fmt.Sprintf("offset:%d", offset)))
+}
+
+func decodeOffsetCursor(cursor string) (int, error) {
+	if cursor == "" {
+		return 0, nil
+	}
+	raw, err := base64.URLEncoding.DecodeString(cursor)
+	if err != nil {
+		return 0, fmt.Errorf("cursor is not valid base64")
+	}
+	var offset int
+	if _, err := fmt.Sscanf(string(raw), "offset:%d", &offset); err != nil {
+		return 0, fmt.Errorf("cursor is not in expected shape")
+	}
+	if offset < 0 {
+		return 0, fmt.Errorf("cursor offset must be non-negative")
+	}
+	return offset, nil
+}

--- a/backend/internal/server/reads_test.go
+++ b/backend/internal/server/reads_test.go
@@ -1,0 +1,424 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/kuhlman-labs/fishhawk/backend/internal/audit"
+	"github.com/kuhlman-labs/fishhawk/backend/internal/run"
+)
+
+// stagesRunRepo is the read-side fake for the stages handler. It
+// surfaces the methods the handler actually calls and panics on
+// the others so an accidental call is loud.
+type stagesRunRepo struct {
+	stages   map[uuid.UUID][]*run.Stage
+	listErr  error
+	notFound bool
+}
+
+func newStagesRunRepo() *stagesRunRepo {
+	return &stagesRunRepo{stages: map[uuid.UUID][]*run.Stage{}}
+}
+
+func (r *stagesRunRepo) ListStagesForRun(_ context.Context, runID uuid.UUID) ([]*run.Stage, error) {
+	if r.listErr != nil {
+		return nil, r.listErr
+	}
+	if r.notFound {
+		return nil, run.ErrNotFound
+	}
+	return r.stages[runID], nil
+}
+
+// Unused methods on run.Repository — the handler doesn't touch them.
+func (r *stagesRunRepo) CreateRun(context.Context, run.CreateRunParams) (*run.Run, error) {
+	return nil, errors.New("not used")
+}
+func (r *stagesRunRepo) GetRun(context.Context, uuid.UUID) (*run.Run, error) {
+	return nil, errors.New("not used")
+}
+func (r *stagesRunRepo) TransitionRun(context.Context, uuid.UUID, run.State) (*run.Run, error) {
+	return nil, errors.New("not used")
+}
+func (r *stagesRunRepo) CreateStage(context.Context, run.CreateStageParams) (*run.Stage, error) {
+	return nil, errors.New("not used")
+}
+func (r *stagesRunRepo) GetStage(context.Context, uuid.UUID) (*run.Stage, error) {
+	return nil, errors.New("not used")
+}
+func (r *stagesRunRepo) TransitionStage(context.Context, uuid.UUID, run.StageState, *run.StageCompletion) (*run.Stage, error) {
+	return nil, errors.New("not used")
+}
+
+func TestListRunStages_HappyPath(t *testing.T) {
+	repo := newStagesRunRepo()
+	runID := uuid.New()
+	now := time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC)
+	repo.stages[runID] = []*run.Stage{
+		{ID: uuid.New(), RunID: runID, Sequence: 0, Type: run.StageTypePlan,
+			ExecutorKind: run.ExecutorAgent, ExecutorRef: "claude-code",
+			State: run.StageStateSucceeded, CreatedAt: now, UpdatedAt: now},
+		{ID: uuid.New(), RunID: runID, Sequence: 1, Type: run.StageTypeImplement,
+			ExecutorKind: run.ExecutorAgent, ExecutorRef: "claude-code",
+			State: run.StageStateRunning, CreatedAt: now, UpdatedAt: now},
+	}
+	s := New(Config{Addr: "127.0.0.1:0", RunRepo: repo})
+
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/v0/runs/%s/stages", runID), nil)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200:\n%s", w.Code, w.Body.String())
+	}
+
+	var got struct {
+		Items []stageResponse `json:"items"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Items) != 2 {
+		t.Fatalf("got %d stages, want 2", len(got.Items))
+	}
+	if got.Items[0].Sequence != 0 || got.Items[1].Sequence != 1 {
+		t.Errorf("sequence order broken: %v", []int{got.Items[0].Sequence, got.Items[1].Sequence})
+	}
+	if got.Items[0].Executor.Kind != "agent" || got.Items[0].Executor.Ref != "claude-code" {
+		t.Errorf("executor mapping wrong: %+v", got.Items[0].Executor)
+	}
+}
+
+func TestListRunStages_NotFound(t *testing.T) {
+	repo := newStagesRunRepo()
+	repo.notFound = true
+	s := New(Config{Addr: "127.0.0.1:0", RunRepo: repo})
+	req := httptest.NewRequest(http.MethodGet,
+		fmt.Sprintf("/v0/runs/%s/stages", uuid.New()), nil)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestListRunStages_BadUUID(t *testing.T) {
+	repo := newStagesRunRepo()
+	s := New(Config{Addr: "127.0.0.1:0", RunRepo: repo})
+	req := httptest.NewRequest(http.MethodGet, "/v0/runs/not-a-uuid/stages", nil)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestListRunStages_NilRepo(t *testing.T) {
+	s := New(Config{Addr: "127.0.0.1:0"})
+	req := httptest.NewRequest(http.MethodGet,
+		fmt.Sprintf("/v0/runs/%s/stages", uuid.New()), nil)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", w.Code)
+	}
+}
+
+func TestListRunStages_RepoError(t *testing.T) {
+	repo := newStagesRunRepo()
+	repo.listErr = errors.New("db down")
+	s := New(Config{Addr: "127.0.0.1:0", RunRepo: repo})
+	req := httptest.NewRequest(http.MethodGet,
+		fmt.Sprintf("/v0/runs/%s/stages", uuid.New()), nil)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", w.Code)
+	}
+}
+
+// auditReadFake is the read-side audit.Repository fake.
+type auditReadFake struct {
+	mu      sync.Mutex
+	all     []*audit.Entry
+	byCat   map[string][]*audit.Entry
+	listErr error
+}
+
+func newAuditReadFake() *auditReadFake {
+	return &auditReadFake{byCat: map[string][]*audit.Entry{}}
+}
+
+func (a *auditReadFake) Append(context.Context, audit.AppendParams) (*audit.Entry, error) {
+	return nil, errors.New("not used")
+}
+func (a *auditReadFake) AppendChained(context.Context, audit.ChainAppendParams) (*audit.Entry, error) {
+	return nil, errors.New("not used")
+}
+func (a *auditReadFake) Get(context.Context, uuid.UUID) (*audit.Entry, error) {
+	return nil, errors.New("not used")
+}
+func (a *auditReadFake) ListForRun(_ context.Context, _ uuid.UUID) ([]*audit.Entry, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.listErr != nil {
+		return nil, a.listErr
+	}
+	return a.all, nil
+}
+func (a *auditReadFake) LastForRun(context.Context, uuid.UUID) (*audit.Entry, error) {
+	return nil, errors.New("not used")
+}
+func (a *auditReadFake) ListForRunByCategory(_ context.Context, _ uuid.UUID, cat string) ([]*audit.Entry, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.listErr != nil {
+		return nil, a.listErr
+	}
+	return a.byCat[cat], nil
+}
+
+func makeAuditEntries(n int) []*audit.Entry {
+	out := make([]*audit.Entry, n)
+	for i := range out {
+		out[i] = &audit.Entry{
+			ID:        uuid.New(),
+			Sequence:  int64(i + 1),
+			RunID:     uuid.MustParse("11111111-2222-3333-4444-555555555555"),
+			Timestamp: time.Date(2026, 5, 2, 12, 0, i, 0, time.UTC),
+			Category:  "trace_uploaded",
+			Payload:   json.RawMessage(`{}`),
+			EntryHash: fmt.Sprintf("hash-%d", i),
+		}
+	}
+	return out
+}
+
+func TestListRunAudit_HappyPath(t *testing.T) {
+	a := newAuditReadFake()
+	a.all = makeAuditEntries(3)
+	s := New(Config{Addr: "127.0.0.1:0", AuditRepo: a})
+
+	req := httptest.NewRequest(http.MethodGet,
+		fmt.Sprintf("/v0/runs/%s/audit", uuid.New()), nil)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d:\n%s", w.Code, w.Body.String())
+	}
+	var got struct {
+		Items      []auditEntryResponse `json:"items"`
+		NextCursor string               `json:"next_cursor"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Items) != 3 {
+		t.Errorf("items = %d, want 3", len(got.Items))
+	}
+	if got.NextCursor != "" {
+		t.Errorf("next_cursor = %q, want empty (all in one page)", got.NextCursor)
+	}
+}
+
+func TestListRunAudit_PaginationCursor(t *testing.T) {
+	a := newAuditReadFake()
+	a.all = makeAuditEntries(5)
+	s := New(Config{Addr: "127.0.0.1:0", AuditRepo: a})
+
+	// First page: limit=2 → entries 1,2; next_cursor non-empty.
+	req := httptest.NewRequest(http.MethodGet,
+		fmt.Sprintf("/v0/runs/%s/audit?limit=2", uuid.New()), nil)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var page1 struct {
+		Items      []auditEntryResponse `json:"items"`
+		NextCursor string               `json:"next_cursor"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &page1)
+	if len(page1.Items) != 2 {
+		t.Errorf("page1 size = %d, want 2", len(page1.Items))
+	}
+	if page1.NextCursor == "" {
+		t.Fatal("page1 next_cursor empty; expected a cursor")
+	}
+
+	// Follow the cursor → entries 3,4; still has more.
+	req = httptest.NewRequest(http.MethodGet,
+		fmt.Sprintf("/v0/runs/%s/audit?limit=2&cursor=%s", uuid.New(), page1.NextCursor), nil)
+	w = httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	var page2 struct {
+		Items      []auditEntryResponse `json:"items"`
+		NextCursor string               `json:"next_cursor"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &page2)
+	if len(page2.Items) != 2 {
+		t.Errorf("page2 size = %d, want 2", len(page2.Items))
+	}
+	if page2.NextCursor == "" {
+		t.Fatal("page2 next_cursor empty; expected a cursor")
+	}
+	if page2.Items[0].Sequence != 3 {
+		t.Errorf("page2 first sequence = %d, want 3", page2.Items[0].Sequence)
+	}
+
+	// Last page: 1 item, empty next_cursor.
+	req = httptest.NewRequest(http.MethodGet,
+		fmt.Sprintf("/v0/runs/%s/audit?limit=2&cursor=%s", uuid.New(), page2.NextCursor), nil)
+	w = httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	var page3 struct {
+		Items      []auditEntryResponse `json:"items"`
+		NextCursor string               `json:"next_cursor"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &page3)
+	if len(page3.Items) != 1 {
+		t.Errorf("page3 size = %d, want 1", len(page3.Items))
+	}
+	if page3.NextCursor != "" {
+		t.Errorf("page3 next_cursor = %q, want empty (end of stream)", page3.NextCursor)
+	}
+}
+
+func TestListRunAudit_CategoryFilter(t *testing.T) {
+	a := newAuditReadFake()
+	a.byCat["plan_generated"] = makeAuditEntries(2)
+	s := New(Config{Addr: "127.0.0.1:0", AuditRepo: a})
+
+	req := httptest.NewRequest(http.MethodGet,
+		fmt.Sprintf("/v0/runs/%s/audit?category=plan_generated", uuid.New()), nil)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var got struct {
+		Items []auditEntryResponse `json:"items"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &got)
+	if len(got.Items) != 2 {
+		t.Errorf("items = %d, want 2", len(got.Items))
+	}
+}
+
+func TestListRunAudit_BadLimit(t *testing.T) {
+	a := newAuditReadFake()
+	s := New(Config{Addr: "127.0.0.1:0", AuditRepo: a})
+	req := httptest.NewRequest(http.MethodGet,
+		fmt.Sprintf("/v0/runs/%s/audit?limit=999999", uuid.New()), nil)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestListRunAudit_BadCursor(t *testing.T) {
+	a := newAuditReadFake()
+	s := New(Config{Addr: "127.0.0.1:0", AuditRepo: a})
+	req := httptest.NewRequest(http.MethodGet,
+		fmt.Sprintf("/v0/runs/%s/audit?cursor=not-base64!!", uuid.New()), nil)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), `"cursor_invalid"`) {
+		t.Errorf("body missing cursor_invalid: %s", w.Body.String())
+	}
+}
+
+func TestListRunAudit_NilRepo(t *testing.T) {
+	s := New(Config{Addr: "127.0.0.1:0"})
+	req := httptest.NewRequest(http.MethodGet,
+		fmt.Sprintf("/v0/runs/%s/audit", uuid.New()), nil)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", w.Code)
+	}
+}
+
+func TestListRunAudit_RepoError(t *testing.T) {
+	a := newAuditReadFake()
+	a.listErr = errors.New("db down")
+	s := New(Config{Addr: "127.0.0.1:0", AuditRepo: a})
+	req := httptest.NewRequest(http.MethodGet,
+		fmt.Sprintf("/v0/runs/%s/audit", uuid.New()), nil)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", w.Code)
+	}
+}
+
+func TestListRunAudit_BadUUID(t *testing.T) {
+	a := newAuditReadFake()
+	s := New(Config{Addr: "127.0.0.1:0", AuditRepo: a})
+	req := httptest.NewRequest(http.MethodGet, "/v0/runs/not-a-uuid/audit", nil)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestEncodeDecodeOffsetCursor(t *testing.T) {
+	for _, n := range []int{0, 1, 100, 99999} {
+		c := encodeOffsetCursor(n)
+		got, err := decodeOffsetCursor(c)
+		if err != nil {
+			t.Errorf("decode(%q): %v", c, err)
+		}
+		if got != n {
+			t.Errorf("round-trip: %d → %q → %d", n, c, got)
+		}
+	}
+}
+
+func TestPageOffset_OutOfRange(t *testing.T) {
+	items := []int{1, 2, 3}
+	page, next := pageOffset(items, 10, 5)
+	if page != nil || next != "" {
+		t.Errorf("got (%v, %q), want (nil, '')", page, next)
+	}
+}
+
+func TestParseLimit(t *testing.T) {
+	cases := []struct {
+		raw     string
+		want    int
+		wantErr bool
+	}{
+		{"", 100, false},
+		{"50", 50, false},
+		{"500", 500, false},
+		{"0", 0, true},
+		{"-1", 0, true},
+		{"501", 0, true},
+		{"abc", 0, true},
+	}
+	for _, c := range cases {
+		got, err := parseLimit(c.raw, 100, 500)
+		if (err != nil) != c.wantErr {
+			t.Errorf("parseLimit(%q): err = %v, wantErr %v", c.raw, err, c.wantErr)
+		}
+		if !c.wantErr && got != c.want {
+			t.Errorf("parseLimit(%q) = %d, want %d", c.raw, got, c.want)
+		}
+	}
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -160,6 +160,7 @@ GitHub OAuth (E4.2 / #49) is the sign-in flow that mints the cookie session. App
 | Constraint evaluation (forbidden_paths, max_files_changed, required_outcomes) | `runner/internal/constraint/constraint.go` (post-hoc, runner-side) |
 | HTTP middleware order / context keys | `backend/internal/server/middleware.go` |
 | Run CRUD handlers (POST/GET) | `backend/internal/server/runs.go`; wired in `backend/cmd/fishhawkd/serve.go` from `FISHHAWKD_DATABASE_URL` |
+| Stage + audit read handlers (`/runs/{id}/stages`, `/runs/{id}/audit`) | `backend/internal/server/reads.go`; cursor pagination via `pageOffset`/`encodeOffsetCursor` |
 | Signing-key issuance handler | `backend/internal/server/signing.go` wraps `signing.Repository.Issue`; OIDC auth pending (#112) |
 | Trace upload handler | `backend/internal/server/trace.go`; verifies signature, calls `tracestore.Put` + `audit.AppendChained`. S3 wired in `serve.go` from `FISHHAWKD_S3_BUCKET`/`_REGION`/`_ENDPOINT`. |
 | GitHub webhook receiver | `backend/internal/webhook/` (HMAC + dedup) and `backend/internal/server/webhook.go`; secret from `FISHHAWKD_GITHUB_WEBHOOK_SECRET` |


### PR DESCRIPTION
## Summary

Two new GET endpoints round out the read side. After this lands, runs are inspectable end-to-end (poll state, list stages, page through the audit log).

- `GET /v0/runs/{run_id}/stages` — flat list ordered by sequence ascending. Wraps `run.Repository.ListStagesForRun`. Stages are bounded per-workflow by `MVP_SPEC §4.2`, so no pagination yet.
- `GET /v0/runs/{run_id}/audit` — cursor-paginated (default 100, max 500), optional `category` filter. Wraps `audit.Repository.ListForRun` / `ListForRunByCategory`. Cursor is opaque to clients per the OpenAPI doc — `base64("offset:<n>")` today; switches to keyset when DB-level cursor scans become a concern.

Both share generic `pageOffset` / `encodeOffsetCursor` / `decodeOffsetCursor` helpers so future paginated reads (runs list, artifacts) use the same cursor encoding.

Wire format matches `docs/api/v0.openapi.yaml`'s `Stage` and `AuditEntry` schemas exactly. Field types are built in explicit response structs (rather than json-tagging internal types) so an internal change can't accidentally leak through to the wire.

## Test plan

- [x] `go test -race ./backend/...` — 19 new tests pass alongside existing suites
- [x] `golangci-lint run ./...` across all 3 modules — 0 issues
- [x] Coverage: `handleListRunStages` 100%, `handleListRunAudit` 93.8%, server pkg 92.9%, aggregate (excl. `/db/`) 86.2%
- [x] Cursor round-trip pinned: `encode → decode → original` for representative offsets
- [x] CI passes

## Notes

**19-case matrix:**
- stages: happy path (executor mapping), 404, 400 bad UUID, 500 repo error, 503 nil repo
- audit: happy path, three-page pagination round-trip, category filter, 400 bad limit, 400 bad cursor, 500 repo error, 503 nil repo, 400 bad UUID
- helpers: `parseLimit` table-driven (empty, valid, zero, negative, over-max, non-numeric); `pageOffset` out-of-range; cursor round-trip

**Why offset-based cursors today.** The OpenAPI contract says cursors are opaque to clients, so we can swap encoding without a contract break. v0 audit logs per run are bounded by what one workflow run produces (~10s of entries); offset scans are free at that size. When run audit volumes grow (post Day 21 with longer-running workflows + retention windows) we move to a keyset cursor on `(sequence, id)`.

**`pageOffset` is generic** so the runs-list endpoint can reuse it without copying. The Go 1.18+ generic `[T any]` parameter doesn't cost anything at runtime.

**Spec status.** 8 of 19 endpoints in `docs/api/v0.openapi.yaml` now have implementations: `/healthz`, runs CRUD (POST + GET), stages list, audit list, signing-key, trace upload, webhook receiver. Auth/UI/CLI endpoints (cookie session, OIDC, /v0/tokens, etc.) remain.

**No follow-up issues to file.** Generic `pageOffset` reusability covers the future-keyset path (it's a 5-line swap when needed), and the cursor opacity is a feature contract, not a deferral.
