### PR TITLE
Fix boot-order bug: GitHub client must be set before dispatcher + orchestrator

### DIFF
--- a/backend/cmd/fishhawkd/serve.go
+++ b/backend/cmd/fishhawkd/serve.go
@@ -180,6 +180,40 @@ func runServe(args []string, logSink io.Writer) int {
 		logger.Warn("FISHHAWKD_GITHUB_WEBHOOK_SECRET not set; /webhooks/github will respond 503")
 	}
 
+	// GitHub App installation-token provider. Both ID and key file
+	// must be set; either alone is a misconfiguration. Wired before
+	// the webhook dispatcher / orchestrator below because both
+	// capture cfg.GitHub at construction time — initializing them
+	// before the App is set produces a silently-degraded backend
+	// that accepts webhooks but never creates Run records.
+	if *githubAppIDStr != "" || *githubAppKeyFile != "" {
+		if *githubAppIDStr == "" || *githubAppKeyFile == "" {
+			logger.Error("github app misconfigured: both --github-app-id and --github-app-private-key-file required")
+			return exitFailure
+		}
+		appID, err := strconv.ParseInt(*githubAppIDStr, 10, 64)
+		if err != nil || appID <= 0 {
+			logger.Error("github app id invalid", slog.String("got", *githubAppIDStr))
+			return exitFailure
+		}
+		keyBytes, err := os.ReadFile(*githubAppKeyFile)
+		if err != nil {
+			logger.Error("github app key read failed", slog.String("error", err.Error()))
+			return exitFailure
+		}
+		signer, err := githubapp.NewSignerFromPEM(appID, keyBytes)
+		if err != nil {
+			logger.Error("github app key parse failed", slog.String("error", err.Error()))
+			return exitFailure
+		}
+		cfg.GitHubTokens = githubapp.NewCachedProvider(githubapp.NewClient(signer))
+		cfg.GitHub = githubclient.New(cfg.GitHubTokens)
+		logger.Info("github app + REST client configured",
+			slog.Int64("app_id", appID))
+	} else {
+		logger.Warn("FISHHAWKD_GITHUB_APP_ID not set; webhook dispatch and GitHub-side actions will be disabled")
+	}
+
 	// Webhook dispatcher requires both the GitHub REST client (for
 	// fetching the workflow spec + firing workflow_dispatch) and a
 	// run repository (for creating Run records). Without either,
@@ -228,39 +262,6 @@ func runServe(args []string, logSink io.Writer) int {
 		cfg.OIDCAudience = *oidcAudience
 	} else {
 		logger.Warn("FISHHAWKD_OIDC_AUDIENCE not set; signing-key endpoint accepts unauthenticated requests")
-	}
-
-	// GitHub App installation-token provider. Both ID and key file
-	// must be set; either alone is a misconfiguration. Currently
-	// no handlers consume cfg.GitHubTokens — the dispatcher (#109)
-	// will pick it up — but wire it now so future handlers find it
-	// already constructed.
-	if *githubAppIDStr != "" || *githubAppKeyFile != "" {
-		if *githubAppIDStr == "" || *githubAppKeyFile == "" {
-			logger.Error("github app misconfigured: both --github-app-id and --github-app-private-key-file required")
-			return exitFailure
-		}
-		appID, err := strconv.ParseInt(*githubAppIDStr, 10, 64)
-		if err != nil || appID <= 0 {
-			logger.Error("github app id invalid", slog.String("got", *githubAppIDStr))
-			return exitFailure
-		}
-		keyBytes, err := os.ReadFile(*githubAppKeyFile)
-		if err != nil {
-			logger.Error("github app key read failed", slog.String("error", err.Error()))
-			return exitFailure
-		}
-		signer, err := githubapp.NewSignerFromPEM(appID, keyBytes)
-		if err != nil {
-			logger.Error("github app key parse failed", slog.String("error", err.Error()))
-			return exitFailure
-		}
-		cfg.GitHubTokens = githubapp.NewCachedProvider(githubapp.NewClient(signer))
-		cfg.GitHub = githubclient.New(cfg.GitHubTokens)
-		logger.Info("github app + REST client configured",
-			slog.Int64("app_id", appID))
-	} else {
-		logger.Warn("FISHHAWKD_GITHUB_APP_ID not set; webhook dispatch and GitHub-side actions will be disabled")
 	}
 
 	// Role resolver for the approval handler. Wired only when the


### PR DESCRIPTION
## Summary

The webhook dispatcher and stage orchestrator both capture `cfg.GitHub` at construction time. They were initialized at lines 189 and 203 respectively, but `cfg.GitHub` wasn't assigned until line 259 — so both consistently saw `nil`.

**Effect:** webhooks were accepted (202s in the access log) and dedup'd correctly, but no Run records were ever created and no `workflow_dispatch` was ever fired. The "webhook dispatcher configured" log line never appeared, but no warning either — it was a silent skip.

Caught while bringing up the local-dev stack end-to-end with a freshly-installed GitHub App: a labeled issue webhook arrived at `/webhooks/github`, returned 202, and went nowhere. Boot log only showed "stage orchestrator configured" before "github app + REST client configured" — the dispatcher line was missing entirely.

The fix moves the GitHub App init block above the dispatcher + orchestrator blocks. Added an explicit comment so the next contributor who tries to reorder this gets a heads-up:

> Wired before the webhook dispatcher / orchestrator below because both capture `cfg.GitHub` at construction time — initializing them before the App is set produces a silently-degraded backend that accepts webhooks but never creates Run records.

OIDC verifier block doesn't depend on `cfg.GitHub` (only on `*oidcAudience`); kept its current position.

## Test plan

- [x] `(cd backend && go build ./...)` clean.
- [x] `(cd backend && go test -race ./...)` passes.
- [x] `(cd backend && golangci-lint run ./...)` clean.
- [ ] Manual end-to-end: with `FISHHAWKD_GITHUB_APP_ID` + key file set, boot logs emit `github app + REST client configured` → `webhook dispatcher configured` → `stage orchestrator configured`. Apply the `fishhawk` label to an issue; webhook lands at `/webhooks/github`; a Run is created and `workflow_dispatch` fires.

## Notes

The existing `cmd/fishhawkd/main_test.go` covers flag parsing only, not config-wiring. To cover this regression with a real test we'd need to refactor `serve()` so the config-building portion is exposed separately from `http.ListenAndServe`. Left as a follow-up if this class of bug recurs — for now the inline comment is the guardrail.