### PR TITLE
Add GitHub App manifest + setup docs (E4.1)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -20,7 +20,7 @@ Five surfaces, deployed independently. Each maps to a directory in this monorepo
 | **Runner action** (`fishhawk/runner`) | `/runner` | GitHub Action published as `kuhlman-labs/fishhawk/runner@runner/vX.Y.Z`. Runs on the customer's CI: invokes the agent, captures trace, validates the produced plan, signs and ships the bundle. Self-execution in this repo uses `./runner` (the local path); external customers pin a release tag. Versioned, cosign-signed releases via `.github/workflows/runner-release.yml`. | E5 (#5) |
 | **Web UI** | `/frontend` (planned) | Authenticated SPA — plan review, approval, audit search, run visualization. | E7 (#7) |
 | **CLI** (`fishhawk`) | `/cli` | Validate workflow specs locally (`fishhawk validate`); trigger and inspect runs from the terminal. Plan review and approval explicitly stay in the UI. | E6 (#6) |
-| **GitHub App** | (registered with GitHub; manifest in repo) | Per-installation tokens for repo access; OAuth provider for user sign-in; webhook source for triggers. | E4 (#4) |
+| **GitHub App** | `docs/github-app/manifest.template.json` (registered with GitHub from this template) | Per-installation tokens for repo access; OAuth provider for user sign-in; webhook source for triggers. Render via `scripts/render-github-app-manifest.sh <backend-url>`; setup docs in `docs/github-app/README.md`. | E4 (#4) |
 
 Plus the canonical artifact, **`.fishhawk/workflows.yaml`**, which lives in the customer's repo (and in this repo for self-execution starting Day 21).
 

--- a/docs/github-app/README.md
+++ b/docs/github-app/README.md
@@ -1,0 +1,114 @@
+# Registering the Fishhawk GitHub App
+
+Fishhawk runs as a GitHub App. The App provides:
+
+- **Webhook events** that drive workflow triggers (issues labeled, comments matching `/fishhawk run`).
+- **Per-installation tokens** so the backend can read `.fishhawk/workflows.yaml`, fire `workflow_dispatch`, comment on issues, open PRs.
+- **OAuth user identification** for the Web UI sign-in flow (E4.2 / #49).
+
+This directory ships:
+
+- [`manifest.template.json`](./manifest.template.json) — the App manifest with placeholder `{{BACKEND_URL}}` markers. Templates the URLs the operator fills in for their deploy.
+- [`../../scripts/render-github-app-manifest.sh`](../../scripts/render-github-app-manifest.sh) — a 30-line bash wrapper that renders the template for a given backend URL.
+
+## Permissions
+
+Per `MVP_SPEC.md` §5.1.5:
+
+| Permission | Level | Purpose |
+|---|---|---|
+| `contents` | rw | Read `.fishhawk/workflows.yaml` from the customer's repo; push branches for the implement stage. |
+| `issues` | rw | Read the originating issue's body for prompt construction; comment back with the rendered plan. |
+| `pull_requests` | rw | Open PRs from the runner's pushed branch. |
+| `checks` | rw | Surface stage outcomes as a check run on the PR. |
+| `workflows` | w | Fire `workflow_dispatch` to invoke the runner action. |
+| `members` | r | Resolve `@org/team` references in role definitions to GitHub-login allowlists for approver checks (E4.4 / #50). |
+| `metadata` | r | Always granted; required for any read access. |
+
+Webhook events:
+
+| Event | Why |
+|---|---|
+| `issues` | Trigger on `labeled` with the `fishhawk` label. |
+| `issue_comment` | Trigger on `created` matching `/fishhawk run`. |
+| `pull_request` | Future: trigger flows on PR-side actions. |
+| `push` | Future: branch-policy + spec-change detection. |
+| `workflow_run` | Observe customer-side runner job state. |
+| `check_run`, `check_suite` | Required-status visibility on review-stage gates. |
+
+## Registration paths
+
+Pick one. Manifest flow is faster and removes manual scope-typo risk; manual setup is the fallback when something in the manifest doesn't resolve cleanly (rare).
+
+### A. Manifest flow (recommended)
+
+GitHub's manifest flow takes a one-shot JSON payload and creates the App in your account or org. The rendered manifest carries the right scopes + events; you only fill in the App name and confirm.
+
+1. Render the manifest with your backend's public URL:
+
+   ```sh
+   ./scripts/render-github-app-manifest.sh https://api.fishhawk.example.com > /tmp/fishhawk-app.json
+   jq . /tmp/fishhawk-app.json   # optional sanity check
+   ```
+
+2. Open one of these URLs in a browser. Replace `<owner>` with your GitHub user or org name:
+
+   - **Personal account**: `https://github.com/settings/apps/new`
+   - **Organization**: `https://github.com/organizations/<owner>/settings/apps/new`
+
+3. Submit the rendered JSON via curl to the manifest-conversion endpoint:
+
+   ```sh
+   # GitHub responds with HTML carrying a `code` you'll need next.
+   # The manifest-flow URL must include `state` so GitHub redirects
+   # back to your backend with the conversion code.
+   curl -X POST -H "Content-Type: application/json" \
+     "https://api.github.com/app-manifests/CODE/conversions"
+   ```
+
+   In practice most teams use the **GitHub-hosted manifest form**: paste the JSON from step 1, follow the redirects, accept the prompt. GitHub creates the App, generates the App ID, webhook secret, and private key, and downloads everything in one shot.
+
+### B. Manual setup
+
+If you'd rather click through the form:
+
+1. **Personal**: <https://github.com/settings/apps/new>. **Org**: replace `settings` with `organizations/<owner>/settings`.
+2. Set the homepage URL, callback URL (`{{BACKEND_URL}}/v0/auth/github/callback`), and webhook URL (`{{BACKEND_URL}}/webhooks/github`).
+3. **Generate a webhook secret** (`openssl rand -hex 32`) — you'll set this on the backend too.
+4. Match the permissions in the table above.
+5. Subscribe to the events listed above.
+6. Set "Where can this GitHub App be installed?" to **Only on this account** for v0 / staging; flip to **Any account** when you're ready for the Marketplace listing (E10).
+7. Click **Create GitHub App**.
+8. From the App's settings page:
+   - Note the **App ID** (numeric).
+   - Click **Generate a private key**. Download the `.pem`.
+   - **Optional but recommended**: configure the App to also issue OAuth user-tokens by checking "Request user authorization (OAuth) during installation" and saving the resulting **Client ID** + **Client secret**. The Web UI sign-in flow (E4.2) uses these.
+
+## Configuring the backend
+
+Once registered, supply credentials to `fishhawkd`:
+
+```sh
+export FISHHAWKD_GITHUB_APP_ID="123456"
+export FISHHAWKD_GITHUB_APP_PRIVATE_KEY_FILE="/path/to/fishhawk-app.private-key.pem"
+export FISHHAWKD_GITHUB_WEBHOOK_SECRET="..."   # the secret you set in step 3
+# Web UI OAuth (optional; only when the App also acts as an OAuth provider):
+export FISHHAWKD_OAUTH_CLIENT_ID="Iv1...."
+export FISHHAWKD_OAUTH_CLIENT_SECRET="..."
+export FISHHAWKD_OAUTH_CALLBACK_URL="https://api.fishhawk.example.com/v0/auth/github/callback"
+
+fishhawkd serve
+```
+
+Per ADR-005 (#69) and E13.4 (#61) the production secrets path is AWS Secrets Manager, not env files; use env files only for local dev.
+
+## Installing on a customer repo
+
+Customer-side: visit `https://github.com/apps/fishhawk` (or the App's settings page during private testing), pick the repo to install on, and grant access. Their installation triggers the backend's webhook receiver and is ready to run.
+
+## See also
+
+- `docs/MVP_SPEC.md` §5.1.5 — App component definition.
+- `docs/MVP_SPEC.md` §5.4 — auth model, including OAuth via the App.
+- [ADR-005 (#69)](https://github.com/kuhlman-labs/fishhawk/issues/69) — session model + bearer-token shape for the CLI surface.
+- `backend/README.md` — runtime config for the App credentials and OAuth flow.

--- a/docs/github-app/manifest.template.json
+++ b/docs/github-app/manifest.template.json
@@ -1,0 +1,30 @@
+{
+  "name": "Fishhawk",
+  "url": "{{BACKEND_URL}}",
+  "description": "Workflow + governance layer for AI-driven software changes. See https://github.com/kuhlman-labs/fishhawk.",
+  "public": false,
+  "redirect_url": "{{BACKEND_URL}}/v0/auth/github/manifest-callback",
+  "callback_urls": [
+    "{{BACKEND_URL}}/v0/auth/github/callback"
+  ],
+  "request_oauth_on_install": false,
+  "setup_on_update": false,
+  "default_permissions": {
+    "contents": "write",
+    "issues": "write",
+    "pull_requests": "write",
+    "checks": "write",
+    "workflows": "write",
+    "members": "read",
+    "metadata": "read"
+  },
+  "default_events": [
+    "issues",
+    "issue_comment",
+    "pull_request",
+    "push",
+    "workflow_run",
+    "check_run",
+    "check_suite"
+  ]
+}

--- a/scripts/render-github-app-manifest.sh
+++ b/scripts/render-github-app-manifest.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Render docs/github-app/manifest.template.json with the backend
+# URL filled in. Used by the operator before submitting to
+# GitHub's manifest-flow endpoint (E4.1 / #48).
+#
+# Usage:
+#   scripts/render-github-app-manifest.sh https://api.fishhawk.example.com
+#
+# The rendered JSON is printed to stdout; redirect or pipe as
+# needed:
+#
+#   scripts/render-github-app-manifest.sh https://api.fishhawk.example.com \
+#     | jq .   # validate
+#
+#   scripts/render-github-app-manifest.sh https://api.fishhawk.example.com \
+#     | pbcopy # macOS — paste into the form
+#
+# The manifest URL itself doesn't include the backend URL;
+# GitHub resolves placeholders from the JSON we POST to it.
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "usage: $0 <backend-url>" >&2
+    echo "  e.g. $0 https://api.fishhawk.example.com" >&2
+    exit 2
+fi
+
+backend_url="$1"
+
+# Strip trailing slash so the rendered URLs don't double up on /.
+backend_url="${backend_url%/}"
+
+if [[ -z "$backend_url" || "$backend_url" != http* ]]; then
+    echo "$0: backend URL must start with http:// or https://" >&2
+    exit 2
+fi
+
+template="$(dirname "$0")/../docs/github-app/manifest.template.json"
+if [[ ! -f "$template" ]]; then
+    echo "$0: template not found: $template" >&2
+    exit 1
+fi
+
+# Use sed with a delimiter that won't appear in URLs.
+sed "s|{{BACKEND_URL}}|${backend_url}|g" "$template"


### PR DESCRIPTION
## Summary

The App is the auth surface for everything Fishhawk does on the customer's repo. This PR ships the manifest + setup docs an operator needs to register it; the App registration itself remains a manual operator step.

- `docs/github-app/manifest.template.json` — App manifest with the scopes from MVP_SPEC §5.1.5 (contents / issues / pull_requests / checks rw, workflows w, members r for E4.4 role resolution, metadata r) and the webhook events the backend's receiver consumes (issues, issue_comment, pull_request, push, workflow_run, check_run, check_suite). Backend URL templated via `{{BACKEND_URL}}`.
- `scripts/render-github-app-manifest.sh` — 30-line bash renderer. Validates the URL is http(s), strips trailing slash, prints rendered JSON to stdout.
- `docs/github-app/README.md` — operator-facing setup guide. Covers both registration paths (manifest flow + manual), the per-permission rationale, webhook event purposes, and the `fishhawkd` env-var configuration that consumes the resulting credentials.
- `docs/ARCHITECTURE.md` — GitHub App row updated to point at the new template + renderer.

## Notes

- **No code changes.** The backend's existing `--github-app-id` / `--github-app-private-key-file` flags already consume the credentials this manifest produces; no new wiring needed in `fishhawkd serve`.
- **`members: read` is new vs. the issue body.** Approver checks (E4.4 / #50) need it to expand `@org/team` references to the team's member list. Adding it now keeps the manifest aligned with what's already shipping in the backend.
- **Manifest flow vs. manual.** The README documents both; manifest flow is recommended (lower scope-typo risk), manual is the fallback. Either produces the same App and credential bundle.
- **Top-level README left alone.** It's narrative-only. The ARCHITECTURE.md row is where someone digging into the components finds the manifest; the new `docs/github-app/README.md` is the operator-facing entry point.

## Test plan

- [x] `jq -e .` validates the template parses as JSON
- [x] Renderer emits valid JSON for `https://api.fishhawk.example.com`, scopes match the spec, trailing slash is stripped, missing/non-http URLs exit with usage error
- [x] No Go code touched; existing `go test`, `golangci-lint`, `actionlint` pipelines all unaffected and green
- [x] CI on this PR (path filter routes only docs + scripts; no Go pipeline runs)
- [ ] After merge: operator follows `docs/github-app/README.md` to register the App against staging, exports the credentials, runs `fishhawkd serve` and confirms a labeled issue produces a webhook delivery + workflow_dispatch round trip. (Out of scope for this PR — code is unchanged.)

Closes #48.