### PR TITLE
Pass --dangerously-skip-permissions and --add-dir /tmp to claude

### DIFF
--- a/runner/internal/agent/claudecode/claudecode.go
+++ b/runner/internal/agent/claudecode/claudecode.go
@@ -6,7 +6,8 @@
 // ANTHROPIC_API_KEY env var on the child. Centralized issuance
 // (Fishhawk-managed ephemeral keys) is a v0.x story, not v0.
 //
-// The adapter spawns `claude --print --verbose --output-format stream-json -p
+// The adapter spawns `claude --print --verbose --output-format
+// stream-json --dangerously-skip-permissions --add-dir /tmp -p
 // <prompt>` and reads one JSON event per line from stdout. Each
 // line becomes an agent.Event; if the line carries a `usage` block
 // we update the running token total and enforce the budget. A
@@ -102,7 +103,28 @@ func (i *Invoker) Invoke(ctx context.Context, inv agent.Invocation) (agent.Resul
 	// --verbose"). --verbose forces emission of intermediate events
 	// alongside the final result, which is exactly what the trace
 	// bundle wants anyway.
-	args := []string{"--print", "--verbose", "--output-format", "stream-json", "-p", inv.Prompt}
+	//
+	// --dangerously-skip-permissions: --print is a non-interactive
+	// invocation, so Claude's "may I read / write / run X?" prompts
+	// have no human to answer them and every tool call returns
+	// "permissions not granted". The whole point of running under
+	// the Fishhawk runner is that the audit log captures every tool
+	// call after-the-fact; an interactive permission gate is not an
+	// additional safety boundary in that model. The trace bundle is
+	// the authoritative record.
+	//
+	// --add-dir /tmp: Claude restricts writes to the working
+	// directory tree by default. The runner needs the agent to write
+	// its plan artifact to /tmp/fishhawk-plan.json (matched by
+	// backend/internal/prompt.PlanArtifactPath); /tmp is outside the
+	// customer's repo checkout so we explicitly expand the allowlist.
+	args := []string{
+		"--print", "--verbose",
+		"--output-format", "stream-json",
+		"--dangerously-skip-permissions",
+		"--add-dir", "/tmp",
+		"-p", inv.Prompt,
+	}
 	cmd := cmdFn(ctx, binary, args...)
 	cmd.Dir = inv.WorkingDir
 	// Compose env so a Cmd builder (e.g. tests) can pre-set


### PR DESCRIPTION
## Summary

The runner invokes Claude Code under `--print` (non-interactive). Two default-on Claude Code safeties were silently breaking the plan stage in #184:

1. **Permission prompts.** Every Read / Write / Bash tool call returned `Claude requested permissions to … but you haven't granted it yet.` Nobody to grant them in `--print` mode → every call failed. The trace from the failed run (run id `0c323822-…`) shows Claude burning 32 905 tokens hitting the same permission wall over and over.
2. **Working-directory sandbox.** Even with permissions, Claude limits write tool calls to the configured working dir. The plan-stage prompt (per #191) asks the agent to write to `/tmp/fishhawk-plan.json`, which is outside the runner's checkout: `Claude Code may only create or modify files in the allowed working directories: '/home/runner/work/fishhawk/fishhawk/runner'`.

Pass both flags now:

- `--dangerously-skip-permissions` — skip the interactive prompts. The Fishhawk runner model is "agent does the work; trace captures it for after-the-fact audit"; an interactive permission gate is not an additional safety boundary in that model, the trace bundle is.
- `--add-dir /tmp` — extend the write allowlist so the plan artifact lands where the runner expects.

Both flags documented inline so the next maintainer doesn't quietly remove them.

## Test plan

- [x] `(cd runner && go test -race ./...)` passes (existing tests use a helper-process pattern that doesn't pin args).
- [x] `(cd runner && golangci-lint run ./...)` clean.
- [ ] Re-label issue #184 against this branch + PR #192 merged: agent should now write `/tmp/fishhawk-plan.json` successfully, runner ships it, backend creates the artifact, UI renders the plan.

## Notes

This depends on PR #192 being merged for the end-to-end test — without #192 the runner has nowhere to ship the plan even if the agent writes it. They're conceptually one feature; kept separate so each carries one concern in its commit history.