### PR TITLE
Smooth out local-dev setup discovered while bringing up Fishhawk

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,60 @@
+# Fishhawk local-dev environment variables.
+#
+# Copy to .env (gitignored) and fill in the values you need:
+#   cp .env.example .env
+#
+# The Makefile auto-includes .env if present, so `make dev-backend`
+# picks these up without `set -a; source .env; set +a` plumbing.
+#
+# `fishhawkd` ignores any variable that isn't set, but it logs a
+# warning on startup for each missing piece (OAuth, webhooks, etc.).
+# See docs/github-app/README.md for the local-dev modes that
+# determine which of these you need.
+
+# --- core (required) ---
+
+# Postgres connection string. Matches docker-compose.yml.
+FISHHAWKD_DATABASE_URL=postgres://fishhawk:fishhawk@localhost:5432/fishhawk?sslmode=disable
+
+# Listen address. Defaults to :8080 if unset; uncomment to override.
+# FISHHAWKD_ADDR=:8080
+
+# --- background workers ---
+# Off by default so dev runs aren't racing the timer/watchdog.
+
+# FISHHAWKD_ENABLE_SLA_TIMER=true
+# FISHHAWKD_ENABLE_DISPATCH_WATCHDOG=true
+
+# --- GitHub App (Mode B / C in docs/github-app/README.md) ---
+# Without these, /webhooks/github responds 503 and dispatch is disabled.
+
+# FISHHAWKD_GITHUB_APP_ID=123456
+# FISHHAWKD_GITHUB_APP_PRIVATE_KEY_FILE=/path/to/private-key.pem
+# FISHHAWKD_GITHUB_WEBHOOK_SECRET=...
+
+# --- OAuth sign-in (Mode B / C) ---
+# All three must be set together; mismatch fails fast.
+# Without these, /v0/auth/github/* responds 503.
+
+# FISHHAWKD_OAUTH_CLIENT_ID=Iv1.xxxx
+# FISHHAWKD_OAUTH_CLIENT_SECRET=...
+# FISHHAWKD_OAUTH_CALLBACK_URL=http://localhost:8080/v0/auth/github/callback
+# FISHHAWKD_OAUTH_REDIRECT_AFTER_LOGIN=http://localhost:5173/
+
+# --- runner OIDC (only when iterating on the signing-key endpoint) ---
+# Off by default — endpoint accepts any caller (v0 self-execution
+# posture). Set to a non-empty audience to enforce verification.
+
+# FISHHAWKD_OIDC_AUDIENCE=fishhawkd-local
+# FISHHAWKD_OIDC_JWKS_URL=https://token.actions.githubusercontent.com/.well-known/jwks
+
+# --- trace storage (S3 / MinIO) ---
+# Without FISHHAWKD_S3_BUCKET, /v0/runs/{id}/trace responds 503.
+# docker-compose.yml ships a MinIO instance on :9000; create a
+# bucket and uncomment the four lines below to wire it in.
+
+# FISHHAWKD_S3_BUCKET=fishhawk-traces
+# FISHHAWKD_S3_REGION=us-east-1
+# FISHHAWKD_S3_ENDPOINT=http://localhost:9000
+# AWS_ACCESS_KEY_ID=fishhawk
+# AWS_SECRET_ACCESS_KEY=fishhawk-dev-secret

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,15 @@ SHELL := /bin/bash
 .SHELLFLAGS := -eu -o pipefail -c
 .DEFAULT_GOAL := help
 
-DATABASE_URL ?= postgres://fishhawk:fishhawk@localhost:5432/fishhawk?sslmode=disable
+# Auto-load .env if present so `make dev-backend` picks up GitHub App
+# credentials etc. without `set -a; source .env; set +a` plumbing.
+# .env is gitignored; copy .env.example to get started.
+ifneq (,$(wildcard .env))
+include .env
+export
+endif
+
+DATABASE_URL ?= $(or $(FISHHAWKD_DATABASE_URL),postgres://fishhawk:fishhawk@localhost:5432/fishhawk?sslmode=disable)
 COVERAGE_THRESHOLD ?= 80
 
 GO_MODULES := $(shell go work edit -json | jq -r '.Use[].DiskPath')

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Prerequisites:
 The repository ships a [`Makefile`](Makefile) that wraps the common loops. Run `make help` to see every target. The quickstart:
 
 ```sh
+cp .env.example .env        # populate later for GitHub App / OAuth (see below)
 make up                     # docker compose: Postgres :5432, MinIO :9000/:9001
 make migrate                # apply backend migrations
 make dev-backend            # run fishhawkd on :8080
@@ -49,6 +50,8 @@ make test                   # all Go modules (-race) + Web UI vitest
 make lint                   # golangci-lint v2 + eslint + tsc --noEmit
 make coverage               # reproduce the CI 80% gate
 ```
+
+The Makefile auto-loads `.env` if present, so credentials and overrides flow into `make dev-backend` without manual `source` plumbing.
 
 If you'd rather run things by hand, the Makefile targets are thin wrappers over these commands:
 

--- a/docs/github-app/README.md
+++ b/docs/github-app/README.md
@@ -9,7 +9,7 @@ Fishhawk runs as a GitHub App. The App provides:
 This directory ships:
 
 - [`manifest.template.json`](./manifest.template.json) — the App manifest with placeholder `{{BACKEND_URL}}` markers. Templates the URLs the operator fills in for their deploy.
-- [`../../scripts/render-github-app-manifest.sh`](../../scripts/render-github-app-manifest.sh) — a 30-line bash wrapper that renders the template for a given backend URL.
+- [`../../scripts/render-github-app-manifest.sh`](../../scripts/render-github-app-manifest.sh) — bash wrapper that renders the template for a given backend URL + webhook URL.
 
 ## Permissions
 
@@ -118,12 +118,17 @@ Pick one. Manifest flow is faster and removes manual scope-typo risk; manual set
 
 GitHub's manifest flow takes a one-shot JSON payload and creates the App in your account or org. The rendered manifest carries the right scopes + events; you only fill in the App name and confirm.
 
-1. Render the manifest with your backend's public URL:
+1. Render the manifest with your backend's public URL and webhook URL. In production they're typically the same host:
 
    ```sh
-   ./scripts/render-github-app-manifest.sh https://api.fishhawk.example.com > /tmp/fishhawk-app.json
+   ./scripts/render-github-app-manifest.sh \
+     https://api.fishhawk.example.com \
+     https://api.fishhawk.example.com/webhooks/github \
+     > /tmp/fishhawk-app.json
    jq . /tmp/fishhawk-app.json   # optional sanity check
    ```
+
+   For local dev, see the **Local development** section above — the backend URL is `http://localhost:8080` and the webhook URL is your smee.io forwarder.
 
 2. Open one of these URLs in a browser. Replace `<owner>` with your GitHub user or org name:
 

--- a/docs/github-app/manifest.template.json
+++ b/docs/github-app/manifest.template.json
@@ -9,6 +9,10 @@
   ],
   "request_oauth_on_install": false,
   "setup_on_update": false,
+  "hook_attributes": {
+    "url": "{{WEBHOOK_URL}}",
+    "active": true
+  },
   "default_permissions": {
     "contents": "write",
     "issues": "write",

--- a/scripts/render-github-app-manifest.sh
+++ b/scripts/render-github-app-manifest.sh
@@ -1,38 +1,56 @@
 #!/usr/bin/env bash
 # Render docs/github-app/manifest.template.json with the backend
-# URL filled in. Used by the operator before submitting to
-# GitHub's manifest-flow endpoint (E4.1 / #48).
+# URL and webhook URL filled in. Used by the operator before
+# submitting to GitHub's manifest-flow endpoint (E4.1 / #48).
 #
 # Usage:
-#   scripts/render-github-app-manifest.sh https://api.fishhawk.example.com
+#   scripts/render-github-app-manifest.sh <backend-url> <webhook-url>
+#
+# Examples:
+#   # Production: webhook hits the backend directly.
+#   scripts/render-github-app-manifest.sh \
+#     https://api.fishhawk.example.com \
+#     https://api.fishhawk.example.com/webhooks/github
+#
+#   # Local dev: backend on localhost, webhooks via smee.io.
+#   scripts/render-github-app-manifest.sh \
+#     http://localhost:8080 \
+#     https://smee.io/abc123
+#
+# The webhook URL is required because GitHub's manifest validator
+# rejects manifests with a blank `hook_attributes.url`. For local
+# dev where the backend isn't internet-reachable, point it at a
+# smee.io forwarder.
 #
 # The rendered JSON is printed to stdout; redirect or pipe as
 # needed:
 #
-#   scripts/render-github-app-manifest.sh https://api.fishhawk.example.com \
-#     | jq .   # validate
-#
-#   scripts/render-github-app-manifest.sh https://api.fishhawk.example.com \
-#     | pbcopy # macOS — paste into the form
-#
-# The manifest URL itself doesn't include the backend URL;
-# GitHub resolves placeholders from the JSON we POST to it.
+#   scripts/render-github-app-manifest.sh ... | jq .   # validate
+#   scripts/render-github-app-manifest.sh ... | pbcopy # macOS
 
 set -euo pipefail
 
-if [[ $# -ne 1 ]]; then
-    echo "usage: $0 <backend-url>" >&2
-    echo "  e.g. $0 https://api.fishhawk.example.com" >&2
+if [[ $# -ne 2 ]]; then
+    echo "usage: $0 <backend-url> <webhook-url>" >&2
+    echo "  e.g. $0 https://api.fishhawk.example.com https://api.fishhawk.example.com/webhooks/github" >&2
+    echo "  e.g. $0 http://localhost:8080 https://smee.io/abc123" >&2
     exit 2
 fi
 
 backend_url="$1"
+webhook_url="$2"
 
 # Strip trailing slash so the rendered URLs don't double up on /.
 backend_url="${backend_url%/}"
+webhook_url="${webhook_url%/}"
 
 if [[ -z "$backend_url" || "$backend_url" != http* ]]; then
     echo "$0: backend URL must start with http:// or https://" >&2
+    exit 2
+fi
+
+if [[ -z "$webhook_url" || "$webhook_url" != http* ]]; then
+    echo "$0: webhook URL must start with http:// or https://" >&2
     exit 2
 fi
 
@@ -43,4 +61,6 @@ if [[ ! -f "$template" ]]; then
 fi
 
 # Use sed with a delimiter that won't appear in URLs.
-sed "s|{{BACKEND_URL}}|${backend_url}|g" "$template"
+sed -e "s|{{BACKEND_URL}}|${backend_url}|g" \
+    -e "s|{{WEBHOOK_URL}}|${webhook_url}|g" \
+    "$template"


### PR DESCRIPTION
## Summary

Bundle of small fixes uncovered while standing up a fresh local dev environment. Each one would have saved time on the walkthrough — none are blocking, but together they remove the rough edges.

- **`docs/github-app/manifest.template.json`** — add `hook_attributes` with `{{WEBHOOK_URL}}` placeholder. GitHub's manifest-flow validator rejects manifests with a blank webhook URL ("Hook url cannot be blank") — every operator who runs the script today hits this.
- **`scripts/render-github-app-manifest.sh`** — take webhook URL as a required second positional arg. For prod, point both args at the backend; for local dev, point the second at smee.io.
- **`docs/github-app/README.md`** — update the example invocation to match.
- **`.env.example`** — committed template covering every `FISHHAWKD_*` variable, grouped by feature (core / GitHub App / OAuth / OIDC / S3) with notes on what each unlocks and which 503 they suppress when missing.
- **`Makefile`** — auto-include `.env` when present so `make dev-backend` picks up credentials without `set -a; source .env; set +a` plumbing.
- **`README.md`** — add `cp .env.example .env` to the quickstart and call out the auto-load behaviour.

## Companion issue

#180 ([E4.7] Implement `/v0/auth/github/manifest-callback` handler) tracks the missing backend handler the manifest's `redirect_url` points at. Until that lands, manifest-flow operators still have to grab the `code` from the URL bar and `curl` the conversion endpoint by hand. This PR makes the manifest itself valid so they get that far in the first place.

## Test plan

- [x] `bash scripts/render-github-app-manifest.sh http://localhost:8080 https://smee.io/abc123 | jq .` — emits valid JSON containing `hook_attributes.url: "https://smee.io/abc123"`.
- [x] `make -p` shows `FISHHAWKD_GITHUB_APP_ID`, `FISHHAWKD_OAUTH_CLIENT_ID`, etc. resolved from `.env` when one exists.
- [x] `make help` still renders cleanly (no new targets affected).
- [ ] Walk through the local-dev manifest flow end-to-end against a fresh personal-account App and confirm GitHub no longer rejects the manifest with "Hook url cannot be blank".

## Notes

The existing render script signature was a single arg. Anyone who scripted around it will get a usage error on next run rather than a silently-broken manifest — feels like the right failure mode given the change is correctness, not preference.