### PR TITLE
Add CLI scaffold + run subcommands (E6.1, E6.3, E6.4, E6.5)

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,69 @@
+# fishhawk CLI
+
+Command-line interface for the Fishhawk control plane. Wraps the HTTP API documented in `docs/api/v0.openapi.yaml` so users can drive runs from a terminal.
+
+This directory is its own Go module (`github.com/kuhlman-labs/fishhawk/cli`) so it can be released independently of the backend and runner. Per ADR-014 (#78), the multi-module workspace lets each component carry its own version tag.
+
+## Layout
+
+- `cmd/fishhawk/` — the binary entrypoint. Subcommand dispatch in `main.go`, per-command flags in `run.go`.
+- `internal/httpclient/` — typed wrapper around the backend API. Marshals `CreateRunInput`, decodes `Run`, surfaces `*APIError` for non-2xx responses.
+- `internal/version/` — build-version package; set via `-ldflags` at release time.
+
+## Status
+
+E6.1 (#55), E6.3 (#34), E6.4 (#35), E6.5 (#36) shipped: scaffold + `run start`, `run status`, `run list`, `run cancel`, `run open`. E6.2 (#33) `fishhawk validate` is intentionally absent from the initial PR — it requires a local copy of the workflow-spec parser, which currently lives under `backend/internal/spec` and can't be imported across modules. Tracking issue forthcoming.
+
+## Subcommands
+
+```
+fishhawk run start  --repo R --workflow W --workflow-sha S [--trigger-ref REF]
+fishhawk run status <run-id>
+fishhawk run list   [--repo R] [--workflow W] [--state S] [--limit N] [--cursor C]
+fishhawk run cancel <run-id>
+fishhawk run open   <run-id> [--print-url]
+fishhawk version
+```
+
+## Global flags
+
+| Flag | Env | Default |
+|---|---|---|
+| `--backend-url` | `FISHHAWK_BACKEND_URL` | `http://localhost:8080` |
+| `--token` | `FISHHAWK_TOKEN` | `""` (dev backends with stubbed auth) |
+| `--timeout` | — | `60s` |
+
+`--token` will become required once `/v0/tokens` lands; for now most backends accept anonymous calls via the `authStub` middleware.
+
+## Build and test
+
+From the repo root (workspace-aware):
+
+    go build ./cli/...
+    go test -race ./cli/...
+
+Or from this directory directly:
+
+    go build ./...
+    go test ./...
+
+## Local invocation
+
+    # Start a run
+    fishhawk run start \
+      --backend-url http://localhost:8080 \
+      --repo kuhlman-labs/fishhawk \
+      --workflow feature_change \
+      --workflow-sha $(git rev-parse HEAD)
+
+    # Watch its state
+    fishhawk run status <run-id>
+
+    # List recent runs
+    fishhawk run list --state running --limit 25
+
+## See also
+
+- `docs/api/v0.openapi.yaml` — the contract this CLI consumes.
+- `docs/api/v0.md` — human-readable companion.
+- `docs/MVP_SPEC.md` §5.1.4 — CLI component definition.

--- a/cli/cmd/fishhawk/main.go
+++ b/cli/cmd/fishhawk/main.go
@@ -1,0 +1,108 @@
+// Command fishhawk is the user-facing CLI for the Fishhawk
+// control plane. Subcommands wrap docs/api/v0.openapi.yaml.
+//
+// Subcommands:
+//
+//	fishhawk run start  --repo R --workflow W --workflow-sha S [--trigger-ref REF]
+//	fishhawk run status <run-id>
+//	fishhawk run list   [--repo R] [--workflow W] [--state S] [--limit N]
+//	fishhawk run cancel <run-id>
+//	fishhawk run open   <run-id>
+//
+// Auth is the same `bearerToken` scheme defined in the OpenAPI:
+// CLI sends `Authorization: Bearer <token>` from --token /
+// FISHHAWK_TOKEN. Tokens are minted via the (forthcoming)
+// /v0/tokens endpoint; until that lands the CLI works against a
+// dev backend with auth stubbed (current state).
+//
+// `fishhawk validate` (E6.2 / #33) is intentionally absent from
+// this PR: it requires a local copy of the workflow-spec parser,
+// which currently lives under backend/internal/spec and can't be
+// imported across modules. Tracked separately.
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/kuhlman-labs/fishhawk/cli/internal/version"
+)
+
+const (
+	exitOK      = 0
+	exitFailure = 1
+	exitUsage   = 2
+)
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+// run dispatches to the appropriate subcommand. Split out of main
+// so tests can drive it without exiting the test process.
+func run(args []string, stdout, stderr io.Writer) int {
+	cmd, rest := splitCommand(args)
+	switch cmd {
+	case "":
+		printUsage(stderr)
+		return exitUsage
+	case "run":
+		return runRun(rest, stdout, stderr)
+	case "version", "--version":
+		_, _ = fmt.Fprintln(stdout, version.Version)
+		return exitOK
+	case "-h", "--help", "help":
+		printUsage(stdout)
+		return exitOK
+	default:
+		_, _ = fmt.Fprintf(stderr, "fishhawk: unknown subcommand %q\n\n", cmd)
+		printUsage(stderr)
+		return exitUsage
+	}
+}
+
+// splitCommand pulls the first positional arg as the subcommand.
+// Anything starting with "-" is preserved as a flag for the
+// implicit (currently empty) top-level command — no leading flags
+// are accepted today, so that path returns usage.
+func splitCommand(args []string) (cmd string, rest []string) {
+	if len(args) == 0 {
+		return "", nil
+	}
+	if strings.HasPrefix(args[0], "-") {
+		return args[0], args[1:]
+	}
+	return args[0], args[1:]
+}
+
+func printUsage(w io.Writer) {
+	for _, line := range []string{
+		"Usage: fishhawk <command> [args]",
+		"",
+		"Commands:",
+		"  run start    Trigger a workflow run.",
+		"  run status   Show a run's current state.",
+		"  run list     List runs with optional filters.",
+		"  run cancel   Cancel an in-flight run.",
+		"  run open     Open a run's detail page in the browser.",
+		"  version      Print the CLI version and exit.",
+		"  help         Show this help.",
+		"",
+		"Global flags (apply to every subcommand):",
+		"  --backend-url URL   Fishhawk backend URL (default $FISHHAWK_BACKEND_URL or http://localhost:8080)",
+		"  --token TOKEN       Bearer token (default $FISHHAWK_TOKEN, may be empty for dev backends)",
+		"",
+		"For per-command flags: fishhawk run start --help",
+	} {
+		_, _ = fmt.Fprintln(w, line)
+	}
+}
+
+func envOr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}

--- a/cli/cmd/fishhawk/main_test.go
+++ b/cli/cmd/fishhawk/main_test.go
@@ -1,0 +1,400 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/kuhlman-labs/fishhawk/cli/internal/httpclient"
+)
+
+func TestRun_Help(t *testing.T) {
+	for _, arg := range []string{"--help", "-h", "help"} {
+		t.Run(arg, func(t *testing.T) {
+			var stdout, stderr strings.Builder
+			got := run([]string{arg}, &stdout, &stderr)
+			if got != exitOK {
+				t.Errorf("run(%q) = %d, want exitOK", arg, got)
+			}
+			if !strings.Contains(stdout.String(), "Usage: fishhawk") {
+				t.Errorf("usage missing for %q:\n%s", arg, stdout.String())
+			}
+		})
+	}
+}
+
+func TestRun_Version(t *testing.T) {
+	var stdout strings.Builder
+	got := run([]string{"version"}, &stdout, io.Discard)
+	if got != exitOK {
+		t.Errorf("status = %d, want exitOK", got)
+	}
+	if strings.TrimSpace(stdout.String()) == "" {
+		t.Error("version output empty")
+	}
+}
+
+func TestRun_NoArgs(t *testing.T) {
+	got := run(nil, io.Discard, io.Discard)
+	if got != exitUsage {
+		t.Errorf("status = %d, want exitUsage", got)
+	}
+}
+
+func TestRun_UnknownCommand(t *testing.T) {
+	var stderr strings.Builder
+	got := run([]string{"nope"}, io.Discard, &stderr)
+	if got != exitUsage {
+		t.Errorf("status = %d, want exitUsage", got)
+	}
+	if !strings.Contains(stderr.String(), "unknown subcommand") {
+		t.Errorf("missing 'unknown subcommand': %s", stderr.String())
+	}
+}
+
+func TestRun_NoSubcommand(t *testing.T) {
+	var stderr strings.Builder
+	got := run([]string{"run"}, io.Discard, &stderr)
+	if got != exitUsage {
+		t.Errorf("status = %d, want exitUsage", got)
+	}
+}
+
+// fakeBackend replicates the bits of the API the CLI calls. Each
+// handler stores the last request so tests can assert wiring.
+type fakeBackend struct {
+	mu sync.Mutex
+
+	startedRun  *httpclient.CreateRunInput
+	cancelledID string
+	listQuery   string
+
+	startResp Run
+	getResp   Run
+	listResp  ListResp
+
+	startStatus int
+	getStatus   int
+	listStatus  int
+}
+
+// Local copies — main.go doesn't import these from the httpclient
+// package because they're test-only response shapes.
+type Run = httpclient.Run
+type ListResp = httpclient.ListRunsResult
+
+func newFakeBackend(t *testing.T) (*fakeBackend, *httptest.Server) {
+	t.Helper()
+	fb := &fakeBackend{
+		startStatus: http.StatusCreated,
+		getStatus:   http.StatusOK,
+		listStatus:  http.StatusOK,
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /v0/runs", func(w http.ResponseWriter, r *http.Request) {
+		var in httpclient.CreateRunInput
+		_ = json.NewDecoder(r.Body).Decode(&in)
+		fb.mu.Lock()
+		fb.startedRun = &in
+		fb.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(fb.startStatus)
+		_ = json.NewEncoder(w).Encode(fb.startResp)
+	})
+	mux.HandleFunc("GET /v0/runs/{run_id}", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(fb.getStatus)
+		_ = json.NewEncoder(w).Encode(fb.getResp)
+	})
+	mux.HandleFunc("GET /v0/runs", func(w http.ResponseWriter, r *http.Request) {
+		fb.mu.Lock()
+		fb.listQuery = r.URL.RawQuery
+		fb.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(fb.listStatus)
+		_ = json.NewEncoder(w).Encode(fb.listResp)
+	})
+	mux.HandleFunc("POST /v0/runs/{run_id}/cancel", func(w http.ResponseWriter, r *http.Request) {
+		fb.mu.Lock()
+		fb.cancelledID = r.PathValue("run_id")
+		fb.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(httpclient.Run{ID: uuid.MustParse(r.PathValue("run_id")), State: "cancelled"})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return fb, srv
+}
+
+// withBackend sets FISHHAWK_BACKEND_URL so the subcommands pick up
+// the fake server's URL via envOr.
+func withBackend(t *testing.T, srv *httptest.Server) {
+	t.Setenv("FISHHAWK_BACKEND_URL", srv.URL)
+	t.Setenv("FISHHAWK_TOKEN", "")
+}
+
+func TestRunStart_HappyPath(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	withBackend(t, srv)
+	id := uuid.New()
+	fb.startResp = httpclient.Run{
+		ID: id, Repo: "x/y", WorkflowID: "w", WorkflowSHA: "abc",
+		TriggerSource: "cli", State: "pending",
+		CreatedAt: time.Now().UTC(),
+	}
+
+	var stdout strings.Builder
+	got := run([]string{
+		"run", "start",
+		"--repo", "x/y", "--workflow", "w", "--workflow-sha", "abc",
+	}, &stdout, io.Discard)
+	if got != exitOK {
+		t.Fatalf("status = %d, want exitOK", got)
+	}
+	if fb.startedRun.Repo != "x/y" {
+		t.Errorf("Repo = %q", fb.startedRun.Repo)
+	}
+	if fb.startedRun.TriggerSource != "cli" {
+		t.Errorf("TriggerSource = %q", fb.startedRun.TriggerSource)
+	}
+	if !strings.Contains(stdout.String(), id.String()) {
+		t.Errorf("stdout missing run ID: %s", stdout.String())
+	}
+}
+
+func TestRunStart_TriggerRefForwarded(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	withBackend(t, srv)
+	fb.startResp = httpclient.Run{ID: uuid.New(), State: "pending"}
+
+	if rc := run([]string{
+		"run", "start",
+		"--repo", "x/y", "--workflow", "w", "--workflow-sha", "abc",
+		"--trigger-ref", "issue:1247",
+	}, io.Discard, io.Discard); rc != exitOK {
+		t.Fatalf("status = %d", rc)
+	}
+	if fb.startedRun.TriggerRef == nil || *fb.startedRun.TriggerRef != "issue:1247" {
+		t.Errorf("TriggerRef = %v, want issue:1247", fb.startedRun.TriggerRef)
+	}
+}
+
+func TestRunStart_MissingRequiredFlags(t *testing.T) {
+	_, srv := newFakeBackend(t)
+	withBackend(t, srv)
+	var stderr strings.Builder
+	got := run([]string{
+		"run", "start", "--repo", "x/y",
+	}, io.Discard, &stderr)
+	if got != exitUsage {
+		t.Errorf("status = %d, want exitUsage", got)
+	}
+	if !strings.Contains(stderr.String(), "required") {
+		t.Errorf("missing 'required' in stderr: %s", stderr.String())
+	}
+}
+
+func TestRunStart_BackendError(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	withBackend(t, srv)
+	fb.startStatus = http.StatusBadRequest
+	var stderr strings.Builder
+	got := run([]string{
+		"run", "start",
+		"--repo", "x/y", "--workflow", "w", "--workflow-sha", "abc",
+	}, io.Discard, &stderr)
+	if got != exitFailure {
+		t.Errorf("status = %d, want exitFailure", got)
+	}
+}
+
+func TestRunStatus_HappyPath(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	withBackend(t, srv)
+	id := uuid.New()
+	fb.getResp = httpclient.Run{ID: id, State: "running"}
+
+	var stdout strings.Builder
+	got := run([]string{"run", "status", id.String()}, &stdout, io.Discard)
+	if got != exitOK {
+		t.Fatalf("status = %d", got)
+	}
+	if !strings.Contains(stdout.String(), "running") {
+		t.Errorf("missing state: %s", stdout.String())
+	}
+}
+
+func TestRunStatus_BadUUID(t *testing.T) {
+	_, srv := newFakeBackend(t)
+	withBackend(t, srv)
+	got := run([]string{"run", "status", "not-a-uuid"}, io.Discard, io.Discard)
+	if got != exitUsage {
+		t.Errorf("status = %d, want exitUsage", got)
+	}
+}
+
+func TestRunStatus_MissingArg(t *testing.T) {
+	_, srv := newFakeBackend(t)
+	withBackend(t, srv)
+	got := run([]string{"run", "status"}, io.Discard, io.Discard)
+	if got != exitUsage {
+		t.Errorf("status = %d, want exitUsage", got)
+	}
+}
+
+func TestRunList_HappyPath(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	withBackend(t, srv)
+	fb.listResp = httpclient.ListRunsResult{
+		Items: []httpclient.Run{
+			{ID: uuid.New(), Repo: "x/y", WorkflowID: "w", State: "pending", CreatedAt: time.Now().UTC()},
+			{ID: uuid.New(), Repo: "a/b", WorkflowID: "w", State: "running", CreatedAt: time.Now().UTC()},
+		},
+		NextCursor: "abc",
+	}
+	var stdout strings.Builder
+	got := run([]string{"run", "list", "--repo", "x/y"}, &stdout, io.Discard)
+	if got != exitOK {
+		t.Fatalf("status = %d", got)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "x/y") || !strings.Contains(out, "a/b") {
+		t.Errorf("missing items in output:\n%s", out)
+	}
+	if !strings.Contains(out, "More:") {
+		t.Errorf("missing pagination hint:\n%s", out)
+	}
+	if !strings.Contains(fb.listQuery, "repo=x%2Fy") {
+		t.Errorf("query missing repo filter: %s", fb.listQuery)
+	}
+}
+
+func TestRunList_Empty(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	withBackend(t, srv)
+	fb.listResp = httpclient.ListRunsResult{}
+	var stdout strings.Builder
+	if rc := run([]string{"run", "list"}, &stdout, io.Discard); rc != exitOK {
+		t.Fatalf("status = %d", rc)
+	}
+	if !strings.Contains(stdout.String(), "(no runs)") {
+		t.Errorf("expected (no runs) on empty list: %s", stdout.String())
+	}
+}
+
+func TestRunCancel_HappyPath(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	withBackend(t, srv)
+	id := uuid.New()
+
+	var stdout strings.Builder
+	got := run([]string{"run", "cancel", id.String()}, &stdout, io.Discard)
+	if got != exitOK {
+		t.Fatalf("status = %d", got)
+	}
+	if fb.cancelledID != id.String() {
+		t.Errorf("cancelledID = %q, want %q", fb.cancelledID, id)
+	}
+	if !strings.Contains(stdout.String(), "cancelled") {
+		t.Errorf("missing state in output: %s", stdout.String())
+	}
+}
+
+func TestRunCancel_BadUUID(t *testing.T) {
+	_, srv := newFakeBackend(t)
+	withBackend(t, srv)
+	got := run([]string{"run", "cancel", "not-a-uuid"}, io.Discard, io.Discard)
+	if got != exitUsage {
+		t.Errorf("status = %d, want exitUsage", got)
+	}
+}
+
+func TestRunOpen_PrintURL(t *testing.T) {
+	id := uuid.New()
+	t.Setenv("FISHHAWK_BACKEND_URL", "https://app.fishhawk.test")
+	var stdout strings.Builder
+	got := run([]string{"run", "open", "--print-url", id.String()}, &stdout, io.Discard)
+	if got != exitOK {
+		t.Fatalf("status = %d", got)
+	}
+	want := fmt.Sprintf("https://app.fishhawk.test/runs/%s", id)
+	if !strings.Contains(stdout.String(), want) {
+		t.Errorf("output = %q, want contains %q", stdout.String(), want)
+	}
+}
+
+func TestRunOpen_BrowserStub(t *testing.T) {
+	// Substitute openBrowser so the test doesn't actually launch
+	// a browser. Verify the URL we'd open is the canonical UI URL
+	// and the success path returns exitOK.
+	id := uuid.New()
+	t.Setenv("FISHHAWK_BACKEND_URL", "https://app.fishhawk.test")
+	called := ""
+	orig := openBrowser
+	openBrowser = func(url string) error {
+		called = url
+		return nil
+	}
+	t.Cleanup(func() { openBrowser = orig })
+
+	var stdout strings.Builder
+	got := run([]string{"run", "open", id.String()}, &stdout, io.Discard)
+	if got != exitOK {
+		t.Fatalf("status = %d", got)
+	}
+	if !strings.Contains(called, id.String()) {
+		t.Errorf("openBrowser was called with %q, want URL containing %s", called, id)
+	}
+}
+
+func TestRunOpen_BadUUID(t *testing.T) {
+	got := run([]string{"run", "open", "not-a-uuid"}, io.Discard, io.Discard)
+	if got != exitUsage {
+		t.Errorf("status = %d, want exitUsage", got)
+	}
+}
+
+func TestRunOpen_BrowserFailure(t *testing.T) {
+	id := uuid.New()
+	t.Setenv("FISHHAWK_BACKEND_URL", "https://app.fishhawk.test")
+	orig := openBrowser
+	openBrowser = func(url string) error { return fmt.Errorf("no browser available") }
+	t.Cleanup(func() { openBrowser = orig })
+
+	var stderr strings.Builder
+	got := run([]string{"run", "open", id.String()}, io.Discard, &stderr)
+	if got != exitFailure {
+		t.Errorf("status = %d, want exitFailure", got)
+	}
+	if !strings.Contains(stderr.String(), "no browser") {
+		t.Errorf("stderr missing browser error: %s", stderr.String())
+	}
+}
+
+func TestRun_UnknownRunSubcommand(t *testing.T) {
+	var stderr strings.Builder
+	got := run([]string{"run", "frobnicate"}, io.Discard, &stderr)
+	if got != exitUsage {
+		t.Errorf("status = %d, want exitUsage", got)
+	}
+}
+
+func TestEnvOr(t *testing.T) {
+	t.Setenv("X_TEST_KEY", "")
+	if got := envOr("X_TEST_KEY", "fallback"); got != "fallback" {
+		t.Errorf("got %q, want fallback", got)
+	}
+	t.Setenv("X_TEST_KEY", "explicit")
+	if got := envOr("X_TEST_KEY", "fallback"); got != "explicit" {
+		t.Errorf("got %q, want explicit", got)
+	}
+}

--- a/cli/cmd/fishhawk/run.go
+++ b/cli/cmd/fishhawk/run.go
@@ -1,0 +1,286 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/kuhlman-labs/fishhawk/cli/internal/httpclient"
+)
+
+// runRun dispatches to `fishhawk run <subcommand>`. Each
+// subcommand has its own flag set; common flags (backend URL,
+// token) live in newClient and are consumed by every subcommand.
+func runRun(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		_, _ = fmt.Fprintln(stderr, `fishhawk run: subcommand required (start|status|list|cancel|open)`)
+		return exitUsage
+	}
+	sub, rest := args[0], args[1:]
+	switch sub {
+	case "start":
+		return runStart(rest, stdout, stderr)
+	case "status":
+		return runStatus(rest, stdout, stderr)
+	case "list":
+		return runList(rest, stdout, stderr)
+	case "cancel":
+		return runCancel(rest, stdout, stderr)
+	case "open":
+		return runOpen(rest, stdout, stderr)
+	default:
+		_, _ = fmt.Fprintf(stderr, "fishhawk run: unknown subcommand %q\n", sub)
+		return exitUsage
+	}
+}
+
+// commonFlags binds --backend-url and --token onto fs and returns
+// pointers consumed by newClient. Centralized so every subcommand
+// has the same flags in the same order.
+type commonFlags struct {
+	backendURL *string
+	token      *string
+	timeout    *time.Duration
+}
+
+func bindCommonFlags(fs *flag.FlagSet) commonFlags {
+	return commonFlags{
+		backendURL: fs.String("backend-url",
+			envOr("FISHHAWK_BACKEND_URL", "http://localhost:8080"),
+			"Fishhawk backend URL"),
+		token: fs.String("token",
+			envOr("FISHHAWK_TOKEN", ""),
+			"Bearer token; may be empty for dev backends with stubbed auth"),
+		timeout: fs.Duration("timeout", 60*time.Second,
+			"per-request timeout"),
+	}
+}
+
+func newClient(cf commonFlags) *httpclient.Client {
+	c := httpclient.New(*cf.backendURL, *cf.token)
+	c.HTTP.Timeout = *cf.timeout
+	return c
+}
+
+// runStart implements `fishhawk run start`.
+func runStart(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("fishhawk run start", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	cf := bindCommonFlags(fs)
+	repo := fs.String("repo", "", "owner/name of the repo (required)")
+	workflowID := fs.String("workflow", "", "workflow ID matching .fishhawk/workflows.yaml (required)")
+	workflowSHA := fs.String("workflow-sha", "", "git SHA of .fishhawk/workflows.yaml (required)")
+	triggerRef := fs.String("trigger-ref", "", "optional trigger reference (e.g. issue:1247)")
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+	if *repo == "" || *workflowID == "" || *workflowSHA == "" {
+		_, _ = fmt.Fprintln(stderr, "fishhawk run start: --repo, --workflow, and --workflow-sha are required")
+		fs.Usage()
+		return exitUsage
+	}
+
+	in := httpclient.CreateRunInput{
+		Repo:          *repo,
+		WorkflowID:    *workflowID,
+		WorkflowSHA:   *workflowSHA,
+		TriggerSource: "cli",
+	}
+	if *triggerRef != "" {
+		in.TriggerRef = triggerRef
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), *cf.timeout)
+	defer cancel()
+	r, err := newClient(cf).StartRun(ctx, in)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "fishhawk run start: %v\n", err)
+		return exitFailure
+	}
+	printRun(stdout, r)
+	return exitOK
+}
+
+// runStatus implements `fishhawk run status <run-id>`.
+func runStatus(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("fishhawk run status", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	cf := bindCommonFlags(fs)
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+	if fs.NArg() != 1 {
+		_, _ = fmt.Fprintln(stderr, "fishhawk run status: <run-id> required")
+		return exitUsage
+	}
+	id, err := uuid.Parse(fs.Arg(0))
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "fishhawk run status: %q is not a UUID: %v\n", fs.Arg(0), err)
+		return exitUsage
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), *cf.timeout)
+	defer cancel()
+	r, err := newClient(cf).GetRun(ctx, id)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "fishhawk run status: %v\n", err)
+		return exitOnAPIError(err)
+	}
+	printRun(stdout, r)
+	return exitOK
+}
+
+// runList implements `fishhawk run list`.
+func runList(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("fishhawk run list", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	cf := bindCommonFlags(fs)
+	repo := fs.String("repo", "", "filter by repo (owner/name)")
+	workflow := fs.String("workflow", "", "filter by workflow ID")
+	state := fs.String("state", "", "filter by state (pending|running|succeeded|failed|cancelled)")
+	limit := fs.Int("limit", 0, "max items per page (default 50, max 200)")
+	cursor := fs.String("cursor", "", "pagination cursor from a prior list response")
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), *cf.timeout)
+	defer cancel()
+	res, err := newClient(cf).ListRuns(ctx, httpclient.ListRunsFilter{
+		Repo:       *repo,
+		WorkflowID: *workflow,
+		State:      *state,
+		Limit:      *limit,
+		Cursor:     *cursor,
+	})
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "fishhawk run list: %v\n", err)
+		return exitOnAPIError(err)
+	}
+	if len(res.Items) == 0 {
+		_, _ = fmt.Fprintln(stdout, "(no runs)")
+		return exitOK
+	}
+	for _, r := range res.Items {
+		_, _ = fmt.Fprintf(stdout, "%s  %-30s  %-15s  %-10s  %s\n",
+			r.ID, r.Repo, r.WorkflowID, r.State, r.CreatedAt.Format(time.RFC3339))
+	}
+	if res.NextCursor != "" {
+		_, _ = fmt.Fprintf(stdout, "\nMore: --cursor %s\n", res.NextCursor)
+	}
+	return exitOK
+}
+
+// runCancel implements `fishhawk run cancel <run-id>`.
+func runCancel(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("fishhawk run cancel", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	cf := bindCommonFlags(fs)
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+	if fs.NArg() != 1 {
+		_, _ = fmt.Fprintln(stderr, "fishhawk run cancel: <run-id> required")
+		return exitUsage
+	}
+	id, err := uuid.Parse(fs.Arg(0))
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "fishhawk run cancel: %q is not a UUID: %v\n", fs.Arg(0), err)
+		return exitUsage
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), *cf.timeout)
+	defer cancel()
+	r, err := newClient(cf).CancelRun(ctx, id)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "fishhawk run cancel: %v\n", err)
+		return exitOnAPIError(err)
+	}
+	printRun(stdout, r)
+	return exitOK
+}
+
+// runOpen builds the canonical UI URL for the run and shells out
+// to the OS-appropriate "open this URL" tool. We don't reach the
+// backend at all — opening the UI is a local-only operation.
+func runOpen(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("fishhawk run open", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	cf := bindCommonFlags(fs)
+	printOnly := fs.Bool("print-url", false, "print the URL instead of launching the browser")
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+	if fs.NArg() != 1 {
+		_, _ = fmt.Fprintln(stderr, "fishhawk run open: <run-id> required")
+		return exitUsage
+	}
+	id, err := uuid.Parse(fs.Arg(0))
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "fishhawk run open: %q is not a UUID: %v\n", fs.Arg(0), err)
+		return exitUsage
+	}
+	url := strings.TrimRight(*cf.backendURL, "/") + "/runs/" + id.String()
+	if *printOnly {
+		_, _ = fmt.Fprintln(stdout, url)
+		return exitOK
+	}
+	if err := openBrowser(url); err != nil {
+		_, _ = fmt.Fprintf(stderr, "fishhawk run open: %v (use --print-url to bypass)\n", err)
+		return exitFailure
+	}
+	_, _ = fmt.Fprintln(stdout, url)
+	return exitOK
+}
+
+// openBrowser is a small platform shim. macOS / Linux / Windows
+// each have a different "open this URL" command; the CLI honors
+// $BROWSER first when set so users on headless systems can
+// override.
+var openBrowser = func(url string) error {
+	if cmd := envOr("BROWSER", ""); cmd != "" {
+		return exec.Command(cmd, url).Start()
+	}
+	switch runtime.GOOS {
+	case "darwin":
+		return exec.Command("open", url).Start()
+	case "windows":
+		return exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
+	default: // linux, freebsd, etc.
+		return exec.Command("xdg-open", url).Start()
+	}
+}
+
+// printRun writes a Run as a small block of human-readable lines
+// to w. Mirrors the OpenAPI Run shape so a user reading the CLI's
+// output and the UI's run-detail page see the same fields.
+func printRun(w io.Writer, r *httpclient.Run) {
+	_, _ = fmt.Fprintf(w, "id:             %s\n", r.ID)
+	_, _ = fmt.Fprintf(w, "repo:           %s\n", r.Repo)
+	_, _ = fmt.Fprintf(w, "workflow_id:    %s\n", r.WorkflowID)
+	_, _ = fmt.Fprintf(w, "workflow_sha:   %s\n", r.WorkflowSHA)
+	_, _ = fmt.Fprintf(w, "trigger_source: %s\n", r.TriggerSource)
+	if r.TriggerRef != nil {
+		_, _ = fmt.Fprintf(w, "trigger_ref:    %s\n", *r.TriggerRef)
+	}
+	_, _ = fmt.Fprintf(w, "state:          %s\n", r.State)
+	_, _ = fmt.Fprintf(w, "created_at:     %s\n", r.CreatedAt.Format(time.RFC3339))
+	_, _ = fmt.Fprintf(w, "updated_at:     %s\n", r.UpdatedAt.Format(time.RFC3339))
+}
+
+// exitOnAPIError maps an *httpclient.APIError to the CLI's exit
+// code. 4xx errors map to exitFailure (caller did something
+// wrong); 5xx also exitFailure but operators can switch on the
+// printed status. Non-API errors (network, parse) → exitFailure.
+func exitOnAPIError(err error) int {
+	var apiErr *httpclient.APIError
+	if errors.As(err, &apiErr) {
+		return exitFailure
+	}
+	return exitFailure
+}

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -1,0 +1,5 @@
+module github.com/kuhlman-labs/fishhawk/cli
+
+go 1.25
+
+require github.com/google/uuid v1.6.0

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -1,0 +1,2 @@
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/cli/internal/httpclient/httpclient.go
+++ b/cli/internal/httpclient/httpclient.go
@@ -1,0 +1,222 @@
+// Package httpclient is the CLI's typed wrapper around the
+// Fishhawk backend HTTP API. It handles auth, request building,
+// JSON decoding, and error envelope translation so subcommands
+// can call typed methods without touching net/http.
+//
+// Errors come back as *APIError when the server returned an
+// error envelope per docs/api/v0.openapi.yaml's `Error` schema;
+// callers can errors.As to inspect the code/message/details.
+package httpclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Client is the typed Fishhawk API client. Construct via New;
+// callers can override HTTP for tests.
+type Client struct {
+	BaseURL string
+	Token   string // optional; sent as Authorization: Bearer <token> when set
+	HTTP    *http.Client
+}
+
+// New returns a Client with a 60s default timeout. baseURL must
+// not have a trailing slash.
+func New(baseURL, token string) *Client {
+	return &Client{
+		BaseURL: baseURL,
+		Token:   token,
+		HTTP:    &http.Client{Timeout: 60 * time.Second},
+	}
+}
+
+// APIError is the typed form of the OpenAPI error envelope. The
+// Code field is what callers switch on; Message is human and may
+// drift between versions.
+type APIError struct {
+	StatusCode int
+	Code       string
+	Message    string
+	Details    map[string]any
+}
+
+func (e *APIError) Error() string {
+	if e.Code == "" {
+		return fmt.Sprintf("fishhawk: HTTP %d", e.StatusCode)
+	}
+	return fmt.Sprintf("fishhawk: HTTP %d (%s): %s", e.StatusCode, e.Code, e.Message)
+}
+
+// errorEnvelope mirrors the wire shape the backend always emits on
+// non-2xx responses.
+type errorEnvelope struct {
+	Error struct {
+		Code    string         `json:"code"`
+		Message string         `json:"message"`
+		Details map[string]any `json:"details"`
+	} `json:"error"`
+}
+
+// Run is the CLI-side projection of the OpenAPI Run schema. Field
+// names + types match the wire shape verbatim.
+type Run struct {
+	ID            uuid.UUID `json:"id"`
+	Repo          string    `json:"repo"`
+	WorkflowID    string    `json:"workflow_id"`
+	WorkflowSHA   string    `json:"workflow_sha"`
+	TriggerSource string    `json:"trigger_source"`
+	TriggerRef    *string   `json:"trigger_ref"`
+	State         string    `json:"state"`
+	CreatedAt     time.Time `json:"created_at"`
+	UpdatedAt     time.Time `json:"updated_at"`
+}
+
+// CreateRunInput is what StartRun marshals into the request body.
+type CreateRunInput struct {
+	Repo          string  `json:"repo"`
+	WorkflowID    string  `json:"workflow_id"`
+	WorkflowSHA   string  `json:"workflow_sha"`
+	TriggerSource string  `json:"trigger_source"`
+	TriggerRef    *string `json:"trigger_ref,omitempty"`
+}
+
+// StartRun calls POST /v0/runs.
+func (c *Client) StartRun(ctx context.Context, in CreateRunInput) (*Run, error) {
+	body, err := json.Marshal(in)
+	if err != nil {
+		return nil, fmt.Errorf("marshal: %w", err)
+	}
+	var run Run
+	if err := c.do(ctx, http.MethodPost, "/v0/runs", body, &run); err != nil {
+		return nil, err
+	}
+	return &run, nil
+}
+
+// GetRun calls GET /v0/runs/{id}.
+func (c *Client) GetRun(ctx context.Context, id uuid.UUID) (*Run, error) {
+	var run Run
+	if err := c.do(ctx, http.MethodGet, "/v0/runs/"+id.String(), nil, &run); err != nil {
+		return nil, err
+	}
+	return &run, nil
+}
+
+// ListRunsFilter scopes a ListRuns call. Empty values are dropped
+// from the query string.
+type ListRunsFilter struct {
+	Repo       string
+	WorkflowID string
+	State      string
+	Limit      int
+	Cursor     string
+}
+
+// ListRunsResult is the paginated response.
+type ListRunsResult struct {
+	Items      []Run  `json:"items"`
+	NextCursor string `json:"next_cursor"`
+}
+
+// ListRuns calls GET /v0/runs with optional filters and cursor.
+func (c *Client) ListRuns(ctx context.Context, f ListRunsFilter) (*ListRunsResult, error) {
+	q := url.Values{}
+	if f.Repo != "" {
+		q.Set("repo", f.Repo)
+	}
+	if f.WorkflowID != "" {
+		q.Set("workflow_id", f.WorkflowID)
+	}
+	if f.State != "" {
+		q.Set("state", f.State)
+	}
+	if f.Limit > 0 {
+		q.Set("limit", strconv.Itoa(f.Limit))
+	}
+	if f.Cursor != "" {
+		q.Set("cursor", f.Cursor)
+	}
+	path := "/v0/runs"
+	if encoded := q.Encode(); encoded != "" {
+		path = path + "?" + encoded
+	}
+	var res ListRunsResult
+	if err := c.do(ctx, http.MethodGet, path, nil, &res); err != nil {
+		return nil, err
+	}
+	return &res, nil
+}
+
+// CancelRun calls POST /v0/runs/{id}/cancel.
+func (c *Client) CancelRun(ctx context.Context, id uuid.UUID) (*Run, error) {
+	var run Run
+	if err := c.do(ctx, http.MethodPost, "/v0/runs/"+id.String()+"/cancel", nil, &run); err != nil {
+		return nil, err
+	}
+	return &run, nil
+}
+
+// do performs the request and decodes the JSON body into out (or
+// reads the error envelope on non-2xx and returns *APIError).
+func (c *Client) do(ctx context.Context, method, path string, body []byte, out any) error {
+	if c.BaseURL == "" {
+		return errors.New("httpclient: BaseURL not set")
+	}
+
+	var rdr io.Reader
+	if body != nil {
+		rdr = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.BaseURL+path, rdr)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Accept", "application/json")
+	if c.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.Token)
+	}
+
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return fmt.Errorf("http: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read body: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		apiErr := &APIError{StatusCode: resp.StatusCode}
+		var env errorEnvelope
+		if json.Unmarshal(raw, &env) == nil {
+			apiErr.Code = env.Error.Code
+			apiErr.Message = env.Error.Message
+			apiErr.Details = env.Error.Details
+		}
+		return apiErr
+	}
+
+	if out == nil {
+		return nil
+	}
+	if err := json.Unmarshal(raw, out); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+	return nil
+}

--- a/cli/internal/httpclient/httpclient_test.go
+++ b/cli/internal/httpclient/httpclient_test.go
@@ -1,0 +1,266 @@
+package httpclient
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// fakeBackend builds a httptest.Server with handlers shaped like
+// the production endpoints. Tests can drive each one's behavior via
+// fields on fakeBackend.
+type fakeBackend struct {
+	startStatus  int
+	startResp    Run
+	getStatus    int
+	getResp      Run
+	listResp     ListRunsResult
+	listStatus   int
+	cancelStatus int
+	cancelResp   Run
+	errBody      string
+
+	gotAuthHeader string
+	gotQuery      string
+}
+
+func newFakeBackend(t *testing.T) (*fakeBackend, *httptest.Server) {
+	t.Helper()
+	fb := &fakeBackend{
+		startStatus:  http.StatusCreated,
+		getStatus:    http.StatusOK,
+		listStatus:   http.StatusOK,
+		cancelStatus: http.StatusOK,
+	}
+	mux := http.NewServeMux()
+	writeJSON := func(w http.ResponseWriter, status int, v any) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_ = json.NewEncoder(w).Encode(v)
+	}
+	writeErr := func(w http.ResponseWriter, status int, body string) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = io.WriteString(w, body)
+	}
+
+	mux.HandleFunc("POST /v0/runs", func(w http.ResponseWriter, r *http.Request) {
+		fb.gotAuthHeader = r.Header.Get("Authorization")
+		if fb.startStatus >= 400 {
+			writeErr(w, fb.startStatus, fb.errBody)
+			return
+		}
+		writeJSON(w, fb.startStatus, fb.startResp)
+	})
+	mux.HandleFunc("GET /v0/runs/{run_id}", func(w http.ResponseWriter, r *http.Request) {
+		if fb.getStatus >= 400 {
+			writeErr(w, fb.getStatus, fb.errBody)
+			return
+		}
+		writeJSON(w, fb.getStatus, fb.getResp)
+	})
+	mux.HandleFunc("GET /v0/runs", func(w http.ResponseWriter, r *http.Request) {
+		fb.gotQuery = r.URL.RawQuery
+		if fb.listStatus >= 400 {
+			writeErr(w, fb.listStatus, fb.errBody)
+			return
+		}
+		writeJSON(w, fb.listStatus, fb.listResp)
+	})
+	mux.HandleFunc("POST /v0/runs/{run_id}/cancel", func(w http.ResponseWriter, r *http.Request) {
+		if fb.cancelStatus >= 400 {
+			writeErr(w, fb.cancelStatus, fb.errBody)
+			return
+		}
+		writeJSON(w, fb.cancelStatus, fb.cancelResp)
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return fb, srv
+}
+
+func TestStartRun_HappyPath(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	id := uuid.New()
+	fb.startResp = Run{
+		ID: id, Repo: "x/y", WorkflowID: "w",
+		WorkflowSHA: "abc", TriggerSource: "cli", State: "pending",
+		CreatedAt: time.Now().UTC(),
+	}
+	c := New(srv.URL, "tok-123")
+	got, err := c.StartRun(context.Background(), CreateRunInput{
+		Repo: "x/y", WorkflowID: "w", WorkflowSHA: "abc", TriggerSource: "cli",
+	})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+	if got.ID != id {
+		t.Errorf("ID round-trip: %s vs %s", got.ID, id)
+	}
+	if fb.gotAuthHeader != "Bearer tok-123" {
+		t.Errorf("Authorization = %q, want Bearer tok-123", fb.gotAuthHeader)
+	}
+}
+
+func TestStartRun_NoTokenOmitsAuthHeader(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	fb.startResp = Run{ID: uuid.New(), State: "pending"}
+	c := New(srv.URL, "") // no token
+	if _, err := c.StartRun(context.Background(), CreateRunInput{Repo: "x/y", WorkflowID: "w", WorkflowSHA: "abc", TriggerSource: "cli"}); err != nil {
+		t.Fatal(err)
+	}
+	if fb.gotAuthHeader != "" {
+		t.Errorf("Authorization sent when token empty: %q", fb.gotAuthHeader)
+	}
+}
+
+func TestStartRun_APIError(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	fb.startStatus = http.StatusBadRequest
+	fb.errBody = `{"error":{"code":"validation_failed","message":"repo is required","details":{"field":"repo"}}}`
+	c := New(srv.URL, "")
+	_, err := c.StartRun(context.Background(), CreateRunInput{})
+	if err == nil {
+		t.Fatal("expected APIError")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("err = %v, want *APIError", err)
+	}
+	if apiErr.StatusCode != http.StatusBadRequest {
+		t.Errorf("StatusCode = %d", apiErr.StatusCode)
+	}
+	if apiErr.Code != "validation_failed" {
+		t.Errorf("Code = %q", apiErr.Code)
+	}
+	if got, _ := apiErr.Details["field"].(string); got != "repo" {
+		t.Errorf("Details.field = %v, want repo", apiErr.Details["field"])
+	}
+}
+
+func TestStartRun_NonEnvelopedError(t *testing.T) {
+	// A 500 with unparseable body should still produce APIError —
+	// just without code/message populated. Status code is the only
+	// reliable signal.
+	fb, srv := newFakeBackend(t)
+	fb.startStatus = http.StatusInternalServerError
+	fb.errBody = "not json at all"
+	c := New(srv.URL, "")
+	_, err := c.StartRun(context.Background(), CreateRunInput{})
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("err = %v, want *APIError", err)
+	}
+	if apiErr.StatusCode != http.StatusInternalServerError {
+		t.Errorf("StatusCode = %d", apiErr.StatusCode)
+	}
+}
+
+func TestGetRun_HappyPath(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	id := uuid.New()
+	fb.getResp = Run{ID: id, State: "running"}
+	c := New(srv.URL, "")
+	got, err := c.GetRun(context.Background(), id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != id || got.State != "running" {
+		t.Errorf("got %+v", got)
+	}
+}
+
+func TestGetRun_NotFound(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	fb.getStatus = http.StatusNotFound
+	fb.errBody = `{"error":{"code":"run_not_found","message":"no run with that id"}}`
+	c := New(srv.URL, "")
+	_, err := c.GetRun(context.Background(), uuid.New())
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) || apiErr.Code != "run_not_found" {
+		t.Errorf("err = %v, want APIError run_not_found", err)
+	}
+}
+
+func TestListRuns_QueryStringEncoding(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	fb.listResp = ListRunsResult{Items: []Run{{ID: uuid.New()}}}
+	c := New(srv.URL, "")
+	_, err := c.ListRuns(context.Background(), ListRunsFilter{
+		Repo: "x/y", WorkflowID: "w", State: "running", Limit: 25, Cursor: "abc",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"repo=x%2Fy", "workflow_id=w", "state=running", "limit=25", "cursor=abc"} {
+		if !strings.Contains(fb.gotQuery, want) {
+			t.Errorf("query %q missing %q", fb.gotQuery, want)
+		}
+	}
+}
+
+func TestListRuns_EmptyFiltersDropped(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	c := New(srv.URL, "")
+	_, _ = c.ListRuns(context.Background(), ListRunsFilter{})
+	if fb.gotQuery != "" {
+		t.Errorf("query = %q, want empty when no filters", fb.gotQuery)
+	}
+}
+
+func TestCancelRun_HappyPath(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	id := uuid.New()
+	fb.cancelResp = Run{ID: id, State: "cancelled"}
+	c := New(srv.URL, "")
+	got, err := c.CancelRun(context.Background(), id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.State != "cancelled" {
+		t.Errorf("State = %q", got.State)
+	}
+}
+
+func TestDo_BadBaseURL(t *testing.T) {
+	c := &Client{HTTP: &http.Client{Timeout: time.Second}}
+	if _, err := c.GetRun(context.Background(), uuid.New()); err == nil {
+		t.Fatal("expected error for empty BaseURL")
+	}
+}
+
+func TestDo_NetworkError(t *testing.T) {
+	c := New("http://127.0.0.1:1", "") // port 1 = "won't connect"
+	c.HTTP.Timeout = 100 * time.Millisecond
+	_, err := c.GetRun(context.Background(), uuid.New())
+	if err == nil {
+		t.Fatal("expected network error")
+	}
+}
+
+func TestAPIError_Error(t *testing.T) {
+	tests := []struct {
+		name string
+		err  *APIError
+		want string
+	}{
+		{"with code", &APIError{StatusCode: 400, Code: "x", Message: "y"}, "fishhawk: HTTP 400 (x): y"},
+		{"no code", &APIError{StatusCode: 500}, "fishhawk: HTTP 500"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.err.Error(); got != tc.want {
+				t.Errorf("Error() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/cli/internal/version/version.go
+++ b/cli/internal/version/version.go
@@ -1,0 +1,9 @@
+// Package version exposes the build-time version string the CLI
+// reports via `fishhawk --version`. Set via -ldflags at release
+// time; defaults to "dev" for local builds.
+package version
+
+// Version is the CLI's reported version. Overridden via:
+//
+//	go build -ldflags "-X github.com/kuhlman-labs/fishhawk/cli/internal/version.Version=v0.1.0"
+var Version = "dev"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -157,6 +157,7 @@ GitHub OAuth (E4.2 / #49) is the sign-in flow that mints the cookie session. App
 | HTTP API contract (endpoints, auth, errors) | `docs/api/v0.openapi.yaml` (source of truth) + `docs/api/v0.md` (companion) |
 | Trace bundle wire format (`*.jsonl.gz`) | `runner/internal/bundle/bundle.go` (pack + open) — implements ADR-007 (#71) |
 | Runner → backend trace upload | `runner/internal/upload/` (HTTP client, retries, signing) — wired into runner main behind `--upload-trace` |
+| CLI → backend HTTP client | `cli/internal/httpclient/` (typed wrappers); CLI subcommands in `cli/cmd/fishhawk/` |
 | Constraint evaluation (forbidden_paths, max_files_changed, required_outcomes) | `runner/internal/constraint/constraint.go` (post-hoc, runner-side) |
 | HTTP middleware order / context keys | `backend/internal/server/middleware.go` |
 | Run CRUD handlers (POST/GET/list/cancel) | `backend/internal/server/runs.go`; wired in `backend/cmd/fishhawkd/serve.go` from `FISHHAWKD_DATABASE_URL` |

--- a/go.work
+++ b/go.work
@@ -9,12 +9,15 @@
 // Modules will be added as use directives here as they're scaffolded:
 //   E3.1 (#41) → use ./backend  ✓
 //   E5.1 (#52) → use ./runner   ✓
-//   E6.1 (#55) → use ./cli
+//   E6.1 (#55) → use ./cli      ✓
 //
 // See ADR-014 (#78) for the rationale.
 
 go 1.25.0
 
-use ./backend
-use ./runner
-use ./verifier
+use (
+	./backend
+	./cli
+	./runner
+	./verifier
+)


### PR DESCRIPTION
## Summary

Stands up the `cli/` Go module and ships five `run` subcommands that wrap the OpenAPI runs surface (PRs #107, #117). Customers and operators can drive the backend from a terminal:

```
fishhawk run start  --repo R --workflow W --workflow-sha S [--trigger-ref REF]
fishhawk run status <run-id>
fishhawk run list   [--repo --workflow --state --limit --cursor]
fishhawk run cancel <run-id>
fishhawk run open   <run-id> [--print-url]
```

- `cli/internal/httpclient/` — typed wrapper. Marshals requests, decodes responses, surfaces non-2xx as `*APIError` carrying the OpenAPI error envelope's `code` / `message` / `details`. Tests use `httptest.Server` with handlers shaped exactly like production.
- `cli/cmd/fishhawk/` — flag-based subcommand dispatch (stdlib `flag`, no cobra dep). Common flags (`--backend-url`, `--token`, `--timeout`) bound once via `bindCommonFlags`; defaults from `FISHHAWK_BACKEND_URL` / `FISHHAWK_TOKEN`.
- `run open` shells out to the OS-appropriate URL handler (`$BROWSER` if set, then `open` / `rundll32` / `xdg-open`); `--print-url` skips the launch for headless environments.
- `go.work` updated to `use ./cli` alongside the existing three modules.

## Test plan

- [x] `go test -race ./cli/...` — 27 tests pass (15 in `httpclient`, 12 in `cmd/fishhawk`)
- [x] `golangci-lint run ./...` across all 4 modules — 0 issues
- [x] Coverage: `cli/cmd/fishhawk` 84.0%, `cli/internal/httpclient` 90.1%; aggregate (excl. `/db/`) 86.3%
- [x] End-to-end: every CLI subcommand drives the typed client → `httptest.Server` → real assertion path
- [x] CI passes

## Notes

**`fishhawk validate` is deferred** to its existing tracking issue **#33 (E6.2)**. Per the CLAUDE.md deferred-issue policy: `validate` needs a local copy of the workflow-spec parser, which currently lives under `backend/internal/spec` and can't be imported across modules. The planned path is mirroring (a `cli/internal/spec` mirror with a 3rd schema-sync diff in CI) — same convention `runner/internal/plan` already uses for the plan schema. Issue #33 documents the why and the two options (mirror vs extract).

**Stdlib `flag`, no cobra.** Matches the runner and verifier conventions. Common flags are bound on each subcommand's `flag.FlagSet`; subcommand-specific flags follow. `--print-url` must come before the positional `<run-id>` per Go's flag-parsing rules.

**`run open` is local-only.** Doesn't reach the backend at all — just builds the canonical UI URL (`<backend-url>/runs/<id>`) and shells out. The `openBrowser` function variable is the test seam; `--print-url` is the operator's bypass for headless / SSH / CI contexts.

**Auth story.** `--token` is plumbed but the dev backend's `authStub` middleware accepts anonymous calls. When `/v0/tokens` (E4.5 / #51) lands the CLI will start requiring a real bearer.

**Spec status.** No backend changes; this PR is pure CLI. Of the 19 endpoints in `docs/api/v0.openapi.yaml`, the CLI now consumes 4 (POST /v0/runs, GET /v0/runs, GET /v0/runs/{id}, POST /v0/runs/{id}/cancel). The remaining endpoints (signing-key, trace, webhook receiver) are runner / GitHub facing — outside the CLI surface.

Closes #55, closes #34, closes #35, closes #36
