### PR TITLE
Add GitHub REST client (workflows + content)

### DIFF
--- a/backend/cmd/fishhawkd/serve.go
+++ b/backend/cmd/fishhawkd/serve.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/kuhlman-labs/fishhawk/backend/internal/audit"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/githubapp"
+	"github.com/kuhlman-labs/fishhawk/backend/internal/githubclient"
 	runpkg "github.com/kuhlman-labs/fishhawk/backend/internal/run"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/server"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/signing"
@@ -143,7 +144,8 @@ func runServe(args []string, logSink io.Writer) int {
 			return exitFailure
 		}
 		cfg.GitHubTokens = githubapp.NewCachedProvider(githubapp.NewClient(signer))
-		logger.Info("github app installation-token provider configured",
+		cfg.GitHub = githubclient.New(cfg.GitHubTokens)
+		logger.Info("github app + REST client configured",
 			slog.Int64("app_id", appID))
 	} else {
 		logger.Warn("FISHHAWKD_GITHUB_APP_ID not set; webhook dispatch and GitHub-side actions will be disabled")

--- a/backend/internal/githubclient/client.go
+++ b/backend/internal/githubclient/client.go
@@ -1,0 +1,303 @@
+// Package githubclient is the backend's typed wrapper around the
+// GitHub REST API for the small set of operations Fishhawk needs:
+// fetching `.fishhawk/workflows.yaml` from a customer's repo at a
+// given ref, and firing `workflow_dispatch` to start a runner job.
+//
+// Auth comes from a githubapp.TokenProvider passed at construction:
+// every call resolves an installation token first, then uses it as
+// an Authorization: Bearer <token> header. Token caching lives in
+// the provider, not here.
+//
+// What's NOT in scope: a comprehensive GitHub SDK. We only cover
+// the methods Fishhawk's flows demand. New methods land here as
+// the dispatcher (#109), the PR-opening flow (E5.6 follow-on), and
+// the audit-log render path need them.
+package githubclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/kuhlman-labs/fishhawk/backend/internal/githubapp"
+)
+
+// DefaultBaseURL is GitHub's REST API root. Tests override this
+// via Client.BaseURL pointing at httptest fakes.
+const DefaultBaseURL = "https://api.github.com"
+
+// WorkflowSpecPath is the canonical location of the workflow spec
+// in a customer's repo (per MVP_SPEC §4.1).
+const WorkflowSpecPath = ".fishhawk/workflows.yaml"
+
+// Errors callers may want to switch on.
+var (
+	// ErrNotFound means the resource (repo, file, workflow)
+	// doesn't exist OR the App's installation lacks access. GitHub
+	// returns 404 for both cases by design — we can't distinguish.
+	ErrNotFound = errors.New("githubclient: not found")
+	// ErrForbidden means the installation token was rejected (401)
+	// or the App lacks permission for the request (403).
+	ErrForbidden = errors.New("githubclient: forbidden")
+	// ErrValidation means GitHub rejected the request as malformed
+	// (422). Typical: bad ref name, missing required input.
+	ErrValidation = errors.New("githubclient: validation failed")
+)
+
+// RepoRef identifies a GitHub repository by owner + name.
+type RepoRef struct {
+	Owner string
+	Name  string
+}
+
+// String returns "owner/name" for use in log lines and URLs.
+func (r RepoRef) String() string { return r.Owner + "/" + r.Name }
+
+// FileContent is the decoded result of GetFile.
+type FileContent struct {
+	Path    string
+	Content []byte
+	// SHA is GitHub's blob SHA for the file's content at the ref.
+	// Stable per content, so two refs pointing to the same content
+	// produce the same SHA — the dedup we want for workflow_sha.
+	SHA string
+}
+
+// Client wraps a TokenProvider and net/http.Client with the small
+// set of GitHub operations Fishhawk needs. Concurrent use is safe.
+type Client struct {
+	// BaseURL is the API root. Empty → DefaultBaseURL.
+	BaseURL string
+
+	// Tokens issues installation-scoped Authorization tokens.
+	Tokens githubapp.TokenProvider
+
+	// HTTP is the underlying client. Defaults applied by New.
+	HTTP *http.Client
+}
+
+// New returns a Client with sensible defaults. tokens is required;
+// without it every call returns an error before touching the wire.
+func New(tokens githubapp.TokenProvider) *Client {
+	return &Client{
+		Tokens: tokens,
+		HTTP:   &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// GetFile fetches a single file from a repo at the given ref.
+// path is relative to the repo root (no leading slash).
+//
+//	GET /repos/{owner}/{repo}/contents/{path}?ref={ref}
+//
+// The response carries content base64-encoded; we decode here so
+// callers see []byte. Returns ErrNotFound if the file or repo
+// isn't visible to the installation, ErrForbidden on auth issues.
+func (c *Client) GetFile(ctx context.Context, installationID int64, repo RepoRef, path, ref string) (*FileContent, error) {
+	if c.Tokens == nil {
+		return nil, errors.New("githubclient: client missing TokenProvider")
+	}
+	if repo.Owner == "" || repo.Name == "" {
+		return nil, errors.New("githubclient: repo owner and name required")
+	}
+	if path == "" {
+		return nil, errors.New("githubclient: path required")
+	}
+
+	endpoint := c.endpoint("/repos/" + url.PathEscape(repo.Owner) +
+		"/" + url.PathEscape(repo.Name) +
+		"/contents/" + escapePath(path))
+	if ref != "" {
+		endpoint = endpoint + "?ref=" + url.QueryEscape(ref)
+	}
+
+	req, err := c.buildRequest(ctx, http.MethodGet, endpoint, nil, installationID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("githubclient: get file: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if err := classifyStatus("get file", resp); err != nil {
+		return nil, err
+	}
+
+	var body struct {
+		Path     string `json:"path"`
+		SHA      string `json:"sha"`
+		Content  string `json:"content"`  // base64
+		Encoding string `json:"encoding"` // "base64"
+		Type     string `json:"type"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return nil, fmt.Errorf("githubclient: decode file: %w", err)
+	}
+	if body.Type != "" && body.Type != "file" {
+		return nil, fmt.Errorf("githubclient: %s is a %q, not a file", path, body.Type)
+	}
+	if body.Encoding != "base64" {
+		return nil, fmt.Errorf("githubclient: unexpected content encoding %q", body.Encoding)
+	}
+	// GitHub wraps base64 at 60 chars; the standard decoder requires
+	// the input to be unwrapped first (or padded properly).
+	clean := strings.ReplaceAll(body.Content, "\n", "")
+	decoded, err := base64.StdEncoding.DecodeString(clean)
+	if err != nil {
+		return nil, fmt.Errorf("githubclient: decode content: %w", err)
+	}
+	return &FileContent{
+		Path:    body.Path,
+		Content: decoded,
+		SHA:     body.SHA,
+	}, nil
+}
+
+// GetWorkflowSpec is the canonical wrapper around GetFile for
+// `.fishhawk/workflows.yaml`. Callers want the content + the
+// blob SHA (used as workflow_sha on Run records); having a single
+// helper eliminates the per-call risk of a path typo.
+func (c *Client) GetWorkflowSpec(ctx context.Context, installationID int64, repo RepoRef, ref string) (*FileContent, error) {
+	return c.GetFile(ctx, installationID, repo, WorkflowSpecPath, ref)
+}
+
+// DispatchInputs is the JSON body of a workflow_dispatch event.
+// Per GitHub's contract, inputs is a flat map[string]string —
+// non-string values must be JSON-encoded by the caller.
+type DispatchInputs map[string]string
+
+// DispatchWorkflow fires a `workflow_dispatch` event for the given
+// workflow file at ref.
+//
+//	POST /repos/{owner}/{repo}/actions/workflows/{workflow_file}/dispatches
+//
+// workflowFile is the YAML file name inside .github/workflows/
+// (e.g. "fishhawk.yml"). ref is a branch / tag / commit SHA.
+//
+// On success returns nil; the customer's GitHub Actions runner
+// picks up the event and starts the job. Returns ErrValidation
+// for bad refs / unrecognized inputs (422), ErrNotFound for an
+// unknown workflow file (404).
+func (c *Client) DispatchWorkflow(ctx context.Context, installationID int64, repo RepoRef, workflowFile, ref string, inputs DispatchInputs) error {
+	if c.Tokens == nil {
+		return errors.New("githubclient: client missing TokenProvider")
+	}
+	if repo.Owner == "" || repo.Name == "" {
+		return errors.New("githubclient: repo owner and name required")
+	}
+	if workflowFile == "" {
+		return errors.New("githubclient: workflowFile required")
+	}
+	if ref == "" {
+		return errors.New("githubclient: ref required")
+	}
+
+	body := map[string]any{"ref": ref}
+	if len(inputs) > 0 {
+		body["inputs"] = inputs
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("githubclient: marshal dispatch body: %w", err)
+	}
+
+	endpoint := c.endpoint("/repos/" + url.PathEscape(repo.Owner) +
+		"/" + url.PathEscape(repo.Name) +
+		"/actions/workflows/" + url.PathEscape(workflowFile) +
+		"/dispatches")
+
+	req, err := c.buildRequest(ctx, http.MethodPost, endpoint, bytes.NewReader(raw), installationID)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return fmt.Errorf("githubclient: dispatch: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNoContent {
+		return nil
+	}
+	return classifyStatus("dispatch", resp)
+}
+
+// buildRequest constructs an http.Request with the standard
+// GitHub headers (auth, accept, version). Centralized so every
+// call site uses the same shape.
+func (c *Client) buildRequest(ctx context.Context, method, url string, body io.Reader, installationID int64) (*http.Request, error) {
+	token, err := c.Tokens.Token(ctx, installationID)
+	if err != nil {
+		return nil, fmt.Errorf("githubclient: get token: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, url, body)
+	if err != nil {
+		return nil, fmt.Errorf("githubclient: build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	return req, nil
+}
+
+// endpoint returns BaseURL + path, defaulting to api.github.com.
+func (c *Client) endpoint(path string) string {
+	base := c.BaseURL
+	if base == "" {
+		base = DefaultBaseURL
+	}
+	return base + path
+}
+
+// classifyStatus turns a non-2xx response into a typed error.
+// 401/403 → ErrForbidden, 404 → ErrNotFound, 422 → ErrValidation,
+// everything else gets a numeric prefix + body excerpt for
+// observability.
+func classifyStatus(op string, resp *http.Response) error {
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+	body := readBriefBody(resp.Body)
+	switch resp.StatusCode {
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return fmt.Errorf("%w: %s: %d: %s", ErrForbidden, op, resp.StatusCode, body)
+	case http.StatusNotFound:
+		return fmt.Errorf("%w: %s: %s", ErrNotFound, op, body)
+	case http.StatusUnprocessableEntity:
+		return fmt.Errorf("%w: %s: %s", ErrValidation, op, body)
+	default:
+		return fmt.Errorf("githubclient: %s: %d: %s", op, resp.StatusCode, body)
+	}
+}
+
+// readBriefBody returns up to 256 bytes of the response body for
+// inclusion in error messages. Caller closes the body.
+func readBriefBody(r io.Reader) string {
+	limited := io.LimitReader(r, 256)
+	b, _ := io.ReadAll(limited)
+	return strings.TrimSpace(string(b))
+}
+
+// escapePath URL-escapes a multi-segment path while preserving
+// the slashes between segments. url.PathEscape escapes slashes,
+// which would break GitHub's contents-API path matching.
+func escapePath(p string) string {
+	parts := strings.Split(p, "/")
+	for i, seg := range parts {
+		parts[i] = url.PathEscape(seg)
+	}
+	return strings.Join(parts, "/")
+}

--- a/backend/internal/githubclient/client_test.go
+++ b/backend/internal/githubclient/client_test.go
@@ -1,0 +1,451 @@
+package githubclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// stubTokens is a minimal TokenProvider for tests that doesn't
+// touch GitHub for token issuance. Returns a canned token, or
+// errs deterministically.
+type stubTokens struct {
+	token string
+	err   error
+
+	// installationCalled records the most recent installationID
+	// passed to Token(). Tests assert it matches expectations.
+	installationCalled int64
+}
+
+func (s *stubTokens) Token(_ context.Context, installationID int64) (string, error) {
+	s.installationCalled = installationID
+	if s.err != nil {
+		return "", s.err
+	}
+	return s.token, nil
+}
+
+// fakeGitHub stands in for api.github.com. Tests configure paths
+// + responses via fields; the server captures the last request so
+// assertions can verify wiring.
+type fakeGitHub struct {
+	getFileStatus int
+	getFileBody   string
+
+	dispatchStatus int
+	dispatchBody   string
+
+	gotAuth        string
+	gotPath        string
+	gotQuery       string
+	gotMethod      string
+	gotAcceptHdr   string
+	gotAPIVersion  string
+	gotContentType string
+	gotBody        []byte
+}
+
+func newFakeGitHub(t *testing.T) (*fakeGitHub, *httptest.Server) {
+	t.Helper()
+	fg := &fakeGitHub{
+		getFileStatus:  http.StatusOK,
+		dispatchStatus: http.StatusNoContent,
+	}
+	mux := http.NewServeMux()
+
+	// Capture every request that lands.
+	capture := func(r *http.Request) {
+		fg.gotAuth = r.Header.Get("Authorization")
+		fg.gotPath = r.URL.Path
+		fg.gotQuery = r.URL.RawQuery
+		fg.gotMethod = r.Method
+		fg.gotAcceptHdr = r.Header.Get("Accept")
+		fg.gotAPIVersion = r.Header.Get("X-GitHub-Api-Version")
+		fg.gotContentType = r.Header.Get("Content-Type")
+		fg.gotBody, _ = io.ReadAll(r.Body)
+	}
+
+	mux.HandleFunc("GET /repos/{owner}/{repo}/contents/", func(w http.ResponseWriter, r *http.Request) {
+		capture(r)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(fg.getFileStatus)
+		if fg.getFileBody != "" {
+			_, _ = io.WriteString(w, fg.getFileBody)
+		}
+	})
+
+	mux.HandleFunc("POST /repos/{owner}/{repo}/actions/workflows/{file}/dispatches",
+		func(w http.ResponseWriter, r *http.Request) {
+			capture(r)
+			w.WriteHeader(fg.dispatchStatus)
+			if fg.dispatchBody != "" {
+				_, _ = io.WriteString(w, fg.dispatchBody)
+			}
+		})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return fg, srv
+}
+
+// Build a Client wired to fg/srv with stub tokens.
+func newTestClient(t *testing.T, srv *httptest.Server, tokenErr error) (*Client, *stubTokens) {
+	t.Helper()
+	stub := &stubTokens{token: "ghs_canned_token", err: tokenErr}
+	return &Client{
+		BaseURL: srv.URL,
+		Tokens:  stub,
+		HTTP:    &http.Client{Timeout: 5 * time.Second},
+	}, stub
+}
+
+func TestGetFile_HappyPath(t *testing.T) {
+	fg, srv := newFakeGitHub(t)
+	content := []byte("workflows:\n  feature_change:\n    description: test\n")
+	encoded := base64.StdEncoding.EncodeToString(content)
+	// GitHub wraps base64 at 60 chars; insert an escaped newline
+	// (JSON's \n) so the parsed string carries a literal newline
+	// the unwrap path then strips.
+	wrapped := encoded[:30] + `\n` + encoded[30:]
+	fg.getFileBody = `{"path":".fishhawk/workflows.yaml","sha":"abc123","content":"` +
+		wrapped + `","encoding":"base64","type":"file"}`
+
+	c, stub := newTestClient(t, srv, nil)
+	got, err := c.GetFile(context.Background(), 42, RepoRef{Owner: "x", Name: "y"},
+		".fishhawk/workflows.yaml", "main")
+	if err != nil {
+		t.Fatalf("GetFile: %v", err)
+	}
+	if !bytes.Equal(got.Content, content) {
+		t.Errorf("Content = %q, want %q", got.Content, content)
+	}
+	if got.SHA != "abc123" {
+		t.Errorf("SHA = %q", got.SHA)
+	}
+	if got.Path != ".fishhawk/workflows.yaml" {
+		t.Errorf("Path = %q", got.Path)
+	}
+
+	// Wiring assertions.
+	if stub.installationCalled != 42 {
+		t.Errorf("installation = %d, want 42", stub.installationCalled)
+	}
+	if fg.gotAuth != "Bearer ghs_canned_token" {
+		t.Errorf("Authorization = %q", fg.gotAuth)
+	}
+	if fg.gotAcceptHdr != "application/vnd.github+json" {
+		t.Errorf("Accept = %q", fg.gotAcceptHdr)
+	}
+	if fg.gotAPIVersion != "2022-11-28" {
+		t.Errorf("X-GitHub-Api-Version = %q", fg.gotAPIVersion)
+	}
+	if !strings.Contains(fg.gotPath, "/contents/.fishhawk/workflows.yaml") {
+		t.Errorf("path = %q", fg.gotPath)
+	}
+	if fg.gotQuery != "ref=main" {
+		t.Errorf("query = %q, want ref=main", fg.gotQuery)
+	}
+}
+
+func TestGetFile_NoRefOmitsQuery(t *testing.T) {
+	fg, srv := newFakeGitHub(t)
+	fg.getFileBody = `{"path":"x","sha":"a","content":"YQ==","encoding":"base64","type":"file"}`
+	c, _ := newTestClient(t, srv, nil)
+	if _, err := c.GetFile(context.Background(), 1, RepoRef{Owner: "x", Name: "y"}, "x", ""); err != nil {
+		t.Fatal(err)
+	}
+	if fg.gotQuery != "" {
+		t.Errorf("query = %q, want empty when ref is empty", fg.gotQuery)
+	}
+}
+
+func TestGetFile_NotFound(t *testing.T) {
+	fg, srv := newFakeGitHub(t)
+	fg.getFileStatus = http.StatusNotFound
+	fg.getFileBody = `{"message":"Not Found"}`
+	c, _ := newTestClient(t, srv, nil)
+	_, err := c.GetFile(context.Background(), 1, RepoRef{Owner: "x", Name: "y"}, "x", "main")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestGetFile_Forbidden(t *testing.T) {
+	cases := []int{http.StatusUnauthorized, http.StatusForbidden}
+	for _, status := range cases {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			fg, srv := newFakeGitHub(t)
+			fg.getFileStatus = status
+			c, _ := newTestClient(t, srv, nil)
+			_, err := c.GetFile(context.Background(), 1, RepoRef{Owner: "x", Name: "y"}, "x", "main")
+			if !errors.Is(err, ErrForbidden) {
+				t.Errorf("err = %v, want ErrForbidden", err)
+			}
+		})
+	}
+}
+
+func TestGetFile_OtherStatus(t *testing.T) {
+	fg, srv := newFakeGitHub(t)
+	fg.getFileStatus = http.StatusInternalServerError
+	fg.getFileBody = `{"message":"upstream timeout"}`
+	c, _ := newTestClient(t, srv, nil)
+	_, err := c.GetFile(context.Background(), 1, RepoRef{Owner: "x", Name: "y"}, "x", "main")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("err = %v, want contains 500", err)
+	}
+}
+
+func TestGetFile_NotAFile(t *testing.T) {
+	fg, srv := newFakeGitHub(t)
+	fg.getFileBody = `{"path":"x","sha":"a","content":"","encoding":"none","type":"dir"}`
+	c, _ := newTestClient(t, srv, nil)
+	_, err := c.GetFile(context.Background(), 1, RepoRef{Owner: "x", Name: "y"}, "x", "main")
+	if err == nil || !strings.Contains(err.Error(), `"dir"`) {
+		t.Errorf("err = %v, want dir-not-file error", err)
+	}
+}
+
+func TestGetFile_BadEncoding(t *testing.T) {
+	fg, srv := newFakeGitHub(t)
+	fg.getFileBody = `{"path":"x","sha":"a","content":"raw","encoding":"utf-8","type":"file"}`
+	c, _ := newTestClient(t, srv, nil)
+	_, err := c.GetFile(context.Background(), 1, RepoRef{Owner: "x", Name: "y"}, "x", "main")
+	if err == nil || !strings.Contains(err.Error(), "encoding") {
+		t.Errorf("err = %v, want encoding error", err)
+	}
+}
+
+func TestGetFile_CorruptBase64(t *testing.T) {
+	fg, srv := newFakeGitHub(t)
+	fg.getFileBody = `{"path":"x","sha":"a","content":"!!!!","encoding":"base64","type":"file"}`
+	c, _ := newTestClient(t, srv, nil)
+	_, err := c.GetFile(context.Background(), 1, RepoRef{Owner: "x", Name: "y"}, "x", "main")
+	if err == nil || !strings.Contains(err.Error(), "decode content") {
+		t.Errorf("err = %v, want decode error", err)
+	}
+}
+
+func TestGetFile_TokenError(t *testing.T) {
+	_, srv := newFakeGitHub(t)
+	c, _ := newTestClient(t, srv, errors.New("no installation"))
+	_, err := c.GetFile(context.Background(), 1, RepoRef{Owner: "x", Name: "y"}, "x", "main")
+	if err == nil || !strings.Contains(err.Error(), "no installation") {
+		t.Errorf("err = %v, want token error wrapped", err)
+	}
+}
+
+func TestGetFile_ValidationErrors(t *testing.T) {
+	c := New(&stubTokens{})
+	cases := []struct {
+		name      string
+		repo      RepoRef
+		path      string
+		wantSubst string
+	}{
+		{"missing owner", RepoRef{Name: "y"}, "x", "owner and name"},
+		{"missing name", RepoRef{Owner: "x"}, "x", "owner and name"},
+		{"missing path", RepoRef{Owner: "x", Name: "y"}, "", "path required"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := c.GetFile(context.Background(), 1, tc.repo, tc.path, "main")
+			if err == nil || !strings.Contains(err.Error(), tc.wantSubst) {
+				t.Errorf("err = %v, want substring %q", err, tc.wantSubst)
+			}
+		})
+	}
+}
+
+func TestGetWorkflowSpec_DelegatesToCanonicalPath(t *testing.T) {
+	fg, srv := newFakeGitHub(t)
+	fg.getFileBody = `{"path":".fishhawk/workflows.yaml","sha":"feedf00d","content":"YQ==","encoding":"base64","type":"file"}`
+	c, _ := newTestClient(t, srv, nil)
+	got, err := c.GetWorkflowSpec(context.Background(), 42, RepoRef{Owner: "x", Name: "y"}, "main")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.SHA != "feedf00d" {
+		t.Errorf("SHA = %q", got.SHA)
+	}
+	if !strings.Contains(fg.gotPath, ".fishhawk/workflows.yaml") {
+		t.Errorf("path = %q, want canonical workflow path", fg.gotPath)
+	}
+}
+
+func TestDispatchWorkflow_HappyPath(t *testing.T) {
+	fg, srv := newFakeGitHub(t)
+	c, _ := newTestClient(t, srv, nil)
+	err := c.DispatchWorkflow(context.Background(), 42, RepoRef{Owner: "x", Name: "y"},
+		"fishhawk.yml", "main", DispatchInputs{"run_id": "abc-123"})
+	if err != nil {
+		t.Fatalf("DispatchWorkflow: %v", err)
+	}
+	if fg.gotMethod != http.MethodPost {
+		t.Errorf("method = %q", fg.gotMethod)
+	}
+	if !strings.Contains(fg.gotPath, "/actions/workflows/fishhawk.yml/dispatches") {
+		t.Errorf("path = %q", fg.gotPath)
+	}
+	if fg.gotContentType != "application/json" {
+		t.Errorf("Content-Type = %q", fg.gotContentType)
+	}
+	// Body shape: {"ref":"main","inputs":{"run_id":"abc-123"}}
+	var body struct {
+		Ref    string            `json:"ref"`
+		Inputs map[string]string `json:"inputs"`
+	}
+	if err := json.Unmarshal(fg.gotBody, &body); err != nil {
+		t.Fatalf("body unmarshal: %v", err)
+	}
+	if body.Ref != "main" {
+		t.Errorf("ref = %q", body.Ref)
+	}
+	if body.Inputs["run_id"] != "abc-123" {
+		t.Errorf("inputs = %v", body.Inputs)
+	}
+}
+
+func TestDispatchWorkflow_NoInputs(t *testing.T) {
+	fg, srv := newFakeGitHub(t)
+	c, _ := newTestClient(t, srv, nil)
+	if err := c.DispatchWorkflow(context.Background(), 1, RepoRef{Owner: "x", Name: "y"},
+		"fishhawk.yml", "main", nil); err != nil {
+		t.Fatal(err)
+	}
+	// inputs should be omitted when nil.
+	var body map[string]any
+	_ = json.Unmarshal(fg.gotBody, &body)
+	if _, present := body["inputs"]; present {
+		t.Errorf("inputs key present when nil: %v", body)
+	}
+}
+
+func TestDispatchWorkflow_Validation(t *testing.T) {
+	fg, srv := newFakeGitHub(t)
+	fg.dispatchStatus = http.StatusUnprocessableEntity
+	fg.dispatchBody = `{"message":"No ref found"}`
+	c, _ := newTestClient(t, srv, nil)
+	err := c.DispatchWorkflow(context.Background(), 1, RepoRef{Owner: "x", Name: "y"},
+		"fishhawk.yml", "no-such-branch", nil)
+	if !errors.Is(err, ErrValidation) {
+		t.Errorf("err = %v, want ErrValidation", err)
+	}
+}
+
+func TestDispatchWorkflow_NotFound(t *testing.T) {
+	fg, srv := newFakeGitHub(t)
+	fg.dispatchStatus = http.StatusNotFound
+	c, _ := newTestClient(t, srv, nil)
+	err := c.DispatchWorkflow(context.Background(), 1, RepoRef{Owner: "x", Name: "y"},
+		"missing.yml", "main", nil)
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestDispatchWorkflow_ValidationErrors(t *testing.T) {
+	c := New(&stubTokens{})
+	cases := []struct {
+		name      string
+		repo      RepoRef
+		file      string
+		ref       string
+		wantSubst string
+	}{
+		{"missing owner", RepoRef{Name: "y"}, "f.yml", "main", "owner and name"},
+		{"missing file", RepoRef{Owner: "x", Name: "y"}, "", "main", "workflowFile"},
+		{"missing ref", RepoRef{Owner: "x", Name: "y"}, "f.yml", "", "ref required"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := c.DispatchWorkflow(context.Background(), 1, tc.repo, tc.file, tc.ref, nil)
+			if err == nil || !strings.Contains(err.Error(), tc.wantSubst) {
+				t.Errorf("err = %v, want substring %q", err, tc.wantSubst)
+			}
+		})
+	}
+}
+
+func TestDispatchWorkflow_TokenError(t *testing.T) {
+	_, srv := newFakeGitHub(t)
+	c, _ := newTestClient(t, srv, errors.New("install revoked"))
+	err := c.DispatchWorkflow(context.Background(), 1, RepoRef{Owner: "x", Name: "y"},
+		"f.yml", "main", nil)
+	if err == nil || !strings.Contains(err.Error(), "install revoked") {
+		t.Errorf("err = %v", err)
+	}
+}
+
+func TestDispatchWorkflow_NilTokens(t *testing.T) {
+	c := &Client{} // no Tokens
+	err := c.DispatchWorkflow(context.Background(), 1, RepoRef{Owner: "x", Name: "y"},
+		"f.yml", "main", nil)
+	if err == nil || !strings.Contains(err.Error(), "TokenProvider") {
+		t.Errorf("err = %v", err)
+	}
+}
+
+func TestGetFile_NilTokens(t *testing.T) {
+	c := &Client{}
+	_, err := c.GetFile(context.Background(), 1, RepoRef{Owner: "x", Name: "y"}, "x", "main")
+	if err == nil || !strings.Contains(err.Error(), "TokenProvider") {
+		t.Errorf("err = %v", err)
+	}
+}
+
+func TestRepoRef_String(t *testing.T) {
+	if got := (RepoRef{Owner: "x", Name: "y"}).String(); got != "x/y" {
+		t.Errorf("String() = %q", got)
+	}
+}
+
+func TestEscapePath_PreservesSlashes(t *testing.T) {
+	if got := escapePath(".fishhawk/workflows.yaml"); got != ".fishhawk/workflows.yaml" {
+		t.Errorf("escapePath = %q", got)
+	}
+	if got := escapePath("path with spaces/sub.yaml"); got != "path%20with%20spaces/sub.yaml" {
+		t.Errorf("escapePath = %q", got)
+	}
+}
+
+func TestNew_Defaults(t *testing.T) {
+	c := New(&stubTokens{})
+	if c.HTTP.Timeout != 30*time.Second {
+		t.Errorf("Timeout = %v", c.HTTP.Timeout)
+	}
+	if c.BaseURL != "" {
+		t.Errorf("BaseURL = %q, want empty", c.BaseURL)
+	}
+}
+
+func TestEndpoint_DefaultsToGitHub(t *testing.T) {
+	c := &Client{}
+	if got := c.endpoint("/x"); got != DefaultBaseURL+"/x" {
+		t.Errorf("endpoint = %q", got)
+	}
+}
+
+func TestReadBriefBody(t *testing.T) {
+	long := strings.Repeat("a", 1000)
+	got := readBriefBody(strings.NewReader(long))
+	if len(got) != 256 {
+		t.Errorf("len = %d, want 256", len(got))
+	}
+	got2 := readBriefBody(strings.NewReader("  trim  "))
+	if got2 != "trim" {
+		t.Errorf("got = %q, want trim", got2)
+	}
+}

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/kuhlman-labs/fishhawk/backend/internal/audit"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/githubapp"
+	"github.com/kuhlman-labs/fishhawk/backend/internal/githubclient"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/run"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/signing"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/tracestore"
@@ -73,6 +74,12 @@ type Config struct {
 	// it directly today; the webhook dispatcher (#109) is the
 	// first planned reader.
 	GitHubTokens githubapp.TokenProvider
+
+	// GitHub is the typed REST wrapper consumers use for repo
+	// operations (fetching the workflow spec, firing
+	// workflow_dispatch). Built on top of GitHubTokens. Nil when
+	// GitHubTokens is nil.
+	GitHub *githubclient.Client
 }
 
 // Server wraps an http.Server with the routes and middleware stack

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -166,6 +166,7 @@ GitHub OAuth (E4.2 / #49) is the sign-in flow that mints the cookie session. App
 | Trace upload handler | `backend/internal/server/trace.go`; verifies signature, calls `tracestore.Put` + `audit.AppendChained`. S3 wired in `serve.go` from `FISHHAWKD_S3_BUCKET`/`_REGION`/`_ENDPOINT`. |
 | GitHub webhook receiver | `backend/internal/webhook/` (HMAC + dedup) and `backend/internal/server/webhook.go`; secret from `FISHHAWKD_GITHUB_WEBHOOK_SECRET` |
 | GitHub App installation tokens | `backend/internal/githubapp/` (RS256 signer + client + TTL cache + telemetry); App ID + key file from `FISHHAWKD_GITHUB_APP_ID` / `FISHHAWKD_GITHUB_APP_PRIVATE_KEY_FILE` |
+| GitHub REST operations (read workflow spec, fire workflow_dispatch) | `backend/internal/githubclient/`; consumes `githubapp.TokenProvider` |
 | How a new Go module gets added | `CLAUDE.md` "Adding a Go module" |
 
 ## 11. Open work


### PR DESCRIPTION
## Summary

Lays the typed wrapper that #109 (webhook dispatcher) needs: fetching the customer's `.fishhawk/workflows.yaml` and firing `workflow_dispatch`. Both routes are scaffolded on top of the `TokenProvider` from PR #119.

Two methods, one package:

- `GetFile(ctx, installationID, repo, path, ref) → *FileContent` — wraps `GET /repos/{owner}/{repo}/contents/{path}?ref={ref}`. Decodes the base64 content GitHub returns and unwraps its 60-char line wrapping. Path preserved across slashes via per-segment escaping.
- `DispatchWorkflow(ctx, installationID, repo, workflowFile, ref, inputs) → error` — wraps `POST /repos/{owner}/{repo}/actions/workflows/{file}/dispatches` with body `{ref, inputs}`. Returns nil on 204; inputs key omitted when nil.

Plus `GetWorkflowSpec` — a one-line wrapper around `GetFile` keyed to the canonical `.fishhawk/workflows.yaml` path.

**Status mapping:**

| GitHub | Returned |
|---|---|
| 401, 403 | `ErrForbidden` |
| 404 | `ErrNotFound` |
| 422 | `ErrValidation` |
| other | numeric prefix + body excerpt |

`Server.Config` grows `GitHub *githubclient.Client`. Wired in `fishhawkd serve` when the GitHub App is configured. No handler consumes it yet — #109 will.

## Test plan

- [x] `go test -race ./backend/internal/githubclient/...` — 23 tests pass
- [x] `golangci-lint run ./...` across all 4 modules — 0 issues
- [x] Package coverage 94.4%; aggregate (excl. `/db/`) 86.3%
- [x] Stub `TokenProvider` so we test wiring (token forwarding, installation ID forwarding) without the real cache — and a real `httptest.Server` so we test the GitHub interaction shape end-to-end
- [ ] CI passes

## Notes

**Why distinguish ErrForbidden / ErrNotFound / ErrValidation.** GitHub returns 404 for both "doesn't exist" and "you can't see it" by design — we can't distinguish, so the typed error stays neutral. `ErrForbidden` covers 401 (token expired) and 403 (App lacks permission); `ErrValidation` is reserved for 422 (bad ref name, missing required input). Caller-facing audit narratives can switch on these without parsing prose.

**Per-segment URL escaping.** `url.PathEscape(".fishhawk/workflows.yaml")` would escape the slash to `%2F`, which GitHub's contents API interprets as a single directory name and 404s. The custom `escapePath` helper splits on `/`, escapes each segment, and rejoins — preserves multi-segment paths while still escaping spaces / unicode in segment names.

**Base64 line-wrapping.** GitHub's contents API documents base64 but doesn't document the 60-char line wrapping it applies. The handler unwraps newlines before decoding so the decoder sees clean input. Tests exercise both the wrapped and unwrapped forms.

**Spec status.** No new public endpoints. Internal pipe ready for the dispatcher (#109) and any future flow that needs to talk to a customer's repo. The Day 21 demo path is one PR away.

**No follow-up issues.** Package is self-contained; the consumer (#109) is already tracked. PRs that open PRs / comment on issues will add methods here as needed.
