### PR TITLE
Add stage + artifact GET handlers

### DIFF
--- a/backend/cmd/fishhawkd/serve.go
+++ b/backend/cmd/fishhawkd/serve.go
@@ -17,6 +17,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/kuhlman-labs/fishhawk/backend/internal/approval"
+	"github.com/kuhlman-labs/fishhawk/backend/internal/artifact"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/audit"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/githubapp"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/githubclient"
@@ -78,7 +79,8 @@ func runServe(args []string, logSink io.Writer) int {
 		cfg.SigningRepo = signing.NewPostgresRepository(pool)
 		cfg.AuditRepo = audit.NewPostgresRepository(pool)
 		cfg.ApprovalRepo = approval.NewPostgresRepository(pool)
-		logger.Info("run + signing + audit + approval repositories configured", slog.String("driver", "postgres"))
+		cfg.ArtifactRepo = artifact.NewPostgresRepository(pool)
+		logger.Info("repositories configured (run + signing + audit + approval + artifact)", slog.String("driver", "postgres"))
 	} else {
 		logger.Warn("FISHHAWKD_DATABASE_URL not set; /v0/runs and /v0/runs/{id}/signing-key endpoints will respond 503")
 	}

--- a/backend/internal/server/handlers.go
+++ b/backend/internal/server/handlers.go
@@ -21,7 +21,10 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /v0/runs/{run_id}/audit", s.handleListRunAudit)
 	mux.HandleFunc("POST /v0/runs/{run_id}/signing-key", s.handleIssueSigningKey)
 	mux.HandleFunc("POST /v0/runs/{run_id}/trace", s.handleShipTrace)
+	mux.HandleFunc("GET /v0/stages/{stage_id}", s.handleGetStage)
+	mux.HandleFunc("GET /v0/stages/{stage_id}/artifacts", s.handleListStageArtifacts)
 	mux.HandleFunc("POST /v0/stages/{stage_id}/approvals", s.handleSubmitApproval)
+	mux.HandleFunc("GET /v0/artifacts/{artifact_id}", s.handleGetArtifact)
 	mux.HandleFunc("POST /webhooks/github", s.handleWebhook)
 }
 

--- a/backend/internal/server/reads.go
+++ b/backend/internal/server/reads.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/kuhlman-labs/fishhawk/backend/internal/artifact"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/audit"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/run"
 )
@@ -96,6 +97,125 @@ func (s *Server) handleListRunStages(w http.ResponseWriter, r *http.Request) {
 		items = append(items, toStageResponse(st))
 	}
 	s.writeJSON(w, r, http.StatusOK, map[string]any{"items": items})
+}
+
+// handleGetStage implements GET /v0/stages/{stage_id}. Returns
+// the canonical Stage shape from docs/api/v0.openapi.yaml.
+func (s *Server) handleGetStage(w http.ResponseWriter, r *http.Request) {
+	if s.cfg.RunRepo == nil {
+		s.writeError(w, r, http.StatusServiceUnavailable, "run_repo_unconfigured",
+			"stage endpoint requires a configured run repository", nil)
+		return
+	}
+	stageID, err := uuid.Parse(r.PathValue("stage_id"))
+	if err != nil {
+		s.writeError(w, r, http.StatusBadRequest, "validation_failed",
+			"stage_id must be a valid UUID",
+			map[string]any{"field": "stage_id", "got": r.PathValue("stage_id")})
+		return
+	}
+	got, err := s.cfg.RunRepo.GetStage(r.Context(), stageID)
+	if err != nil {
+		if errors.Is(err, run.ErrNotFound) {
+			s.writeError(w, r, http.StatusNotFound, "stage_not_found",
+				"no stage with that id", map[string]any{"stage_id": stageID.String()})
+			return
+		}
+		s.writeError(w, r, http.StatusInternalServerError, "internal_error",
+			"get stage failed", map[string]any{"error": err.Error()})
+		return
+	}
+	s.writeJSON(w, r, http.StatusOK, toStageResponse(got))
+}
+
+// artifactResponse mirrors docs/api/v0.openapi.yaml's `Artifact`
+// schema. Like the Stage / AuditEntry envelopes, this is built
+// explicitly rather than json-tagged on the internal type.
+type artifactResponse struct {
+	ID            uuid.UUID       `json:"id"`
+	StageID       uuid.UUID       `json:"stage_id"`
+	Kind          string          `json:"kind"`
+	SchemaVersion *string         `json:"schema_version"`
+	ContentHash   string          `json:"content_hash"`
+	Content       json.RawMessage `json:"content,omitempty"`
+	CreatedAt     time.Time       `json:"created_at"`
+}
+
+func toArtifactResponse(a *artifact.Artifact) artifactResponse {
+	return artifactResponse{
+		ID:            a.ID,
+		StageID:       a.StageID,
+		Kind:          string(a.Kind),
+		SchemaVersion: a.SchemaVersion,
+		ContentHash:   a.ContentHash,
+		Content:       a.Content,
+		CreatedAt:     a.CreatedAt,
+	}
+}
+
+// handleListStageArtifacts implements GET /v0/stages/{stage_id}/artifacts.
+// Returns artifacts ordered by created_at ascending. We don't 404
+// when the stage exists but has zero artifacts — empty list is the
+// honest answer.
+//
+// We do NOT verify the stage exists first; ListForStage returns an
+// empty slice for unknown IDs and the round-trip-saving wins. If
+// callers care about the distinction they can hit GET /stages/{id}.
+func (s *Server) handleListStageArtifacts(w http.ResponseWriter, r *http.Request) {
+	if s.cfg.ArtifactRepo == nil {
+		s.writeError(w, r, http.StatusServiceUnavailable, "artifact_repo_unconfigured",
+			"artifacts endpoint requires a configured artifact repository", nil)
+		return
+	}
+	stageID, err := uuid.Parse(r.PathValue("stage_id"))
+	if err != nil {
+		s.writeError(w, r, http.StatusBadRequest, "validation_failed",
+			"stage_id must be a valid UUID",
+			map[string]any{"field": "stage_id", "got": r.PathValue("stage_id")})
+		return
+	}
+	rows, err := s.cfg.ArtifactRepo.ListForStage(r.Context(), stageID)
+	if err != nil {
+		s.writeError(w, r, http.StatusInternalServerError, "internal_error",
+			"list artifacts failed", map[string]any{"error": err.Error()})
+		return
+	}
+	items := make([]artifactResponse, 0, len(rows))
+	for _, a := range rows {
+		items = append(items, toArtifactResponse(a))
+	}
+	s.writeJSON(w, r, http.StatusOK, map[string]any{"items": items})
+}
+
+// handleGetArtifact implements GET /v0/artifacts/{artifact_id}.
+// Returns the artifact (including content) or 404. v0.x will add a
+// "?include=metadata-only" query for clients that don't want the
+// content payload.
+func (s *Server) handleGetArtifact(w http.ResponseWriter, r *http.Request) {
+	if s.cfg.ArtifactRepo == nil {
+		s.writeError(w, r, http.StatusServiceUnavailable, "artifact_repo_unconfigured",
+			"artifact endpoint requires a configured artifact repository", nil)
+		return
+	}
+	id, err := uuid.Parse(r.PathValue("artifact_id"))
+	if err != nil {
+		s.writeError(w, r, http.StatusBadRequest, "validation_failed",
+			"artifact_id must be a valid UUID",
+			map[string]any{"field": "artifact_id", "got": r.PathValue("artifact_id")})
+		return
+	}
+	got, err := s.cfg.ArtifactRepo.Get(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, artifact.ErrNotFound) {
+			s.writeError(w, r, http.StatusNotFound, "artifact_not_found",
+				"no artifact with that id", map[string]any{"artifact_id": id.String()})
+			return
+		}
+		s.writeError(w, r, http.StatusInternalServerError, "internal_error",
+			"get artifact failed", map[string]any{"error": err.Error()})
+		return
+	}
+	s.writeJSON(w, r, http.StatusOK, toArtifactResponse(got))
 }
 
 // auditEntryResponse mirrors docs/api/v0.openapi.yaml's

--- a/backend/internal/server/reads_test.go
+++ b/backend/internal/server/reads_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/kuhlman-labs/fishhawk/backend/internal/artifact"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/audit"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/run"
 )
@@ -143,6 +144,311 @@ func TestListRunStages_RepoError(t *testing.T) {
 	s := New(Config{Addr: "127.0.0.1:0", RunRepo: repo})
 	req := httptest.NewRequest(http.MethodGet,
 		fmt.Sprintf("/v0/runs/%s/stages", uuid.New()), nil)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", w.Code)
+	}
+}
+
+// --- Stage detail handler ---
+
+func TestGetStage_HappyPath(t *testing.T) {
+	repo := newStagesRunRepo()
+	runID := uuid.New()
+	now := time.Date(2026, 5, 3, 10, 0, 0, 0, time.UTC)
+	stageID := uuid.New()
+	repo.stages[runID] = []*run.Stage{{
+		ID: stageID, RunID: runID, Sequence: 0, Type: run.StageTypePlan,
+		ExecutorKind: run.ExecutorAgent, ExecutorRef: "claude-code",
+		State: run.StageStateAwaitingApproval, CreatedAt: now, UpdatedAt: now,
+	}}
+	// stagesRunRepo's GetStage isn't implemented; extend the
+	// fake by direct map lookup. Build a small adapter.
+	s := New(Config{Addr: "127.0.0.1:0", RunRepo: &stageGetRepo{stagesRunRepo: repo}})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet,
+		fmt.Sprintf("/v0/stages/%s", stageID), nil)
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200:\n%s", w.Code, w.Body.String())
+	}
+	var got stageResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != stageID {
+		t.Errorf("ID = %s", got.ID)
+	}
+	if got.State != string(run.StageStateAwaitingApproval) {
+		t.Errorf("State = %q", got.State)
+	}
+}
+
+// stageGetRepo extends stagesRunRepo with a working GetStage so the
+// handler test can resolve stages.
+type stageGetRepo struct {
+	*stagesRunRepo
+}
+
+func (r *stageGetRepo) GetStage(_ context.Context, id uuid.UUID) (*run.Stage, error) {
+	for _, list := range r.stages {
+		for _, st := range list {
+			if st.ID == id {
+				return st, nil
+			}
+		}
+	}
+	return nil, run.ErrNotFound
+}
+
+func TestGetStage_NotFound(t *testing.T) {
+	s := New(Config{Addr: "127.0.0.1:0", RunRepo: &stageGetRepo{stagesRunRepo: newStagesRunRepo()}})
+	req := httptest.NewRequest(http.MethodGet,
+		fmt.Sprintf("/v0/stages/%s", uuid.New()), nil)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestGetStage_BadUUID(t *testing.T) {
+	s := New(Config{Addr: "127.0.0.1:0", RunRepo: &stageGetRepo{stagesRunRepo: newStagesRunRepo()}})
+	req := httptest.NewRequest(http.MethodGet, "/v0/stages/not-a-uuid", nil)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestGetStage_NilRepo(t *testing.T) {
+	s := New(Config{Addr: "127.0.0.1:0"})
+	req := httptest.NewRequest(http.MethodGet,
+		fmt.Sprintf("/v0/stages/%s", uuid.New()), nil)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", w.Code)
+	}
+}
+
+// --- Artifact handlers ---
+
+// fakeArtifactRepo is the in-memory artifact.Repository for handler
+// tests. The other Repository methods (Create, GetByHash) aren't
+// touched by the read handlers, so they return "not used" errors.
+type fakeArtifactRepo struct {
+	mu       sync.Mutex
+	all      []*artifact.Artifact
+	listErr  error
+	getErr   error
+	notFound bool
+}
+
+func newFakeArtifactRepo() *fakeArtifactRepo {
+	return &fakeArtifactRepo{}
+}
+
+func (f *fakeArtifactRepo) Create(_ context.Context, _ artifact.CreateParams) (*artifact.Artifact, error) {
+	return nil, errors.New("not used")
+}
+
+func (f *fakeArtifactRepo) Get(_ context.Context, id uuid.UUID) (*artifact.Artifact, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	if f.notFound {
+		return nil, artifact.ErrNotFound
+	}
+	for _, a := range f.all {
+		if a.ID == id {
+			return a, nil
+		}
+	}
+	return nil, artifact.ErrNotFound
+}
+
+func (f *fakeArtifactRepo) ListForStage(_ context.Context, stageID uuid.UUID) ([]*artifact.Artifact, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	var out []*artifact.Artifact
+	for _, a := range f.all {
+		if a.StageID == stageID {
+			out = append(out, a)
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeArtifactRepo) GetByHash(_ context.Context, _ uuid.UUID, _ string) (*artifact.Artifact, error) {
+	return nil, errors.New("not used")
+}
+
+func samplePlanArtifact(stageID uuid.UUID) *artifact.Artifact {
+	v := "standard_v1"
+	return &artifact.Artifact{
+		ID:            uuid.New(),
+		StageID:       stageID,
+		Kind:          artifact.KindPlan,
+		SchemaVersion: &v,
+		Content:       json.RawMessage(`{"plan_version":"standard_v1"}`),
+		ContentHash:   "abc123",
+		CreatedAt:     time.Now().UTC(),
+	}
+}
+
+func TestListStageArtifacts_HappyPath(t *testing.T) {
+	repo := newFakeArtifactRepo()
+	stageID := uuid.New()
+	repo.all = []*artifact.Artifact{samplePlanArtifact(stageID), samplePlanArtifact(stageID)}
+	s := New(Config{Addr: "127.0.0.1:0", ArtifactRepo: repo})
+
+	req := httptest.NewRequest(http.MethodGet,
+		fmt.Sprintf("/v0/stages/%s/artifacts", stageID), nil)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var got struct {
+		Items []artifactResponse `json:"items"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &got)
+	if len(got.Items) != 2 {
+		t.Errorf("items = %d, want 2", len(got.Items))
+	}
+}
+
+func TestListStageArtifacts_EmptyForUnknownStage(t *testing.T) {
+	// We don't 404 — empty list is the honest answer (stage might
+	// exist but have produced nothing yet).
+	repo := newFakeArtifactRepo()
+	s := New(Config{Addr: "127.0.0.1:0", ArtifactRepo: repo})
+	req := httptest.NewRequest(http.MethodGet,
+		fmt.Sprintf("/v0/stages/%s/artifacts", uuid.New()), nil)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", w.Code)
+	}
+}
+
+func TestListStageArtifacts_BadUUID(t *testing.T) {
+	s := New(Config{Addr: "127.0.0.1:0", ArtifactRepo: newFakeArtifactRepo()})
+	req := httptest.NewRequest(http.MethodGet, "/v0/stages/not-a-uuid/artifacts", nil)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestListStageArtifacts_NilRepo(t *testing.T) {
+	s := New(Config{Addr: "127.0.0.1:0"})
+	req := httptest.NewRequest(http.MethodGet,
+		fmt.Sprintf("/v0/stages/%s/artifacts", uuid.New()), nil)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", w.Code)
+	}
+}
+
+func TestListStageArtifacts_RepoError(t *testing.T) {
+	repo := newFakeArtifactRepo()
+	repo.listErr = errors.New("db down")
+	s := New(Config{Addr: "127.0.0.1:0", ArtifactRepo: repo})
+	req := httptest.NewRequest(http.MethodGet,
+		fmt.Sprintf("/v0/stages/%s/artifacts", uuid.New()), nil)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", w.Code)
+	}
+}
+
+func TestGetArtifact_HappyPath(t *testing.T) {
+	repo := newFakeArtifactRepo()
+	a := samplePlanArtifact(uuid.New())
+	repo.all = []*artifact.Artifact{a}
+	s := New(Config{Addr: "127.0.0.1:0", ArtifactRepo: repo})
+
+	req := httptest.NewRequest(http.MethodGet,
+		fmt.Sprintf("/v0/artifacts/%s", a.ID), nil)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d:\n%s", w.Code, w.Body.String())
+	}
+	var got artifactResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != a.ID {
+		t.Errorf("ID = %s", got.ID)
+	}
+	if got.Kind != string(artifact.KindPlan) {
+		t.Errorf("Kind = %q", got.Kind)
+	}
+	if got.SchemaVersion == nil || *got.SchemaVersion != "standard_v1" {
+		t.Errorf("SchemaVersion = %v", got.SchemaVersion)
+	}
+	if !strings.Contains(string(got.Content), "standard_v1") {
+		t.Errorf("Content not preserved: %s", got.Content)
+	}
+}
+
+func TestGetArtifact_NotFound(t *testing.T) {
+	repo := newFakeArtifactRepo()
+	repo.notFound = true
+	s := New(Config{Addr: "127.0.0.1:0", ArtifactRepo: repo})
+	req := httptest.NewRequest(http.MethodGet,
+		fmt.Sprintf("/v0/artifacts/%s", uuid.New()), nil)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), `"artifact_not_found"`) {
+		t.Errorf("body missing artifact_not_found: %s", w.Body.String())
+	}
+}
+
+func TestGetArtifact_BadUUID(t *testing.T) {
+	s := New(Config{Addr: "127.0.0.1:0", ArtifactRepo: newFakeArtifactRepo()})
+	req := httptest.NewRequest(http.MethodGet, "/v0/artifacts/not-a-uuid", nil)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestGetArtifact_NilRepo(t *testing.T) {
+	s := New(Config{Addr: "127.0.0.1:0"})
+	req := httptest.NewRequest(http.MethodGet,
+		fmt.Sprintf("/v0/artifacts/%s", uuid.New()), nil)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", w.Code)
+	}
+}
+
+func TestGetArtifact_RepoError(t *testing.T) {
+	repo := newFakeArtifactRepo()
+	repo.getErr = errors.New("db down")
+	s := New(Config{Addr: "127.0.0.1:0", ArtifactRepo: repo})
+	req := httptest.NewRequest(http.MethodGet,
+		fmt.Sprintf("/v0/artifacts/%s", uuid.New()), nil)
 	w := httptest.NewRecorder()
 	s.Handler().ServeHTTP(w, req)
 	if w.Code != http.StatusInternalServerError {

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/kuhlman-labs/fishhawk/backend/internal/approval"
+	"github.com/kuhlman-labs/fishhawk/backend/internal/artifact"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/audit"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/githubapp"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/githubclient"
@@ -61,6 +62,11 @@ type Config struct {
 	// ApprovalRepo persists gate decisions. Wired by
 	// POST /v0/stages/{id}/approvals; nil leaves it 503.
 	ApprovalRepo approval.Repository
+
+	// ArtifactRepo persists typed stage outputs (plans, PR refs).
+	// Wired by GET /v0/stages/{id}/artifacts and
+	// GET /v0/artifacts/{id}; nil leaves both 503.
+	ArtifactRepo artifact.Repository
 
 	// GitHubWebhookSecret is the shared secret GitHub uses to
 	// HMAC-sign webhook deliveries. Empty disables the

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -167,6 +167,7 @@ GitHub OAuth (E4.2 / #49) is the sign-in flow that mints the cookie session. App
 | GitHub webhook receiver | `backend/internal/webhook/` (HMAC + dedup) and `backend/internal/server/webhook.go`; secret from `FISHHAWKD_GITHUB_WEBHOOK_SECRET` |
 | Webhook event dispatcher (events → runs + stages) | `backend/internal/webhook/dispatcher.go` (`MatchEvent` pure + `Dispatcher.Handle` orchestrator); wired via `cfg.WebhookDispatcher`. Creates one `Stage` row per spec-stage definition; first stage transitions to `dispatched` on workflow_dispatch. |
 | Approval state management (`POST /v0/stages/{id}/approvals`) | `backend/internal/approval/` + `backend/internal/server/approvals.go`. approve → succeeded; reject → failed-D. Idempotent on (stage_id, approver_subject). SLA timeout deferred to #123. |
+| Stage detail + artifact reads | `backend/internal/server/reads.go`: `GET /v0/stages/{id}`, `GET /v0/stages/{id}/artifacts`, `GET /v0/artifacts/{id}` |
 | GitHub App installation tokens | `backend/internal/githubapp/` (RS256 signer + client + TTL cache + telemetry); App ID + key file from `FISHHAWKD_GITHUB_APP_ID` / `FISHHAWKD_GITHUB_APP_PRIVATE_KEY_FILE` |
 | GitHub REST operations (read workflow spec, fire workflow_dispatch) | `backend/internal/githubclient/`; consumes `githubapp.TokenProvider` |
 | How a new Go module gets added | `CLAUDE.md` "Adding a Go module" |


### PR DESCRIPTION
## Summary

Three new read endpoints round out the read surface for the demo path; clients (CLI, future UI) can now inspect any stage and any artifact a stage produced:

- `GET /v0/stages/{stage_id}` — wraps `RunRepo.GetStage`
- `GET /v0/stages/{stage_id}/artifacts` — wraps `ArtifactRepo.ListForStage`
- `GET /v0/artifacts/{artifact_id}` — wraps `ArtifactRepo.Get`

`artifactResponse` mirrors the OpenAPI `Artifact` schema verbatim (id, stage_id, kind, schema_version, content_hash, content, created_at). `content` is included in the response — clients fetching a plan need it to render. v0.x can add a `?include=metadata-only` query when callers want the envelope without the payload.

`Server.Config.ArtifactRepo` is the integration point. `fishhawkd serve` constructs it alongside the existing repos when `FISHHAWKD_DATABASE_URL` is set.

## Test plan

- [x] `go test -race ./backend/...` — 13 new tests pass alongside existing suite
- [x] `golangci-lint run ./...` across all 4 modules — 0 issues
- [x] Coverage: `handleListStageArtifacts` 100%, `handleGetArtifact` 100%, `handleGetStage` 86.7%, server pkg 92.8%, aggregate (excl. `/db/`) 86.8%
- [x] CI passes

## Notes

**Design choices.**
- `ListForStage` on an unknown stage returns 200 with `items=[]`, not 404. Empty list is the honest answer — the stage might exist but produced nothing yet; 404-on-no-rows would force a separate `GET /v0/stages/{id}` call to disambiguate.
- `handleGetStage` and `handleGetArtifact` 404 on missing rows; `artifact_not_found` is a stable code clients can switch on.
- Same shared error-envelope shape as the rest of the surface.
- Wire format built explicitly in response structs (rather than json-tagged on the internal types) so an internal representation change can't accidentally leak through.

**13-case matrix:**
- stage detail: happy path, 404, 400 bad UUID, 503 nil repo
- artifact list: happy path (multiple), empty for unknown stage, 400 bad UUID, 500 repo error, 503 nil repo
- artifact detail: happy path (with content + schema_version), 404, 400 bad UUID, 500 repo error, 503 nil repo

**Spec status.** 14 of 19 endpoints in `docs/api/v0.openapi.yaml` now have implementations. Remaining: `/v0/auth/*` (login, callback, me, logout) and `/v0/tokens/*` — all depend on E4.1 (#48) GitHub App registration + E4.2 (#49) OAuth + E4.5 (#51) tokens.

**No follow-up issues to file.** All write-side gaps remaining (subsequent-stage orchestration, OIDC on signing-key, SLA timer, postgres webhook dedup) are tracked in #109 follow-ups #112, #110, #123. This PR is purely additive on the read side.
