### PR TITLE
Add fishhawkd container build pipeline (E13.3)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,37 @@
+# Keep Docker build context narrow + deterministic.
+#
+# The Dockerfile only consumes go.work + the four module trees,
+# so anything outside of those is wasted bytes in the build
+# context. Listing modules + go.work explicitly via COPY also
+# means we don't accidentally bundle local dev artifacts (.env,
+# editor caches, IDE files) into the image.
+
+# VCS / CI / docs / scripts — never needed in the image.
+.git
+.github
+docs
+scripts
+README.md
+LICENSE
+
+# Dev / agent caches.
+.claude
+.cursor
+.vscode
+.idea
+*.swp
+
+# Test / coverage artifacts.
+**/coverage.out
+**/coverage.html
+**/dist
+**/bin
+
+# Frontend (when E7 ships) — has its own pipeline.
+frontend
+node_modules
+**/*.tsbuildinfo
+
+# Loose junk.
+.DS_Store
+*.log

--- a/.github/release-notes/backend.md
+++ b/.github/release-notes/backend.md
@@ -1,0 +1,55 @@
+<!--
+  Header for fishhawkd backend releases. The backend-release
+  workflow appends GitHub's auto-generated changelog (commits
+  since the previous backend/v* tag) underneath this body via
+  `generate_release_notes: true`.
+-->
+
+## Fishhawk Backend (`fishhawkd`)
+
+The Go control-plane service that orchestrates workflow runs, persists state, evaluates policy, and exposes the REST API consumed by the CLI and Web UI.
+
+## What's in this release
+
+- **Container image**: `ghcr.io/kuhlman-labs/fishhawkd:<version>` and `:latest`. Multi-stage build → distroless static binary, ~25 MB. Runs as `nonroot` (uid 65532), no shell, no package manager.
+- **`fishhawkd-<version>.sbom.spdx.json`** — SPDX-JSON SBOM of the image, listing every Go module the binary links against.
+- Image is signed with [cosign](https://docs.sigstore.dev/cosign/overview/) keyless via GitHub Actions OIDC. No managed PGP key in the loop.
+
+## Pulling and verifying
+
+```sh
+cosign verify ghcr.io/kuhlman-labs/fishhawkd:<version> \
+  --certificate-identity-regexp '\.github/workflows/backend-(build|release)\.yml@.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+
+docker pull ghcr.io/kuhlman-labs/fishhawkd:<version>
+```
+
+The verify-identity covers both the per-commit build workflow (`backend-build.yml`) and the tagged-release workflow (`backend-release.yml`). Either is acceptable provenance.
+
+## Running
+
+The image's entrypoint is `/fishhawkd serve`. Configure via env vars / flags:
+
+```sh
+docker run --rm \
+  -p 8080:8080 \
+  -e FISHHAWKD_DATABASE_URL=postgres://… \
+  -e FISHHAWKD_S3_BUCKET=… \
+  -e FISHHAWKD_GITHUB_APP_ID=… \
+  -e FISHHAWKD_GITHUB_APP_PRIVATE_KEY_FILE=/secrets/app-key.pem \
+  -v /local/path/app-key.pem:/secrets/app-key.pem:ro \
+  ghcr.io/kuhlman-labs/fishhawkd:<version>
+```
+
+Full env-var list in `backend/README.md`. Production deploys to AWS ECS Fargate per [ADR-009](https://github.com/kuhlman-labs/fishhawk/issues/73); the task-definition + IAM scaffolding is tracked in a follow-up.
+
+## Compatibility
+
+`fishhawkd` speaks:
+
+- The v0 REST API (`docs/api/v0.openapi.yaml`)
+- The v0 trace bundle wire format (ADR-007 / [#71](https://github.com/kuhlman-labs/fishhawk/issues/71))
+- The v0 workflow spec (`docs/spec/workflow-v0.schema.json`)
+
+Migrations are applied by the `migrate up` subcommand: `docker run … migrate up`. They're embedded in the binary; no external SQL files needed.

--- a/.github/workflows/backend-build.yml
+++ b/.github/workflows/backend-build.yml
@@ -1,0 +1,102 @@
+# fishhawkd container build (E13.3 / #60).
+#
+# Triggered by push to main when backend code (or this workflow
+# itself) changes. Publishes:
+#   ghcr.io/kuhlman-labs/fishhawkd:main
+#   ghcr.io/kuhlman-labs/fishhawkd:sha-<short>
+#
+# Tagged releases use a separate workflow (backend-release.yml)
+# that mirrors the runner-release pattern: re-runs lint+tests at
+# the tag, signs the image, and publishes :vX.Y.Z + :latest.
+#
+# Both workflows produce the same image artifact + cosign
+# signature; the split is just about trigger semantics. Verify
+# downstream:
+#
+#   cosign verify ghcr.io/kuhlman-labs/fishhawkd:<tag> \
+#     --certificate-identity-regexp '\.github/workflows/backend-(build|release)\.yml@.*' \
+#     --certificate-oidc-issuer https://token.actions.githubusercontent.com
+
+name: Backend Build
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'backend/**'
+      - 'go.work'
+      - 'go.work.sum'
+      - 'runner/go.mod'
+      - 'runner/go.sum'
+      - 'cli/go.mod'
+      - 'cli/go.sum'
+      - 'verifier/go.mod'
+      - 'verifier/go.sum'
+      - '.github/workflows/backend-build.yml'
+      - '.dockerignore'
+
+permissions:
+  contents: read
+  packages: write    # push to ghcr.io
+  id-token: write    # cosign keyless signing via GitHub OIDC
+
+jobs:
+  build-and-push:
+    name: Build, sign, and push fishhawkd image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/kuhlman-labs/fishhawkd
+          tags: |
+            type=ref,event=branch
+            type=sha,prefix=sha-
+          labels: |
+            org.opencontainers.image.title=fishhawkd
+            org.opencontainers.image.description=Fishhawk backend control plane.
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.licenses=Apache-2.0
+
+      - name: Build and push image
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: backend/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=sha-${{ github.sha }}
+          cache-from: type=gha,scope=backend-build
+          cache-to: type=gha,mode=max,scope=backend-build
+          provenance: true
+          sbom: true
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign image (keyless)
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -eu
+          # Sign by digest so the signature stays attached to the
+          # exact image bytes — re-tagging doesn't break verify.
+          cosign sign --yes "ghcr.io/kuhlman-labs/fishhawkd@${DIGEST}"

--- a/.github/workflows/backend-release.yml
+++ b/.github/workflows/backend-release.yml
@@ -1,0 +1,140 @@
+# fishhawkd release workflow (E13.3 / #60).
+#
+# Triggered by a tag push matching `backend/v*` (mirrors the
+# runner module-tag convention from E5.7). The workflow:
+#
+#  1. Re-runs lint + tests at the tag's commit (catches a tag
+#     pushed from a dirty branch).
+#  2. Builds the multi-stage Dockerfile with -ldflags=-X stamping
+#     the tag version into internal/version.Version.
+#  3. Pushes ghcr.io/kuhlman-labs/fishhawkd:vX.Y.Z + :latest.
+#  4. Signs the resulting image digest with cosign keyless.
+#  5. Generates an SPDX-JSON SBOM as a downloadable artifact.
+#  6. Publishes a GitHub Release with the SBOM + image-digest
+#     reference. (No separate binary asset — the image IS the
+#     release; tag-only operators can pull it from GHCR.)
+#
+# Versioning convention: `backend/vX.Y.Z`. Path-prefixed tags are
+# the Go-module convention for non-root modules in a monorepo.
+
+name: Backend Release
+
+on:
+  push:
+    tags:
+      - 'backend/v*'
+
+permissions:
+  contents: write    # create release + upload assets
+  packages: write    # push to ghcr.io
+  id-token: write    # cosign keyless signing via GitHub OIDC
+
+jobs:
+  release:
+    name: Build, sign, and publish fishhawkd release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.25'
+          cache: false
+
+      - name: Install golangci-lint
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
+            | sh -s -- -b "$(go env GOPATH)/bin" v2.8.0
+
+      - name: Verify the tagged commit passes lint + tests
+        run: |
+          set -eu
+          GOLANGCI_LINT="$(go env GOPATH)/bin/golangci-lint"
+          (
+            cd backend
+            "$GOLANGCI_LINT" run ./...
+            go build ./...
+            go test -race ./...
+          )
+
+      - name: Compute version
+        id: ver
+        run: |
+          set -eu
+          # refs/tags/backend/v0.1.0 → v0.1.0
+          version="${GITHUB_REF#refs/tags/backend/}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/kuhlman-labs/fishhawkd
+          tags: |
+            type=match,pattern=backend/(v.+),group=1
+            type=raw,value=latest
+          labels: |
+            org.opencontainers.image.title=fishhawkd
+            org.opencontainers.image.description=Fishhawk backend control plane.
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.ver.outputs.version }}
+            org.opencontainers.image.licenses=Apache-2.0
+
+      - name: Build and push image
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: backend/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.ver.outputs.version }}
+          cache-from: type=gha,scope=backend-release
+          cache-to: type=gha,mode=max,scope=backend-release
+          provenance: true
+          sbom: true
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign image (keyless)
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -eu
+          cosign sign --yes "ghcr.io/kuhlman-labs/fishhawkd@${DIGEST}"
+
+      - name: Generate SPDX SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          image: ghcr.io/kuhlman-labs/fishhawkd@${{ steps.build.outputs.digest }}
+          format: spdx-json
+          output-file: ./fishhawkd-${{ steps.ver.outputs.version }}.sbom.spdx.json
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: fishhawkd ${{ steps.ver.outputs.version }}
+          generate_release_notes: true
+          body_path: .github/release-notes/backend.md
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          files: |
+            ./fishhawkd-${{ steps.ver.outputs.version }}.sbom.spdx.json

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,71 @@
+# Multi-stage build for fishhawkd (E13.3 / #60).
+#
+# Stage 1: full Go toolchain compiles a static binary with the
+# version stamped via -ldflags (matching runner/release.yml's
+# convention).
+#
+# Stage 2: distroless/static-debian12 runs the binary as a
+# non-root user. The image carries no shell, no package manager,
+# and no libc beyond what a static Go binary needs — small
+# attack surface, ~25 MB.
+
+ARG GO_VERSION=1.25
+
+# ---- builder ----
+FROM golang:${GO_VERSION}-bookworm AS builder
+
+WORKDIR /src
+
+# Copy go.work + modules first so dependency-only changes hit
+# the docker layer cache instead of re-running every build.
+COPY go.work go.work.sum ./
+COPY backend/go.mod backend/go.sum ./backend/
+COPY runner/go.mod runner/go.sum ./runner/
+COPY cli/go.mod cli/go.sum ./cli/
+COPY verifier/go.mod verifier/go.sum ./verifier/
+
+# Pre-download deps. With a populated cache, source-only changes
+# avoid re-resolving the module graph.
+RUN cd backend && go mod download
+
+# Now bring in the actual sources. We only need backend's tree
+# plus go.work; the other modules are referenced by go.work but
+# go build ./backend/... resolves their packages from the local
+# paths above.
+COPY backend ./backend
+COPY runner ./runner
+COPY cli ./cli
+COPY verifier ./verifier
+
+ARG VERSION=dev
+
+# CGO_ENABLED=0 produces a fully static binary — required by the
+# distroless/static base image (no libc).
+RUN cd backend && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+        -trimpath \
+        -ldflags="-s -w -X github.com/kuhlman-labs/fishhawk/backend/internal/version.Version=${VERSION}" \
+        -o /out/fishhawkd \
+        ./cmd/fishhawkd
+
+# ---- runtime ----
+# distroless/static-debian12: glibc-free, no shell, runs as
+# uid 65532 (`nonroot`). Pin by digest in production deploys.
+FROM gcr.io/distroless/static-debian12:nonroot AS runtime
+
+# OCI labels make `docker inspect` + GHCR's UI carry useful
+# provenance without us hand-building extra metadata files.
+LABEL org.opencontainers.image.source="https://github.com/kuhlman-labs/fishhawk"
+LABEL org.opencontainers.image.description="Fishhawk backend control plane (fishhawkd)."
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.title="fishhawkd"
+
+# Default listen port from cmd/fishhawkd/serve.go's --addr
+# default; operators override via FISHHAWKD_ADDR.
+EXPOSE 8080
+
+# Use the binary directly — no shell to inherit signals or rewrite
+# the command line.
+ENTRYPOINT ["/fishhawkd"]
+CMD ["serve"]
+
+COPY --from=builder /out/fishhawkd /fishhawkd

--- a/backend/README.md
+++ b/backend/README.md
@@ -81,4 +81,33 @@ fishhawkd token issue --subject github:42 --scopes runs:read,runs:write
 
 The plaintext is printed to stdout exactly once (suitable for `... | head -n1`); only the sha256 hash is stored. Subsequent tokens can be minted via `POST /v0/tokens` once you have one bearer in hand.
 
+## Container image
+
+`fishhawkd` ships as a distroless static-binary image at
+`ghcr.io/kuhlman-labs/fishhawkd`. Two tag streams:
+
+- `:main` and `:sha-<commit>` — pushed by `.github/workflows/backend-build.yml` on every merge to `main`.
+- `:v<version>` and `:latest` — pushed by `.github/workflows/backend-release.yml` on `backend/v*` tags. Tagged releases also attach an SPDX-JSON SBOM to the GitHub Release.
+
+Both streams are signed keylessly with [cosign](https://docs.sigstore.dev/cosign/overview/) via GitHub Actions OIDC. To verify before pulling:
+
+```sh
+cosign verify ghcr.io/kuhlman-labs/fishhawkd:<tag> \
+  --certificate-identity-regexp '\.github/workflows/backend-(build|release)\.yml@.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+To build locally (matches the CI build, including version stamping):
+
+```sh
+docker build \
+  --build-arg VERSION=$(git rev-parse --short HEAD) \
+  -f backend/Dockerfile \
+  -t fishhawkd:dev .
+```
+
+The image's entrypoint is `/fishhawkd serve`; override with the `migrate` subcommand to apply migrations: `docker run … fishhawkd:dev migrate up`. Hosted deploy (ECS Fargate task definition + IAM scaffolding per [ADR-009](https://github.com/kuhlman-labs/fishhawk/issues/73)) is tracked separately in [#148](https://github.com/kuhlman-labs/fishhawk/issues/148).
+
+## See also
+
 Larger context: `docs/MVP_SPEC.md` §5.1.1 (component) and §5.2 (execution flow); `docs/ARCHITECTURE.md` §4–§6 for the workflow lifecycle, storage model, and invariants.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -179,6 +179,7 @@ GitHub OAuth (E4.2 / #49) is the sign-in flow that mints the cookie session. App
 | GitHub App installation tokens | `backend/internal/githubapp/` (RS256 signer + client + TTL cache + telemetry); App ID + key file from `FISHHAWKD_GITHUB_APP_ID` / `FISHHAWKD_GITHUB_APP_PRIVATE_KEY_FILE` |
 | GitHub REST operations (read workflow spec, fire workflow_dispatch) | `backend/internal/githubclient/`; consumes `githubapp.TokenProvider` |
 | How a new Go module gets added | `CLAUDE.md` "Adding a Go module" |
+| `fishhawkd` container image | `backend/Dockerfile` (multi-stage → distroless static, ~28 MB; `-X version.Version` stamped from `VERSION` build-arg). `.github/workflows/backend-build.yml` builds + pushes `ghcr.io/kuhlman-labs/fishhawkd:main` and `:sha-<commit>` on every push to `main`; `.github/workflows/backend-release.yml` fires on `backend/v*` tags, attaches an SPDX-JSON SBOM, cuts a GitHub Release. Both are signed keylessly via cosign + GHA OIDC; verify with the regex in `.github/release-notes/backend.md`. ECS task-definition + IAM scaffolding (per ADR-009) tracked separately in [#148](https://github.com/kuhlman-labs/fishhawk/issues/148). |
 
 ## 11. Open work
 


### PR DESCRIPTION
## Summary

- Multi-stage `backend/Dockerfile` builds a version-stamped static `fishhawkd` binary on `golang:1.25-bookworm`, ships it on `gcr.io/distroless/static-debian12:nonroot` (~28 MB, no shell, runs as uid 65532).
- `.github/workflows/backend-build.yml` rebuilds the image on every push to `main` touching `backend/**`, `go.work*`, the workflow, or `.dockerignore`, and pushes `ghcr.io/kuhlman-labs/fishhawkd:main` + `:sha-<commit>`.
- `.github/workflows/backend-release.yml` fires on `backend/v*` tags: re-runs lint + build + test, pushes `:v<x.y.z>` + `:latest`, attaches an SPDX-JSON SBOM, and cuts a GitHub Release seeded from `.github/release-notes/backend.md`.
- Both flows sign by digest with cosign keyless via GitHub Actions OIDC; the `--certificate-identity-regexp` in the release-notes header covers either workflow as valid provenance.

## Test plan

- [x] `docker build --build-arg VERSION=v0.0.0-test -f backend/Dockerfile -t fishhawkd:test .` succeeds locally.
- [x] `docker run --rm -p 8080:8080 fishhawkd:test` starts cleanly; `curl localhost:8080/healthz` returns `{"status":"ok","version":"v0.0.0-test"}`, confirming the `-ldflags=-X` stamp threads through the multi-stage build.
- [x] `actionlint` clean across both new workflow files.
- [x] Backend-build path filter only matches files that can change the image (`backend/**`, `go.work*`, the workflow itself, `.dockerignore`).
- [ ] Verified post-merge: first push to `main` pushes a `:main` + `:sha-<commit>` image to GHCR with a cosign signature.
- [ ] Verified post-tag (deferred): `backend/v0.1.0` tag fixture cuts a Release with attached SBOM. Will exercise once we cut v0.1.0.

## Notes

Hosted deploy (ECS Fargate task definition + IAM scaffolding per [ADR-009](https://github.com/kuhlman-labs/fishhawk/issues/73)) is deliberately out of scope here and tracked separately in #148 (E13.7). This PR is the build half; #148 is the deploy half.

Cosign verify command operators will use:

```sh
cosign verify ghcr.io/kuhlman-labs/fishhawkd:<tag> \
  --certificate-identity-regexp '\.github/workflows/backend-(build|release)\.yml@.*' \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com
```

Closes #60.