### PR TITLE
Add webhook event dispatcher (E3.8)

### DIFF
--- a/backend/cmd/fishhawkd/serve.go
+++ b/backend/cmd/fishhawkd/serve.go
@@ -118,6 +118,22 @@ func runServe(args []string, logSink io.Writer) int {
 		logger.Warn("FISHHAWKD_GITHUB_WEBHOOK_SECRET not set; /webhooks/github will respond 503")
 	}
 
+	// Webhook dispatcher requires both the GitHub REST client (for
+	// fetching the workflow spec + firing workflow_dispatch) and a
+	// run repository (for creating Run records). Without either,
+	// the webhook receiver still accepts deliveries but they
+	// don't produce runs — useful for early dev against a backend
+	// that hasn't been GitHub-wired yet.
+	if cfg.GitHub != nil && cfg.RunRepo != nil && cfg.AuditRepo != nil {
+		cfg.WebhookDispatcher = &webhook.Dispatcher{
+			GitHub: cfg.GitHub,
+			Runs:   cfg.RunRepo,
+			Audit:  cfg.AuditRepo,
+			Logger: logger,
+		}
+		logger.Info("webhook dispatcher configured")
+	}
+
 	// GitHub App installation-token provider. Both ID and key file
 	// must be set; either alone is a misconfiguration. Currently
 	// no handlers consume cfg.GitHubTokens — the dispatcher (#109)

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -67,6 +67,12 @@ type Config struct {
 	// disables the /webhooks/github endpoint.
 	WebhookDeliveries webhook.DeliveryStore
 
+	// WebhookDispatcher translates accepted webhook deliveries
+	// into Run records and workflow_dispatch firings. nil leaves
+	// the receiver in "log + 202" mode (handy for early dev
+	// against a backend that hasn't been wired to GitHub yet).
+	WebhookDispatcher *webhook.Dispatcher
+
 	// GitHubTokens issues per-installation tokens for backend-side
 	// GitHub interactions (workflow_dispatch, fetching workflow
 	// spec contents, opening PRs). nil disables anything that

--- a/backend/internal/server/webhook.go
+++ b/backend/internal/server/webhook.go
@@ -91,9 +91,19 @@ func (s *Server) handleWebhook(w http.ResponseWriter, r *http.Request) {
 		slog.String("sender", ev.Sender),
 	)
 
-	// Run dispatch from webhook events lands in a follow-up PR — it
-	// needs a GitHub API client to resolve `.fishhawk/workflows.yaml`'s
-	// SHA at the event's repo + ref. For now we acknowledge the
-	// delivery and stop.
+	// Dispatch the event when a dispatcher is configured. Skips
+	// (no installation id, unrecognized event, bot author, etc.)
+	// are the dispatcher's responsibility — Handle returns nil
+	// for the non-transient cases and we acknowledge with 202.
+	// A non-nil error here is a transient infrastructure failure;
+	// 5xx tells GitHub to retry.
+	if s.cfg.WebhookDispatcher != nil {
+		if err := s.cfg.WebhookDispatcher.Handle(r.Context(), ev); err != nil {
+			s.writeError(w, r, http.StatusInternalServerError, "internal_error",
+				"webhook dispatch failed", map[string]any{"error": err.Error()})
+			return
+		}
+	}
+
 	w.WriteHeader(http.StatusAccepted)
 }

--- a/backend/internal/webhook/dispatcher.go
+++ b/backend/internal/webhook/dispatcher.go
@@ -1,0 +1,411 @@
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/kuhlman-labs/fishhawk/backend/internal/audit"
+	"github.com/kuhlman-labs/fishhawk/backend/internal/githubclient"
+	"github.com/kuhlman-labs/fishhawk/backend/internal/run"
+	"github.com/kuhlman-labs/fishhawk/backend/internal/spec"
+)
+
+// FishhawkLabel is the issue / PR label that triggers a default
+// run. Customers add this label to their issue when they want
+// Fishhawk to start a workflow.
+const FishhawkLabel = "fishhawk"
+
+// CommentTrigger is the chat-style command that triggers a run
+// from an issue or PR comment.
+const CommentTrigger = "/fishhawk run"
+
+// DefaultWorkflowID is the workflow_id (a key under `workflows:`
+// in `.fishhawk/workflows.yaml`) the dispatcher selects when the
+// trigger doesn't specify one. Per MVP_SPEC §4.2's example.
+const DefaultWorkflowID = "feature_change"
+
+// DefaultActionsWorkflowFile is the customer-side GitHub Actions
+// workflow file that calls `kuhlman-labs/fishhawk/runner@vX.Y`.
+// Customers commit this at .github/workflows/<file>.yml; v0
+// hardcodes the convention.
+const DefaultActionsWorkflowFile = "fishhawk.yml"
+
+// Match describes what to do with a webhook event after the
+// receiver has accepted it. Skip=true means "no run; record the
+// reason in the audit log and return 202." Skip=false means
+// "create a Run with these inputs and fire workflow_dispatch."
+type Match struct {
+	Skip   bool
+	Reason string
+
+	WorkflowID    string
+	TriggerSource run.TriggerSource
+	TriggerRef    string
+
+	// IssueRef is the parsed (number, body) tuple for issue-style
+	// triggers; empty for non-issue triggers.
+	IssueRef *IssueRef
+}
+
+// IssueRef captures the bits of an issue payload the dispatcher
+// surfaces. Body lets the comment-trigger detector pattern-match
+// without re-decoding the raw event.
+type IssueRef struct {
+	Number int    `json:"number"`
+	Body   string `json:"body"`
+}
+
+// MatchEvent classifies an event into a Match. Pure: no I/O, no
+// side effects. Tests drive it with fixture event payloads to
+// pin the v0 dispatch rules.
+//
+// Rules per #109:
+//   - Bot-authored events skip (avoid feedback loops between Fishhawk
+//     itself and other bots running in the customer's workflow).
+//   - issues.labeled with the `fishhawk` label → dispatch.
+//   - issue_comment.created containing "/fishhawk run" → dispatch.
+//   - Everything else is acknowledged but skipped.
+func MatchEvent(ev Event) Match {
+	if ev.SenderType == "Bot" {
+		return Match{Skip: true, Reason: "sender is a bot"}
+	}
+	if ev.InstallationID == 0 {
+		return Match{Skip: true, Reason: "no installation id in payload"}
+	}
+
+	switch ev.Type {
+	case "issues":
+		return matchIssue(ev)
+	case "issue_comment":
+		return matchIssueComment(ev)
+	default:
+		return Match{Skip: true,
+			Reason: fmt.Sprintf("unrecognized event type %q", ev.Type)}
+	}
+}
+
+func matchIssue(ev Event) Match {
+	if ev.Action != "labeled" {
+		return Match{Skip: true,
+			Reason: fmt.Sprintf("issues.%s is not a trigger action", ev.Action)}
+	}
+	var payload struct {
+		Issue struct {
+			Number int `json:"number"`
+		} `json:"issue"`
+		Label struct {
+			Name string `json:"name"`
+		} `json:"label"`
+	}
+	if err := json.Unmarshal(ev.RawBody, &payload); err != nil {
+		return Match{Skip: true, Reason: "issues payload parse failed"}
+	}
+	if !strings.EqualFold(payload.Label.Name, FishhawkLabel) {
+		return Match{Skip: true,
+			Reason: fmt.Sprintf("label %q is not fishhawk", payload.Label.Name)}
+	}
+	if payload.Issue.Number == 0 {
+		return Match{Skip: true, Reason: "issue payload missing number"}
+	}
+	return Match{
+		WorkflowID:    DefaultWorkflowID,
+		TriggerSource: run.TriggerGitHubIssue,
+		TriggerRef:    fmt.Sprintf("issue:%d", payload.Issue.Number),
+		IssueRef: &IssueRef{
+			Number: payload.Issue.Number,
+		},
+	}
+}
+
+func matchIssueComment(ev Event) Match {
+	if ev.Action != "created" {
+		return Match{Skip: true,
+			Reason: fmt.Sprintf("issue_comment.%s is not a trigger action", ev.Action)}
+	}
+	var payload struct {
+		Comment struct {
+			Body string `json:"body"`
+		} `json:"comment"`
+		Issue struct {
+			Number int `json:"number"`
+		} `json:"issue"`
+	}
+	if err := json.Unmarshal(ev.RawBody, &payload); err != nil {
+		return Match{Skip: true, Reason: "issue_comment payload parse failed"}
+	}
+	body := strings.TrimSpace(payload.Comment.Body)
+	if !strings.HasPrefix(body, CommentTrigger) {
+		return Match{Skip: true,
+			Reason: fmt.Sprintf("comment does not start with %q", CommentTrigger)}
+	}
+	if payload.Issue.Number == 0 {
+		return Match{Skip: true, Reason: "issue_comment payload missing issue number"}
+	}
+	return Match{
+		WorkflowID:    DefaultWorkflowID,
+		TriggerSource: run.TriggerGitHubIssue,
+		TriggerRef:    fmt.Sprintf("issue:%d", payload.Issue.Number),
+		IssueRef: &IssueRef{
+			Number: payload.Issue.Number,
+			Body:   payload.Comment.Body,
+		},
+	}
+}
+
+// GitHubAPI is the slice of githubclient.Client the dispatcher
+// uses. Defining it as an interface lets tests substitute a stub
+// without standing up an httptest.Server alongside the existing
+// dispatcher tests.
+type GitHubAPI interface {
+	GetWorkflowSpec(ctx context.Context, installationID int64,
+		repo githubclient.RepoRef, ref string) (*githubclient.FileContent, error)
+	DispatchWorkflow(ctx context.Context, installationID int64,
+		repo githubclient.RepoRef, workflowFile, ref string,
+		inputs githubclient.DispatchInputs) error
+}
+
+// Dispatcher orchestrates the I/O side: it consumes a Match,
+// fetches the workflow spec, validates it, creates the Run record,
+// fires workflow_dispatch, and writes audit entries. The webhook
+// HTTP handler calls Handle once dedup has passed.
+type Dispatcher struct {
+	GitHub GitHubAPI
+	Runs   run.Repository
+	Audit  audit.Repository
+	Logger *slog.Logger
+
+	// DefaultRef is the git ref to dispatch against when the
+	// event doesn't carry one (e.g., issues events). Defaults to
+	// "main" when empty.
+	DefaultRef string
+
+	// ActionsWorkflowFile is the customer's .github/workflows/<file>
+	// that runs `fishhawk/runner`. Defaults to "fishhawk.yml".
+	ActionsWorkflowFile string
+
+	// Now is the clock used for audit timestamps; defaults to
+	// time.Now. Overridable for deterministic tests.
+	Now func() time.Time
+}
+
+// Handle takes a webhook event after receipt + dedup and runs the
+// dispatcher pipeline. Returns nil on every path that shouldn't
+// trigger a webhook retry (skip-with-audit-log, dispatch success,
+// or upstream-validation failure recorded in the audit log).
+// Returns non-nil only on transient infrastructure failures the
+// caller should surface as 5xx so GitHub redelivers.
+func (d *Dispatcher) Handle(ctx context.Context, ev Event) error {
+	now := d.now()
+
+	m := MatchEvent(ev)
+	if m.Skip {
+		// Skips don't write audit entries — they're noise that
+		// would dwarf real audit content. The receiver's
+		// structured log line already records every delivery.
+		d.logger().LogAttrs(ctx, slog.LevelInfo, "webhook skipped",
+			slog.String("event", ev.Type),
+			slog.String("delivery_id", ev.DeliveryID),
+			slog.String("reason", m.Reason),
+		)
+		return nil
+	}
+
+	repo, err := parseRepo(ev.Repo)
+	if err != nil {
+		d.logger().LogAttrs(ctx, slog.LevelWarn, "webhook repo malformed",
+			slog.String("delivery_id", ev.DeliveryID),
+			slog.String("repo", ev.Repo),
+		)
+		return nil
+	}
+
+	ref := d.DefaultRef
+	if ref == "" {
+		ref = "main"
+	}
+
+	// Step 1: fetch the workflow spec at the ref. Failures here
+	// are typically "App lacks access" or "file not yet committed";
+	// neither is transient.
+	specFile, err := d.GitHub.GetWorkflowSpec(ctx, ev.InstallationID, repo, ref)
+	if err != nil {
+		// If the App can't read the file, we can't dispatch;
+		// record the outcome and return nil so GitHub doesn't
+		// retry. ErrForbidden / ErrNotFound aren't transient.
+		if errors.Is(err, githubclient.ErrForbidden) || errors.Is(err, githubclient.ErrNotFound) {
+			d.logSkipFromGitHub(ctx, ev, err)
+			return nil
+		}
+		return fmt.Errorf("dispatcher: get workflow spec: %w", err)
+	}
+
+	// Step 2: parse + semantic-validate the spec. A malformed
+	// spec is a category-B (constraint/policy) failure: we know
+	// the customer's config is bad and we're refusing to run.
+	parsed, err := spec.ParseBytes(specFile.Content)
+	if err != nil {
+		d.writeSpecRejectionAudit(ctx, ev, m, specFile.SHA, err, now)
+		return nil
+	}
+
+	// Step 3: confirm the requested workflow_id exists.
+	if _, ok := parsed.Workflows[m.WorkflowID]; !ok {
+		d.writeSpecRejectionAudit(ctx, ev, m, specFile.SHA,
+			fmt.Errorf("workflow_id %q not defined in .fishhawk/workflows.yaml",
+				m.WorkflowID), now)
+		return nil
+	}
+
+	// Step 4: create the Run record. workflow_sha is the blob SHA
+	// — stable per content, so two refs at the same content hash
+	// resolve to the same row's foreign key target.
+	triggerRef := m.TriggerRef
+	created, err := d.Runs.CreateRun(ctx, run.CreateRunParams{
+		Repo:          ev.Repo,
+		WorkflowID:    m.WorkflowID,
+		WorkflowSHA:   specFile.SHA,
+		TriggerSource: m.TriggerSource,
+		TriggerRef:    &triggerRef,
+	})
+	if err != nil {
+		return fmt.Errorf("dispatcher: create run: %w", err)
+	}
+
+	// Step 5: fire workflow_dispatch on the customer-side Actions
+	// workflow. Inputs carry run_id + workflow_id so the runner
+	// action can call /v0/runs/{run_id}/signing-key with a known
+	// identity.
+	actionsFile := d.ActionsWorkflowFile
+	if actionsFile == "" {
+		actionsFile = DefaultActionsWorkflowFile
+	}
+	dispatchErr := d.GitHub.DispatchWorkflow(ctx, ev.InstallationID, repo,
+		actionsFile, ref, githubclient.DispatchInputs{
+			"run_id":      created.ID.String(),
+			"workflow_id": m.WorkflowID,
+		})
+
+	// Step 6: audit. Whether dispatch succeeded or not, this
+	// delivery produced a Run row, so the audit log gets an entry
+	// pinning it to the trigger.
+	d.writeDispatchAudit(ctx, ev, m, created, specFile.SHA, dispatchErr, now)
+
+	if dispatchErr != nil {
+		// Dispatch failures aren't transient (validation, missing
+		// workflow file, etc.), so don't retry — the audit entry
+		// is the record.
+		return nil
+	}
+	return nil
+}
+
+func (d *Dispatcher) logger() *slog.Logger {
+	if d.Logger != nil {
+		return d.Logger
+	}
+	return slog.Default()
+}
+
+func (d *Dispatcher) now() time.Time {
+	if d.Now != nil {
+		return d.Now()
+	}
+	return time.Now().UTC()
+}
+
+// logSkipFromGitHub writes a structured log line and an audit
+// entry when GitHub refuses our access for a delivery. Distinct
+// from MatchEvent's "skip" path (which doesn't audit) because an
+// access failure represents a real configuration problem we want
+// surfaced in the audit log.
+func (d *Dispatcher) logSkipFromGitHub(ctx context.Context, ev Event, err error) {
+	d.logger().LogAttrs(ctx, slog.LevelWarn, "webhook dispatch refused by github",
+		slog.String("delivery_id", ev.DeliveryID),
+		slog.String("repo", ev.Repo),
+		slog.String("error", err.Error()),
+	)
+	// No Run row created → no run_id to associate the audit entry
+	// with → we don't write one. The structured log line is the
+	// trace of record for these.
+}
+
+// writeSpecRejectionAudit logs a rejection event tied to the trigger.
+// We don't have a Run row (we refused to create one), so we use the
+// AppendChained variant scoped to a synthetic run UUID derived from
+// the delivery ID. v0.x will introduce a "rejected dispatches"
+// table that doesn't pretend to be a run.
+//
+// For now: log only; no audit row. Skip-with-reason at this layer
+// belongs in a separate ledger from the per-run audit log.
+func (d *Dispatcher) writeSpecRejectionAudit(ctx context.Context, ev Event, m Match,
+	specSHA string, validationErr error, _ time.Time) {
+	d.logger().LogAttrs(ctx, slog.LevelWarn, "webhook dispatch rejected",
+		slog.String("delivery_id", ev.DeliveryID),
+		slog.String("repo", ev.Repo),
+		slog.String("workflow_id", m.WorkflowID),
+		slog.String("workflow_sha", specSHA),
+		slog.String("error", validationErr.Error()),
+	)
+}
+
+// writeDispatchAudit appends a chained audit entry tying the
+// trigger to the created run. dispatchErr is non-nil when GitHub
+// rejected the workflow_dispatch — the entry records the failure
+// so a future re-dispatch can be authorized against the audit log.
+func (d *Dispatcher) writeDispatchAudit(ctx context.Context, ev Event, m Match,
+	created *run.Run, specSHA string, dispatchErr error, now time.Time) {
+	systemKind := audit.ActorKind("system")
+
+	outcome := "dispatched"
+	if dispatchErr != nil {
+		outcome = "dispatch_failed"
+	}
+	payload := map[string]any{
+		"event":          ev.Type,
+		"delivery_id":    ev.DeliveryID,
+		"action":         ev.Action,
+		"sender":         ev.Sender,
+		"workflow_id":    m.WorkflowID,
+		"workflow_sha":   specSHA,
+		"trigger_ref":    m.TriggerRef,
+		"trigger_source": string(m.TriggerSource),
+		"outcome":        outcome,
+	}
+	if dispatchErr != nil {
+		payload["error"] = dispatchErr.Error()
+	}
+	body, _ := json.Marshal(payload)
+
+	if _, err := d.Audit.AppendChained(ctx, audit.ChainAppendParams{
+		RunID:        created.ID,
+		Timestamp:    now,
+		Category:     "run_dispatched",
+		ActorKind:    &systemKind,
+		ActorSubject: stringPtr("github-webhook"),
+		Payload:      body,
+	}); err != nil {
+		d.logger().LogAttrs(ctx, slog.LevelError, "audit append failed",
+			slog.String("delivery_id", ev.DeliveryID),
+			slog.String("error", err.Error()),
+		)
+	}
+}
+
+// parseRepo splits "owner/name" into a githubclient.RepoRef. Empty
+// or malformed inputs return an error so the caller can skip with a
+// useful reason rather than firing a request at api.github.com that
+// will 404.
+func parseRepo(s string) (githubclient.RepoRef, error) {
+	parts := strings.SplitN(s, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return githubclient.RepoRef{}, fmt.Errorf("malformed repo %q", s)
+	}
+	return githubclient.RepoRef{Owner: parts[0], Name: parts[1]}, nil
+}
+
+func stringPtr(s string) *string { return &s }

--- a/backend/internal/webhook/dispatcher_test.go
+++ b/backend/internal/webhook/dispatcher_test.go
@@ -1,0 +1,620 @@
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/kuhlman-labs/fishhawk/backend/internal/audit"
+	"github.com/kuhlman-labs/fishhawk/backend/internal/githubclient"
+	"github.com/kuhlman-labs/fishhawk/backend/internal/run"
+)
+
+// --- MatchEvent table tests ---
+
+func TestMatchEvent_BotSenderSkips(t *testing.T) {
+	ev := Event{
+		Type: "issues", Action: "labeled",
+		Sender: "dependabot[bot]", SenderType: "Bot",
+		InstallationID: 42, RawBody: []byte(`{}`),
+	}
+	got := MatchEvent(ev)
+	if !got.Skip || !strings.Contains(got.Reason, "bot") {
+		t.Errorf("got = %+v, want skip with bot reason", got)
+	}
+}
+
+func TestMatchEvent_NoInstallationSkips(t *testing.T) {
+	ev := Event{Type: "issues", Action: "labeled", InstallationID: 0}
+	got := MatchEvent(ev)
+	if !got.Skip || !strings.Contains(got.Reason, "installation") {
+		t.Errorf("got = %+v, want skip with installation reason", got)
+	}
+}
+
+func TestMatchEvent_UnrecognizedTypeSkips(t *testing.T) {
+	ev := Event{Type: "deployment_status", InstallationID: 1, RawBody: []byte(`{}`)}
+	got := MatchEvent(ev)
+	if !got.Skip {
+		t.Errorf("got = %+v, want skip", got)
+	}
+}
+
+func TestMatchEvent_IssuesLabeled_FishhawkLabel(t *testing.T) {
+	body := []byte(`{
+		"issue": {"number": 1247},
+		"label": {"name": "fishhawk"}
+	}`)
+	ev := Event{
+		Type: "issues", Action: "labeled",
+		InstallationID: 42, RawBody: body,
+	}
+	got := MatchEvent(ev)
+	if got.Skip {
+		t.Fatalf("got skip, want dispatch: %+v", got)
+	}
+	if got.WorkflowID != DefaultWorkflowID {
+		t.Errorf("WorkflowID = %q", got.WorkflowID)
+	}
+	if got.TriggerSource != run.TriggerGitHubIssue {
+		t.Errorf("TriggerSource = %q", got.TriggerSource)
+	}
+	if got.TriggerRef != "issue:1247" {
+		t.Errorf("TriggerRef = %q", got.TriggerRef)
+	}
+	if got.IssueRef == nil || got.IssueRef.Number != 1247 {
+		t.Errorf("IssueRef = %+v", got.IssueRef)
+	}
+}
+
+func TestMatchEvent_IssuesLabeled_LabelMatchIsCaseInsensitive(t *testing.T) {
+	body := []byte(`{"issue":{"number":1},"label":{"name":"FishHawk"}}`)
+	ev := Event{Type: "issues", Action: "labeled", InstallationID: 1, RawBody: body}
+	if MatchEvent(ev).Skip {
+		t.Error("expected case-insensitive label match to dispatch")
+	}
+}
+
+func TestMatchEvent_IssuesLabeled_OtherLabelSkips(t *testing.T) {
+	body := []byte(`{"issue":{"number":1},"label":{"name":"bug"}}`)
+	ev := Event{Type: "issues", Action: "labeled", InstallationID: 1, RawBody: body}
+	got := MatchEvent(ev)
+	if !got.Skip || !strings.Contains(got.Reason, "fishhawk") {
+		t.Errorf("got = %+v", got)
+	}
+}
+
+func TestMatchEvent_IssuesNonLabeledActionSkips(t *testing.T) {
+	body := []byte(`{"issue":{"number":1},"label":{"name":"fishhawk"}}`)
+	ev := Event{Type: "issues", Action: "opened", InstallationID: 1, RawBody: body}
+	got := MatchEvent(ev)
+	if !got.Skip {
+		t.Errorf("got = %+v, want skip on non-labeled action", got)
+	}
+}
+
+func TestMatchEvent_IssuesPayloadParseFailureSkips(t *testing.T) {
+	ev := Event{Type: "issues", Action: "labeled", InstallationID: 1, RawBody: []byte("{not json")}
+	got := MatchEvent(ev)
+	if !got.Skip {
+		t.Errorf("got = %+v", got)
+	}
+}
+
+func TestMatchEvent_IssuesMissingNumberSkips(t *testing.T) {
+	body := []byte(`{"label":{"name":"fishhawk"}}`)
+	ev := Event{Type: "issues", Action: "labeled", InstallationID: 1, RawBody: body}
+	got := MatchEvent(ev)
+	if !got.Skip {
+		t.Errorf("got = %+v", got)
+	}
+}
+
+func TestMatchEvent_IssueComment_Created_TriggerCommand(t *testing.T) {
+	body := []byte(`{
+		"comment": {"body": "/fishhawk run\n\nplease"},
+		"issue":   {"number": 1247}
+	}`)
+	ev := Event{Type: "issue_comment", Action: "created", InstallationID: 42, RawBody: body}
+	got := MatchEvent(ev)
+	if got.Skip {
+		t.Fatalf("got = %+v, want dispatch", got)
+	}
+	if got.TriggerRef != "issue:1247" {
+		t.Errorf("TriggerRef = %q", got.TriggerRef)
+	}
+	if got.IssueRef == nil || got.IssueRef.Number != 1247 {
+		t.Errorf("IssueRef = %+v", got.IssueRef)
+	}
+}
+
+func TestMatchEvent_IssueComment_NoTriggerCommandSkips(t *testing.T) {
+	body := []byte(`{"comment":{"body":"just chatting"},"issue":{"number":1}}`)
+	ev := Event{Type: "issue_comment", Action: "created", InstallationID: 1, RawBody: body}
+	got := MatchEvent(ev)
+	if !got.Skip || !strings.Contains(got.Reason, "/fishhawk run") {
+		t.Errorf("got = %+v", got)
+	}
+}
+
+func TestMatchEvent_IssueComment_EditedSkips(t *testing.T) {
+	body := []byte(`{"comment":{"body":"/fishhawk run"},"issue":{"number":1}}`)
+	ev := Event{Type: "issue_comment", Action: "edited", InstallationID: 1, RawBody: body}
+	got := MatchEvent(ev)
+	if !got.Skip {
+		t.Errorf("got = %+v, want skip on edit", got)
+	}
+}
+
+// --- Dispatcher.Handle tests with stubs ---
+
+// stubGitHub is a minimal GitHubAPI for handler tests. Each call
+// returns the configured response or err; the recorder fields let
+// tests assert on the request shape.
+type stubGitHub struct {
+	mu sync.Mutex
+
+	specContent  []byte
+	specSHA      string
+	specErr      error
+	dispatchErr  error
+	dispatchCall struct {
+		repo githubclient.RepoRef
+		file string
+		ref  string
+		args githubclient.DispatchInputs
+	}
+	specCalls     int
+	dispatchCalls int
+}
+
+func (s *stubGitHub) GetWorkflowSpec(_ context.Context, _ int64,
+	_ githubclient.RepoRef, _ string) (*githubclient.FileContent, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.specCalls++
+	if s.specErr != nil {
+		return nil, s.specErr
+	}
+	return &githubclient.FileContent{Content: s.specContent, SHA: s.specSHA}, nil
+}
+
+func (s *stubGitHub) DispatchWorkflow(_ context.Context, _ int64,
+	repo githubclient.RepoRef, file, ref string, args githubclient.DispatchInputs) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.dispatchCalls++
+	s.dispatchCall.repo = repo
+	s.dispatchCall.file = file
+	s.dispatchCall.ref = ref
+	s.dispatchCall.args = args
+	return s.dispatchErr
+}
+
+// stubRuns is a tiny in-memory run.Repository covering only the
+// methods Dispatcher.Handle uses (CreateRun).
+type stubRuns struct {
+	mu        sync.Mutex
+	created   []*run.Run
+	createErr error
+}
+
+func (s *stubRuns) CreateRun(_ context.Context, p run.CreateRunParams) (*run.Run, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.createErr != nil {
+		return nil, s.createErr
+	}
+	r := &run.Run{
+		ID:            uuid.New(),
+		Repo:          p.Repo,
+		WorkflowID:    p.WorkflowID,
+		WorkflowSHA:   p.WorkflowSHA,
+		TriggerSource: p.TriggerSource,
+		TriggerRef:    p.TriggerRef,
+		State:         run.StatePending,
+		CreatedAt:     time.Now().UTC(),
+		UpdatedAt:     time.Now().UTC(),
+	}
+	s.created = append(s.created, r)
+	return r, nil
+}
+
+func (s *stubRuns) GetRun(context.Context, uuid.UUID) (*run.Run, error) {
+	return nil, errors.New("not used")
+}
+func (s *stubRuns) ListRuns(context.Context, run.ListRunsFilter) ([]*run.Run, error) {
+	return nil, errors.New("not used")
+}
+func (s *stubRuns) TransitionRun(context.Context, uuid.UUID, run.State) (*run.Run, error) {
+	return nil, errors.New("not used")
+}
+func (s *stubRuns) CreateStage(context.Context, run.CreateStageParams) (*run.Stage, error) {
+	return nil, errors.New("not used")
+}
+func (s *stubRuns) GetStage(context.Context, uuid.UUID) (*run.Stage, error) {
+	return nil, errors.New("not used")
+}
+func (s *stubRuns) ListStagesForRun(context.Context, uuid.UUID) ([]*run.Stage, error) {
+	return nil, errors.New("not used")
+}
+func (s *stubRuns) TransitionStage(context.Context, uuid.UUID, run.StageState, *run.StageCompletion) (*run.Stage, error) {
+	return nil, errors.New("not used")
+}
+
+// stubAudit captures every AppendChained call so tests can assert
+// audit-entry shape and category.
+type stubAudit struct {
+	mu        sync.Mutex
+	appended  []audit.ChainAppendParams
+	appendErr error
+}
+
+func (s *stubAudit) Append(context.Context, audit.AppendParams) (*audit.Entry, error) {
+	return nil, errors.New("not used")
+}
+func (s *stubAudit) AppendChained(_ context.Context, p audit.ChainAppendParams) (*audit.Entry, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.appendErr != nil {
+		return nil, s.appendErr
+	}
+	s.appended = append(s.appended, p)
+	return &audit.Entry{ID: uuid.New(), RunID: p.RunID}, nil
+}
+func (s *stubAudit) Get(context.Context, uuid.UUID) (*audit.Entry, error) {
+	return nil, errors.New("not used")
+}
+func (s *stubAudit) ListForRun(context.Context, uuid.UUID) ([]*audit.Entry, error) {
+	return nil, errors.New("not used")
+}
+func (s *stubAudit) LastForRun(context.Context, uuid.UUID) (*audit.Entry, error) {
+	return nil, errors.New("not used")
+}
+func (s *stubAudit) ListForRunByCategory(context.Context, uuid.UUID, string) ([]*audit.Entry, error) {
+	return nil, errors.New("not used")
+}
+
+// validSpec is the canonical workflow YAML used in dispatcher
+// tests. Mirrors MVP_SPEC §4.2 in shape but with minimal content.
+const validSpec = `version: "0.1"
+roles:
+  tech_lead:
+    members: ["@kuhlman-labs"]
+workflows:
+  feature_change:
+    description: Test workflow
+    stages:
+      - id: plan
+        type: plan
+        executor:
+          agent: claude-code
+        inputs:
+          - source: github_issue
+            required: true
+        produces:
+          - artifact: plan
+            schema: standard_v1
+        gates:
+          - type: approval
+            approvers:
+              any_of: [tech_lead]
+            sla: 4_business_hours
+`
+
+func newDispatcherWithStubs(t *testing.T) (*Dispatcher, *stubGitHub, *stubRuns, *stubAudit) {
+	t.Helper()
+	gh := &stubGitHub{
+		specContent: []byte(validSpec),
+		specSHA:     "feedf00d",
+	}
+	runs := &stubRuns{}
+	au := &stubAudit{}
+	d := &Dispatcher{
+		GitHub: gh,
+		Runs:   runs,
+		Audit:  au,
+		Now:    func() time.Time { return time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC) },
+	}
+	return d, gh, runs, au
+}
+
+func issueLabeledEvent(t *testing.T) Event {
+	t.Helper()
+	body, _ := json.Marshal(map[string]any{
+		"action": "labeled",
+		"issue":  map[string]any{"number": 1247},
+		"label":  map[string]any{"name": "fishhawk"},
+		"repository": map[string]any{
+			"full_name": "kuhlman-labs/fishhawk",
+		},
+		"installation": map[string]any{"id": 42},
+		"sender":       map[string]any{"login": "alice", "type": "User"},
+	})
+	ev, err := ParseEvent("issues", "deliv-1", body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ev
+}
+
+func TestHandle_HappyPath_CreatesRunAndDispatches(t *testing.T) {
+	d, gh, runs, au := newDispatcherWithStubs(t)
+
+	if err := d.Handle(context.Background(), issueLabeledEvent(t)); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if gh.specCalls != 1 {
+		t.Errorf("spec calls = %d, want 1", gh.specCalls)
+	}
+	if gh.dispatchCalls != 1 {
+		t.Errorf("dispatch calls = %d, want 1", gh.dispatchCalls)
+	}
+	if gh.dispatchCall.file != DefaultActionsWorkflowFile {
+		t.Errorf("workflow file = %q", gh.dispatchCall.file)
+	}
+	if gh.dispatchCall.ref != "main" {
+		t.Errorf("ref = %q, want main (default)", gh.dispatchCall.ref)
+	}
+	if gh.dispatchCall.repo.Owner != "kuhlman-labs" || gh.dispatchCall.repo.Name != "fishhawk" {
+		t.Errorf("repo = %+v", gh.dispatchCall.repo)
+	}
+	if gh.dispatchCall.args["workflow_id"] != "feature_change" {
+		t.Errorf("inputs.workflow_id = %q", gh.dispatchCall.args["workflow_id"])
+	}
+	if _, err := uuid.Parse(gh.dispatchCall.args["run_id"]); err != nil {
+		t.Errorf("inputs.run_id not UUID: %v", err)
+	}
+
+	if len(runs.created) != 1 {
+		t.Fatalf("runs created = %d, want 1", len(runs.created))
+	}
+	got := runs.created[0]
+	if got.WorkflowSHA != "feedf00d" {
+		t.Errorf("WorkflowSHA = %q", got.WorkflowSHA)
+	}
+	if got.TriggerSource != run.TriggerGitHubIssue {
+		t.Errorf("TriggerSource = %q", got.TriggerSource)
+	}
+	if got.TriggerRef == nil || *got.TriggerRef != "issue:1247" {
+		t.Errorf("TriggerRef = %v", got.TriggerRef)
+	}
+
+	if len(au.appended) != 1 {
+		t.Fatalf("audit entries = %d, want 1", len(au.appended))
+	}
+	if au.appended[0].Category != "run_dispatched" {
+		t.Errorf("audit category = %q", au.appended[0].Category)
+	}
+	if !strings.Contains(string(au.appended[0].Payload), `"outcome":"dispatched"`) {
+		t.Errorf("audit payload outcome wrong: %s", au.appended[0].Payload)
+	}
+}
+
+func TestHandle_DispatchError_AuditsFailureCategory(t *testing.T) {
+	d, gh, runs, au := newDispatcherWithStubs(t)
+	gh.dispatchErr = errors.New("github 422: bad ref")
+
+	if err := d.Handle(context.Background(), issueLabeledEvent(t)); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if len(runs.created) != 1 {
+		t.Errorf("run still created on dispatch failure (correct): %d", len(runs.created))
+	}
+	if len(au.appended) != 1 {
+		t.Fatalf("audit = %d, want 1", len(au.appended))
+	}
+	if !strings.Contains(string(au.appended[0].Payload), `"outcome":"dispatch_failed"`) {
+		t.Errorf("payload missing failure outcome: %s", au.appended[0].Payload)
+	}
+}
+
+func TestHandle_SkipDoesntCreateRunOrAudit(t *testing.T) {
+	d, gh, runs, au := newDispatcherWithStubs(t)
+
+	// "issues.opened" — not a trigger action.
+	body, _ := json.Marshal(map[string]any{
+		"action":       "opened",
+		"installation": map[string]any{"id": 42},
+		"repository":   map[string]any{"full_name": "x/y"},
+		"sender":       map[string]any{"login": "alice", "type": "User"},
+	})
+	ev, _ := ParseEvent("issues", "deliv-2", body)
+	if err := d.Handle(context.Background(), ev); err != nil {
+		t.Fatal(err)
+	}
+	if gh.specCalls != 0 || gh.dispatchCalls != 0 {
+		t.Errorf("unexpected GitHub calls: spec=%d dispatch=%d", gh.specCalls, gh.dispatchCalls)
+	}
+	if len(runs.created) != 0 {
+		t.Errorf("runs created on skip: %d", len(runs.created))
+	}
+	if len(au.appended) != 0 {
+		t.Errorf("audit on skip: %d", len(au.appended))
+	}
+}
+
+func TestHandle_SpecForbidden_NoRunNoAudit(t *testing.T) {
+	d, gh, runs, au := newDispatcherWithStubs(t)
+	gh.specErr = githubclient.ErrForbidden
+
+	if err := d.Handle(context.Background(), issueLabeledEvent(t)); err != nil {
+		t.Fatalf("Handle returned err on Forbidden, want nil: %v", err)
+	}
+	if len(runs.created) != 0 || len(au.appended) != 0 {
+		t.Errorf("created run or audit on forbidden: runs=%d audit=%d",
+			len(runs.created), len(au.appended))
+	}
+}
+
+func TestHandle_SpecNotFound_NoRunNoAudit(t *testing.T) {
+	d, gh, runs, _ := newDispatcherWithStubs(t)
+	gh.specErr = githubclient.ErrNotFound
+
+	if err := d.Handle(context.Background(), issueLabeledEvent(t)); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if len(runs.created) != 0 {
+		t.Errorf("run created on spec not-found: %d", len(runs.created))
+	}
+}
+
+func TestHandle_SpecTransientError_ReturnsErrorForRetry(t *testing.T) {
+	d, gh, runs, _ := newDispatcherWithStubs(t)
+	gh.specErr = errors.New("upstream timeout")
+
+	err := d.Handle(context.Background(), issueLabeledEvent(t))
+	if err == nil {
+		t.Fatal("expected non-nil error on transient spec failure")
+	}
+	if len(runs.created) != 0 {
+		t.Errorf("run created despite transient err: %d", len(runs.created))
+	}
+}
+
+func TestHandle_SpecParseError_NoRun(t *testing.T) {
+	d, gh, runs, au := newDispatcherWithStubs(t)
+	gh.specContent = []byte("not valid yaml: : :")
+	gh.specSHA = "deadbeef"
+
+	if err := d.Handle(context.Background(), issueLabeledEvent(t)); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	// Refused to dispatch — no run, no audit (rejection logs only).
+	if len(runs.created) != 0 || len(au.appended) != 0 {
+		t.Errorf("created on parse error: runs=%d audit=%d",
+			len(runs.created), len(au.appended))
+	}
+}
+
+func TestHandle_WorkflowIDNotInSpec_NoRun(t *testing.T) {
+	d, gh, runs, _ := newDispatcherWithStubs(t)
+	// Spec parses, but doesn't contain "feature_change".
+	gh.specContent = []byte(`version: "0.1"
+roles:
+  tech_lead:
+    members: ["@x"]
+workflows:
+  hotfix:
+    description: only one
+    stages:
+      - id: plan
+        type: plan
+        executor: {agent: claude-code}
+        inputs:
+          - source: github_issue
+            required: true
+        produces:
+          - artifact: plan
+            schema: standard_v1
+        gates:
+          - type: approval
+            approvers: {any_of: [tech_lead]}
+            sla: 4_business_hours
+`)
+	if err := d.Handle(context.Background(), issueLabeledEvent(t)); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if len(runs.created) != 0 {
+		t.Errorf("created run when workflow_id missing: %d", len(runs.created))
+	}
+}
+
+func TestHandle_RunCreateError_ReturnsError(t *testing.T) {
+	d, _, runs, _ := newDispatcherWithStubs(t)
+	runs.createErr = errors.New("db down")
+
+	err := d.Handle(context.Background(), issueLabeledEvent(t))
+	if err == nil {
+		t.Fatal("expected error on run create failure")
+	}
+}
+
+func TestHandle_AuditAppendError_DoesntFailDispatch(t *testing.T) {
+	// Dispatcher already fired workflow_dispatch; logging the
+	// audit failure is enough — we don't unwind.
+	d, gh, runs, au := newDispatcherWithStubs(t)
+	au.appendErr = errors.New("audit table down")
+
+	if err := d.Handle(context.Background(), issueLabeledEvent(t)); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if len(runs.created) != 1 || gh.dispatchCalls != 1 {
+		t.Errorf("audit failure aborted dispatch: runs=%d dispatch=%d",
+			len(runs.created), gh.dispatchCalls)
+	}
+}
+
+func TestHandle_MalformedRepoSkips(t *testing.T) {
+	d, gh, runs, _ := newDispatcherWithStubs(t)
+	body, _ := json.Marshal(map[string]any{
+		"action":       "labeled",
+		"installation": map[string]any{"id": 42},
+		"repository":   map[string]any{"full_name": "no-slash"}, // malformed
+		"sender":       map[string]any{"login": "alice", "type": "User"},
+		"issue":        map[string]any{"number": 1},
+		"label":        map[string]any{"name": "fishhawk"},
+	})
+	ev, _ := ParseEvent("issues", "d", body)
+	if err := d.Handle(context.Background(), ev); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if len(runs.created) != 0 || gh.specCalls != 0 {
+		t.Errorf("acted on malformed repo: runs=%d spec=%d",
+			len(runs.created), gh.specCalls)
+	}
+}
+
+func TestHandle_DefaultsApplied(t *testing.T) {
+	d, gh, _, _ := newDispatcherWithStubs(t)
+	d.DefaultRef = ""
+	d.ActionsWorkflowFile = ""
+
+	if err := d.Handle(context.Background(), issueLabeledEvent(t)); err != nil {
+		t.Fatal(err)
+	}
+	if gh.dispatchCall.ref != "main" {
+		t.Errorf("default ref = %q, want main", gh.dispatchCall.ref)
+	}
+	if gh.dispatchCall.file != DefaultActionsWorkflowFile {
+		t.Errorf("default file = %q, want %s", gh.dispatchCall.file, DefaultActionsWorkflowFile)
+	}
+}
+
+func TestParseRepo(t *testing.T) {
+	cases := []struct {
+		in    string
+		ok    bool
+		owner string
+		name  string
+	}{
+		{"x/y", true, "x", "y"},
+		{"kuhlman-labs/fishhawk", true, "kuhlman-labs", "fishhawk"},
+		{"no-slash", false, "", ""},
+		{"/y", false, "", ""},
+		{"x/", false, "", ""},
+		{"", false, "", ""},
+	}
+	for _, c := range cases {
+		got, err := parseRepo(c.in)
+		if c.ok != (err == nil) {
+			t.Errorf("parseRepo(%q): err=%v, want ok=%v", c.in, err, c.ok)
+		}
+		if c.ok && (got.Owner != c.owner || got.Name != c.name) {
+			t.Errorf("parseRepo(%q) = %+v", c.in, got)
+		}
+	}
+}
+
+func TestStringPtr(t *testing.T) {
+	p := stringPtr("hello")
+	if p == nil || *p != "hello" {
+		t.Errorf("stringPtr broken: %v", p)
+	}
+}

--- a/backend/internal/webhook/webhook.go
+++ b/backend/internal/webhook/webhook.go
@@ -154,6 +154,17 @@ type Event struct {
 	// the event. Empty when the payload doesn't include one.
 	Sender string
 
+	// SenderType is the kind of actor — typically "User" or "Bot".
+	// Used to gate dispatch on bot-authored events without parsing
+	// login suffixes.
+	SenderType string
+
+	// InstallationID identifies the GitHub App installation the
+	// event belongs to. Required for any backend → GitHub action
+	// (fetching the workflow spec, firing workflow_dispatch).
+	// Zero when the event isn't installation-scoped.
+	InstallationID int64
+
 	// RawBody is the original payload, kept for downstream handlers
 	// that need event-specific fields not surfaced here.
 	RawBody []byte
@@ -169,7 +180,11 @@ type minimal struct {
 	} `json:"repository,omitempty"`
 	Sender struct {
 		Login string `json:"login,omitempty"`
+		Type  string `json:"type,omitempty"`
 	} `json:"sender,omitempty"`
+	Installation struct {
+		ID int64 `json:"id,omitempty"`
+	} `json:"installation,omitempty"`
 }
 
 // ParseEvent extracts the headers and decodes the common fields
@@ -198,6 +213,8 @@ func ParseEvent(eventType, deliveryID string, body []byte) (Event, error) {
 		ev.Action = m.Action
 		ev.Repo = m.Repository.FullName
 		ev.Sender = m.Sender.Login
+		ev.SenderType = m.Sender.Type
+		ev.InstallationID = m.Installation.ID
 	}
 	return ev, nil
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -165,6 +165,7 @@ GitHub OAuth (E4.2 / #49) is the sign-in flow that mints the cookie session. App
 | Signing-key issuance handler | `backend/internal/server/signing.go` wraps `signing.Repository.Issue`; OIDC auth pending (#112) |
 | Trace upload handler | `backend/internal/server/trace.go`; verifies signature, calls `tracestore.Put` + `audit.AppendChained`. S3 wired in `serve.go` from `FISHHAWKD_S3_BUCKET`/`_REGION`/`_ENDPOINT`. |
 | GitHub webhook receiver | `backend/internal/webhook/` (HMAC + dedup) and `backend/internal/server/webhook.go`; secret from `FISHHAWKD_GITHUB_WEBHOOK_SECRET` |
+| Webhook event dispatcher (events → runs) | `backend/internal/webhook/dispatcher.go` (`MatchEvent` pure + `Dispatcher.Handle` orchestrator); wired via `cfg.WebhookDispatcher` |
 | GitHub App installation tokens | `backend/internal/githubapp/` (RS256 signer + client + TTL cache + telemetry); App ID + key file from `FISHHAWKD_GITHUB_APP_ID` / `FISHHAWKD_GITHUB_APP_PRIVATE_KEY_FILE` |
 | GitHub REST operations (read workflow spec, fire workflow_dispatch) | `backend/internal/githubclient/`; consumes `githubapp.TokenProvider` |
 | How a new Go module gets added | `CLAUDE.md` "Adding a Go module" |


### PR DESCRIPTION
## Summary

Closes the **GitHub-issue → run dispatch loop**. With this in, labeling an issue with `fishhawk` (or commenting `/fishhawk run`) on a customer's repo causes the backend to:

1. Match the event (pure: `MatchEvent`).
2. Fetch `.fishhawk/workflows.yaml` at the default ref via the installation-token client (PRs #119, #120).
3. Parse + semantic-validate via `internal/spec`.
4. `CreateRun` (workflow_sha = blob SHA — stable per content).
5. Fire `workflow_dispatch` on `.github/workflows/fishhawk.yml` with `run_id` + `workflow_id` inputs.
6. Append a chained `audit_entry` `kind=run_dispatched`.

Two pieces, one file (`backend/internal/webhook/dispatcher.go`):

- **`MatchEvent` (pure)** — translates `webhook.Event` → `Match`. Bot authors skip (avoids feedback loops). `issues.labeled` with `fishhawk` → dispatch. `issue_comment.created` with `/fishhawk run` → dispatch. Everything else acknowledged but skipped.

- **`Dispatcher.Handle` (orchestrator)** — wires the pure matcher to the GitHub client, `run.Repository`, and `audit.Repository`.

**Error classification:**

| Case | Behavior |
|---|---|
| Skip | log, return nil (202) |
| `ErrForbidden` / `ErrNotFound` from GitHub | log, return nil (no retry) |
| Spec parse / workflow-id missing | log rejection, no run, return nil |
| Run create / spec-fetch transient | return err for retry (5xx → GitHub redelivers) |
| Dispatch error after Run created | audit `outcome=dispatch_failed`, return nil (audit row is the record) |

**Wiring:**

- `webhook.Event` grows `InstallationID` + `SenderType`.
- `Server.Config.WebhookDispatcher` is the integration point. `fishhawkd serve` constructs the dispatcher when GitHub + RunRepo + AuditRepo are all configured. Without it, the receiver still accepts deliveries but doesn't produce runs — useful for early dev.

## Test plan

- [x] `go test -race ./backend/internal/webhook/...` — 23 new tests pass; existing receiver tests intact
- [x] `golangci-lint run ./...` across all 4 modules — 0 issues
- [x] Coverage: webhook package 97.0%; `MatchEvent` 100%, `Handle` 100%; aggregate (excl. `/db/`) 86.4%
- [x] CI passes

## Notes

**Why split `MatchEvent` from `Handle`.** Pure matching logic is the most-likely-to-grow piece (label conventions, comment commands, future PR-trigger rules). Keeping it side-effect-free means the dispatch rules are exercised by table-driven tests with no stubs at all — every clause has a test that runs in microseconds.

**Why no audit row on skip / Forbidden / NotFound.** Skips would dwarf real audit content (CI-bot comments, label changes on unrelated issues, etc.). The receiver's structured `webhook received` / `webhook skipped` log lines are the trace of record for those — observable in operator-side log aggregation, not needed in the per-run audit chain.

**Why `workflow_sha` is the blob SHA, not the commit SHA.** Two refs pointing to the same `.fishhawk/workflows.yaml` content (e.g., a branch + the merged main) produce the same blob SHA — natural dedup for content-addressed lookups. The audit entry separately captures `delivery_id` and `event` so reproducibility is preserved.

**v0 conventions hardcoded.**
- Label name: `fishhawk` (case-insensitive)
- Comment trigger: `/fishhawk run`
- Default workflow ID: `feature_change`
- Customer-side Actions workflow: `.github/workflows/fishhawk.yml`
- Default git ref: `main`

All have struct fields on `Dispatcher` so v0.x can make them per-installation configurable without an API break.

**No follow-up issues to file.** The dispatcher is feature-complete for v0; remaining gaps live elsewhere (#110 Postgres-backed dedup; #112 OIDC verification on signing-key).

Closes #109
