### PR TITLE
Add actions:write to the GitHub App manifest

### DIFF
--- a/backend/internal/server/manifest.go
+++ b/backend/internal/server/manifest.go
@@ -215,6 +215,12 @@ func buildManifest(backendURL, webhookURL, name string) map[string]any {
 			"active": true,
 		},
 		"default_permissions": map[string]string{
+			// actions:write is required to fire workflow_dispatch
+			// (POST /repos/.../actions/workflows/{file}/dispatches).
+			// workflows:write below is a separate scope — it lets
+			// the App edit .github/workflows/*.yml files but does
+			// NOT include the dispatch endpoint. Both are needed.
+			"actions":       "write",
 			"contents":      "write",
 			"issues":        "write",
 			"pull_requests": "write",

--- a/docs/github-app/README.md
+++ b/docs/github-app/README.md
@@ -17,11 +17,12 @@ Per `MVP_SPEC.md` §5.1.5:
 
 | Permission | Level | Purpose |
 |---|---|---|
+| `actions` | rw | Fire `workflow_dispatch` to invoke the runner action (`POST /repos/.../actions/workflows/{file}/dispatches`). Distinct from `workflows`, which only covers editing workflow files. |
 | `contents` | rw | Read `.fishhawk/workflows.yaml` from the customer's repo; push branches for the implement stage. |
 | `issues` | rw | Read the originating issue's body for prompt construction; comment back with the rendered plan. |
 | `pull_requests` | rw | Open PRs from the runner's pushed branch. |
 | `checks` | rw | Surface stage outcomes as a check run on the PR. |
-| `workflows` | w | Fire `workflow_dispatch` to invoke the runner action. |
+| `workflows` | w | Edit `.github/workflows/*.yml` (e.g. install-time provisioning of the customer's `fishhawk.yml`). Does NOT cover the dispatch endpoint — see `actions` above. |
 | `members` | r | Resolve `@org/team` references in role definitions to GitHub-login allowlists for approver checks (E4.4 / #50). |
 | `metadata` | r | Always granted; required for any read access. |
 

--- a/docs/github-app/manifest.template.json
+++ b/docs/github-app/manifest.template.json
@@ -14,6 +14,7 @@
     "active": true
   },
   "default_permissions": {
+    "actions": "write",
     "contents": "write",
     "issues": "write",
     "pull_requests": "write",


### PR DESCRIPTION
## Summary

The dispatcher fires `workflow_dispatch` via `POST /repos/.../actions/workflows/{file}/dispatches`, which requires the App's `actions:write` permission. Both the manifest template and the `buildManifest()` helper omitted it, so manifest-flow registrations produced an App that could fetch the workflow spec, read issues, comment on PRs — but couldn't actually start a run.

Caught while running #184 end-to-end. The webhook landed, the dispatcher ran, the `Run` row was created — but the workflow never showed up in the Actions tab. Audit row revealed the cause:

```json
{
  "outcome": "dispatch_failed",
  "error": "githubclient: forbidden: dispatch: 403: Resource not accessible by integration"
}
```

Counterintuitive bit: `workflows:write` (which the manifest already had) covers editing `.github/workflows/*.yml` **files**, not the dispatch **endpoint**. The two scopes are separate. Fixed the permissions table in `docs/github-app/README.md` to call that out so the next reader doesn't make the same assumption.

## Test plan

- [x] `(cd backend && go test -race ./internal/server/ ./internal/auth/)` passes (manifest-handler tests still match the new permissions map).
- [x] `(cd backend && golangci-lint run ./...)` clean.
- [ ] Manual end-to-end: re-register an App via the manifest flow, install on a repo, label an issue with `fishhawk` → confirm the run transitions past `pending` and the Actions workflow fires.

## Notes

Existing installations (including the local-dev App registered against the previous manifest) need their permissions updated by hand on the App's settings page (**Permissions → Actions → Read and write**) and the installation must accept the new scope. The new manifest only helps future registrations.

Worth flagging that the App may not actually need `workflows:write` at all in v0 — we don't push workflow files to customer repos, customers commit `fishhawk.yml` themselves. Tightening the manifest is a separate concern; this PR is scoped to the missing scope that's blocking dispatch today.