### PR TITLE
Add versioned release workflow for fishhawk/runner (E5.7)

### DIFF
--- a/.github/release-notes/runner.md
+++ b/.github/release-notes/runner.md
@@ -1,0 +1,45 @@
+<!--
+  Header for runner releases. The runner-release workflow appends
+  GitHub's auto-generated changelog (commits since the previous
+  runner/v* tag) underneath this body via
+  `generate_release_notes: true`.
+
+  To customize per-release: edit this template before tagging, or
+  open the GitHub Release after publication and revise the body.
+-->
+
+## Fishhawk Runner
+
+GitHub Action that runs an agent under a Fishhawk workflow stage and ships the signed trace bundle to the backend. Pin via:
+
+```yaml
+- uses: kuhlman-labs/fishhawk/runner@runner/vX.Y.Z
+```
+
+## What's in this release
+
+- `fishhawk-runner-<version>-linux-amd64` — standalone binary (`-ldflags`-stamped with this tag's version). Useful for ad-hoc invocation, replay, and supply-chain inspection.
+- `runner-<version>.sbom.spdx.json` — SPDX-JSON Software Bill of Materials produced by [`anchore/sbom-action`](https://github.com/anchore/sbom-action). Lists every Go module the runner links against.
+- `SHA256SUMS` — sha256 of every artifact above.
+- `SHA256SUMS.sig` + `SHA256SUMS.pem` — keyless [cosign](https://docs.sigstore.dev/cosign/overview/) signature + Fulcio certificate chain. Issued by the GitHub Actions OIDC identity for this repo + workflow.
+
+## Verifying the release
+
+```sh
+# Download SHA256SUMS, SHA256SUMS.sig, SHA256SUMS.pem from this release.
+cosign verify-blob \
+  --certificate-identity-regexp 'https://github.com/kuhlman-labs/fishhawk/\.github/workflows/runner-release\.yml@.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --signature SHA256SUMS.sig \
+  --certificate SHA256SUMS.pem \
+  SHA256SUMS
+sha256sum -c SHA256SUMS
+```
+
+A passing verify means the file came from this repo's runner-release workflow on this tag — no managed PGP key in the loop.
+
+## Compatibility
+
+Pinned tags are the supported customer surface. `@main` exists for self-execution in this repo only and may break across commits.
+
+The runner speaks the v0 trace bundle wire format (ADR-007 / [#71](https://github.com/kuhlman-labs/fishhawk/issues/71)) and the v0 backend API (`docs/api/v0.openapi.yaml`).

--- a/.github/workflows/runner-release.yml
+++ b/.github/workflows/runner-release.yml
@@ -1,0 +1,144 @@
+# Runner release workflow (E5.7 / #54).
+#
+# Triggered by a tag push matching `runner/v*` (the Go-module
+# convention for a monorepo submodule, per the Go reference). The
+# workflow:
+#
+#  1. Re-runs lint + tests at the tag's commit (catches a tag
+#     pushed from a dirty branch).
+#  2. Builds a `fishhawk-runner` binary with -ldflags=-X to inject
+#     the tag version. Customers don't actually need a binary —
+#     the published Action is composite — but the binary is
+#     useful for ad-hoc CLI invocation, supply-chain verification,
+#     and as a reference for what the Action runs.
+#  3. Generates an SPDX-JSON SBOM of the runner module via
+#     anchore/sbom-action.
+#  4. Computes SHA-256 checksums of every release artifact.
+#  5. Signs the SHA256SUMS file with cosign (keyless / OIDC) so
+#     downstream consumers can verify the artifacts were produced
+#     by this workflow on this repo, without needing a managed
+#     PGP key.
+#  6. Publishes a GitHub Release with the artifacts attached.
+#
+# Versioning convention: `runner/vX.Y.Z`. Go's module system
+# requires a path-prefixed tag for any module not at the repo
+# root; that prefix doubles as a namespace for backend / cli /
+# verifier release workflows when those land.
+
+name: Runner Release
+
+on:
+  push:
+    tags:
+      - 'runner/v*'
+
+permissions:
+  contents: write   # create release + upload assets
+  id-token: write   # cosign keyless signing via GitHub OIDC
+
+jobs:
+  release:
+    name: Build, sign, and publish runner release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          # Need full history so release-notes generation tools
+          # (and the version-stamping step's `git describe`) work.
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.25'
+          cache: false
+
+      - name: Install golangci-lint
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
+            | sh -s -- -b "$(go env GOPATH)/bin" v2.8.0
+
+      - name: Verify the tagged commit passes lint + tests
+        run: |
+          set -eu
+          GOLANGCI_LINT="$(go env GOPATH)/bin/golangci-lint"
+          (
+            cd runner
+            "$GOLANGCI_LINT" run ./...
+            go build ./...
+            go test -race ./...
+          )
+
+      - name: Compute version and build binary
+        id: build
+        run: |
+          set -eu
+          # refs/tags/runner/v0.1.0 → v0.1.0
+          version="${GITHUB_REF#refs/tags/runner/}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          mkdir -p dist
+          cd runner
+          CGO_ENABLED=0 go build \
+            -ldflags="-s -w -X github.com/kuhlman-labs/fishhawk/runner/internal/version.Version=${version}" \
+            -o "../dist/fishhawk-runner-${version}-linux-amd64" \
+            ./cmd/fishhawk-runner
+          # Sanity-check the embedded version.
+          "../dist/fishhawk-runner-${version}-linux-amd64" --help 2>&1 | head -n 3 || true
+
+      - name: Generate SBOM (SPDX-JSON)
+        uses: anchore/sbom-action@v0
+        with:
+          path: ./runner
+          format: spdx-json
+          output-file: ./dist/runner-${{ steps.build.outputs.version }}.sbom.spdx.json
+
+      - name: Compute checksums
+        run: |
+          set -eu
+          cd dist
+          # `./*` keeps shellcheck happy: filenames starting with `-`
+          # would otherwise be interpreted as flags.
+          sha256sum ./* > SHA256SUMS
+          cat SHA256SUMS
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign checksums (keyless)
+        run: |
+          set -eu
+          cd dist
+          # --yes opts in to signing without an interactive prompt.
+          # Keyless signing emits two artifacts: a Sigstore bundle
+          # (.sig) and the Fulcio certificate chain (.pem). Verify
+          # downstream with:
+          #
+          #   cosign verify-blob \
+          #     --certificate-identity-regexp 'https://github.com/kuhlman-labs/fishhawk/.+' \
+          #     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+          #     --signature SHA256SUMS.sig \
+          #     --certificate SHA256SUMS.pem \
+          #     SHA256SUMS
+          cosign sign-blob --yes \
+            --output-signature SHA256SUMS.sig \
+            --output-certificate SHA256SUMS.pem \
+            SHA256SUMS
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: Runner ${{ steps.build.outputs.version }}
+          generate_release_notes: true
+          body_path: .github/release-notes/runner.md
+          # Pre-release for any tag with a prerelease suffix
+          # (e.g. runner/v0.1.0-rc.1). softprops's prerelease
+          # flag is OR'd with the tag-name heuristic.
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          files: |
+            dist/fishhawk-runner-${{ steps.build.outputs.version }}-linux-amd64
+            dist/runner-${{ steps.build.outputs.version }}.sbom.spdx.json
+            dist/SHA256SUMS
+            dist/SHA256SUMS.sig
+            dist/SHA256SUMS.pem

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -17,7 +17,7 @@ Five surfaces, deployed independently. Each maps to a directory in this monorepo
 | Component | Path | Role | Epic |
 |---|---|---|---|
 | **Backend control plane** (`fishhawkd`) | `/backend` | Workflow state machine, policy evaluator, approval state, audit writer, REST API, GitHub App webhook receiver. | E3 (#3) |
-| **Runner action** (`fishhawk/runner`) | `/runner` | GitHub Action published as `kuhlman-labs/fishhawk/runner@vX.Y`. Runs on the customer's CI: invokes the agent, captures trace, validates the produced plan, signs and ships the bundle. Currently a scaffold (E5.1) — flag parsing only, no agent invocation yet. | E5 (#5) |
+| **Runner action** (`fishhawk/runner`) | `/runner` | GitHub Action published as `kuhlman-labs/fishhawk/runner@runner/vX.Y.Z`. Runs on the customer's CI: invokes the agent, captures trace, validates the produced plan, signs and ships the bundle. Self-execution in this repo uses `./runner` (the local path); external customers pin a release tag. Versioned, cosign-signed releases via `.github/workflows/runner-release.yml`. | E5 (#5) |
 | **Web UI** | `/frontend` (planned) | Authenticated SPA — plan review, approval, audit search, run visualization. | E7 (#7) |
 | **CLI** (`fishhawk`) | `/cli` (planned) | Validate workflow specs locally; trigger and inspect runs from the terminal. Plan review and approval explicitly stay in the UI. | E6 (#6) |
 | **GitHub App** | (registered with GitHub; manifest in repo) | Per-installation tokens for repo access; OAuth provider for user sign-in; webhook source for triggers. | E4 (#4) |
@@ -50,7 +50,7 @@ Consolidated from the resolved ADRs (#65–#73, #78). Each row links to the issu
 
 Per `docs/MVP_SPEC.md` §5.2. Concrete realization in this codebase:
 
-1. **Trigger** — GitHub issue label/assignment (webhook → backend), CLI `fishhawk run start`, or UI button. Backend validates the workflow spec at the issue's `.fishhawk/workflows.yaml` SHA, creates a `runs` row, and emits `workflow_dispatch` to the customer's repo invoking `fishhawk/runner@vX.Y`.
+1. **Trigger** — GitHub issue label/assignment (webhook → backend), CLI `fishhawk run start`, or UI button. Backend validates the workflow spec at the issue's `.fishhawk/workflows.yaml` SHA, creates a `runs` row, and emits `workflow_dispatch` to the customer's repo invoking `fishhawk/runner@runner/vX.Y.Z`.
 2. **Plan stage** — Runner checks out the repo, calls backend `POST /v0/runs/{id}/signing-key` (with GitHub OIDC token) and receives an Ed25519 private key + run metadata. Invokes Claude Code with the plan prompt. Captures full trace as JSON Lines events. Validates the plan artifact against `standard_v1` schema (E1.5 / #20). Signs `sha256(bundle)`. Ships `(bundle, sig)` to `POST /v0/runs/{id}/trace`.
 3. **Backend ingest** — Verifies signature against the stored public key for `run_id`. Stores the bundle in S3 keyed by content sha256. Persists the plan artifact in `artifacts` and renders it as a comment on the originating GitHub issue (mode: `rendered_comment`, kept in sync). Transitions stage state.
 4. **Plan approval** — Approver reads the plan in the Web UI (canonical surface) or the issue comment (read-only echo). Clicks Approve. Backend records `(approver_subject, surface, ts)` in the audit log and transitions to implement.

--- a/runner/README.md
+++ b/runner/README.md
@@ -2,9 +2,11 @@
 
 The GitHub Action that runs an agent under a Fishhawk workflow stage and ships the signed trace bundle back to the backend. Customers reference the action as:
 
-    uses: kuhlman-labs/fishhawk/runner@v0.1
+    uses: kuhlman-labs/fishhawk/runner@runner/v0.1.0
 
 This directory is its own Go module (`github.com/kuhlman-labs/fishhawk/runner`) so it can be tagged independently of the backend and the CLI — the customer-facing version pin is on the runner alone. See [ADR-014 (#78)](https://github.com/kuhlman-labs/fishhawk/issues/78) for the multi-module rationale.
+
+Tag prefix `runner/v…` follows the Go module convention for non-root modules in a monorepo. Self-execution in this repo uses `./runner` (the local path) rather than a tag; external customers pin a release.
 
 ## Layout
 
@@ -86,6 +88,30 @@ The same binary the action runs can be invoked locally for development:
     gunzip -c /tmp/trace.jsonl.gz | jq -c .
 
 When `--prompt-file` is set the runner invokes Claude Code; the structured runner log lines (`runner_started`, `runner_completed`) go to stderr. With `--bundle-out`, captured events are packed into `*.jsonl.gz` per ADR-007. Without it, events fall back to JSONL on stdout.
+
+## Releases
+
+The release workflow at `.github/workflows/runner-release.yml` triggers on tags matching `runner/v*`. To cut a release:
+
+1. Land everything on `main`. Verify `golangci-lint run ./runner/...` and `go test -race ./runner/...` are clean.
+2. Tag the release commit: `git tag runner/v0.1.0 && git push origin runner/v0.1.0`.
+3. The workflow re-runs lint + tests at the tag, builds a `linux-amd64` binary with the version stamped via `-ldflags`, generates an SPDX-JSON SBOM (anchore/sbom-action), computes SHA-256 checksums, signs `SHA256SUMS` keyless via cosign + GitHub OIDC, and publishes a GitHub Release with all artifacts attached.
+4. Update `docs/spec/examples/` (or any sample workflow) to point at the new tag if appropriate.
+
+Verify a release locally:
+
+```sh
+# Download SHA256SUMS, SHA256SUMS.sig, SHA256SUMS.pem from the GitHub Release.
+cosign verify-blob \
+  --certificate-identity-regexp 'https://github.com/kuhlman-labs/fishhawk/\.github/workflows/runner-release\.yml@.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --signature SHA256SUMS.sig \
+  --certificate SHA256SUMS.pem \
+  SHA256SUMS
+sha256sum -c SHA256SUMS
+```
+
+The verify-identity is the workflow file's path; that's the URL Fulcio embeds in the cert when keyless-signing from a GitHub Action.
 
 ## See also
 

--- a/runner/action.yml
+++ b/runner/action.yml
@@ -6,9 +6,12 @@ branding:
   color: 'blue'
 
 # Customers reference this action as
-#   uses: kuhlman-labs/fishhawk/runner@vX.Y
-# and pass the inputs below. The composite action checks out a Go
-# toolchain and invokes ./cmd/fishhawk-runner from this directory.
+#   uses: kuhlman-labs/fishhawk/runner@runner/vX.Y.Z
+# and pass the inputs below. The `runner/v…` tag prefix follows
+# the Go module convention for non-root modules in a monorepo;
+# E5.7's release workflow publishes signed releases at that tag
+# pattern. The composite action checks out a Go toolchain and
+# invokes ./cmd/fishhawk-runner from this directory.
 #
 # E5.1 (#52) shipped the scaffold; E5.2 (#29) added the Claude Code
 # invocation harness. With prompt-file unset the runner still


### PR DESCRIPTION
## Summary

Per MVP_SPEC §5.3, the runner is published, versioned, and pinned via the workflow spec; signed releases + SBOM mitigate the supply-chain failure mode.

- `.github/workflows/runner-release.yml` — tag-triggered workflow. Re-lints + tests at the tagged commit, builds a `linux-amd64` binary with `-ldflags=-X` stamping the tag version, generates an SPDX-JSON SBOM (anchore/sbom-action), computes SHA-256 checksums, signs `SHA256SUMS` with cosign keyless via GitHub OIDC, and publishes a GitHub Release with all artifacts attached.
- `.github/release-notes/runner.md` — header template; the workflow appends auto-generated changelog underneath.
- `runner/README.md`, `runner/action.yml`, `docs/ARCHITECTURE.md` — updated to reflect the new tag pattern (`runner/vX.Y.Z`).

## Notes

- **Tag prefix `runner/v…`** follows the Go module convention for non-root modules in a monorepo; the prefix doubles as a namespace when backend / cli / verifier release workflows land.
- **Cosign keyless** instead of a managed PGP key. Verifiers trust the Sigstore transparency log + the embedded Fulcio certificate's workflow identity. Runtime verification:
  ```sh
  cosign verify-blob \
    --certificate-identity-regexp 'https://github.com/kuhlman-labs/fishhawk/\.github/workflows/runner-release\.yml@.*' \
    --certificate-oidc-issuer https://token.actions.githubusercontent.com \
    --signature SHA256SUMS.sig --certificate SHA256SUMS.pem \
    SHA256SUMS
  ```
- **The binary is a convenience artifact, not the primary deliverable.** The Action is composite (`go run ./cmd/fishhawk-runner`); customers don't need the binary to consume the Action. It's there for ad-hoc CLI use, replay, and inspection.
- **No tag is pushed in this PR.** Cutting `runner/v0.1.0` is a separate operator step once the workflow is on `main`. The runner README documents the procedure.
- **Self-execution unchanged.** `.github/workflows/fishhawk.yml` still uses `./runner` (the local path); only external consumers pin a tag.

## Test plan

- [x] `actionlint .github/workflows/*.yml` — clean across the new file and existing ones
- [x] Locally verified `-ldflags=-X` stamps the version: built with `runner/v0.1.0-test`, the `runner_started` log line carries `"version":"v0.1.0-test"`
- [x] `go test -race`, `go build`, `golangci-lint` clean across all four modules (no Go code changes — touches docs + workflow + action manifest only)
- [x] CI on this PR (path filter routes only the workflow + docs paths; release workflow itself runs only on tag push)

Closes #54.