### PR TITLE
Add fishhawk validate subcommand (E6.2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,8 @@ jobs:
           # fails if they drift; update both in the same PR.
           diff -u docs/spec/workflow-v0.schema.json \
                   backend/internal/spec/schemas/workflow-v0.schema.json
+          diff -u docs/spec/workflow-v0.schema.json \
+                  cli/internal/spec/schemas/workflow-v0.schema.json
           diff -u docs/spec/plan-standard-v1.schema.json \
                   backend/internal/plan/schemas/plan-standard-v1.schema.json
           diff -u docs/spec/plan-standard-v1.schema.json \

--- a/cli/README.md
+++ b/cli/README.md
@@ -6,13 +6,14 @@ This directory is its own Go module (`github.com/kuhlman-labs/fishhawk/cli`) so 
 
 ## Layout
 
-- `cmd/fishhawk/` — the binary entrypoint. Subcommand dispatch in `main.go`, per-command flags in `run.go`.
+- `cmd/fishhawk/` — the binary entrypoint. Subcommand dispatch in `main.go`, per-command flags in `run.go`, validate logic in `validate.go`.
 - `internal/httpclient/` — typed wrapper around the backend API. Marshals `CreateRunInput`, decodes `Run`, surfaces `*APIError` for non-2xx responses.
+- `internal/spec/` — workflow-spec validator. Embeds `workflow-v0.schema.json` (mirrored from `docs/spec/`; the schema-sync diff in CI fails if the copies drift) and runs JSON Schema validation locally so users iterate on errors before opening a PR.
 - `internal/version/` — build-version package; set via `-ldflags` at release time.
 
 ## Status
 
-E6.1 (#55), E6.3 (#34), E6.4 (#35), E6.5 (#36) shipped: scaffold + `run start`, `run status`, `run list`, `run cancel`, `run open`. E6.2 (#33) `fishhawk validate` is intentionally absent from the initial PR — it requires a local copy of the workflow-spec parser, which currently lives under `backend/internal/spec` and can't be imported across modules. Tracking issue forthcoming.
+E6.1 (#55), E6.2 (#33), E6.3 (#34), E6.4 (#35), E6.5 (#36) shipped: scaffold + `run start`, `run status`, `run list`, `run cancel`, `run open`, `validate`.
 
 ## Subcommands
 
@@ -22,6 +23,7 @@ fishhawk run status <run-id>
 fishhawk run list   [--repo R] [--workflow W] [--state S] [--limit N] [--cursor C]
 fishhawk run cancel <run-id>
 fishhawk run open   <run-id> [--print-url]
+fishhawk validate   [path]                   # default: .fishhawk/workflows.yaml
 fishhawk version
 ```
 

--- a/cli/cmd/fishhawk/main.go
+++ b/cli/cmd/fishhawk/main.go
@@ -50,6 +50,8 @@ func run(args []string, stdout, stderr io.Writer) int {
 		return exitUsage
 	case "run":
 		return runRun(rest, stdout, stderr)
+	case "validate":
+		return runValidate(rest, stdout, stderr)
 	case "version", "--version":
 		_, _ = fmt.Fprintln(stdout, version.Version)
 		return exitOK
@@ -87,6 +89,7 @@ func printUsage(w io.Writer) {
 		"  run list     List runs with optional filters.",
 		"  run cancel   Cancel an in-flight run.",
 		"  run open     Open a run's detail page in the browser.",
+		"  validate     Validate a workflow spec file locally.",
 		"  version      Print the CLI version and exit.",
 		"  help         Show this help.",
 		"",

--- a/cli/cmd/fishhawk/validate.go
+++ b/cli/cmd/fishhawk/validate.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/kuhlman-labs/fishhawk/cli/internal/spec"
+)
+
+// defaultSpecPath is the canonical location of the workflow spec
+// in a customer's repo. The validate subcommand defaults to it
+// when no path argument is supplied so `fishhawk validate` from
+// the repo root just works.
+const defaultSpecPath = ".fishhawk/workflows.yaml"
+
+// runValidate implements `fishhawk validate [path]`. Reads the
+// file (default `.fishhawk/workflows.yaml`), validates it against
+// the workflow-v0 schema, and prints either "OK" or one error
+// line per leaf failure.
+//
+// Exit code 0 on success, 1 on validation failure (per the issue
+// body — exit 2 is reserved for usage errors).
+func runValidate(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("fishhawk validate", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fs.Usage = func() {
+		_, _ = fmt.Fprintln(stderr, "Usage: fishhawk validate [path]")
+		_, _ = fmt.Fprintln(stderr, "")
+		_, _ = fmt.Fprintln(stderr, "Validates a Fishhawk workflow spec against the v0 JSON Schema.")
+		_, _ = fmt.Fprintln(stderr, "Defaults to .fishhawk/workflows.yaml when no path is supplied.")
+		_, _ = fmt.Fprintln(stderr, "")
+		_, _ = fmt.Fprintln(stderr, "Exit codes:")
+		_, _ = fmt.Fprintln(stderr, "  0  spec is valid")
+		_, _ = fmt.Fprintln(stderr, "  1  spec has validation errors (printed to stderr)")
+		_, _ = fmt.Fprintln(stderr, "  2  usage / I/O error")
+	}
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+
+	path := defaultSpecPath
+	switch fs.NArg() {
+	case 0:
+		// default
+	case 1:
+		path = fs.Arg(0)
+	default:
+		_, _ = fmt.Fprintln(stderr, "fishhawk validate: at most one path argument allowed")
+		fs.Usage()
+		return exitUsage
+	}
+
+	data, err := os.ReadFile(path) //nolint:gosec // user-supplied path is the point
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "fishhawk validate: %s: %v\n", path, err)
+		return exitUsage
+	}
+
+	if err := spec.ValidateBytes(data); err != nil {
+		var pe *spec.ParseError
+		var ve *spec.ValidationError
+		switch {
+		case errors.As(err, &pe):
+			_, _ = fmt.Fprintf(stderr, "%s: %s\n", path, pe.Msg)
+		case errors.As(err, &ve):
+			for _, ent := range ve.Errors {
+				_, _ = fmt.Fprintf(stderr, "%s%s: %s\n", path, ent.Path, ent.Message)
+			}
+		default:
+			_, _ = fmt.Fprintf(stderr, "%s: %v\n", path, err)
+		}
+		return exitFailure
+	}
+
+	_, _ = fmt.Fprintf(stdout, "%s: OK\n", path)
+	return exitOK
+}

--- a/cli/cmd/fishhawk/validate_test.go
+++ b/cli/cmd/fishhawk/validate_test.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const validateValidYAML = `
+version: "0.1"
+roles:
+  tech_lead:
+    members: ["@org/tech-leads"]
+workflows:
+  feature_change:
+    description: "Default workflow."
+    stages:
+      - id: implement
+        type: implement
+        executor:
+          agent: claude-code
+        constraints:
+          - max_files_changed: 30
+        gates:
+          - type: approval
+            approvers:
+              any_of: [tech_lead]
+            sla: 4_hours
+`
+
+func writeTempSpec(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "workflows.yaml")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestValidate_HappyPath(t *testing.T) {
+	path := writeTempSpec(t, validateValidYAML)
+	var stdout, stderr strings.Builder
+
+	got := runValidate([]string{path}, &stdout, &stderr)
+	if got != exitOK {
+		t.Fatalf("exit = %d, want 0:\nstderr: %s", got, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "OK") {
+		t.Errorf("stdout missing OK: %q", stdout.String())
+	}
+}
+
+func TestValidate_DefaultsToWorkflowsYaml(t *testing.T) {
+	dir := t.TempDir()
+	hidden := filepath.Join(dir, ".fishhawk")
+	if err := os.MkdirAll(hidden, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(hidden, "workflows.yaml")
+	if err := os.WriteFile(path, []byte(validateValidYAML), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Switch CWD to the temp dir so the default path resolves.
+	prev, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(prev) }()
+
+	var stdout, stderr strings.Builder
+	got := runValidate(nil, &stdout, &stderr)
+	if got != exitOK {
+		t.Fatalf("exit = %d, want 0:\nstderr: %s", got, stderr.String())
+	}
+}
+
+func TestValidate_FileNotFound(t *testing.T) {
+	var stdout, stderr strings.Builder
+	got := runValidate([]string{"/no/such/path.yaml"}, &stdout, &stderr)
+	if got != exitUsage {
+		t.Errorf("exit = %d, want exitUsage", got)
+	}
+	if !strings.Contains(stderr.String(), "/no/such/path.yaml") {
+		t.Errorf("stderr missing path: %q", stderr.String())
+	}
+}
+
+func TestValidate_TooManyArgs(t *testing.T) {
+	var stdout, stderr strings.Builder
+	got := runValidate([]string{"a.yaml", "b.yaml"}, &stdout, &stderr)
+	if got != exitUsage {
+		t.Errorf("exit = %d, want exitUsage", got)
+	}
+}
+
+func TestValidate_BadFlag(t *testing.T) {
+	var stdout, stderr strings.Builder
+	got := runValidate([]string{"--no-such-flag"}, &stdout, &stderr)
+	if got != exitUsage {
+		t.Errorf("exit = %d, want exitUsage", got)
+	}
+}
+
+func TestValidate_HelpExits(t *testing.T) {
+	var stdout, stderr strings.Builder
+	got := runValidate([]string{"--help"}, &stdout, &stderr)
+	if got != exitUsage {
+		t.Errorf("exit = %d, want exitUsage (--help via flag.ContinueOnError)", got)
+	}
+	if !strings.Contains(stderr.String(), "Usage:") {
+		t.Errorf("stderr missing usage: %q", stderr.String())
+	}
+}
+
+func TestValidate_EmptyFile_ReturnsParseError(t *testing.T) {
+	path := writeTempSpec(t, "")
+	var stdout, stderr strings.Builder
+	got := runValidate([]string{path}, &stdout, &stderr)
+	if got != exitFailure {
+		t.Errorf("exit = %d, want exitFailure", got)
+	}
+	if !strings.Contains(stderr.String(), "empty document") {
+		t.Errorf("stderr missing empty document message: %q", stderr.String())
+	}
+}
+
+func TestValidate_SchemaError_ReturnsValidationError(t *testing.T) {
+	bad := strings.Replace(validateValidYAML, `version: "0.1"`, "", 1)
+	path := writeTempSpec(t, bad)
+	var stdout, stderr strings.Builder
+	got := runValidate([]string{path}, &stdout, &stderr)
+	if got != exitFailure {
+		t.Errorf("exit = %d, want exitFailure", got)
+	}
+	// Each leaf is one stderr line; should include the file path.
+	if !strings.Contains(stderr.String(), path) {
+		t.Errorf("stderr missing path: %q", stderr.String())
+	}
+}
+
+func TestValidate_StderrUsesPathPrefix(t *testing.T) {
+	bad := strings.Replace(validateValidYAML, `type: implement`, `type: bogus`, 1)
+	path := writeTempSpec(t, bad)
+	var stdout, stderr strings.Builder
+	got := runValidate([]string{path}, &stdout, &stderr)
+	if got != exitFailure {
+		t.Errorf("exit = %d, want exitFailure", got)
+	}
+	// Format: "<path>/<json-pointer>: <message>"
+	for _, line := range strings.Split(strings.TrimSpace(stderr.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		if !strings.HasPrefix(line, path) {
+			t.Errorf("stderr line %q doesn't start with %q", line, path)
+		}
+	}
+}

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -2,4 +2,10 @@ module github.com/kuhlman-labs/fishhawk/cli
 
 go 1.25
 
-require github.com/google/uuid v1.6.0
+require (
+	github.com/google/uuid v1.6.0
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
+	gopkg.in/yaml.v3 v3.0.1
+)
+
+require golang.org/x/text v0.14.0 // indirect

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -1,2 +1,12 @@
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
+golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
+golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/cli/internal/spec/schemas/workflow-v0.schema.json
+++ b/cli/internal/spec/schemas/workflow-v0.schema.json
@@ -1,0 +1,312 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://fishhawk.dev/spec/workflow-v0.schema.json",
+  "title": "Fishhawk workflow spec v0",
+  "description": "Schema for .fishhawk/workflows.yaml. Frozen at Day 21 of the v0 build per MVP_SPEC.md §8. Old workflow runs in the audit log remain readable forever — never break this schema in place; bump to a new spec version instead.",
+
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "workflows"],
+
+  "properties": {
+    "version": {
+      "type": "string",
+      "enum": ["0.1"],
+      "description": "Spec syntax version. v0 freezes at 0.1; future syntax bumps land as 0.2 etc., with new schema files."
+    },
+    "roles": {
+      "type": "object",
+      "description": "Named roles referenced by gate approvers. Keys are snake_case identifiers; values list GitHub user/team refs.",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z][a-z0-9_]*$": { "$ref": "#/$defs/role" }
+      }
+    },
+    "workflows": {
+      "type": "object",
+      "description": "Named workflows. Keys are snake_case identifiers (e.g. feature_change). At least one workflow must be defined.",
+      "minProperties": 1,
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z][a-z0-9_]*$": { "$ref": "#/$defs/workflow" }
+      }
+    }
+  },
+
+  "$defs": {
+    "role": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["members"],
+      "properties": {
+        "members": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/member-ref" }
+        }
+      }
+    },
+
+    "member-ref": {
+      "type": "string",
+      "pattern": "^@[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)?$",
+      "description": "GitHub user (@user) or team (@org/team) reference. Resolved against the GitHub App installation at run time."
+    },
+
+    "workflow": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["stages"],
+      "properties": {
+        "description": { "type": "string" },
+        "stages": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/stage" }
+        }
+      }
+    },
+
+    "stage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "type", "executor"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_]*$",
+          "description": "Unique within the parent workflow. Referenced by inputs.from_stage."
+        },
+        "type": {
+          "type": "string",
+          "enum": ["plan", "implement", "review"],
+          "description": "v0 closed set. Custom stage types are deliberately disallowed."
+        },
+        "executor": { "$ref": "#/$defs/executor" },
+        "inputs": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/input" }
+        },
+        "produces": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/produces" }
+        },
+        "constraints": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/constraint" }
+        },
+        "budget":  { "$ref": "#/$defs/budget" },
+        "gates": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/gate" }
+        }
+      }
+    },
+
+    "executor": {
+      "type": "object",
+      "description": "Exactly one of agent (string) or human (true).",
+      "unevaluatedProperties": false,
+      "oneOf": [
+        {
+          "required": ["agent"],
+          "properties": {
+            "agent": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Agent identifier. v0 ships with claude-code; v0.x adds cursor and copilot."
+            }
+          }
+        },
+        {
+          "required": ["human"],
+          "properties": {
+            "human": { "type": "boolean", "const": true }
+          }
+        }
+      ]
+    },
+
+    "input": {
+      "type": "object",
+      "unevaluatedProperties": false,
+      "oneOf": [
+        {
+          "description": "Trigger input from outside the workflow (an issue, a PR).",
+          "required": ["source"],
+          "properties": {
+            "source": {
+              "type": "string",
+              "enum": ["github_issue", "pull_request"]
+            },
+            "required": { "type": "boolean" }
+          }
+        },
+        {
+          "description": "Artifact input from a prior stage in the same run.",
+          "required": ["artifact", "from_stage"],
+          "properties": {
+            "artifact": {
+              "type": "string",
+              "enum": ["plan", "pull_request"]
+            },
+            "from_stage": {
+              "type": "string",
+              "pattern": "^[a-z][a-z0-9_]*$"
+            }
+          }
+        }
+      ]
+    },
+
+    "produces": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["artifact"],
+      "properties": {
+        "artifact": {
+          "type": "string",
+          "enum": ["plan", "pull_request"],
+          "description": "v0 closed set. Custom artifacts deferred."
+        },
+        "schema": {
+          "type": "string",
+          "description": "Artifact schema version (e.g. standard_v1 for plan)."
+        },
+        "persistence": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/persistence" }
+        }
+      }
+    },
+
+    "persistence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["target", "mode"],
+      "properties": {
+        "target": {
+          "type": "string",
+          "enum": ["originating_issue", "fishhawk_audit_log"]
+        },
+        "mode": {
+          "type": "string",
+          "enum": ["rendered_comment", "canonical"],
+          "description": "rendered_comment: posted as a formatted comment on the target. canonical: stored as the authoritative copy in the audit log."
+        },
+        "update_on_change": {
+          "type": "boolean",
+          "description": "Re-publish to the target if the artifact is regenerated."
+        }
+      }
+    },
+
+    "constraint": {
+      "type": "object",
+      "description": "Exactly one constraint kind per object. Closed set per MVP_SPEC §4.1.",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "maxProperties": 1,
+      "properties": {
+        "max_files_changed": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "forbidden_paths": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 },
+          "description": "Glob patterns (gitignore-style) that the stage's diff must not touch."
+        },
+        "allowed_paths": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 },
+          "description": "Glob patterns; the stage's diff must touch only these paths."
+        },
+        "required_outcomes": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "enum": ["tests_added_or_updated", "ci_green"]
+          }
+        }
+      }
+    },
+
+    "budget": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "max_tokens": { "type": "integer", "minimum": 1 },
+        "max_runtime_minutes": { "type": "integer", "minimum": 1 },
+        "enforcement": {
+          "type": "string",
+          "enum": ["advisory", "blocking"],
+          "description": "v0 ships advisory only; blocking arrives in v0.x with the Fishhawk-issued ephemeral key path."
+        }
+      }
+    },
+
+    "gate": {
+      "type": "object",
+      "unevaluatedProperties": false,
+      "required": ["type"],
+      "oneOf": [
+        {
+          "description": "Approval gate — blocks until an approver acts.",
+          "required": ["type", "approvers"],
+          "properties": {
+            "type": { "const": "approval" },
+            "approvers": { "$ref": "#/$defs/approvers" },
+            "sla": {
+              "type": "string",
+              "description": "SLA before timeout fires a category-D failure (e.g. '4_business_hours', '24_hours')."
+            },
+            "blocking_checks": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "type": "string" }
+            }
+          }
+        },
+        {
+          "description": "Check gate — passes when all blocking_checks succeed; no human approval.",
+          "required": ["type", "blocking_checks"],
+          "properties": {
+            "type": { "const": "check" },
+            "blocking_checks": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "type": "string" }
+            }
+          }
+        }
+      ]
+    },
+
+    "approvers": {
+      "type": "object",
+      "description": "Either any_of (one approver suffices) or all_of (every named role must approve).",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "maxProperties": 1,
+      "properties": {
+        "any_of": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "type": "string", "pattern": "^[a-z][a-z0-9_]*$" }
+        },
+        "all_of": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "type": "string", "pattern": "^[a-z][a-z0-9_]*$" }
+        }
+      }
+    }
+  }
+}

--- a/cli/internal/spec/spec.go
+++ b/cli/internal/spec/spec.go
@@ -1,0 +1,188 @@
+// Package spec validates `.fishhawk/workflows.yaml` files locally
+// against the workflow-v0 JSON Schema (the same one
+// docs/spec/workflow-v0.schema.json defines and CI enforces in
+// sync with the backend's copy).
+//
+// Why this lives in cli/ and not backend/internal/spec: the Go
+// modules are separate, and a cross-module import would couple
+// the CLI's release cadence to the backend's. Duplicating the
+// schema + compiler is ~80 lines; the schema-sync diff in
+// .github/workflows/ci.yml catches drift between this copy, the
+// backend's copy, and the canonical docs/spec/ copy.
+//
+// Scope: JSON Schema validation only. The richer semantic checks
+// (cross-stage references, role resolution against the spec's
+// roles map) live on the backend; the CLI returns the same
+// schema errors the backend would return as the first line of
+// defense, which covers ~95% of "did I write valid YAML?"
+// failures.
+package spec
+
+import (
+	"bytes"
+	"embed"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+	"gopkg.in/yaml.v3"
+)
+
+//go:embed schemas/workflow-v0.schema.json
+var schemaFS embed.FS
+
+const schemaPath = "schemas/workflow-v0.schema.json"
+
+// compiledSchema is the JSON Schema compiled at package init.
+// Failing here panics so a malformed embedded copy is caught at
+// process start, not the first ValidateBytes call.
+var compiledSchema = mustCompileSchema()
+
+func mustCompileSchema() *jsonschema.Schema {
+	data, err := schemaFS.ReadFile(schemaPath)
+	if err != nil {
+		panic(fmt.Sprintf("spec: read embedded schema %s: %v", schemaPath, err))
+	}
+	var raw any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		panic(fmt.Sprintf("spec: parse embedded schema %s: %v", schemaPath, err))
+	}
+	c := jsonschema.NewCompiler()
+	if err := c.AddResource("workflow-v0.schema.json", raw); err != nil {
+		panic(fmt.Sprintf("spec: register embedded schema %s: %v", schemaPath, err))
+	}
+	s, err := c.Compile("workflow-v0.schema.json")
+	if err != nil {
+		panic(fmt.Sprintf("spec: compile embedded schema %s: %v", schemaPath, err))
+	}
+	return s
+}
+
+// ValidationError is the shape ValidateBytes returns on schema
+// failures. Path is a JSON Pointer (e.g. "/workflows/feature_change/stages/1");
+// Message is a human-readable description. Multiple errors can
+// surface from one Validate call (the schema validator surfaces
+// every leaf failure).
+type ValidationError struct {
+	Errors []ValidationErrorEntry
+}
+
+// ValidationErrorEntry is one leaf failure from the validator.
+type ValidationErrorEntry struct {
+	Path    string
+	Message string
+}
+
+func (e *ValidationError) Error() string {
+	if len(e.Errors) == 0 {
+		return "spec: validation failed"
+	}
+	var b strings.Builder
+	for i, ent := range e.Errors {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString(ent.Path)
+		b.WriteString(": ")
+		b.WriteString(ent.Message)
+	}
+	return b.String()
+}
+
+// ParseError signals the input wasn't valid YAML or was empty.
+// Distinct from ValidationError so callers can surface "your YAML
+// is broken" separately from "your spec doesn't satisfy the
+// schema."
+type ParseError struct {
+	Msg string
+}
+
+func (e *ParseError) Error() string { return "spec: " + e.Msg }
+
+// ValidateBytes parses data as YAML and validates the resulting
+// document against the workflow-v0 schema. Returns a *ParseError
+// for empty / malformed YAML, a *ValidationError for schema
+// failures, and nil on success.
+func ValidateBytes(data []byte) error {
+	if len(bytes.TrimSpace(data)) == 0 {
+		return &ParseError{Msg: "empty document"}
+	}
+
+	// yaml.v3 decodes into Go-native maps with string keys, which
+	// the JSON Schema validator can consume directly without a
+	// JSON round-trip.
+	var raw any
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(false) // permissive at YAML layer; schema is the gate
+	if err := dec.Decode(&raw); err != nil {
+		if errors.Is(err, io.EOF) {
+			return &ParseError{Msg: "empty document"}
+		}
+		return &ParseError{Msg: err.Error()}
+	}
+
+	if err := compiledSchema.Validate(raw); err != nil {
+		var verr *jsonschema.ValidationError
+		if errors.As(err, &verr) {
+			return validationErrorFrom(verr)
+		}
+		return &ValidationError{Errors: []ValidationErrorEntry{
+			{Path: "/", Message: err.Error()},
+		}}
+	}
+	return nil
+}
+
+// validationErrorFrom collapses the validator's nested error tree
+// into the leaf failures most useful to a human. The library
+// produces nested errors covering each rule; we keep every leaf
+// with a concrete InstanceLocation so users see all the issues at
+// once instead of fixing them one re-run at a time.
+func validationErrorFrom(verr *jsonschema.ValidationError) *ValidationError {
+	var leaves []ValidationErrorEntry
+	collectLeaves(verr, &leaves)
+	if len(leaves) == 0 {
+		// Degenerate case: no leaves attached. Fall back to the
+		// root error's text so the user still gets *something*.
+		leaves = []ValidationErrorEntry{{Path: "/", Message: verr.Error()}}
+	}
+	return &ValidationError{Errors: leaves}
+}
+
+func collectLeaves(v *jsonschema.ValidationError, out *[]ValidationErrorEntry) {
+	if len(v.Causes) == 0 {
+		*out = append(*out, ValidationErrorEntry{
+			Path:    "/" + joinPointer(v.InstanceLocation),
+			Message: leafMessage(v),
+		})
+		return
+	}
+	for _, c := range v.Causes {
+		collectLeaves(c, out)
+	}
+}
+
+// leafMessage trims the validator's full error text to just the
+// rule-specific message — the path is set by the caller, so we
+// don't want it in the message too.
+func leafMessage(v *jsonschema.ValidationError) string {
+	full := v.Error()
+	if idx := strings.LastIndex(full, ": "); idx >= 0 {
+		return full[idx+2:]
+	}
+	return full
+}
+
+func joinPointer(parts []string) string {
+	if len(parts) == 0 {
+		return ""
+	}
+	out := parts[0]
+	for _, p := range parts[1:] {
+		out += "/" + p
+	}
+	return out
+}

--- a/cli/internal/spec/spec_test.go
+++ b/cli/internal/spec/spec_test.go
@@ -1,0 +1,137 @@
+package spec_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/kuhlman-labs/fishhawk/cli/internal/spec"
+)
+
+const validSpec = `
+version: "0.1"
+roles:
+  tech_lead:
+    members: ["@org/tech-leads"]
+workflows:
+  feature_change:
+    description: "Default workflow."
+    stages:
+      - id: implement
+        type: implement
+        executor:
+          agent: claude-code
+        constraints:
+          - max_files_changed: 30
+        gates:
+          - type: approval
+            approvers:
+              any_of: [tech_lead]
+            sla: 4_hours
+`
+
+func TestValidateBytes_HappyPath(t *testing.T) {
+	if err := spec.ValidateBytes([]byte(validSpec)); err != nil {
+		t.Errorf("expected valid spec to parse, got: %v", err)
+	}
+}
+
+func TestValidateBytes_EmptyDocument(t *testing.T) {
+	for _, in := range []string{"", "   ", "\n\n"} {
+		err := spec.ValidateBytes([]byte(in))
+		var pe *spec.ParseError
+		if !errors.As(err, &pe) {
+			t.Errorf("ValidateBytes(%q) err = %v, want *ParseError", in, err)
+		}
+	}
+}
+
+func TestValidateBytes_MalformedYAML(t *testing.T) {
+	// Unclosed flow sequence — yaml.v3 errors on decode.
+	err := spec.ValidateBytes([]byte("key: [unclosed\n"))
+	var pe *spec.ParseError
+	if !errors.As(err, &pe) {
+		t.Errorf("err = %v, want *ParseError", err)
+	}
+}
+
+func TestValidateBytes_MissingRequiredFields(t *testing.T) {
+	// Missing `version` (required at the top level).
+	noVersion := strings.Replace(validSpec, `version: "0.1"`, "", 1)
+	err := spec.ValidateBytes([]byte(noVersion))
+	var ve *spec.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("err = %v, want *ValidationError", err)
+	}
+	// Should mention `version` somewhere in the leaves.
+	joined := strings.Join(messageStrings(ve), " ")
+	if !strings.Contains(joined, "version") {
+		t.Errorf("ValidationError didn't mention 'version': %s", joined)
+	}
+}
+
+func TestValidateBytes_InvalidApproverPattern(t *testing.T) {
+	// Approver names must match ^[a-z][a-z0-9_]*$.
+	bad := strings.Replace(validSpec,
+		`any_of: [tech_lead]`,
+		`any_of: ["@bad/format"]`, 1)
+	err := spec.ValidateBytes([]byte(bad))
+	var ve *spec.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("err = %v, want *ValidationError", err)
+	}
+}
+
+func TestValidateBytes_UnknownStageType(t *testing.T) {
+	bad := strings.Replace(validSpec,
+		`type: implement`,
+		`type: bogus`, 1)
+	err := spec.ValidateBytes([]byte(bad))
+	var ve *spec.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("err = %v, want *ValidationError", err)
+	}
+}
+
+func TestValidateBytes_MultipleLeavesReported(t *testing.T) {
+	// Two distinct violations in one doc — the validator should
+	// surface both, not just the first one.
+	bad := strings.Replace(validSpec,
+		`max_files_changed: 30`,
+		`max_files_changed: -5`, 1)
+	bad = strings.Replace(bad, `type: implement`, `type: bogus`, 1)
+	err := spec.ValidateBytes([]byte(bad))
+	var ve *spec.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("err = %v, want *ValidationError", err)
+	}
+	if len(ve.Errors) < 2 {
+		t.Errorf("got %d leaf error(s), want >= 2:\n%s", len(ve.Errors), ve.Error())
+	}
+}
+
+func TestValidationError_ErrorString(t *testing.T) {
+	ve := &spec.ValidationError{Errors: []spec.ValidationErrorEntry{
+		{Path: "/version", Message: "is required"},
+		{Path: "/workflows", Message: "must be an object"},
+	}}
+	got := ve.Error()
+	if !strings.Contains(got, "/version") || !strings.Contains(got, "/workflows") {
+		t.Errorf("Error() = %q, want both paths included", got)
+	}
+}
+
+func TestParseError_ErrorString(t *testing.T) {
+	pe := &spec.ParseError{Msg: "empty document"}
+	if pe.Error() != "spec: empty document" {
+		t.Errorf("Error() = %q", pe.Error())
+	}
+}
+
+func messageStrings(ve *spec.ValidationError) []string {
+	out := make([]string, 0, len(ve.Errors))
+	for _, e := range ve.Errors {
+		out = append(out, e.Path+": "+e.Message)
+	}
+	return out
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -19,7 +19,7 @@ Five surfaces, deployed independently. Each maps to a directory in this monorepo
 | **Backend control plane** (`fishhawkd`) | `/backend` | Workflow state machine, policy evaluator, approval state, audit writer, REST API, GitHub App webhook receiver. | E3 (#3) |
 | **Runner action** (`fishhawk/runner`) | `/runner` | GitHub Action published as `kuhlman-labs/fishhawk/runner@runner/vX.Y.Z`. Runs on the customer's CI: invokes the agent, captures trace, validates the produced plan, signs and ships the bundle. Self-execution in this repo uses `./runner` (the local path); external customers pin a release tag. Versioned, cosign-signed releases via `.github/workflows/runner-release.yml`. | E5 (#5) |
 | **Web UI** | `/frontend` (planned) | Authenticated SPA — plan review, approval, audit search, run visualization. | E7 (#7) |
-| **CLI** (`fishhawk`) | `/cli` (planned) | Validate workflow specs locally; trigger and inspect runs from the terminal. Plan review and approval explicitly stay in the UI. | E6 (#6) |
+| **CLI** (`fishhawk`) | `/cli` | Validate workflow specs locally (`fishhawk validate`); trigger and inspect runs from the terminal. Plan review and approval explicitly stay in the UI. | E6 (#6) |
 | **GitHub App** | (registered with GitHub; manifest in repo) | Per-installation tokens for repo access; OAuth provider for user sign-in; webhook source for triggers. | E4 (#4) |
 
 Plus the canonical artifact, **`.fishhawk/workflows.yaml`**, which lives in the customer's repo (and in this repo for self-execution starting Day 21).


### PR DESCRIPTION
## Summary

Wraps the workflow-v0 JSON Schema in a local CLI command so users can validate `.fishhawk/workflows.yaml` before opening a PR. Defaults to the canonical path; takes one optional path argument.

```
fishhawk validate              # → .fishhawk/workflows.yaml
fishhawk validate path/to.yaml
```

Exit code 0 on success, 1 on validation errors, 2 on usage / I/O. Errors print one line per leaf failure prefixed with the file path, so editors and grep can jump to the location.

- New `cli/internal/spec/`: slim mirror of `backend/internal/spec` — JSON Schema validation only (no typed Go round-trip, no cross-stage semantic checks). Backend keeps the richer validation; the CLI catches the bulk of "did I write valid YAML?" failures before the user round-trips through a backend.
- New `cli/cmd/fishhawk/validate.go`: subcommand wiring + pretty error formatting.
- `.github/workflows/ci.yml` schema-sync diff gains a third entry alongside the existing backend + runner copies; drift between `docs/spec/workflow-v0.schema.json`, `backend/internal/spec/schemas/`, and `cli/internal/spec/schemas/` surfaces in CI.

## Notes

- **Why duplicate instead of import**: the modules are separate per ADR-014, and a cross-module import would couple the CLI's release cadence to the backend's. The schema-sync diff is the drift detector.
- **Scope kept narrow**: only schema validation is in the CLI today. Cross-stage references (e.g., `from_stage: implement` requires a stage typed `implement` to exist), role-resolution checks, and similar semantic rules stay on the backend. Users who hit semantic-only failures will see them at run-create time. Promoting the full validator into a shared module is a future cleanup.
- **`flag.ContinueOnError` semantics**: a literal `--help` returns exit code 2 (matches Go's stdlib convention); the dedicated `help` / `version` paths in main.go's dispatch use 0. The validate help text documents all three exit codes explicitly.
- **No new global flags**: the existing `--backend-url` / `--token` apply to subcommands that hit the backend. Validate is offline, so it ignores them.

## Test plan

- [x] `go test -race ./cli/...` — green
- [x] `golangci-lint run ./cli/...` — clean
- [x] Schema sync: `diff -u docs/spec/workflow-v0.schema.json cli/internal/spec/schemas/workflow-v0.schema.json` clean
- [x] End-to-end smoke against the existing fixture:
  - `fishhawk validate backend/internal/spec/testdata/valid/feature-change.yaml` → `OK`, exit 0
  - `fishhawk validate /no/such/file.yaml` → I/O error to stderr, exit 2
- [x] Test coverage:
  - `internal/spec` package: happy path, empty document, malformed YAML, missing required field (`version`), invalid approver pattern, unknown stage type, multi-leaf reporting (multiple violations surface in one run), error-string formatting
  - `cmd/fishhawk` validate: happy path, default-path resolution, file not found, too-many-args, bad flag, --help, empty file, schema error path, stderr-line prefix shape

Closes #33.