### PR TITLE
Pass --verbose to claude when using --output-format stream-json

### DIFF
--- a/runner/internal/agent/claudecode/claudecode.go
+++ b/runner/internal/agent/claudecode/claudecode.go
@@ -6,7 +6,7 @@
 // ANTHROPIC_API_KEY env var on the child. Centralized issuance
 // (Fishhawk-managed ephemeral keys) is a v0.x story, not v0.
 //
-// The adapter spawns `claude --print --output-format stream-json -p
+// The adapter spawns `claude --print --verbose --output-format stream-json -p
 // <prompt>` and reads one JSON event per line from stdout. Each
 // line becomes an agent.Event; if the line carries a `usage` block
 // we update the running token total and enforce the budget. A
@@ -96,7 +96,13 @@ func (i *Invoker) Invoke(ctx context.Context, inv agent.Invocation) (agent.Resul
 		},
 	}
 
-	args := []string{"--print", "--output-format", "stream-json", "-p", inv.Prompt}
+	// Claude Code requires --verbose when --print is combined with
+	// --output-format=stream-json (validated by `claude` itself with
+	// "Error: When using --print, --output-format=stream-json requires
+	// --verbose"). --verbose forces emission of intermediate events
+	// alongside the final result, which is exactly what the trace
+	// bundle wants anyway.
+	args := []string{"--print", "--verbose", "--output-format", "stream-json", "-p", inv.Prompt}
 	cmd := cmdFn(ctx, binary, args...)
 	cmd.Dir = inv.WorkingDir
 	// Compose env so a Cmd builder (e.g. tests) can pre-set


### PR DESCRIPTION
## Summary

Claude Code 2.1.131 (and presumably newer versions) refuses `--print --output-format stream-json` without `--verbose`:

```
Error: When using --print, --output-format=stream-json requires --verbose
```

The runner adapter was hitting this on every invocation, surfacing as a category-A agent failure with `tokens_used=0`. Caught while running the first end-to-end label-triggered workflow on #184. The runner reached the agent invocation with the prompt fetched and signing key issued; the agent died immediately, and the trace bundle's `stderr` event captured the error verbatim:

```json
{
  "kind": "stderr",
  "data": {"text": "Error: When using --print, --output-format=stream-json requires --verbose\n"}
}
```

`--verbose` causes `claude` to emit intermediate stream events alongside the final `result` event, which is the shape the trace bundle wants anyway. The existing parser handles the additional event types without changes.

## Test plan

- [x] `(cd runner && go test -race ./internal/agent/claudecode/)` passes (test uses a helper process; no fixture changes needed).
- [x] `(cd runner && golangci-lint run ./...)` clean.
- [ ] Re-run #184's workflow against this branch; confirm the agent invocation completes (or fails for some *other* reason — at this point any failure is one we haven't seen yet).

## Notes

This is the kind of breakage the diagnostic trace bundle was built for — the actual error never appeared in the GitHub Actions logs (Claude's stderr was captured into the trace, not surfaced upstream), but pulling the trace from MinIO showed it in seconds.