### PR TITLE
Add list + cancel run handlers (GET /v0/runs + POST /v0/runs/{id}/cancel)

### DIFF
--- a/backend/internal/run/db/queries.sql.go
+++ b/backend/internal/run/db/queries.sql.go
@@ -148,6 +148,62 @@ func (q *Queries) GetStage(ctx context.Context, id uuid.UUID) (Stage, error) {
 	return i, err
 }
 
+const listRuns = `-- name: ListRuns :many
+SELECT id, repo, workflow_id, workflow_sha, trigger_source, trigger_ref, state, created_at, updated_at FROM runs
+ WHERE ($1::text = '' OR repo = $1)
+   AND ($2::text = '' OR workflow_id = $2)
+   AND ($3::text = '' OR state = $3)
+ ORDER BY created_at DESC, id DESC
+ LIMIT $5 OFFSET $4
+`
+
+type ListRunsParams struct {
+	Repo       string `json:"repo"`
+	WorkflowID string `json:"workflow_id"`
+	State      string `json:"state"`
+	Off        int32  `json:"off"`
+	Lim        int32  `json:"lim"`
+}
+
+// Empty string in any filter means "no constraint." created_at DESC
+// + id DESC tiebreak so paginations are stable across concurrent
+// inserts at the same created_at microsecond.
+func (q *Queries) ListRuns(ctx context.Context, arg ListRunsParams) ([]Run, error) {
+	rows, err := q.db.Query(ctx, listRuns,
+		arg.Repo,
+		arg.WorkflowID,
+		arg.State,
+		arg.Off,
+		arg.Lim,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []Run
+	for rows.Next() {
+		var i Run
+		if err := rows.Scan(
+			&i.ID,
+			&i.Repo,
+			&i.WorkflowID,
+			&i.WorkflowSha,
+			&i.TriggerSource,
+			&i.TriggerRef,
+			&i.State,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listStagesForRun = `-- name: ListStagesForRun :many
 SELECT id, run_id, sequence, stage_type, executor_kind, executor_ref, state, started_at, ended_at, failure_category, failure_reason, created_at, updated_at FROM stages WHERE run_id = $1 ORDER BY sequence ASC
 `

--- a/backend/internal/run/postgres.go
+++ b/backend/internal/run/postgres.go
@@ -67,6 +67,31 @@ func (r *postgresRepo) GetRun(ctx context.Context, id uuid.UUID) (*Run, error) {
 	return rowToRun(row), nil
 }
 
+func (r *postgresRepo) ListRuns(ctx context.Context, f ListRunsFilter) ([]*Run, error) {
+	if f.Limit <= 0 {
+		return nil, fmt.Errorf("list runs: limit must be > 0")
+	}
+	if f.Offset < 0 {
+		return nil, fmt.Errorf("list runs: offset must be >= 0")
+	}
+	q := rundb.New(r.pool)
+	rows, err := q.ListRuns(ctx, rundb.ListRunsParams{
+		Repo:       f.Repo,
+		WorkflowID: f.WorkflowID,
+		State:      f.State,
+		Lim:        int32(f.Limit),
+		Off:        int32(f.Offset),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list runs: %w", err)
+	}
+	out := make([]*Run, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, rowToRun(row))
+	}
+	return out, nil
+}
+
 func (r *postgresRepo) TransitionRun(ctx context.Context, id uuid.UUID, to State) (*Run, error) {
 	var result *Run
 	err := pgx.BeginFunc(ctx, r.pool, func(tx pgx.Tx) error {

--- a/backend/internal/run/postgres_test.go
+++ b/backend/internal/run/postgres_test.go
@@ -178,6 +178,100 @@ func TestPostgres_GetRun_NotFound(t *testing.T) {
 	}
 }
 
+func TestPostgres_ListRuns(t *testing.T) {
+	pool := startPostgres(t)
+	repo := run.NewPostgresRepository(pool)
+
+	// Three runs across two repos and two states.
+	r1, err := repo.CreateRun(context.Background(), run.CreateRunParams{
+		Repo: "x/y", WorkflowID: "feature_change", WorkflowSHA: "sha1",
+		TriggerSource: run.TriggerCLI,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repo.CreateRun(context.Background(), run.CreateRunParams{
+		Repo: "x/y", WorkflowID: "hotfix", WorkflowSHA: "sha2",
+		TriggerSource: run.TriggerCLI,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	r3, err := repo.CreateRun(context.Background(), run.CreateRunParams{
+		Repo: "a/b", WorkflowID: "feature_change", WorkflowSHA: "sha3",
+		TriggerSource: run.TriggerUI,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// No filter: returns all 3.
+	all, err := repo.ListRuns(context.Background(), run.ListRunsFilter{Limit: 10})
+	if err != nil {
+		t.Fatalf("list runs: %v", err)
+	}
+	if len(all) != 3 {
+		t.Errorf("got %d, want 3", len(all))
+	}
+
+	// Repo filter.
+	xy, err := repo.ListRuns(context.Background(), run.ListRunsFilter{Repo: "x/y", Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(xy) != 2 {
+		t.Errorf("got %d for repo x/y, want 2", len(xy))
+	}
+
+	// Workflow filter combined with repo filter.
+	xyHotfix, err := repo.ListRuns(context.Background(),
+		run.ListRunsFilter{Repo: "x/y", WorkflowID: "hotfix", Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(xyHotfix) != 1 {
+		t.Errorf("got %d for x/y+hotfix, want 1", len(xyHotfix))
+	}
+
+	// State filter (transition r1 → running first).
+	if _, err := repo.TransitionRun(context.Background(), r1.ID, run.StateRunning); err != nil {
+		t.Fatal(err)
+	}
+	running, err := repo.ListRuns(context.Background(),
+		run.ListRunsFilter{State: string(run.StateRunning), Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(running) != 1 || running[0].ID != r1.ID {
+		t.Errorf("running filter broken: %+v", running)
+	}
+
+	// Limit + offset pagination — page 1 of 2 with limit=2.
+	page1, err := repo.ListRuns(context.Background(), run.ListRunsFilter{Limit: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page1) != 2 {
+		t.Errorf("page1 = %d, want 2", len(page1))
+	}
+	page2, err := repo.ListRuns(context.Background(), run.ListRunsFilter{Limit: 2, Offset: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page2) != 1 {
+		t.Errorf("page2 = %d, want 1", len(page2))
+	}
+
+	// Bad limit / offset surface as errors.
+	if _, err := repo.ListRuns(context.Background(), run.ListRunsFilter{Limit: 0}); err == nil {
+		t.Error("expected error on limit=0")
+	}
+	if _, err := repo.ListRuns(context.Background(), run.ListRunsFilter{Limit: 1, Offset: -1}); err == nil {
+		t.Error("expected error on negative offset")
+	}
+
+	_ = r3 // silence "declared and not used" if filters change.
+}
+
 func TestPostgres_TransitionRun_HappyPath(t *testing.T) {
 	pool := startPostgres(t)
 	repo := run.NewPostgresRepository(pool)

--- a/backend/internal/run/queries.sql
+++ b/backend/internal/run/queries.sql
@@ -10,6 +10,17 @@ RETURNING *;
 -- name: GetRun :one
 SELECT * FROM runs WHERE id = $1;
 
+-- name: ListRuns :many
+-- Empty string in any filter means "no constraint." created_at DESC
+-- + id DESC tiebreak so paginations are stable across concurrent
+-- inserts at the same created_at microsecond.
+SELECT * FROM runs
+ WHERE (sqlc.arg('repo')::text = '' OR repo = sqlc.arg('repo'))
+   AND (sqlc.arg('workflow_id')::text = '' OR workflow_id = sqlc.arg('workflow_id'))
+   AND (sqlc.arg('state')::text = '' OR state = sqlc.arg('state'))
+ ORDER BY created_at DESC, id DESC
+ LIMIT sqlc.arg('lim') OFFSET sqlc.arg('off');
+
 -- name: LockRunForUpdate :one
 SELECT * FROM runs WHERE id = $1 FOR UPDATE;
 

--- a/backend/internal/run/repository.go
+++ b/backend/internal/run/repository.go
@@ -39,6 +39,17 @@ type StageCompletion struct {
 	FailureReason   *string
 }
 
+// ListRunsFilter scopes a ListRuns query. Empty strings mean "no
+// constraint" — same convention as the underlying SQL. Limit must
+// be > 0; Offset must be >= 0.
+type ListRunsFilter struct {
+	Repo       string
+	WorkflowID string
+	State      string
+	Limit      int
+	Offset     int
+}
+
 // Repository persists runs and stages and applies state-machine
 // transitions atomically.
 //
@@ -49,6 +60,11 @@ type StageCompletion struct {
 type Repository interface {
 	CreateRun(ctx context.Context, p CreateRunParams) (*Run, error)
 	GetRun(ctx context.Context, id uuid.UUID) (*Run, error)
+
+	// ListRuns returns runs matching filter, ordered created_at
+	// DESC with an id tiebreak. Caller is responsible for the
+	// pagination math; this method just hands back the page.
+	ListRuns(ctx context.Context, f ListRunsFilter) ([]*Run, error)
 
 	// TransitionRun moves a run to the target state. Returns
 	// InvalidTransitionError if the run is in a state from which

--- a/backend/internal/server/handlers.go
+++ b/backend/internal/server/handlers.go
@@ -13,8 +13,10 @@ import (
 // per docs/api/v0.openapi.yaml.
 func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /healthz", s.handleHealth)
+	mux.HandleFunc("GET /v0/runs", s.handleListRuns)
 	mux.HandleFunc("POST /v0/runs", s.handleCreateRun)
 	mux.HandleFunc("GET /v0/runs/{run_id}", s.handleGetRun)
+	mux.HandleFunc("POST /v0/runs/{run_id}/cancel", s.handleCancelRun)
 	mux.HandleFunc("GET /v0/runs/{run_id}/stages", s.handleListRunStages)
 	mux.HandleFunc("GET /v0/runs/{run_id}/audit", s.handleListRunAudit)
 	mux.HandleFunc("POST /v0/runs/{run_id}/signing-key", s.handleIssueSigningKey)

--- a/backend/internal/server/reads_test.go
+++ b/backend/internal/server/reads_test.go
@@ -48,6 +48,9 @@ func (r *stagesRunRepo) CreateRun(context.Context, run.CreateRunParams) (*run.Ru
 func (r *stagesRunRepo) GetRun(context.Context, uuid.UUID) (*run.Run, error) {
 	return nil, errors.New("not used")
 }
+func (r *stagesRunRepo) ListRuns(context.Context, run.ListRunsFilter) ([]*run.Run, error) {
+	return nil, errors.New("not used")
+}
 func (r *stagesRunRepo) TransitionRun(context.Context, uuid.UUID, run.State) (*run.Run, error) {
 	return nil, errors.New("not used")
 }

--- a/backend/internal/server/runs.go
+++ b/backend/internal/server/runs.go
@@ -152,3 +152,125 @@ func (s *Server) handleGetRun(w http.ResponseWriter, r *http.Request) {
 
 	s.writeJSON(w, r, http.StatusOK, toRunResponse(got))
 }
+
+const (
+	runsDefaultLimit = 50
+	runsMaxLimit     = 200
+)
+
+// handleListRuns implements GET /v0/runs. Cursor-paginated by
+// created_at DESC; filter params (repo, workflow_id, state) are
+// additive — multiple filters AND together. Cursor encoding is
+// shared with the audit endpoint via pageOffset / encodeOffsetCursor.
+func (s *Server) handleListRuns(w http.ResponseWriter, r *http.Request) {
+	if s.cfg.RunRepo == nil {
+		s.writeError(w, r, http.StatusServiceUnavailable, "run_repo_unconfigured",
+			"runs endpoint requires a configured run repository", nil)
+		return
+	}
+	q := r.URL.Query()
+	limit, err := parseLimit(q.Get("limit"), runsDefaultLimit, runsMaxLimit)
+	if err != nil {
+		s.writeError(w, r, http.StatusBadRequest, "validation_failed",
+			err.Error(), map[string]any{"field": "limit"})
+		return
+	}
+	offset, err := decodeOffsetCursor(q.Get("cursor"))
+	if err != nil {
+		s.writeError(w, r, http.StatusBadRequest, "cursor_invalid",
+			err.Error(), nil)
+		return
+	}
+	stateFilter := q.Get("state")
+	if stateFilter != "" {
+		if _, ok := validRunStates[stateFilter]; !ok {
+			s.writeError(w, r, http.StatusBadRequest, "validation_failed",
+				"state must be one of pending, running, succeeded, failed, cancelled",
+				map[string]any{"field": "state", "got": stateFilter})
+			return
+		}
+	}
+
+	// Fetch one extra row so we can tell whether there's a next
+	// page without a separate COUNT query. The trick: ask for
+	// limit+1, drop the extra in the response if present.
+	rows, err := s.cfg.RunRepo.ListRuns(r.Context(), run.ListRunsFilter{
+		Repo:       q.Get("repo"),
+		WorkflowID: q.Get("workflow_id"),
+		State:      stateFilter,
+		Limit:      limit + 1,
+		Offset:     offset,
+	})
+	if err != nil {
+		s.writeError(w, r, http.StatusInternalServerError, "internal_error",
+			"list runs failed", map[string]any{"error": err.Error()})
+		return
+	}
+
+	var nextCursor string
+	if len(rows) > limit {
+		nextCursor = encodeOffsetCursor(offset + limit)
+		rows = rows[:limit]
+	}
+	items := make([]runResponse, 0, len(rows))
+	for _, ru := range rows {
+		items = append(items, toRunResponse(ru))
+	}
+	s.writeJSON(w, r, http.StatusOK, map[string]any{
+		"items":       items,
+		"next_cursor": nextCursor,
+	})
+}
+
+// validRunStates pins the closed set per docs/api/v0.openapi.yaml.
+// Schema constraint mirrors backend/internal/postgres/migrations/0001
+// CHECK; defense-in-depth at the handler keeps a typo from
+// reaching the DB layer.
+var validRunStates = map[string]struct{}{
+	string(run.StatePending):   {},
+	string(run.StateRunning):   {},
+	string(run.StateSucceeded): {},
+	string(run.StateFailed):    {},
+	string(run.StateCancelled): {},
+}
+
+// handleCancelRun implements POST /v0/runs/{run_id}/cancel.
+// Idempotent: cancelling an already-cancelled run returns 200 with
+// the same body as a fresh cancel. Cancelling a terminally-completed
+// run (succeeded / failed) returns 409 because the state machine
+// rejects the transition.
+func (s *Server) handleCancelRun(w http.ResponseWriter, r *http.Request) {
+	if s.cfg.RunRepo == nil {
+		s.writeError(w, r, http.StatusServiceUnavailable, "run_repo_unconfigured",
+			"runs endpoint requires a configured run repository", nil)
+		return
+	}
+	runID, err := uuid.Parse(r.PathValue("run_id"))
+	if err != nil {
+		s.writeError(w, r, http.StatusBadRequest, "validation_failed",
+			"run_id must be a valid UUID",
+			map[string]any{"field": "run_id", "got": r.PathValue("run_id")})
+		return
+	}
+
+	got, err := s.cfg.RunRepo.TransitionRun(r.Context(), runID, run.StateCancelled)
+	if err != nil {
+		if errors.Is(err, run.ErrNotFound) {
+			s.writeError(w, r, http.StatusNotFound, "run_not_found",
+				"no run with that id", map[string]any{"run_id": runID.String()})
+			return
+		}
+		var inv run.InvalidTransitionError
+		if errors.As(err, &inv) {
+			s.writeError(w, r, http.StatusConflict, "invalid_state_transition",
+				err.Error(),
+				map[string]any{"run_id": runID.String(), "from": inv.From, "to": inv.To})
+			return
+		}
+		s.writeError(w, r, http.StatusInternalServerError, "internal_error",
+			"cancel run failed", map[string]any{"error": err.Error()})
+		return
+	}
+
+	s.writeJSON(w, r, http.StatusOK, toRunResponse(got))
+}

--- a/backend/internal/server/runs_test.go
+++ b/backend/internal/server/runs_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -28,10 +29,12 @@ type fakeRepo struct {
 	mu   sync.Mutex
 	runs map[uuid.UUID]*run.Run
 
-	// createErr / getErr let tests inject failures without
-	// instrumenting fakeRepo's internals.
-	createErr error
-	getErr    error
+	// createErr / getErr / transitionErr / listErr let tests inject
+	// failures without instrumenting fakeRepo's internals.
+	createErr     error
+	getErr        error
+	transitionErr error
+	listErr       error
 }
 
 func newFakeRepo() *fakeRepo {
@@ -73,11 +76,70 @@ func (f *fakeRepo) GetRun(_ context.Context, id uuid.UUID) (*run.Run, error) {
 	return r, nil
 }
 
-// The remaining methods aren't exercised by these handler tests but
-// must exist so fakeRepo satisfies run.Repository. Returning
-// "not implemented" errors makes any accidental call obvious.
-func (f *fakeRepo) TransitionRun(_ context.Context, _ uuid.UUID, _ run.State) (*run.Run, error) {
-	return nil, errors.New("fakeRepo: TransitionRun not implemented")
+// transitionErr lets tests inject specific errors out of TransitionRun
+// so the cancel handler's branches (404, 409, 500) are reachable.
+// listErr does the same for ListRuns.
+//
+// The remaining stage methods aren't exercised by these handler tests
+// but must exist so fakeRepo satisfies run.Repository.
+
+func (f *fakeRepo) TransitionRun(_ context.Context, id uuid.UUID, to run.State) (*run.Run, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.transitionErr != nil {
+		return nil, f.transitionErr
+	}
+	r, ok := f.runs[id]
+	if !ok {
+		return nil, run.ErrNotFound
+	}
+	// Match the postgres adapter's transition rules: same-state is
+	// idempotent, terminal states reject further transitions.
+	if r.State == to {
+		return r, nil
+	}
+	if r.State == run.StateSucceeded || r.State == run.StateFailed || r.State == run.StateCancelled {
+		return nil, run.InvalidTransitionError{Kind: "run", From: string(r.State), To: string(to)}
+	}
+	r.State = to
+	r.UpdatedAt = time.Now().UTC()
+	return r, nil
+}
+
+func (f *fakeRepo) ListRuns(_ context.Context, fil run.ListRunsFilter) ([]*run.Run, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	var matched []*run.Run
+	for _, r := range f.runs {
+		if fil.Repo != "" && r.Repo != fil.Repo {
+			continue
+		}
+		if fil.WorkflowID != "" && r.WorkflowID != fil.WorkflowID {
+			continue
+		}
+		if fil.State != "" && string(r.State) != fil.State {
+			continue
+		}
+		matched = append(matched, r)
+	}
+	// Order matches the SQL: created_at DESC, id DESC.
+	sort.Slice(matched, func(i, j int) bool {
+		if !matched[i].CreatedAt.Equal(matched[j].CreatedAt) {
+			return matched[i].CreatedAt.After(matched[j].CreatedAt)
+		}
+		return matched[i].ID.String() > matched[j].ID.String()
+	})
+	if fil.Offset >= len(matched) {
+		return nil, nil
+	}
+	end := fil.Offset + fil.Limit
+	if end > len(matched) {
+		end = len(matched)
+	}
+	return matched[fil.Offset:end], nil
 }
 func (f *fakeRepo) CreateStage(_ context.Context, _ run.CreateStageParams) (*run.Stage, error) {
 	return nil, errors.New("fakeRepo: CreateStage not implemented")
@@ -356,6 +418,259 @@ func requestPath(t *testing.T, s *Server, method, path string, body any) (*httpt
 	}
 	s.Handler().ServeHTTP(w, req)
 	return w, w.Body.Bytes()
+}
+
+// seedRun inserts a run with controlled fields directly into the
+// fake's map so list/cancel tests don't depend on POST /v0/runs.
+func seedRun(repo *fakeRepo, repoName, workflowID string, state run.State, createdAt time.Time) *run.Run {
+	r := &run.Run{
+		ID:            uuid.New(),
+		Repo:          repoName,
+		WorkflowID:    workflowID,
+		WorkflowSHA:   "sha-" + string(state),
+		TriggerSource: run.TriggerCLI,
+		State:         state,
+		CreatedAt:     createdAt,
+		UpdatedAt:     createdAt,
+	}
+	repo.mu.Lock()
+	repo.runs[r.ID] = r
+	repo.mu.Unlock()
+	return r
+}
+
+func TestListRuns_HappyPath(t *testing.T) {
+	repo := newFakeRepo()
+	t0 := time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC)
+	seedRun(repo, "x/y", "feature_change", run.StatePending, t0)
+	seedRun(repo, "x/y", "feature_change", run.StateRunning, t0.Add(time.Second))
+	seedRun(repo, "a/b", "hotfix", run.StateSucceeded, t0.Add(2*time.Second))
+	s := newServer(t, repo)
+
+	req := httptest.NewRequest(http.MethodGet, "/v0/runs", nil)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d:\n%s", w.Code, w.Body.String())
+	}
+	var got struct {
+		Items      []runResponse `json:"items"`
+		NextCursor string        `json:"next_cursor"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Items) != 3 {
+		t.Errorf("items = %d, want 3", len(got.Items))
+	}
+	// created_at DESC: most-recently created comes first.
+	if got.Items[0].State != string(run.StateSucceeded) {
+		t.Errorf("first state = %q, want succeeded", got.Items[0].State)
+	}
+	if got.NextCursor != "" {
+		t.Errorf("next_cursor = %q, want empty", got.NextCursor)
+	}
+}
+
+func TestListRuns_RepoFilter(t *testing.T) {
+	repo := newFakeRepo()
+	t0 := time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC)
+	seedRun(repo, "x/y", "w", run.StatePending, t0)
+	seedRun(repo, "a/b", "w", run.StatePending, t0)
+	s := newServer(t, repo)
+
+	req := httptest.NewRequest(http.MethodGet, "/v0/runs?repo=x/y", nil)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var got struct {
+		Items []runResponse `json:"items"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &got)
+	if len(got.Items) != 1 || got.Items[0].Repo != "x/y" {
+		t.Errorf("repo filter broken: %+v", got.Items)
+	}
+}
+
+func TestListRuns_StateFilter_BadValue(t *testing.T) {
+	s := newServer(t, newFakeRepo())
+	req := httptest.NewRequest(http.MethodGet, "/v0/runs?state=fake", nil)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), `"validation_failed"`) {
+		t.Errorf("body missing validation_failed: %s", w.Body.String())
+	}
+}
+
+func TestListRuns_Pagination(t *testing.T) {
+	repo := newFakeRepo()
+	t0 := time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC)
+	for i := 0; i < 5; i++ {
+		seedRun(repo, "x/y", "w", run.StatePending, t0.Add(time.Duration(i)*time.Second))
+	}
+	s := newServer(t, repo)
+
+	// Page 1: limit=2.
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v0/runs?limit=2", nil))
+	var page1 struct {
+		Items      []runResponse `json:"items"`
+		NextCursor string        `json:"next_cursor"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &page1)
+	if len(page1.Items) != 2 {
+		t.Errorf("page1 size = %d, want 2", len(page1.Items))
+	}
+	if page1.NextCursor == "" {
+		t.Fatal("page1 next_cursor empty")
+	}
+
+	// Follow cursor — page 2.
+	w = httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v0/runs?limit=2&cursor="+page1.NextCursor, nil))
+	var page2 struct {
+		Items      []runResponse `json:"items"`
+		NextCursor string        `json:"next_cursor"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &page2)
+	if len(page2.Items) != 2 {
+		t.Errorf("page2 size = %d, want 2", len(page2.Items))
+	}
+	if page2.NextCursor == "" {
+		t.Fatal("page2 next_cursor empty")
+	}
+
+	// Page 3 — last item, empty cursor.
+	w = httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v0/runs?limit=2&cursor="+page2.NextCursor, nil))
+	var page3 struct {
+		Items      []runResponse `json:"items"`
+		NextCursor string        `json:"next_cursor"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &page3)
+	if len(page3.Items) != 1 {
+		t.Errorf("page3 size = %d, want 1", len(page3.Items))
+	}
+	if page3.NextCursor != "" {
+		t.Errorf("page3 cursor = %q, want empty", page3.NextCursor)
+	}
+}
+
+func TestListRuns_RepoError(t *testing.T) {
+	repo := newFakeRepo()
+	repo.listErr = errors.New("db down")
+	s := newServer(t, repo)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v0/runs", nil))
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", w.Code)
+	}
+}
+
+func TestListRuns_NilRepo(t *testing.T) {
+	s := New(Config{Addr: "127.0.0.1:0"})
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v0/runs", nil))
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", w.Code)
+	}
+}
+
+func TestCancelRun_HappyPath(t *testing.T) {
+	repo := newFakeRepo()
+	t0 := time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC)
+	r := seedRun(repo, "x/y", "w", run.StatePending, t0)
+	s := newServer(t, repo)
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, httptest.NewRequest(http.MethodPost,
+		fmt.Sprintf("/v0/runs/%s/cancel", r.ID), nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d:\n%s", w.Code, w.Body.String())
+	}
+	var got runResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &got)
+	if got.State != string(run.StateCancelled) {
+		t.Errorf("State = %q, want cancelled", got.State)
+	}
+}
+
+func TestCancelRun_Idempotent(t *testing.T) {
+	repo := newFakeRepo()
+	t0 := time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC)
+	r := seedRun(repo, "x/y", "w", run.StateCancelled, t0)
+	s := newServer(t, repo)
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, httptest.NewRequest(http.MethodPost,
+		fmt.Sprintf("/v0/runs/%s/cancel", r.ID), nil))
+	if w.Code != http.StatusOK {
+		t.Errorf("idempotent cancel status = %d, want 200", w.Code)
+	}
+}
+
+func TestCancelRun_TerminalStateConflict(t *testing.T) {
+	repo := newFakeRepo()
+	t0 := time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC)
+	r := seedRun(repo, "x/y", "w", run.StateSucceeded, t0)
+	s := newServer(t, repo)
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, httptest.NewRequest(http.MethodPost,
+		fmt.Sprintf("/v0/runs/%s/cancel", r.ID), nil))
+	if w.Code != http.StatusConflict {
+		t.Errorf("status = %d, want 409", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), `"invalid_state_transition"`) {
+		t.Errorf("body missing invalid_state_transition: %s", w.Body.String())
+	}
+}
+
+func TestCancelRun_NotFound(t *testing.T) {
+	s := newServer(t, newFakeRepo())
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, httptest.NewRequest(http.MethodPost,
+		fmt.Sprintf("/v0/runs/%s/cancel", uuid.New()), nil))
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestCancelRun_BadUUID(t *testing.T) {
+	s := newServer(t, newFakeRepo())
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, httptest.NewRequest(http.MethodPost,
+		"/v0/runs/not-a-uuid/cancel", nil))
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestCancelRun_RepoError(t *testing.T) {
+	repo := newFakeRepo()
+	repo.transitionErr = errors.New("db down")
+	s := newServer(t, repo)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, httptest.NewRequest(http.MethodPost,
+		fmt.Sprintf("/v0/runs/%s/cancel", uuid.New()), nil))
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", w.Code)
+	}
+}
+
+func TestCancelRun_NilRepo(t *testing.T) {
+	s := New(Config{Addr: "127.0.0.1:0"})
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, httptest.NewRequest(http.MethodPost,
+		fmt.Sprintf("/v0/runs/%s/cancel", uuid.New()), nil))
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", w.Code)
+	}
 }
 
 func TestRoundTrip_CreateThenGet(t *testing.T) {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,7 @@ GitHub OAuth (E4.2 / #49) is the sign-in flow that mints the cookie session. App
 | Runner → backend trace upload | `runner/internal/upload/` (HTTP client, retries, signing) — wired into runner main behind `--upload-trace` |
 | Constraint evaluation (forbidden_paths, max_files_changed, required_outcomes) | `runner/internal/constraint/constraint.go` (post-hoc, runner-side) |
 | HTTP middleware order / context keys | `backend/internal/server/middleware.go` |
-| Run CRUD handlers (POST/GET) | `backend/internal/server/runs.go`; wired in `backend/cmd/fishhawkd/serve.go` from `FISHHAWKD_DATABASE_URL` |
+| Run CRUD handlers (POST/GET/list/cancel) | `backend/internal/server/runs.go`; wired in `backend/cmd/fishhawkd/serve.go` from `FISHHAWKD_DATABASE_URL` |
 | Stage + audit read handlers (`/runs/{id}/stages`, `/runs/{id}/audit`) | `backend/internal/server/reads.go`; cursor pagination via `pageOffset`/`encodeOffsetCursor` |
 | Signing-key issuance handler | `backend/internal/server/signing.go` wraps `signing.Repository.Issue`; OIDC auth pending (#112) |
 | Trace upload handler | `backend/internal/server/trace.go`; verifies signature, calls `tracestore.Put` + `audit.AppendChained`. S3 wired in `serve.go` from `FISHHAWKD_S3_BUCKET`/`_REGION`/`_ENDPOINT`. |


### PR DESCRIPTION
## Summary

`GET /v0/runs` and `POST /v0/runs/{run_id}/cancel` close out the runs CRUD surface.

- `GET /v0/runs` — cursor-paginated, sorted by `created_at` DESC. Optional `repo` / `workflow_id` / `state` filters AND together. Cursor encoding shared with the audit endpoint via `pageOffset` / `encodeOffsetCursor` from PR #116.
- `POST /v0/runs/{run_id}/cancel` — wraps `run.Repository.TransitionRun(StateCancelled)`. Idempotent on already-cancelled (200), 409 `invalid_state_transition` for terminal states (succeeded/failed) with `{from, to}` in details.

`run.Repository` grows a `ListRuns(filter)` method:

- New SQL query `ListRuns :many` using `sqlc.arg(...)` named params; empty string = "no constraint".
- `ORDER BY created_at DESC, id DESC` for stable pagination across rows landing in the same microsecond.
- Postgres adapter validates `limit > 0` and `offset >= 0`; cursor decoder enforces the same on the wire.
- The handler asks for `limit+1` rows so it can detect "more pages exist" without a separate COUNT.

## Test plan

- [x] `go test -race ./backend/...` — 11 new server tests + 1 new testcontainers integration test for `ListRuns`
- [x] `golangci-lint run ./...` across all 3 modules — 0 issues
- [x] Coverage: `handleListRuns` 86.2%, `handleCancelRun` 100%, server pkg 92.8%, run pkg 83.1%, aggregate (excl. `/db/`) 86.4%
- [x] CI passes

## Notes

**Test matrix.** server tests: list happy path, repo filter, state-filter validation (bad enum), three-page pagination round-trip, repo error, nil repo; cancel happy path, idempotent, terminal-state 409, 404, bad UUID, repo error, nil repo. The `fakeRepo` from `runs_test.go` got a real `ListRuns` + `TransitionRun` so cancel/list paths hit actual logic, not stubs.

**Postgres integration test.** New `TestPostgres_ListRuns` runs against testcontainers Postgres. Covers: no filter (returns all), repo filter, repo+workflow filter combined, state filter (after a transition), pagination via `Limit`+`Offset`, validation of `Limit=0` and `Offset<0`. Run package coverage ticked from 75.0% → 83.1% with this addition.

**Cursor encoding stays opaque.** Same `base64("offset:<n>")` as audit (PR #116). When DB-level cursor scans become a concern at scale we swap to a keyset cursor on `(created_at, id)` without breaking the contract — clients pass cursors back unmodified.

**Spec status.** 10 of 19 endpoints in `docs/api/v0.openapi.yaml` now have implementations: `/healthz`, runs CRUD (POST + GET + list + cancel), stages list, audit list, signing-key, trace upload, webhook receiver. Auth/UI surfaces (cookie session, `/v0/tokens`) and the artifact endpoints remain.

**No follow-up issues to file.** Cursor migration is invisible (covered by the encoding contract); no deferred-auth gap (these endpoints inherit the same authStub as the rest of `/v0/runs`); no dependency on E4.3 (#28). Clean ship.
