### PR TITLE
Make Dockerfile tolerate absent go.work.sum

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -18,7 +18,12 @@ WORKDIR /src
 
 # Copy go.work + modules first so dependency-only changes hit
 # the docker layer cache instead of re-running every build.
-COPY go.work go.work.sum ./
+#
+# go.work.sum is intentionally gitignored (no external imports
+# yet, so it doesn't exist in CI's build context). The glob
+# matches go.work always and go.work.sum opportunistically once
+# external deps land — no Dockerfile change needed at that point.
+COPY go.work* ./
 COPY backend/go.mod backend/go.sum ./backend/
 COPY runner/go.mod runner/go.sum ./runner/
 COPY cli/go.mod cli/go.sum ./cli/


### PR DESCRIPTION
## Summary

The first push-to-main image build after #149 merged failed:

```
ERROR: failed to build: failed to solve: failed to compute cache key:
failed to calculate checksum of ref ...: "/go.work.sum": not found
```

Root cause: the Dockerfile listed \`go.work.sum\` explicitly in COPY, but per CLAUDE.md \`go.work.sum\` is gitignored — it only materializes once an external import lands, and there are none yet. Local builds in #149's smoke test happened to have a stale \`go.work.sum\` lying around, which masked the failure mode.

Fix: \`COPY go.work* ./\` matches \`go.work\` always and picks up \`go.work.sum\` opportunistically once it exists. No further Dockerfile change needed at the point the first external dep lands.

## Test plan

- [x] Removed \`go.work.sum\` from the local tree, rebuilt with \`--no-cache\`: image builds clean, \`/healthz\` returns \`{"status":"ok","version":"v0.0.0-nosum"}\`.
- [x] Re-ran with \`go.work.sum\` present: still builds, still stamps the version.
- [ ] Verified post-merge: backend-build workflow succeeds on the resulting commit, image lands at \`ghcr.io/kuhlman-labs/fishhawkd:main\`.