### PR TITLE
Install Claude Code CLI in the runner action

### DIFF
--- a/runner/README.md
+++ b/runner/README.md
@@ -49,6 +49,8 @@ E5.1 (#52) shipped the scaffold. E5.2 (#29) wired the Claude Code invocation har
 
 The Claude Code API key is supplied via the `ANTHROPIC_API_KEY` environment variable, which customers populate from their GitHub Secrets. v0.x will replace this with a Fishhawk-issued ephemeral key (MVP_SPEC §5.3).
 
+The composite action installs Claude Code (`@anthropic-ai/claude-code` from npm) on every run via Node 22. Hosted Actions runners don't ship with it, and the runner adapter invokes the `claude` binary by name. Cold-cache install adds ~15s; pinning a version is deferred (v1+).
+
 ## Build and test
 
 From the repo root (workspace-aware):

--- a/runner/action.yml
+++ b/runner/action.yml
@@ -96,6 +96,21 @@ runs:
         go-version: '1.25'
         cache: false
 
+    # Claude Code is an npm-distributed CLI. Hosted Actions runners
+    # don't ship with it, and the runner adapter (claudecode.go)
+    # invokes the `claude` binary by name. Install it before the Go
+    # entrypoint runs. v0 pulls latest; pinning is a v1+ concern.
+    - name: Set up Node.js
+      uses: actions/setup-node@v6
+      with:
+        node-version: '22'
+
+    - name: Install Claude Code CLI
+      shell: bash
+      run: |
+        npm install -g @anthropic-ai/claude-code
+        claude --version
+
     - name: Run fishhawk-runner
       shell: bash
       working-directory: ${{ github.action_path }}


### PR DESCRIPTION
## Summary

The runner adapter (`runner/internal/agent/claudecode/claudecode.go`) invokes the `claude` binary by name. GitHub-hosted Actions runners don't ship with it. The first end-to-end run (#184) reached the agent invocation step with everything else working (signing key issued, prompt fetched, trace upload wired) and failed:

```json
{"event":"runner_failed","reason":"agent binary not found: claude","err_class":"binary_not_found"}
```

Add two steps to the composite action between `setup-go` and the Go entrypoint:

1. `actions/setup-node@v6` (Node 22 — matches the frontend toolchain).
2. `npm install -g @anthropic-ai/claude-code` followed by `claude --version` so the boot log makes the install visible if it ever silently breaks.

## Test plan

- [x] `runner/action.yml` parses as valid YAML with the expected top-level keys.
- [ ] Re-run the failed Action on issue #184; confirm `runner_completed` outcome instead of `binary_not_found`. The next failure (if any) should now be in the agent invocation itself, not the binary lookup.

## Notes

v0 pulls the latest published `@anthropic-ai/claude-code`. Pinning is deferred to a v1+ release-stability concern.

Cold-cache install adds ~15s to the runner's wall-clock time. Conditionalising on whether the agent will actually run (dispatch-path probe mode with `prompt-file` unset and `fetch-prompt` false) would save those 15s but adds branching to the composite action — not worth it for v0 where the dominant use is "actually invoke an agent."