### PR TITLE
Add backend policy evaluator (E3.4)

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.16
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.100.1
 	github.com/aws/smithy-go v1.25.1
+	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.9.2

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -42,6 +42,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.42.1 h1:F/M5Y9I3nwr2IEpshZgh1GeHpOIt
 github.com/aws/aws-sdk-go-v2/service/sts v1.42.1/go.mod h1:mTNxImtovCOEEuD65mKW7DCsL+2gjEH+RPEAexAzAio=
 github.com/aws/smithy-go v1.25.1 h1:J8ERsGSU7d+aCmdQur5Txg6bVoYelvQJgtZehD12GkI=
 github.com/aws/smithy-go v1.25.1/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
+github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=
+github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/backend/internal/policy/audit.go
+++ b/backend/internal/policy/audit.go
@@ -1,0 +1,95 @@
+package policy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/kuhlman-labs/fishhawk/backend/internal/audit"
+)
+
+// CategoryPolicyEvaluated is the audit-log category for the chained
+// entry produced by EmitEvaluation. Static so log scrapers and the
+// compliance export can index on it.
+const CategoryPolicyEvaluated = "policy_evaluated"
+
+// EvaluationPayload is the JSON shape of the audit entry's payload
+// for a policy evaluation. The full constraint config, the
+// resulting violation set, and a derived `passed` boolean are
+// included so the audit entry is self-contained — a reader doesn't
+// need to cross-reference the workflow spec to interpret it.
+type EvaluationPayload struct {
+	StageType  string      `json:"stage_type,omitempty"`
+	Diff       []DiffEntry `json:"diff"`
+	Applied    Constraints `json:"applied_constraints"`
+	Violations []Violation `json:"violations"`
+	Passed     bool        `json:"passed"`
+}
+
+// DiffEntry is the per-file shape that lands in the payload. Mirrors
+// ChangedFile but with json tags pinned for the audit on-wire format.
+type DiffEntry struct {
+	Path   string `json:"path"`
+	Status Status `json:"status"`
+}
+
+// EmitEvaluation runs Evaluate against the diff + constraints and
+// writes a single chained audit entry recording the full result.
+// Returns the violations so the caller can decide whether to
+// transition the stage to failed (one or more violations → category
+// B per MVP_SPEC §6).
+//
+// The audit category is constant ("policy_evaluated"); the per-file
+// and per-violation detail lives in the payload. Writing one entry
+// per evaluation rather than one per violation keeps the chain
+// compact and lets a reader see "what was checked" alongside "what
+// failed."
+//
+// actorSubject is optional and identifies the agent or user whose
+// stage output was evaluated; nil leaves it unset.
+func EmitEvaluation(
+	ctx context.Context,
+	repo audit.Repository,
+	runID uuid.UUID,
+	stageID uuid.UUID,
+	stageType string,
+	diff Diff,
+	constraints Constraints,
+	actorSubject *string,
+) ([]Violation, error) {
+	violations := Evaluate(diff, constraints)
+
+	entries := make([]DiffEntry, 0, len(diff.ChangedFiles))
+	for _, f := range diff.ChangedFiles {
+		entries = append(entries, DiffEntry(f))
+	}
+
+	payload, err := json.Marshal(EvaluationPayload{
+		StageType:  stageType,
+		Diff:       entries,
+		Applied:    constraints,
+		Violations: append([]Violation(nil), violations...),
+		Passed:     len(violations) == 0,
+	})
+	if err != nil {
+		return violations, fmt.Errorf("policy: marshal audit payload: %w", err)
+	}
+
+	systemKind := audit.ActorSystem
+	if _, err := repo.AppendChained(ctx, audit.ChainAppendParams{
+		RunID:        runID,
+		StageID:      &stageID,
+		Timestamp:    time.Now().UTC(),
+		Category:     CategoryPolicyEvaluated,
+		ActorKind:    &systemKind,
+		ActorSubject: actorSubject,
+		Payload:      payload,
+	}); err != nil {
+		return violations, fmt.Errorf("policy: append audit entry: %w", err)
+	}
+
+	return violations, nil
+}

--- a/backend/internal/policy/audit_test.go
+++ b/backend/internal/policy/audit_test.go
@@ -1,0 +1,219 @@
+package policy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/kuhlman-labs/fishhawk/backend/internal/audit"
+)
+
+// fakeAuditRepo is the minimum surface EmitEvaluation needs. We
+// don't exercise the full Repository interface here — the chained
+// append path is covered by audit/postgres_test.go via testcontainers.
+type fakeAuditRepo struct {
+	appendChainedErr error
+	captured         audit.ChainAppendParams
+	called           int
+}
+
+func (f *fakeAuditRepo) Append(ctx context.Context, p audit.AppendParams) (*audit.Entry, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeAuditRepo) AppendChained(ctx context.Context, p audit.ChainAppendParams) (*audit.Entry, error) {
+	f.called++
+	f.captured = p
+	if f.appendChainedErr != nil {
+		return nil, f.appendChainedErr
+	}
+	return &audit.Entry{
+		ID:        uuid.New(),
+		Sequence:  1,
+		RunID:     p.RunID,
+		StageID:   p.StageID,
+		Timestamp: p.Timestamp,
+		Category:  p.Category,
+		ActorKind: p.ActorKind,
+		Payload:   p.Payload,
+		EntryHash: "deadbeef",
+	}, nil
+}
+
+func (f *fakeAuditRepo) Get(ctx context.Context, id uuid.UUID) (*audit.Entry, error) {
+	return nil, audit.ErrNotFound
+}
+
+func (f *fakeAuditRepo) ListForRun(ctx context.Context, runID uuid.UUID) ([]*audit.Entry, error) {
+	return nil, nil
+}
+
+func (f *fakeAuditRepo) LastForRun(ctx context.Context, runID uuid.UUID) (*audit.Entry, error) {
+	return nil, audit.ErrNotFound
+}
+
+func (f *fakeAuditRepo) ListForRunByCategory(ctx context.Context, runID uuid.UUID, category string) ([]*audit.Entry, error) {
+	return nil, nil
+}
+
+func TestEmitEvaluation_Pass(t *testing.T) {
+	repo := &fakeAuditRepo{}
+	runID := uuid.New()
+	stageID := uuid.New()
+
+	violations, err := EmitEvaluation(
+		context.Background(), repo, runID, stageID,
+		"implement",
+		diff("backend/main.go", "backend/main_test.go"),
+		Constraints{
+			ForbiddenPaths:   []string{"infra/**"},
+			MaxFilesChanged:  10,
+			RequiredOutcomes: []string{"tests_added_or_updated"},
+		},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("EmitEvaluation: %v", err)
+	}
+	if len(violations) != 0 {
+		t.Errorf("expected no violations, got %+v", violations)
+	}
+	if repo.called != 1 {
+		t.Fatalf("expected 1 audit append, got %d", repo.called)
+	}
+	if repo.captured.Category != CategoryPolicyEvaluated {
+		t.Errorf("category = %q, want %q", repo.captured.Category, CategoryPolicyEvaluated)
+	}
+	if repo.captured.RunID != runID {
+		t.Errorf("RunID mismatch")
+	}
+	if repo.captured.StageID == nil || *repo.captured.StageID != stageID {
+		t.Errorf("StageID mismatch")
+	}
+
+	var got EvaluationPayload
+	if err := json.Unmarshal(repo.captured.Payload, &got); err != nil {
+		t.Fatalf("payload unmarshal: %v", err)
+	}
+	if !got.Passed {
+		t.Errorf("Passed = false, want true")
+	}
+	if got.StageType != "implement" {
+		t.Errorf("StageType = %q", got.StageType)
+	}
+	if len(got.Diff) != 2 {
+		t.Errorf("Diff len = %d, want 2", len(got.Diff))
+	}
+	if got.Applied.MaxFilesChanged != 10 {
+		t.Errorf("Applied.MaxFilesChanged round-trip failed: %d", got.Applied.MaxFilesChanged)
+	}
+}
+
+func TestEmitEvaluation_Violations(t *testing.T) {
+	repo := &fakeAuditRepo{}
+	runID := uuid.New()
+	stageID := uuid.New()
+
+	violations, err := EmitEvaluation(
+		context.Background(), repo, runID, stageID,
+		"implement",
+		diff("infra/main.tf", "backend/main.go"),
+		Constraints{
+			ForbiddenPaths:   []string{"infra/**"},
+			RequiredOutcomes: []string{"tests_added_or_updated"},
+		},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("EmitEvaluation: %v", err)
+	}
+	if len(violations) != 2 {
+		t.Fatalf("expected 2 violations (forbidden + tests), got %+v", violations)
+	}
+
+	var got EvaluationPayload
+	if err := json.Unmarshal(repo.captured.Payload, &got); err != nil {
+		t.Fatalf("payload unmarshal: %v", err)
+	}
+	if got.Passed {
+		t.Errorf("Passed = true, want false")
+	}
+	if len(got.Violations) != 2 {
+		t.Errorf("payload.Violations len = %d", len(got.Violations))
+	}
+}
+
+func TestEmitEvaluation_ActorSubjectPropagated(t *testing.T) {
+	repo := &fakeAuditRepo{}
+	runID := uuid.New()
+	stageID := uuid.New()
+	subject := "claude-code@anthropic"
+
+	if _, err := EmitEvaluation(
+		context.Background(), repo, runID, stageID,
+		"plan",
+		diff("docs/plan.md"),
+		Constraints{},
+		&subject,
+	); err != nil {
+		t.Fatalf("EmitEvaluation: %v", err)
+	}
+	if repo.captured.ActorSubject == nil || *repo.captured.ActorSubject != subject {
+		t.Errorf("ActorSubject = %v, want %q", repo.captured.ActorSubject, subject)
+	}
+	if repo.captured.ActorKind == nil || *repo.captured.ActorKind != audit.ActorSystem {
+		t.Errorf("ActorKind = %v, want system", repo.captured.ActorKind)
+	}
+}
+
+func TestEmitEvaluation_AppendError(t *testing.T) {
+	repo := &fakeAuditRepo{appendChainedErr: errors.New("db down")}
+	runID := uuid.New()
+	stageID := uuid.New()
+
+	violations, err := EmitEvaluation(
+		context.Background(), repo, runID, stageID,
+		"implement",
+		diff("a.go"),
+		Constraints{},
+		nil,
+	)
+	if err == nil {
+		t.Fatal("expected error from append")
+	}
+	// Even on append failure the caller should still see the
+	// computed violations so it can decide locally what to do.
+	if len(violations) != 0 {
+		t.Errorf("violations = %+v", violations)
+	}
+}
+
+func TestEmitEvaluation_EmptyDiff(t *testing.T) {
+	repo := &fakeAuditRepo{}
+	runID := uuid.New()
+	stageID := uuid.New()
+
+	if _, err := EmitEvaluation(
+		context.Background(), repo, runID, stageID,
+		"plan",
+		Diff{},
+		Constraints{MaxFilesChanged: 5},
+		nil,
+	); err != nil {
+		t.Fatalf("EmitEvaluation: %v", err)
+	}
+
+	var got EvaluationPayload
+	if err := json.Unmarshal(repo.captured.Payload, &got); err != nil {
+		t.Fatalf("payload unmarshal: %v", err)
+	}
+	if len(got.Diff) != 0 {
+		t.Errorf("Diff = %+v, want empty", got.Diff)
+	}
+	if !got.Passed {
+		t.Errorf("Passed = false, want true on empty diff with no constraints")
+	}
+}

--- a/backend/internal/policy/policy.go
+++ b/backend/internal/policy/policy.go
@@ -1,0 +1,310 @@
+// Package policy evaluates the closed set of workflow-spec
+// constraints (forbidden_paths, allowed_paths, max_files_changed,
+// required_outcomes) against a stage's actual output. One or more
+// violations means the stage failed as category-B (constraint /
+// policy violation) per MVP_SPEC §6.
+//
+// This package is the backend's source of truth. The runner runs
+// the same checks in-line (runner/internal/constraint) so the
+// agent gets immediate feedback, but the runner is operating on
+// a customer machine and its report alone is not auditable. The
+// backend re-evaluates every uploaded trace using this package
+// and writes the result as a chained audit entry — that audit
+// entry is what's quoted in compliance exports.
+//
+// Glob semantics follow gitignore-style: `**` matches any number
+// of path segments, `*` matches within a segment, leading `/` is
+// implicit (paths are repo-relative). Implementation delegates to
+// github.com/bmatcuk/doublestar/v4.
+package policy
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/bmatcuk/doublestar/v4"
+)
+
+// Status is the per-file change kind. Values mirror the single
+// letter `git diff --name-status` emits, so the runner's parsed
+// diff round-trips through the trace bundle into this package
+// without translation.
+type Status string
+
+// Status letter values mirroring `git diff --name-status` output.
+const (
+	StatusAdded    Status = "A"
+	StatusModified Status = "M"
+	StatusDeleted  Status = "D"
+	StatusRenamed  Status = "R"
+	StatusCopied   Status = "C"
+	StatusTypeChg  Status = "T"
+)
+
+// ChangedFile is one row of a stage's diff. Path is repo-relative
+// and uses forward slashes regardless of platform.
+type ChangedFile struct {
+	Path   string
+	Status Status
+}
+
+// Diff is the input to Evaluate: every file the stage touched, in
+// any order. An empty Diff is itself meaningful for some stages
+// (e.g. plan stages that aren't supposed to change source).
+type Diff struct {
+	ChangedFiles []ChangedFile
+}
+
+// Constraints is the parsed shape of the workflow-spec stage's
+// `constraints` block. Zero values mean "this constraint isn't
+// configured" — Evaluate skips them.
+type Constraints struct {
+	// ForbiddenPaths: any changed file matching ANY pattern is a
+	// violation. Patterns are gitignore-style globs.
+	ForbiddenPaths []string
+	// AllowedPaths: every changed file MUST match at least one
+	// pattern. A file matching none is a violation.
+	AllowedPaths []string
+	// MaxFilesChanged: 0 means "no limit"; otherwise the diff's
+	// file count must be <= this value.
+	MaxFilesChanged int
+	// RequiredOutcomes: closed set per the schema —
+	// "tests_added_or_updated", "ci_green".
+	RequiredOutcomes []string
+	// CIGreen is what an upstream signal said about the customer
+	// CI's outcome. Required only if RequiredOutcomes contains
+	// "ci_green"; nil when no signal is available yet — in which
+	// case the constraint is treated as a violation rather than
+	// silently passing (MVP_SPEC §6: honesty about gaps beats
+	// fictional completeness).
+	CIGreen *bool
+}
+
+// Violation is one constraint failure. Constraint names match the
+// workflow-spec keys so log scrapers and the audit log can index
+// on them. Detail is human-readable; Files lists offending paths
+// when relevant.
+type Violation struct {
+	Constraint string   `json:"constraint"`
+	Detail     string   `json:"detail"`
+	Files      []string `json:"files,omitempty"`
+}
+
+func (v Violation) String() string {
+	if len(v.Files) == 0 {
+		return fmt.Sprintf("%s: %s", v.Constraint, v.Detail)
+	}
+	return fmt.Sprintf("%s: %s [%s]", v.Constraint, v.Detail, strings.Join(v.Files, ", "))
+}
+
+// Evaluate runs every configured constraint against the diff and
+// returns the list of violations in deterministic order (constraint
+// name, then file). An empty slice means the diff satisfies every
+// constraint.
+//
+// Bad glob patterns produce a Violation with Detail = "invalid
+// pattern …" rather than crashing; the audit entry surfaces the
+// typo so the workflow-spec author can fix it without reading
+// backend logs.
+func Evaluate(diff Diff, c Constraints) []Violation {
+	var out []Violation
+
+	if len(c.ForbiddenPaths) > 0 {
+		out = append(out, checkForbidden(diff, c.ForbiddenPaths)...)
+	}
+	if len(c.AllowedPaths) > 0 {
+		out = append(out, checkAllowed(diff, c.AllowedPaths)...)
+	}
+	if c.MaxFilesChanged > 0 {
+		out = append(out, checkMaxFiles(diff, c.MaxFilesChanged)...)
+	}
+	if len(c.RequiredOutcomes) > 0 {
+		out = append(out, checkRequiredOutcomes(diff, c.RequiredOutcomes, c.CIGreen)...)
+	}
+
+	return out
+}
+
+func checkForbidden(diff Diff, patterns []string) []Violation {
+	var v []Violation
+	for _, pat := range patterns {
+		hit := matchAny(diff, pat)
+		if hit.invalidPattern {
+			v = append(v, Violation{
+				Constraint: "forbidden_paths",
+				Detail:     fmt.Sprintf("invalid pattern %q", pat),
+			})
+			continue
+		}
+		if len(hit.matched) > 0 {
+			v = append(v, Violation{
+				Constraint: "forbidden_paths",
+				Detail:     fmt.Sprintf("pattern %q matched", pat),
+				Files:      hit.matched,
+			})
+		}
+	}
+	return v
+}
+
+func checkAllowed(diff Diff, patterns []string) []Violation {
+	// A file is allowed if ANY pattern matches. The violation list
+	// names every file that matched none.
+	var bad []string
+	var hadInvalid bool
+	for _, f := range diff.ChangedFiles {
+		matched := false
+		for _, pat := range patterns {
+			ok, err := doublestar.PathMatch(pat, f.Path)
+			if err != nil {
+				hadInvalid = true
+				continue
+			}
+			if ok {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			bad = append(bad, f.Path)
+		}
+	}
+	var out []Violation
+	if hadInvalid {
+		out = append(out, Violation{
+			Constraint: "allowed_paths",
+			Detail:     "one or more patterns invalid",
+		})
+	}
+	if len(bad) > 0 {
+		out = append(out, Violation{
+			Constraint: "allowed_paths",
+			Detail:     "files outside allowed patterns",
+			Files:      bad,
+		})
+	}
+	return out
+}
+
+func checkMaxFiles(diff Diff, maxFiles int) []Violation {
+	if len(diff.ChangedFiles) <= maxFiles {
+		return nil
+	}
+	return []Violation{{
+		Constraint: "max_files_changed",
+		Detail:     fmt.Sprintf("changed %d files; limit %d", len(diff.ChangedFiles), maxFiles),
+	}}
+}
+
+func checkRequiredOutcomes(diff Diff, outcomes []string, ciGreen *bool) []Violation {
+	var v []Violation
+	for _, o := range outcomes {
+		switch o {
+		case "tests_added_or_updated":
+			if !diffTouchesTests(diff) {
+				v = append(v, Violation{
+					Constraint: "required_outcomes",
+					Detail:     "no test files added or updated",
+				})
+			}
+		case "ci_green":
+			// Same semantics as the runner: nil signal records the
+			// gap honestly rather than passing silently. The
+			// orchestrator can re-evaluate once the CI signal lands.
+			if ciGreen == nil {
+				v = append(v, Violation{
+					Constraint: "required_outcomes",
+					Detail:     "ci_green required but no signal available",
+				})
+			} else if !*ciGreen {
+				v = append(v, Violation{
+					Constraint: "required_outcomes",
+					Detail:     "ci is not green",
+				})
+			}
+		default:
+			// The schema enum bounds this; defense-in-depth catches
+			// drift between schema and code.
+			v = append(v, Violation{
+				Constraint: "required_outcomes",
+				Detail:     fmt.Sprintf("unknown outcome %q", o),
+			})
+		}
+	}
+	return v
+}
+
+func diffTouchesTests(diff Diff) bool {
+	for _, f := range diff.ChangedFiles {
+		if f.Status == StatusDeleted {
+			continue
+		}
+		if isTestPath(f.Path) {
+			return true
+		}
+	}
+	return false
+}
+
+func isTestPath(p string) bool {
+	low := strings.ToLower(p)
+	switch {
+	case strings.HasSuffix(low, "_test.go"): // Go
+		return true
+	case strings.HasSuffix(low, ".test.ts"),
+		strings.HasSuffix(low, ".test.tsx"),
+		strings.HasSuffix(low, ".test.js"),
+		strings.HasSuffix(low, ".test.jsx"),
+		strings.HasSuffix(low, ".spec.ts"),
+		strings.HasSuffix(low, ".spec.tsx"),
+		strings.HasSuffix(low, ".spec.js"),
+		strings.HasSuffix(low, ".spec.jsx"): // JS / TS
+		return true
+	case strings.HasPrefix(low, "tests/") ||
+		strings.Contains(low, "/tests/") ||
+		strings.HasPrefix(low, "test/") ||
+		strings.Contains(low, "/test/"): // Python / Rust / C++ test directories
+		return true
+	case strings.HasSuffix(low, "_test.py"),
+		strings.HasPrefix(filepathBase(low), "test_"): // Python
+		return true
+	case strings.Contains(low, "/spec/"): // Ruby / Elixir
+		return true
+	}
+	return false
+}
+
+func filepathBase(p string) string {
+	if i := strings.LastIndex(p, "/"); i >= 0 {
+		return p[i+1:]
+	}
+	return p
+}
+
+// matchResult collects the per-pattern outcome of a forbidden-paths
+// check. invalidPattern is true when doublestar rejected the
+// pattern itself (separate from "valid pattern matched no files").
+type matchResult struct {
+	matched        []string
+	invalidPattern bool
+}
+
+func matchAny(diff Diff, pattern string) matchResult {
+	// Validate the pattern once against an empty path so we can
+	// distinguish "bad pattern" from "pattern matched nothing."
+	if _, err := doublestar.PathMatch(pattern, ""); err != nil {
+		return matchResult{invalidPattern: true}
+	}
+	var r matchResult
+	for _, f := range diff.ChangedFiles {
+		ok, err := doublestar.PathMatch(pattern, f.Path)
+		if err != nil {
+			r.invalidPattern = true
+			continue
+		}
+		if ok {
+			r.matched = append(r.matched, f.Path)
+		}
+	}
+	return r
+}

--- a/backend/internal/policy/policy_test.go
+++ b/backend/internal/policy/policy_test.go
@@ -1,0 +1,257 @@
+package policy
+
+import (
+	"strings"
+	"testing"
+)
+
+func diff(files ...string) Diff {
+	d := Diff{}
+	for _, f := range files {
+		d.ChangedFiles = append(d.ChangedFiles, ChangedFile{Path: f, Status: StatusModified})
+	}
+	return d
+}
+
+func TestEvaluate_Empty_NoConstraintsConfigured(t *testing.T) {
+	v := Evaluate(diff("a.go"), Constraints{})
+	if len(v) != 0 {
+		t.Errorf("expected no violations, got %+v", v)
+	}
+}
+
+func TestEvaluate_EmptyDiff_NoConstraints(t *testing.T) {
+	v := Evaluate(Diff{}, Constraints{})
+	if len(v) != 0 {
+		t.Errorf("expected no violations, got %+v", v)
+	}
+}
+
+func TestEvaluate_EmptyDiff_WithMaxFiles(t *testing.T) {
+	v := Evaluate(Diff{}, Constraints{MaxFilesChanged: 10})
+	if len(v) != 0 {
+		t.Errorf("empty diff under limit should pass, got %+v", v)
+	}
+}
+
+func TestEvaluate_EmptyDiff_WithRequiredOutcomes(t *testing.T) {
+	v := Evaluate(Diff{}, Constraints{RequiredOutcomes: []string{"tests_added_or_updated"}})
+	if len(v) != 1 {
+		t.Errorf("empty diff should fail tests-added requirement, got %+v", v)
+	}
+}
+
+func TestForbiddenPaths_Hit(t *testing.T) {
+	d := diff("backend/main.go", "infra/terraform.tf")
+	v := Evaluate(d, Constraints{ForbiddenPaths: []string{"infra/**"}})
+	if len(v) != 1 {
+		t.Fatalf("got %d violations, want 1: %+v", len(v), v)
+	}
+	if v[0].Constraint != "forbidden_paths" {
+		t.Errorf("Constraint = %q", v[0].Constraint)
+	}
+	if len(v[0].Files) != 1 || v[0].Files[0] != "infra/terraform.tf" {
+		t.Errorf("Files = %v, want [infra/terraform.tf]", v[0].Files)
+	}
+}
+
+func TestForbiddenPaths_NoHit(t *testing.T) {
+	d := diff("backend/main.go", "frontend/app.tsx")
+	v := Evaluate(d, Constraints{ForbiddenPaths: []string{"infra/**", ".github/workflows/**"}})
+	if len(v) != 0 {
+		t.Errorf("expected no violations, got %+v", v)
+	}
+}
+
+func TestForbiddenPaths_InvalidPattern(t *testing.T) {
+	d := diff("a.go")
+	// `[` opens a character class that's never closed → invalid.
+	v := Evaluate(d, Constraints{ForbiddenPaths: []string{"[bad"}})
+	if len(v) != 1 || !strings.Contains(v[0].Detail, "invalid pattern") {
+		t.Errorf("expected invalid-pattern violation, got %+v", v)
+	}
+}
+
+func TestForbiddenPaths_MultiplePatterns(t *testing.T) {
+	d := diff("infra/main.tf", ".github/workflows/ci.yml", "backend/main.go")
+	v := Evaluate(d, Constraints{ForbiddenPaths: []string{"infra/**", ".github/workflows/**"}})
+	if len(v) != 2 {
+		t.Fatalf("expected 2 violations (one per matching pattern), got %+v", v)
+	}
+}
+
+func TestAllowedPaths_AllAllowed(t *testing.T) {
+	d := diff("backend/main.go", "backend/internal/server/handlers.go")
+	v := Evaluate(d, Constraints{AllowedPaths: []string{"backend/**"}})
+	if len(v) != 0 {
+		t.Errorf("expected no violations, got %+v", v)
+	}
+}
+
+func TestAllowedPaths_OutsideAllowed(t *testing.T) {
+	d := diff("backend/main.go", "frontend/app.tsx")
+	v := Evaluate(d, Constraints{AllowedPaths: []string{"backend/**"}})
+	if len(v) != 1 {
+		t.Fatalf("got %d violations, want 1: %+v", len(v), v)
+	}
+	if len(v[0].Files) != 1 || v[0].Files[0] != "frontend/app.tsx" {
+		t.Errorf("Files = %v", v[0].Files)
+	}
+}
+
+func TestAllowedPaths_InvalidPattern(t *testing.T) {
+	d := diff("a.go")
+	v := Evaluate(d, Constraints{AllowedPaths: []string{"[bad"}})
+	// Two violations: invalid-pattern note + the file matching nothing.
+	if len(v) != 2 {
+		t.Fatalf("got %d violations, want 2: %+v", len(v), v)
+	}
+	if !strings.Contains(v[0].Detail, "invalid") {
+		t.Errorf("first violation = %+v, want invalid", v[0])
+	}
+}
+
+func TestMaxFilesChanged_Under(t *testing.T) {
+	d := diff("a.go", "b.go", "c.go")
+	v := Evaluate(d, Constraints{MaxFilesChanged: 5})
+	if len(v) != 0 {
+		t.Errorf("expected no violations, got %+v", v)
+	}
+}
+
+func TestMaxFilesChanged_Equal(t *testing.T) {
+	d := diff("a.go", "b.go", "c.go")
+	v := Evaluate(d, Constraints{MaxFilesChanged: 3})
+	if len(v) != 0 {
+		t.Errorf("equal-to-limit should pass, got %+v", v)
+	}
+}
+
+func TestMaxFilesChanged_Over(t *testing.T) {
+	d := diff("a.go", "b.go", "c.go", "d.go")
+	v := Evaluate(d, Constraints{MaxFilesChanged: 3})
+	if len(v) != 1 {
+		t.Fatalf("got %d violations, want 1: %+v", len(v), v)
+	}
+	if !strings.Contains(v[0].Detail, "limit 3") {
+		t.Errorf("Detail = %q", v[0].Detail)
+	}
+}
+
+func TestRequiredOutcomes_TestsAddedOrUpdated_Pass(t *testing.T) {
+	cases := []string{
+		"backend/internal/server/handlers_test.go",
+		"frontend/app.test.tsx",
+		"tests/integration/api.py",
+		"backend/internal/server/test/fixtures.go",
+		"src/foo/spec/bar.rb",
+		"py/test_thing.py",
+	}
+	for _, p := range cases {
+		t.Run(p, func(t *testing.T) {
+			v := Evaluate(diff(p), Constraints{RequiredOutcomes: []string{"tests_added_or_updated"}})
+			if len(v) != 0 {
+				t.Errorf("expected pass, got %+v", v)
+			}
+		})
+	}
+}
+
+func TestRequiredOutcomes_TestsAddedOrUpdated_Fail(t *testing.T) {
+	d := diff("backend/main.go", "frontend/app.tsx")
+	v := Evaluate(d, Constraints{RequiredOutcomes: []string{"tests_added_or_updated"}})
+	if len(v) != 1 || !strings.Contains(v[0].Detail, "no test files") {
+		t.Errorf("expected tests-not-added violation, got %+v", v)
+	}
+}
+
+func TestRequiredOutcomes_DeletedTestFileDoesntCount(t *testing.T) {
+	d := Diff{ChangedFiles: []ChangedFile{
+		{Path: "x_test.go", Status: StatusDeleted},
+		{Path: "x.go", Status: StatusModified},
+	}}
+	v := Evaluate(d, Constraints{RequiredOutcomes: []string{"tests_added_or_updated"}})
+	if len(v) != 1 {
+		t.Errorf("expected violation when only test was deleted, got %+v", v)
+	}
+}
+
+func TestRequiredOutcomes_CIGreen_NoSignal(t *testing.T) {
+	v := Evaluate(diff("a.go"), Constraints{RequiredOutcomes: []string{"ci_green"}})
+	if len(v) != 1 || !strings.Contains(v[0].Detail, "no signal") {
+		t.Errorf("expected no-signal violation, got %+v", v)
+	}
+}
+
+func TestRequiredOutcomes_CIGreen_True(t *testing.T) {
+	green := true
+	v := Evaluate(diff("a.go"), Constraints{
+		RequiredOutcomes: []string{"ci_green"},
+		CIGreen:          &green,
+	})
+	if len(v) != 0 {
+		t.Errorf("expected no violations, got %+v", v)
+	}
+}
+
+func TestRequiredOutcomes_CIGreen_False(t *testing.T) {
+	green := false
+	v := Evaluate(diff("a.go"), Constraints{
+		RequiredOutcomes: []string{"ci_green"},
+		CIGreen:          &green,
+	})
+	if len(v) != 1 || !strings.Contains(v[0].Detail, "not green") {
+		t.Errorf("expected ci-not-green violation, got %+v", v)
+	}
+}
+
+func TestRequiredOutcomes_UnknownOutcome(t *testing.T) {
+	v := Evaluate(diff("a.go"), Constraints{RequiredOutcomes: []string{"sky_is_blue"}})
+	if len(v) != 1 || !strings.Contains(v[0].Detail, "unknown outcome") {
+		t.Errorf("expected unknown-outcome violation, got %+v", v)
+	}
+}
+
+func TestEvaluate_MultipleConstraints(t *testing.T) {
+	// Mirror the classic feature_change implement stage from
+	// MVP_SPEC §4.2.
+	d := diff(
+		"backend/internal/server/handlers.go",
+		"backend/internal/server/handlers_test.go",
+		"infra/main.tf", // forbidden
+	)
+	v := Evaluate(d, Constraints{
+		ForbiddenPaths:   []string{"infra/**", ".github/workflows/**", "security/**", ".fishhawk/**"},
+		MaxFilesChanged:  30,
+		RequiredOutcomes: []string{"tests_added_or_updated"},
+	})
+	if len(v) != 1 {
+		t.Fatalf("expected exactly 1 violation (forbidden_paths), got %+v", v)
+	}
+	if v[0].Constraint != "forbidden_paths" {
+		t.Errorf("Constraint = %q, want forbidden_paths", v[0].Constraint)
+	}
+}
+
+func TestViolation_String(t *testing.T) {
+	v := Violation{Constraint: "k", Detail: "d"}
+	if got := v.String(); got != "k: d" {
+		t.Errorf("String() = %q", got)
+	}
+	v2 := Violation{Constraint: "k", Detail: "d", Files: []string{"x", "y"}}
+	if got := v2.String(); got != "k: d [x, y]" {
+		t.Errorf("String() with files = %q", got)
+	}
+}
+
+func TestStatusConstants(t *testing.T) {
+	pairs := map[Status]string{
+		StatusAdded: "A", StatusModified: "M", StatusDeleted: "D",
+		StatusRenamed: "R", StatusCopied: "C", StatusTypeChg: "T",
+	}
+	for s, want := range pairs {
+		if string(s) != want {
+			t.Errorf("Status %q = %q, want %q", s, string(s), want)
+		}
+	}
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ GitHub OAuth (E4.2 / #49) is the sign-in flow that mints the cookie session. App
 | Trace bundle wire format (`*.jsonl.gz`) | `runner/internal/bundle/bundle.go` (pack + open) — implements ADR-007 (#71) |
 | Runner → backend trace upload | `runner/internal/upload/` (HTTP client, retries, signing) — wired into runner main behind `--upload-trace` |
 | CLI → backend HTTP client | `cli/internal/httpclient/` (typed wrappers); CLI subcommands in `cli/cmd/fishhawk/` |
-| Constraint evaluation (forbidden_paths, max_files_changed, required_outcomes) | `runner/internal/constraint/constraint.go` (post-hoc, runner-side) |
+| Constraint evaluation (forbidden_paths, max_files_changed, required_outcomes) | `runner/internal/constraint/constraint.go` (runner-side, immediate feedback to agent); `backend/internal/policy/` (backend-side, source of truth, emits chained `policy_evaluated` audit entry). Trace-ingest wire-up tracked in #130. |
 | HTTP middleware order / context keys | `backend/internal/server/middleware.go` |
 | Run CRUD handlers (POST/GET/list/cancel) | `backend/internal/server/runs.go`; wired in `backend/cmd/fishhawkd/serve.go` from `FISHHAWKD_DATABASE_URL` |
 | Stage + audit read handlers (`/runs/{id}/stages`, `/runs/{id}/audit`) | `backend/internal/server/reads.go`; cursor pagination via `pageOffset`/`encodeOffsetCursor` |


### PR DESCRIPTION
## Summary

- Add `backend/internal/policy/` — the backend-side source-of-truth evaluator for the v0 closed-set constraints (`forbidden_paths`, `allowed_paths`, `max_files_changed`, `required_outcomes`) per MVP_SPEC §4.2.
- Add `EmitEvaluation` helper that runs `Evaluate` and writes one chained `policy_evaluated` audit entry whose payload contains the diff, applied constraints, and resulting violation set.
- Mirrors `runner/internal/constraint` with identical semantics. The runner gives the agent immediate feedback; the backend re-evaluates uploaded traces because a customer-side report alone isn't auditable (MVP_SPEC §4.4).

## Notes

- **Code duplicated, not imported.** Runner and backend are separate Go modules; copying keeps the runner a self-contained Action and lets the backend evolve evaluation independently (e.g., once v0.x adds custom predicates).
- **One audit entry per evaluation, not per violation.** Keeps the chain compact and pairs "what was checked" with "what failed" in a single record.
- **Trace-ingest wire-up deferred to #130 (E3.13).** That work depends on (a) bundle-side diff extraction, (b) spec re-parse at the run's pinned SHA, (c) failure-category-B propagation in `advanceStageAfterTrace`. Each is its own design step; bundling them with the package itself would crowd review.

## Test plan

- [x] `go test -race ./backend/internal/policy/...` — package suite green
- [x] Coverage on the new package: **96.8%**; aggregate gate (≥80% excluding `internal/run/db`): **PASS** at 82.0%
- [x] `golangci-lint run ./backend/internal/policy/...` — clean

Closes #44