### PR TITLE
Trace upload advances stage to awaiting_approval

### DIFF
--- a/backend/internal/server/trace.go
+++ b/backend/internal/server/trace.go
@@ -7,12 +7,14 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"log/slog"
 	"net/http"
 	"time"
 
 	"github.com/google/uuid"
 
 	"github.com/kuhlman-labs/fishhawk/backend/internal/audit"
+	"github.com/kuhlman-labs/fishhawk/backend/internal/run"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/signing"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/tracestore"
 )
@@ -165,12 +167,63 @@ func (s *Server) handleShipTrace(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Advance the stage so the approval handler can act on it.
+	// The state machine requires dispatched → running →
+	// awaiting_approval; we walk both transitions here because
+	// the runner's trace upload IS the "started executing"
+	// signal in v0 (the runner doesn't separately check in).
+	//
+	// v0 hardcodes every agent stage as gated (per MVP_SPEC
+	// §4.2's example); the gateless case (running → succeeded
+	// directly) lands when the workflow spec carries a
+	// per-stage `gates: []` signal.
+	//
+	// We only attempt transitions when the RunRepo is wired —
+	// trace upload doesn't strictly require it (signing +
+	// tracestore are the load-bearing deps), so a deployment
+	// that's not yet on Postgres still accepts uploads.
+	//
+	// Failures here are logged but don't unwind the upload: the
+	// trace is already stored + audited; a stuck stage is
+	// surface-able via GET /v0/runs/{id}/stages and recoverable
+	// via a follow-up call once the orchestrator wraps this.
+	if s.cfg.RunRepo != nil {
+		s.advanceStageAfterTrace(r, runID, stageID)
+	}
+
 	s.writeJSON(w, r, http.StatusAccepted, traceUploadResponse{
 		RunID:       runID,
 		StageID:     stageID,
 		Variant:     string(variant),
 		ContentHash: contentHash,
 	})
+}
+
+// advanceStageAfterTrace walks dispatched → running →
+// awaiting_approval. Each step is idempotent (the state machine
+// allows same-state re-application), so a redelivered trace upload
+// or a parallel transition path doesn't fault. Errors at either
+// step log but don't unwind.
+func (s *Server) advanceStageAfterTrace(r *http.Request, runID, stageID uuid.UUID) {
+	if _, err := s.cfg.RunRepo.TransitionStage(r.Context(), stageID,
+		run.StageStateRunning, nil); err != nil {
+		s.cfg.Logger.LogAttrs(r.Context(), slog.LevelWarn,
+			"trace upload: transition to running failed",
+			slog.String("run_id", runID.String()),
+			slog.String("stage_id", stageID.String()),
+			slog.String("error", err.Error()),
+		)
+		return
+	}
+	if _, err := s.cfg.RunRepo.TransitionStage(r.Context(), stageID,
+		run.StageStateAwaitingApproval, nil); err != nil {
+		s.cfg.Logger.LogAttrs(r.Context(), slog.LevelWarn,
+			"trace upload: transition to awaiting_approval failed",
+			slog.String("run_id", runID.String()),
+			slog.String("stage_id", stageID.String()),
+			slog.String("error", err.Error()),
+		)
+	}
 }
 
 func sha256Hex(b []byte) string {

--- a/backend/internal/server/trace_test.go
+++ b/backend/internal/server/trace_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/kuhlman-labs/fishhawk/backend/internal/audit"
+	"github.com/kuhlman-labs/fishhawk/backend/internal/run"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/signing"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/tracestore"
 )
@@ -406,6 +407,68 @@ func TestShipTrace_NilDepsConfigured(t *testing.T) {
 				t.Errorf("status = %d, want 503", w.Code)
 			}
 		})
+	}
+}
+
+func TestShipTrace_TransitionsStageToAwaitingApproval(t *testing.T) {
+	// Wire a RunRepo seeded with a stage in dispatched, ship a
+	// trace, and confirm the stage advanced to awaiting_approval
+	// so the approval handler can act on it next.
+	s, sf, _, _ := newTraceServer(t)
+	rr := newApprovalRunRepo()
+	stage := rr.seedStage(run.StageStateDispatched)
+	s.cfg.RunRepo = rr // inject after construction; New is the only setup we needed
+
+	priv, _ := sf.issue(t, stage.RunID)
+	w := shipRequest(t, s, stage.RunID, stage.ID, "raw", priv, []byte("b"), "")
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d:\n%s", w.Code, w.Body.String())
+	}
+	if rr.stages[stage.ID].State != run.StageStateAwaitingApproval {
+		t.Errorf("stage state = %q, want awaiting_approval",
+			rr.stages[stage.ID].State)
+	}
+	// Two-step walk: dispatched → running → awaiting_approval.
+	if len(rr.transitions) != 2 {
+		t.Fatalf("transitions = %d, want 2:\n%+v", len(rr.transitions), rr.transitions)
+	}
+	if rr.transitions[0].To != run.StageStateRunning ||
+		rr.transitions[1].To != run.StageStateAwaitingApproval {
+		t.Errorf("transitions = %+v, want [running, awaiting_approval]", rr.transitions)
+	}
+}
+
+func TestShipTrace_TransitionFailureDoesntUnwindUpload(t *testing.T) {
+	// If the post-upload transition errors (e.g., stage already
+	// terminal because of a concurrent path), we log + return 202
+	// — the trace itself is already stored and audited. A stuck
+	// stage is surface-able via GET /v0/runs/{id}/stages.
+	s, sf, _, _ := newTraceServer(t)
+	rr := newApprovalRunRepo()
+	rr.transitionErr = errors.New("state machine refusal")
+	stage := rr.seedStage(run.StageStateDispatched)
+	s.cfg.RunRepo = rr
+
+	priv, _ := sf.issue(t, stage.RunID)
+	w := shipRequest(t, s, stage.RunID, stage.ID, "raw", priv, []byte("b"), "")
+	if w.Code != http.StatusAccepted {
+		t.Errorf("status = %d, want 202 (transition failure must not unwind)", w.Code)
+	}
+}
+
+func TestShipTrace_NoRunRepo_StillAccepts(t *testing.T) {
+	// A backend deployed without a Postgres run repository should
+	// still accept trace uploads; only the post-upload transition
+	// gets skipped. This keeps the trace endpoint useful for
+	// minimal smoke deployments before run-state is wired.
+	s, sf, _, _ := newTraceServer(t)
+	// Don't wire RunRepo.
+	runID := uuid.New()
+	stageID := uuid.New()
+	priv, _ := sf.issue(t, runID)
+	w := shipRequest(t, s, runID, stageID, "raw", priv, []byte("b"), "")
+	if w.Code != http.StatusAccepted {
+		t.Errorf("status = %d, want 202", w.Code)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes the demo-stuck-after-trace gap. Until this PR, the trace upload handler stored the bundle + wrote the audit entry but left the stage in `dispatched` forever — the approval handler then 409'd because `dispatched → succeeded` isn't a valid transition.

After trace stored + audit appended, the handler now walks `dispatched → running → awaiting_approval`. Two transitions because the state machine in `run/transition.go` requires the intermediate `running` state; the runner's trace upload IS the "started executing" signal in v0 (the runner doesn't separately check in).

## Test plan

- [x] `go test -race ./backend/...` — 3 new server tests + existing suite
- [x] `golangci-lint run ./...` — 0 issues
- [x] Coverage: server pkg 92.7%, `handleShipTrace` 94.1%, `advanceStageAfterTrace` 80%, aggregate (excl. `/db/`) 86.8%
- [x] CI passes

## Notes

**v0 hardcodes every agent stage as gated** (per `MVP_SPEC.md §4.2`'s example). The gateless case (`running → succeeded` directly) lands when the workflow spec carries a per-stage `gates: []` signal — that needs the orchestrator next-stage-dispatch piece (the next PR) to be coherent end-to-end.

**Failure handling.** If either transition errors, we log + return 202 anyway. The trace is already stored and audited; a stuck stage surfaces via `GET /v0/runs/{id}/stages` and is recoverable once the orchestrator wraps the next-stage-dispatch logic. A redelivered trace (same `delivery_id` makes it past the runner's retry loop) hits the state machine's idempotent same-state path.

**The RunRepo dependency is opt-in.** A deployment without Postgres still accepts trace uploads — `signing` + `tracestore` are the load-bearing deps for upload integrity. This keeps the trace endpoint usable for minimal smoke deployments before run-state is wired.

**3-case matrix.**
- Happy path: trace upload → both transitions fire in order → stage state = `awaiting_approval`
- Transition error → log warning, return 202 (trace not unwound)
- No `RunRepo` configured → upload accepted, transitions skipped

**Up next.** Orchestrator package wiring "after stage N transitions to `succeeded`, dispatch stage N+1." The approval handler's call site now has somewhere meaningful to go after this PR; without #126, the demo stops at `awaiting_approval` (still better than `dispatched`, but not multi-stage).

**No follow-up issues to file.** The orchestrator and the gateless-stage handling are tracked elsewhere (this thread + the spec/parsing future-work).
