### PR TITLE
Wire frontend OAuth + protected routes (E7.2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,4 +112,6 @@ Error messages: precise about what failed and how to fix. No generic apologies.
 - **macOS bash is 3.2** — no associative arrays. Use zsh, gawk, or awk lookups for scripts that need them.
 - **`go.work` is committed**; `go.work.sum` is not. `go.sum` will appear on first external import.
 - **Project #7 Status field** has 6 options (Backlog/Up Next/In Progress/In Review/Blocked/Done) set via GraphQL `updateProjectV2Field` with `singleSelectOptions` (undocumented input field). Repeat the same workaround if creating new projects.
+- **Project #7 owner is `kuhlman-labs` as a `user`, not an `organization`** — the GraphQL queries that take an owner login must use `user(login:"kuhlman-labs")`, not `organization(...)`, or you get a NOT_FOUND. The repo lives under what looks like an org namespace but it's a user-owned account.
+- **Project #7 has > 100 items.** GraphQL caps `items(first:N)` at 100. To find an item ID for a known issue, query the issue's `projectItems(first:10)` and filter by `project.id` instead of paginating the project's items list — same answer in one round-trip with no cursors.
 - After **Day 21**, every change must flow through a Fishhawk workflow run (today: by convention; later: enforced by the product).

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,7 +1,50 @@
-import { describe, expect, it } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import { App } from './App';
+import type { User } from './auth/types';
+
+const sampleUser: User = {
+  id: '00000000-0000-0000-0000-000000000001',
+  github_login: 'kuhlman-labs',
+  name: 'Brett Kuhlman',
+  email: 'brett@example.com',
+};
+
+type MeResponse = { ok: true; user: User } | { ok: false } | { ok: 'throw' };
+
+function mockAuth(me: MeResponse) {
+  /*
+   * Centralized fetch stub. Anything beyond /v0/auth/* falls through
+   * with a 404 so unrelated network calls in routes that haven't
+   * been wired to the API yet (runs, audit) don't quietly succeed
+   * with stale fixtures.
+   */
+  const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    if (url.endsWith('/v0/auth/me')) {
+      if (me.ok === 'throw') {
+        throw new Error('network');
+      }
+      if (me.ok) {
+        return new Response(JSON.stringify(me.user), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response('{"error":"auth_required"}', {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    if (url.endsWith('/v0/auth/logout')) {
+      return new Response(null, { status: 204 });
+    }
+    return new Response('not stubbed', { status: 404 });
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
 
 function renderAt(path: string) {
   return render(
@@ -11,26 +54,100 @@ function renderAt(path: string) {
   );
 }
 
-describe('App routing', () => {
-  it('renders the runs route as the index', () => {
-    renderAt('/');
-    expect(screen.getByRole('heading', { name: 'Runs' })).toBeInTheDocument();
+describe('App routing + auth', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
-  it('renders the audit route', () => {
-    renderAt('/audit');
-    expect(screen.getByRole('heading', { name: 'Audit log' })).toBeInTheDocument();
+  describe('authenticated', () => {
+    beforeEach(() => {
+      mockAuth({ ok: true, user: sampleUser });
+    });
+
+    it('renders the runs route as the index', async () => {
+      renderAt('/');
+      expect(await screen.findByRole('heading', { name: 'Runs' })).toBeInTheDocument();
+    });
+
+    it('renders the audit route', async () => {
+      renderAt('/audit');
+      expect(await screen.findByRole('heading', { name: 'Audit log' })).toBeInTheDocument();
+    });
+
+    it('shows the signed-in user in the shell', async () => {
+      renderAt('/');
+      expect(await screen.findByText('@kuhlman-labs')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /sign out/i })).toBeInTheDocument();
+    });
+
+    it('redirects /login → / when already signed in', async () => {
+      renderAt('/login');
+      // Lands on the runs index (rendered inside Root) after the redirect.
+      expect(await screen.findByRole('heading', { name: 'Runs' })).toBeInTheDocument();
+    });
+
+    it('signs out via POST /v0/auth/logout and routes to /login', async () => {
+      const fetchMock = mockAuth({ ok: true, user: sampleUser });
+      renderAt('/');
+      const signOut = await screen.findByRole('button', { name: /sign out/i });
+      fireEvent.click(signOut);
+
+      // Logout request fired with credentials.
+      await waitFor(() => {
+        const logoutCall = fetchMock.mock.calls.find(([url]) =>
+          String(url).endsWith('/v0/auth/logout'),
+        );
+        expect(logoutCall).toBeDefined();
+        expect(logoutCall?.[1]).toMatchObject({
+          method: 'POST',
+          credentials: 'include',
+        });
+      });
+
+      // Now on /login, with the OAuth-start link rendered.
+      expect(
+        await screen.findByRole('link', { name: /continue with github/i }),
+      ).toBeInTheDocument();
+    });
   });
 
-  it('renders the login route outside the app shell', () => {
-    renderAt('/login');
-    expect(screen.getByRole('button', { name: /continue with github/i })).toBeInTheDocument();
-    // The shell nav shouldn't be present on /login.
-    expect(screen.queryByRole('link', { name: /runs/i })).not.toBeInTheDocument();
+  describe('unauthenticated', () => {
+    beforeEach(() => {
+      mockAuth({ ok: false });
+    });
+
+    it('renders the login route outside the app shell', async () => {
+      renderAt('/login');
+      const link = await screen.findByRole('link', {
+        name: /continue with github/i,
+      });
+      expect(link).toHaveAttribute('href', '/v0/auth/github/login');
+      expect(screen.queryByRole('link', { name: /^runs$/i })).not.toBeInTheDocument();
+    });
+
+    it('redirects protected routes to /login', async () => {
+      renderAt('/runs');
+      expect(
+        await screen.findByRole('link', { name: /continue with github/i }),
+      ).toBeInTheDocument();
+    });
+
+    it('renders a not-found page for unknown public routes', async () => {
+      renderAt('/does-not-exist');
+      expect(await screen.findByRole('heading', { name: /not found/i })).toBeInTheDocument();
+    });
   });
 
-  it('renders a not-found page for unknown routes', () => {
-    renderAt('/does-not-exist');
-    expect(screen.getByRole('heading', { name: /not found/i })).toBeInTheDocument();
+  describe('network failure', () => {
+    it('falls through to unauthenticated rather than blocking', async () => {
+      mockAuth({ ok: 'throw' });
+      renderAt('/runs');
+      expect(
+        await screen.findByRole('link', { name: /continue with github/i }),
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,6 @@
 import { Route, Routes } from 'react-router';
+import { AuthProvider } from './auth/auth-provider';
+import { RequireAuth } from './auth/require-auth';
 import { Root } from './routes/root';
 import { Login } from './routes/login';
 import { Runs } from './routes/runs';
@@ -7,14 +9,23 @@ import { NotFound } from './routes/not-found';
 
 export function App() {
   return (
-    <Routes>
-      <Route path="/login" element={<Login />} />
-      <Route path="/" element={<Root />}>
-        <Route index element={<Runs />} />
-        <Route path="runs" element={<Runs />} />
-        <Route path="audit" element={<Audit />} />
-      </Route>
-      <Route path="*" element={<NotFound />} />
-    </Routes>
+    <AuthProvider>
+      <Routes>
+        <Route path="/login" element={<Login />} />
+        <Route
+          path="/"
+          element={
+            <RequireAuth>
+              <Root />
+            </RequireAuth>
+          }
+        >
+          <Route index element={<Runs />} />
+          <Route path="runs" element={<Runs />} />
+          <Route path="audit" element={<Audit />} />
+        </Route>
+        <Route path="*" element={<NotFound />} />
+      </Routes>
+    </AuthProvider>
   );
 }

--- a/frontend/src/auth/auth-context.ts
+++ b/frontend/src/auth/auth-context.ts
@@ -1,0 +1,9 @@
+import { createContext } from 'react';
+import type { AuthContextValue } from './types';
+
+/*
+ * Lives in its own module so React Fast Refresh (eslint-plugin-
+ * react-refresh) doesn't trip over a file mixing component and
+ * non-component exports.
+ */
+export const AuthContext = createContext<AuthContextValue | null>(null);

--- a/frontend/src/auth/auth-provider.tsx
+++ b/frontend/src/auth/auth-provider.tsx
@@ -1,0 +1,59 @@
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
+import { AuthContext } from './auth-context';
+import type { AuthStatus, User } from './types';
+
+interface State {
+  status: AuthStatus;
+  user: User | null;
+}
+
+const initial: State = { status: 'loading', user: null };
+
+/*
+ * Owns the conversation with /v0/auth/me. Same-origin fetch (Vite
+ * proxies /v0 → fishhawkd in dev; in prod the SPA is served by the
+ * same backend) means the fishhawk_session cookie rides along
+ * automatically with credentials: 'include'. ADR-005.
+ *
+ * No retry / backoff: if /v0/auth/me errors out (offline, backend
+ * down) we fall through to unauthenticated rather than spinning
+ * forever. The user is then funnelled to /login, which on a clicked
+ * sign-in restarts the flow against a presumably-recovered backend.
+ */
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<State>(initial);
+
+  const reload = useCallback(async () => {
+    setState((s) => ({ ...s, status: 'loading' }));
+    try {
+      const res = await fetch('/v0/auth/me', { credentials: 'include' });
+      if (res.ok) {
+        const user = (await res.json()) as User;
+        setState({ status: 'authenticated', user });
+        return;
+      }
+      setState({ status: 'unauthenticated', user: null });
+    } catch {
+      setState({ status: 'unauthenticated', user: null });
+    }
+  }, []);
+
+  const signOut = useCallback(async () => {
+    try {
+      await fetch('/v0/auth/logout', { method: 'POST', credentials: 'include' });
+    } catch {
+      // The server may already consider us signed out (network
+      // partition, expired session). Either way, drop local state
+      // so the UI matches the user's intent.
+    }
+    setState({ status: 'unauthenticated', user: null });
+  }, []);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  const value = useMemo(() => ({ ...state, reload, signOut }), [state, reload, signOut]);
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}

--- a/frontend/src/auth/require-auth.tsx
+++ b/frontend/src/auth/require-auth.tsx
@@ -1,0 +1,35 @@
+import { Navigate } from 'react-router';
+import type { ReactNode } from 'react';
+import { useAuth } from './use-auth';
+
+interface Props {
+  children: ReactNode;
+}
+
+/*
+ * Gate around the app shell. While auth is loading we render a
+ * minimal placeholder rather than nothing, so refresh on a deep
+ * link doesn't cause the shell to flash empty before the redirect
+ * decision is made.
+ */
+export function RequireAuth({ children }: Props) {
+  const { status } = useAuth();
+
+  if (status === 'loading') {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        className="flex min-h-full items-center justify-center text-sm text-neutral-500"
+      >
+        Checking session…
+      </div>
+    );
+  }
+
+  if (status === 'unauthenticated') {
+    return <Navigate to="/login" replace />;
+  }
+
+  return <>{children}</>;
+}

--- a/frontend/src/auth/types.ts
+++ b/frontend/src/auth/types.ts
@@ -1,0 +1,20 @@
+/*
+ * Mirrors the OpenAPI `User` schema (docs/api/v0.openapi.yaml).
+ * Update both sides together — the schema-sync CI doesn't cover the
+ * frontend type, so drift is silent here.
+ */
+export interface User {
+  id: string;
+  github_login: string;
+  name: string;
+  email: string | null;
+}
+
+export type AuthStatus = 'loading' | 'authenticated' | 'unauthenticated';
+
+export interface AuthContextValue {
+  status: AuthStatus;
+  user: User | null;
+  reload: () => Promise<void>;
+  signOut: () => Promise<void>;
+}

--- a/frontend/src/auth/use-auth.ts
+++ b/frontend/src/auth/use-auth.ts
@@ -1,0 +1,11 @@
+import { useContext } from 'react';
+import { AuthContext } from './auth-context';
+import type { AuthContextValue } from './types';
+
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    throw new Error('useAuth must be used within <AuthProvider>');
+  }
+  return ctx;
+}

--- a/frontend/src/routes/login.tsx
+++ b/frontend/src/routes/login.tsx
@@ -1,11 +1,25 @@
 import { Github } from 'lucide-react';
+import { Navigate } from 'react-router';
 import { Button } from '@/components/ui/button';
+import { useAuth } from '@/auth/use-auth';
 
 /*
- * Stub sign-in surface. Real OAuth wiring (button → /v0/auth/github/login)
- * lands with E7.2 (#38). Until then the button is non-interactive.
+ * The button is a plain anchor pointing at the backend's OAuth start
+ * endpoint, not a fetch — the backend responds with a 302 to GitHub
+ * and the browser must follow it. A fetch() would never see the
+ * Location header in the way the browser does.
+ *
+ * If a user lands here while already authenticated (back-button after
+ * sign-out, deep link, etc.) we send them home instead of showing
+ * a useless "sign in" form.
  */
 export function Login() {
+  const { status } = useAuth();
+
+  if (status === 'authenticated') {
+    return <Navigate to="/" replace />;
+  }
+
   return (
     <div className="flex min-h-full items-center justify-center px-4">
       <div className="w-full max-w-sm space-y-6 rounded-lg border border-neutral-200 bg-white p-8 dark:border-neutral-800 dark:bg-neutral-900">
@@ -15,13 +29,12 @@ export function Login() {
             Sign in to review plans and approve workflow runs.
           </p>
         </div>
-        <Button className="w-full" disabled>
-          <Github className="size-4" aria-hidden />
-          <span>Continue with GitHub</span>
+        <Button asChild className="w-full">
+          <a href="/v0/auth/github/login">
+            <Github className="size-4" aria-hidden />
+            <span>Continue with GitHub</span>
+          </a>
         </Button>
-        <p className="text-xs text-neutral-500 dark:text-neutral-500">
-          OAuth wiring pending (E7.2).
-        </p>
       </div>
     </div>
   );

--- a/frontend/src/routes/root.tsx
+++ b/frontend/src/routes/root.tsx
@@ -1,6 +1,8 @@
-import { NavLink, Outlet } from 'react-router';
-import { ListChecks, ScrollText } from 'lucide-react';
+import { NavLink, Outlet, useNavigate } from 'react-router';
+import { ListChecks, LogOut, ScrollText } from 'lucide-react';
 import { cn } from '@/lib/cn';
+import { Button } from '@/components/ui/button';
+import { useAuth } from '@/auth/use-auth';
 
 const navItems = [
   { to: '/runs', label: 'Runs', icon: ListChecks },
@@ -8,9 +10,17 @@ const navItems = [
 ];
 
 export function Root() {
+  const { user, signOut } = useAuth();
+  const navigate = useNavigate();
+
+  async function handleSignOut() {
+    await signOut();
+    navigate('/login', { replace: true });
+  }
+
   return (
     <div className="grid min-h-full grid-cols-[14rem_1fr]">
-      <aside className="border-r border-neutral-200 bg-neutral-100 px-3 py-4 dark:border-neutral-800 dark:bg-neutral-900">
+      <aside className="flex flex-col border-r border-neutral-200 bg-neutral-100 px-3 py-4 dark:border-neutral-800 dark:bg-neutral-900">
         <div className="px-2 pb-4 font-mono text-sm font-semibold tracking-tight">fishhawk</div>
         <nav className="flex flex-col gap-1">
           {navItems.map(({ to, label, icon: Icon }) => (
@@ -32,6 +42,25 @@ export function Root() {
             </NavLink>
           ))}
         </nav>
+        <div className="mt-auto space-y-2 border-t border-neutral-200 pt-3 dark:border-neutral-800">
+          {user && (
+            <div className="px-2 text-xs text-neutral-600 dark:text-neutral-400">
+              <div className="truncate font-medium text-neutral-800 dark:text-neutral-200">
+                {user.name || user.github_login}
+              </div>
+              <div className="truncate">@{user.github_login}</div>
+            </div>
+          )}
+          <Button
+            variant="ghost"
+            size="sm"
+            className="w-full justify-start"
+            onClick={handleSignOut}
+          >
+            <LogOut className="size-4" aria-hidden />
+            <span>Sign out</span>
+          </Button>
+        </div>
       </aside>
       <main className="px-8 py-6">
         <Outlet />


### PR DESCRIPTION
## Summary

Hook the SPA up to the backend's existing auth surface (E4.2 #49):

- **`AuthProvider`** fetches `GET /v0/auth/me` on mount with `credentials: 'include'`; resolves to `{ status, user, reload, signOut }`. Same-origin fetch + the `fishhawk_session` cookie do all the work — no token plumbing in JS, per [ADR-005](https://github.com/kuhlman-labs/fishhawk/issues/69).
- **`AuthContext`** lives in its own module (`auth-context.ts`) so `eslint-plugin-react-refresh`'s "one export kind per file" rule isn't tripped by mixing the context value with the provider component.
- **`RequireAuth`** gates the app shell: `loading` renders a `role="status"` placeholder so a refresh on a deep link doesn't flash empty before the redirect decision lands; `unauthenticated` redirects to `/login`.
- **`Login`** is `Button asChild` wrapping `<a href="/v0/auth/github/login">` rather than a fetch — the backend's 302 to GitHub must be followed by the browser. An already-authenticated user landing on `/login` is bounced to `/` so the form doesn't render uselessly.
- **Sign-out** POSTs `/v0/auth/logout` with credentials, drops local state even on network failure (server may already consider us signed out), then routes to `/login`.

Vitest suite grows 4 → 9: `authenticated`, `unauthenticated`, and `network failure` describe-blocks all render `App` through `MemoryRouter` against a stubbed `fetch`. The logout test also asserts the POST carries `credentials: 'include'` so the cookie reaches the server.

## Test plan

- [x] `pnpm typecheck` clean.
- [x] `pnpm lint` clean.
- [x] `pnpm test` — 9/9 vitest tests pass.
- [x] `pnpm format:check` clean.
- [x] `pnpm build` — 266 KB JS / 85 KB gzipped (+3 KB from auth wiring).
- [ ] Manual end-to-end against a real backend (deferred until OAuth client/secret is configured for a dev GitHub App).

## Notes

### Deferrals filed

- **E4.6 (#152)** — backend CSRF enforcement on state-changing endpoints. ADR-005 and the OpenAPI spec both promise `X-CSRF-Token` / `__Host-csrf`, but the backend doesn't enforce it yet. v0 self-execution is same-origin so this is a real gap, not a critical one. Frontend will pick up the header read once the backend lands.
- **E7.2.1 (#153)** — preserve post-sign-in redirect intent. Today `/audit` → `/login` → `/` drops the deep link.

### CLAUDE.md traps

Two new "Traps" entries:

- Project #7's owner is the user `kuhlman-labs`, not an organization; GraphQL queries must use `user(login:...)`, not `organization(...)`. Caught me when filing the deferrals.
- Project #7 now has > 100 items, so `items(first:N)` caps at 100. Resolve a known issue's project-item id by querying the issue's `projectItems(first:10)` and filtering by `project.id` instead of paginating the project's items list.

Closes #38.