### PR TITLE
Update root README with v0 status and local-dev quickstart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,130 @@
+# Developer convenience targets. CI does not depend on this Makefile —
+# the workflows under .github/workflows/ run their own commands. Targets
+# here are documented via the `help` target (the default).
+
+SHELL := /bin/bash
+.SHELLFLAGS := -eu -o pipefail -c
+.DEFAULT_GOAL := help
+
+DATABASE_URL ?= postgres://fishhawk:fishhawk@localhost:5432/fishhawk?sslmode=disable
+COVERAGE_THRESHOLD ?= 80
+
+GO_MODULES := $(shell go work edit -json | jq -r '.Use[].DiskPath')
+
+.PHONY: help
+help: ## Show this help.
+	@awk 'BEGIN {FS = ":.*##"; printf "Usage: make <target>\n\nTargets:\n"} \
+		/^[a-zA-Z0-9_-]+:.*##/ {printf "  \033[36m%-22s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+# ----- local stack ---------------------------------------------------------
+
+.PHONY: up
+up: ## Bring up Postgres + MinIO via docker compose.
+	docker compose up -d
+
+.PHONY: down
+down: ## Stop the local stack (preserves volumes).
+	docker compose down
+
+.PHONY: nuke
+nuke: ## Stop the local stack AND drop volumes (destroys data).
+	docker compose down -v
+
+.PHONY: migrate
+migrate: ## Apply backend Postgres migrations.
+	FISHHAWKD_DATABASE_URL='$(DATABASE_URL)' go run ./backend/cmd/fishhawkd migrate up
+
+.PHONY: migrate-down
+migrate-down: ## Roll back the most recent migration.
+	FISHHAWKD_DATABASE_URL='$(DATABASE_URL)' go run ./backend/cmd/fishhawkd migrate down
+
+# ----- run -----------------------------------------------------------------
+
+.PHONY: dev-backend
+dev-backend: ## Run fishhawkd against the local stack on :8080.
+	FISHHAWKD_DATABASE_URL='$(DATABASE_URL)' go run ./backend/cmd/fishhawkd serve
+
+.PHONY: dev-frontend
+dev-frontend: ## Run the Web UI dev server on :5173 (proxies /v0 → :8080).
+	cd frontend && pnpm install && pnpm dev
+
+.PHONY: validate
+validate: ## Validate .fishhawk/workflows.yaml with the CLI.
+	go run ./cli/cmd/fishhawk validate ./.fishhawk/workflows.yaml
+
+# ----- build ---------------------------------------------------------------
+
+.PHONY: build
+build: build-go build-frontend ## Build every Go module and the Web UI.
+
+.PHONY: build-go
+build-go: ## Build every registered Go module in go.work.
+	@for m in $(GO_MODULES); do \
+		echo ">>> build $$m"; \
+		(cd $$m && go build ./...) || exit 1; \
+	done
+
+.PHONY: build-frontend
+build-frontend: ## Type-check and build the Web UI for production.
+	cd frontend && pnpm install && pnpm build
+
+# ----- test ----------------------------------------------------------------
+
+.PHONY: test
+test: test-go test-frontend ## Run every Go module's tests and the Web UI tests.
+
+.PHONY: test-go
+test-go: ## Run `go test -race ./...` across every module in go.work.
+	@for m in $(GO_MODULES); do \
+		echo ">>> test $$m"; \
+		(cd $$m && go test -race ./...) || exit 1; \
+	done
+
+.PHONY: test-frontend
+test-frontend: ## Run vitest in the Web UI.
+	cd frontend && pnpm install && pnpm test
+
+.PHONY: coverage
+coverage: ## Reproduce the CI coverage gate (>= 80%, excluding sqlc-generated db).
+	(cd backend && go test -race -coverprofile=coverage.out -covermode=atomic ./...)
+	python3 scripts/check-coverage.py --threshold $(COVERAGE_THRESHOLD) --exclude internal/run/db backend/coverage.out
+
+# ----- lint / format -------------------------------------------------------
+
+.PHONY: lint
+lint: lint-go lint-frontend ## Run all linters.
+
+.PHONY: lint-go
+lint-go: ## Run golangci-lint v2 across every Go module.
+	@for m in $(GO_MODULES); do \
+		echo ">>> lint $$m"; \
+		(cd $$m && golangci-lint run ./...) || exit 1; \
+	done
+
+.PHONY: lint-frontend
+lint-frontend: ## Run eslint + tsc --noEmit in the Web UI.
+	cd frontend && pnpm install && pnpm lint && pnpm typecheck
+
+.PHONY: fmt
+fmt: ## Format Go (gofmt) and frontend (prettier) sources.
+	@for m in $(GO_MODULES); do \
+		(cd $$m && gofmt -w .) || exit 1; \
+	done
+	cd frontend && pnpm format
+
+# ----- housekeeping --------------------------------------------------------
+
+.PHONY: tidy
+tidy: ## Run `go mod tidy` in every module.
+	@for m in $(GO_MODULES); do \
+		echo ">>> tidy $$m"; \
+		(cd $$m && go mod tidy) || exit 1; \
+	done
+
+.PHONY: clean
+clean: ## Remove build artifacts and coverage profiles.
+	rm -f backend/coverage.out
+	rm -rf frontend/dist frontend/node_modules/.vite
+	@for m in $(GO_MODULES); do \
+		(cd $$m && go clean ./...) || exit 1; \
+	done

--- a/README.md
+++ b/README.md
@@ -6,17 +6,19 @@ Agents do the work. Your team approves the work. Fishhawk holds the record.
 
 ## Status
 
-Very early. This repository is public from day one as a deliberate commitment to the methodology described in [`docs/METHODOLOGY.md`](docs/METHODOLOGY.md): Fishhawk is built using Fishhawk, and the record of how it gets built is open.
+Pre-alpha, but the v0 build is largely landed:
 
-There is no working software here yet. The repository currently contains:
+- **Backend control plane (`fishhawkd`)** — REST API, run/stage state machine on Postgres, signed audit log, policy evaluator, approval gating with SLA timeouts, retry semantics, GitHub App webhook receiver. ([`backend/`](backend/README.md))
+- **Runner action (`fishhawk/runner`)** — published as `kuhlman-labs/fishhawk/runner@runner/vX.Y.Z`. Cosign-signed releases with SBOMs. ([`runner/`](runner/README.md))
+- **CLI (`fishhawk`)** — `validate`, `run start`, `run status`, `run open`. ([`cli/`](cli/README.md))
+- **Web UI** — plan review, approval, audit log per run, retry on failures. ([`frontend/`](frontend/README.md))
+- **Audit-log verifier** — standalone binary that re-verifies an exported chain offline. ([`verifier/`](verifier/README.md))
+- **Hosted infrastructure (Terraform)** — VPC, RDS, ECS Fargate, ALB, OIDC-based deploys. Two cost profiles: dev (~$15/mo, no NAT/no ALB) and prod (~$85/mo, full HA-eligible). ([`infra/terraform/`](infra/terraform/README.md))
+- **CI/CD** — every push to `main` builds + signs the backend image; tagged releases auto-deploy via GitHub Actions OIDC.
 
-- The v0 specification: [`docs/MVP_SPEC.md`](docs/MVP_SPEC.md)
-- The current technical architecture: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)
-- The brand foundations: [`docs/BRAND_FOUNDATIONS.md`](docs/BRAND_FOUNDATIONS.md)
-- The methodology Fishhawk holds itself to: [`docs/METHODOLOGY.md`](docs/METHODOLOGY.md)
-- The (placeholder) workflow spec for Fishhawk's own development: [`.fishhawk/workflows.yaml`](.fishhawk/workflows.yaml)
+What's still ahead is the methodology commitment in [`docs/METHODOLOGY.md`](docs/METHODOLOGY.md): on Day 21 of the v0 build (~2026-05-20), Fishhawk starts shipping its *own* changes through Fishhawk. Until then, the workflow spec at [`.fishhawk/workflows.yaml`](.fishhawk/workflows.yaml) is a public commitment, not yet a running system. Day 21 is the gating event after which every PR carries a link to its workflow run and audit log.
 
-The 90-day plan in [`docs/MVP_SPEC.md`](docs/MVP_SPEC.md) targets day 21 as the milestone where Fishhawk begins shipping its own changes through Fishhawk. Until then, the workflow spec is a public commitment, not a running system.
+For the canonical scope and the technical realization, see [`docs/MVP_SPEC.md`](docs/MVP_SPEC.md) and [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
 
 ## What Fishhawk is
 
@@ -25,6 +27,64 @@ An opinionated workflow engine for agent-driven software changes, a policy enfor
 ## What Fishhawk is not
 
 A coding agent. A project management tool. A CI/CD platform. A general-purpose workflow engine. See [`docs/MVP_SPEC.md`](docs/MVP_SPEC.md) §1 for the full framing.
+
+## Running locally
+
+Prerequisites:
+
+- [Go 1.25+](https://go.dev/dl/) (the workspace targets `~> 1.25`)
+- [Node 22+](https://nodejs.org/) and [pnpm 10+](https://pnpm.io/) (for the Web UI)
+- [Docker](https://www.docker.com/) (for the local Postgres + MinIO stack)
+- Optional: [`golangci-lint v2`](https://golangci-lint.run/) for linting; `actionlint` for workflow files
+
+Bring up the dependencies — Postgres on `:5432`, MinIO on `:9000`/`:9001` ([`docker-compose.yml`](docker-compose.yml) for credentials):
+
+```sh
+docker compose up -d
+```
+
+Run the backend:
+
+```sh
+export FISHHAWKD_DATABASE_URL='postgres://fishhawk:fishhawk@localhost:5432/fishhawk?sslmode=disable'
+go run ./backend/cmd/fishhawkd migrate up
+go run ./backend/cmd/fishhawkd serve
+# http://localhost:8080/healthz
+```
+
+Run the Web UI in another terminal — the dev server proxies `/v0` to `localhost:8080`:
+
+```sh
+cd frontend
+pnpm install
+pnpm dev
+# http://localhost:5173
+```
+
+Validate a workflow spec with the CLI:
+
+```sh
+go run ./cli/cmd/fishhawk validate ./.fishhawk/workflows.yaml
+```
+
+Run the full Go test suite — the workspace has multiple modules, so a plain `go test ./...` from the root won't work. Use the loop:
+
+```sh
+for m in $(go work edit -json | jq -r '.Use[].DiskPath'); do
+  (cd "$m" && go test -race ./...)
+done
+```
+
+Per-component details live in each subdirectory's README:
+
+| Component | README |
+|---|---|
+| Backend (`fishhawkd`) | [`backend/README.md`](backend/README.md) — `serve`, `migrate`, `token issue`, env-var reference |
+| Web UI | [`frontend/README.md`](frontend/README.md) — `pnpm dev`, route layout, OAuth wiring |
+| Runner action | [`runner/README.md`](runner/README.md) — used in GitHub Actions, not typically run locally |
+| CLI | [`cli/README.md`](cli/README.md) — `fishhawk validate`, `fishhawk run start/status/open` |
+| Verifier | [`verifier/README.md`](verifier/README.md) — `fishhawk-verify` against an exported audit log |
+| Infrastructure | [`infra/terraform/README.md`](infra/terraform/README.md) — bootstrap, dev vs prod profiles, CI deploy flow |
 
 ## Following along
 
@@ -41,3 +101,7 @@ Please report vulnerabilities responsibly. See [`SECURITY.md`](SECURITY.md).
 ## License
 
 Apache License 2.0. See [`LICENSE`](LICENSE) and [`NOTICE`](NOTICE).
+
+---
+
+Built in Lithia, Florida.

--- a/README.md
+++ b/README.md
@@ -37,37 +37,33 @@ Prerequisites:
 - [Docker](https://www.docker.com/) (for the local Postgres + MinIO stack)
 - Optional: [`golangci-lint v2`](https://golangci-lint.run/) for linting; `actionlint` for workflow files
 
-Bring up the dependencies — Postgres on `:5432`, MinIO on `:9000`/`:9001` ([`docker-compose.yml`](docker-compose.yml) for credentials):
+The repository ships a [`Makefile`](Makefile) that wraps the common loops. Run `make help` to see every target. The quickstart:
+
+```sh
+make up                     # docker compose: Postgres :5432, MinIO :9000/:9001
+make migrate                # apply backend migrations
+make dev-backend            # run fishhawkd on :8080
+make dev-frontend           # in another terminal: Web UI on :5173 (proxies /v0)
+make validate               # validate .fishhawk/workflows.yaml with the CLI
+make test                   # all Go modules (-race) + Web UI vitest
+make lint                   # golangci-lint v2 + eslint + tsc --noEmit
+make coverage               # reproduce the CI 80% gate
+```
+
+If you'd rather run things by hand, the Makefile targets are thin wrappers over these commands:
 
 ```sh
 docker compose up -d
-```
-
-Run the backend:
-
-```sh
 export FISHHAWKD_DATABASE_URL='postgres://fishhawk:fishhawk@localhost:5432/fishhawk?sslmode=disable'
 go run ./backend/cmd/fishhawkd migrate up
-go run ./backend/cmd/fishhawkd serve
-# http://localhost:8080/healthz
-```
+go run ./backend/cmd/fishhawkd serve   # http://localhost:8080/healthz
 
-Run the Web UI in another terminal — the dev server proxies `/v0` to `localhost:8080`:
+cd frontend && pnpm install && pnpm dev   # http://localhost:5173
 
-```sh
-cd frontend
-pnpm install
-pnpm dev
-# http://localhost:5173
-```
-
-Validate a workflow spec with the CLI:
-
-```sh
 go run ./cli/cmd/fishhawk validate ./.fishhawk/workflows.yaml
 ```
 
-Run the full Go test suite — the workspace has multiple modules, so a plain `go test ./...` from the root won't work. Use the loop:
+A plain `go test ./...` from the root won't work — the repo is a multi-module Go workspace. The Makefile's `test-go` target loops over every module in `go.work`; the equivalent loop:
 
 ```sh
 for m in $(go work edit -json | jq -r '.Use[].DiskPath'); do


### PR DESCRIPTION
## Summary

- Replaced the "Status" section, which still claimed "no working software here yet," with a per-surface bullet list (backend, runner, CLI, Web UI, verifier, infra, CI/CD) pointing at each component's README. Day 21 self-hosting (~2026-05-20) is now the explicit "what's left" anchor.
- Added a "Running locally" section: prereqs (Go 1.25+, Node 22+/pnpm 10+, Docker), `docker compose up -d` for the Postgres + MinIO stack, the `fishhawkd migrate up` + `serve` flow, the frontend `pnpm dev` flow, the multi-module test loop from `CLAUDE.md`, and a links table to the per-component READMEs.

## Test plan

- [ ] Render the README on GitHub and verify links resolve (component READMEs, `docker-compose.yml`, spec docs).
- [ ] Walk a fresh-clone reader through the "Running locally" steps end-to-end and confirm `http://localhost:8080/healthz` and `http://localhost:5173` come up.