### PR TITLE
Allow signing-key rotation per run for multi-stage workflows

### DIFF
--- a/backend/internal/apitoken/db/models.go
+++ b/backend/internal/apitoken/db/models.go
@@ -83,6 +83,7 @@ type SigningKey struct {
 	PublicKey []byte             `json:"public_key"`
 	IssuedAt  pgtype.Timestamptz `json:"issued_at"`
 	ExpiresAt pgtype.Timestamptz `json:"expires_at"`
+	ID        uuid.UUID          `json:"id"`
 }
 
 type Stage struct {

--- a/backend/internal/approval/db/models.go
+++ b/backend/internal/approval/db/models.go
@@ -83,6 +83,7 @@ type SigningKey struct {
 	PublicKey []byte             `json:"public_key"`
 	IssuedAt  pgtype.Timestamptz `json:"issued_at"`
 	ExpiresAt pgtype.Timestamptz `json:"expires_at"`
+	ID        uuid.UUID          `json:"id"`
 }
 
 type Stage struct {

--- a/backend/internal/artifact/db/models.go
+++ b/backend/internal/artifact/db/models.go
@@ -83,6 +83,7 @@ type SigningKey struct {
 	PublicKey []byte             `json:"public_key"`
 	IssuedAt  pgtype.Timestamptz `json:"issued_at"`
 	ExpiresAt pgtype.Timestamptz `json:"expires_at"`
+	ID        uuid.UUID          `json:"id"`
 }
 
 type Stage struct {

--- a/backend/internal/audit/db/models.go
+++ b/backend/internal/audit/db/models.go
@@ -83,6 +83,7 @@ type SigningKey struct {
 	PublicKey []byte             `json:"public_key"`
 	IssuedAt  pgtype.Timestamptz `json:"issued_at"`
 	ExpiresAt pgtype.Timestamptz `json:"expires_at"`
+	ID        uuid.UUID          `json:"id"`
 }
 
 type Stage struct {

--- a/backend/internal/auth/db/models.go
+++ b/backend/internal/auth/db/models.go
@@ -83,6 +83,7 @@ type SigningKey struct {
 	PublicKey []byte             `json:"public_key"`
 	IssuedAt  pgtype.Timestamptz `json:"issued_at"`
 	ExpiresAt pgtype.Timestamptz `json:"expires_at"`
+	ID        uuid.UUID          `json:"id"`
 }
 
 type Stage struct {

--- a/backend/internal/postgres/migrations/0012_signing_keys_allow_rotation.down.sql
+++ b/backend/internal/postgres/migrations/0012_signing_keys_allow_rotation.down.sql
@@ -1,0 +1,18 @@
+-- Roll back 0012. Down is best-effort: if the table now has multiple
+-- rows per run_id (post-rotation production data) the constraint
+-- restoration will fail. Operators rolling back must first dedup
+-- with a query like:
+--   DELETE FROM signing_keys a USING signing_keys b
+--   WHERE a.run_id = b.run_id AND a.issued_at < b.issued_at;
+-- and then re-run this migration.
+
+DROP INDEX IF EXISTS signing_keys_run_id_issued_at_idx;
+
+ALTER TABLE signing_keys
+    DROP CONSTRAINT signing_keys_pkey;
+
+ALTER TABLE signing_keys
+    DROP COLUMN id;
+
+ALTER TABLE signing_keys
+    ADD CONSTRAINT signing_keys_pkey PRIMARY KEY (run_id);

--- a/backend/internal/postgres/migrations/0012_signing_keys_allow_rotation.up.sql
+++ b/backend/internal/postgres/migrations/0012_signing_keys_allow_rotation.up.sql
@@ -1,0 +1,33 @@
+-- 0012: signing_keys — allow multiple keys per run.
+--
+-- Original 0003 modeled signing_keys.run_id as PRIMARY KEY: one
+-- key per run, immutable forever, "externally-verifiable record."
+-- That model assumed the runner ran in one process for the whole
+-- run lifetime. v0's multi-stage workflows break that assumption:
+-- each stage is a separate GitHub Actions runner invocation with
+-- no shared in-memory state, so the implement stage's runner has
+-- no way to obtain the plan stage's private key. It must issue
+-- its own.
+--
+-- New model: one row per (Issue call). Verify picks the latest
+-- unexpired key for the run so the runner-side caller doesn't have
+-- to track which key signed which payload. History is preserved so
+-- the standalone audit-log verifier (verifier/) can still walk
+-- every key that was active at any point during the run.
+--
+-- The append-only triggers from 0003 stay — UPDATE/DELETE are still
+-- forbidden. Rotation happens via additive INSERT, not mutation.
+
+-- A synthetic primary key replaces the run_id PK. Each Issue call
+-- gets its own id; run_id becomes a regular indexed column.
+ALTER TABLE signing_keys
+    DROP CONSTRAINT signing_keys_pkey;
+
+ALTER TABLE signing_keys
+    ADD COLUMN id UUID NOT NULL DEFAULT gen_random_uuid();
+
+ALTER TABLE signing_keys
+    ADD CONSTRAINT signing_keys_pkey PRIMARY KEY (id);
+
+CREATE INDEX signing_keys_run_id_issued_at_idx
+    ON signing_keys (run_id, issued_at DESC);

--- a/backend/internal/postgres/postgres_test.go
+++ b/backend/internal/postgres/postgres_test.go
@@ -202,20 +202,32 @@ func TestMigrateDown_RemovesTables(t *testing.T) {
 	}
 	defer pool.Close()
 
-	// MigrateDown rolls back one step. 0011 drops the
-	// runs.idempotency_key column. Confirm: the column is gone,
-	// but every table / column from earlier migrations (users +
-	// sessions from 0010, audit run_id is still nullable from
-	// 0009, api_tokens from 0008, etc.) is still present.
-	var idempotencyCol, usersCount, sessionsCount, apiTokensCount, deliveriesCount, approvalsCount, runsCount int
+	// MigrateDown rolls back one step. 0012 added a synthetic id
+	// column on signing_keys (and dropped the run_id PRIMARY KEY
+	// constraint). Down restores the prior shape: the id column
+	// is gone, run_id is the PK again. Confirm both, plus that
+	// every table / column from earlier migrations is still there
+	// (e.g. runs.idempotency_key from 0011, users + sessions from
+	// 0010, audit run_id nullability from 0009, api_tokens from
+	// 0008, etc.).
+	var signingIDCol, idempotencyCol, usersCount, sessionsCount, apiTokensCount, deliveriesCount, approvalsCount, runsCount int
+	if err := pool.QueryRow(context.Background(),
+		`SELECT count(*) FROM information_schema.columns
+		 WHERE table_name = 'signing_keys' AND column_name = 'id'`,
+	).Scan(&signingIDCol); err != nil {
+		t.Fatalf("query signing_keys.id column: %v", err)
+	}
+	if signingIDCol != 0 {
+		t.Errorf("signing_keys.id count after MigrateDown = %d, want 0 (0012 rolled back)", signingIDCol)
+	}
 	if err := pool.QueryRow(context.Background(),
 		`SELECT count(*) FROM information_schema.columns
 		 WHERE table_name = 'runs' AND column_name = 'idempotency_key'`,
 	).Scan(&idempotencyCol); err != nil {
 		t.Fatalf("query idempotency_key column: %v", err)
 	}
-	if idempotencyCol != 0 {
-		t.Errorf("runs.idempotency_key count after MigrateDown = %d, want 0 (most-recent migration rolled back)", idempotencyCol)
+	if idempotencyCol != 1 {
+		t.Errorf("runs.idempotency_key count after MigrateDown = %d, want 1 (0011 still applied)", idempotencyCol)
 	}
 	if err := pool.QueryRow(context.Background(),
 		`SELECT count(*) FROM information_schema.tables WHERE table_name = 'sessions'`,

--- a/backend/internal/run/db/models.go
+++ b/backend/internal/run/db/models.go
@@ -83,6 +83,7 @@ type SigningKey struct {
 	PublicKey []byte             `json:"public_key"`
 	IssuedAt  pgtype.Timestamptz `json:"issued_at"`
 	ExpiresAt pgtype.Timestamptz `json:"expires_at"`
+	ID        uuid.UUID          `json:"id"`
 }
 
 type Stage struct {

--- a/backend/internal/server/signing.go
+++ b/backend/internal/server/signing.go
@@ -97,15 +97,8 @@ func (s *Server) handleIssueSigningKey(w http.ResponseWriter, r *http.Request) {
 
 	issued, err := s.cfg.SigningRepo.Issue(r.Context(), runID, ttl)
 	if err != nil {
-		switch {
-		case errors.Is(err, signing.ErrAlreadyIssued):
-			s.writeError(w, r, http.StatusConflict, "signing_key_already_issued",
-				"a signing key has already been issued for this run",
-				map[string]any{"run_id": runID.String()})
-		default:
-			s.writeError(w, r, http.StatusInternalServerError, "internal_error",
-				"issue signing key failed", map[string]any{"error": err.Error()})
-		}
+		s.writeError(w, r, http.StatusInternalServerError, "internal_error",
+			"issue signing key failed", map[string]any{"error": err.Error()})
 		return
 	}
 

--- a/backend/internal/server/signing_test.go
+++ b/backend/internal/server/signing_test.go
@@ -47,9 +47,9 @@ func (f *fakeSigningRepo) Issue(_ context.Context, runID uuid.UUID, ttl time.Dur
 	if f.issueErr != nil {
 		return nil, f.issueErr
 	}
-	if _, ok := f.keys[runID]; ok {
-		return nil, signing.ErrAlreadyIssued
-	}
+	// Multi-call per migration 0012: every Issue gets a fresh key;
+	// any prior key for the same run is superseded but Verify still
+	// uses the latest, so the runner doesn't see a 409.
 	pub, priv, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		return nil, err
@@ -218,20 +218,30 @@ func TestIssueSigningKey_UnknownField(t *testing.T) {
 	}
 }
 
-func TestIssueSigningKey_AlreadyIssued(t *testing.T) {
+func TestIssueSigningKey_RotatesOnSecondCall(t *testing.T) {
+	// Multi-stage runs (per migration 0012) require each stage's
+	// fresh runner process to issue its own key. The second Issue
+	// must succeed and yield a key whose public half differs from
+	// the first; older keys remain in the table for history.
 	repo := newFakeSigningRepo()
 	s := newSigningServer(t, repo)
 	runID := uuid.New()
 
-	if w := issueRequest(t, s, runID, nil); w.Code != http.StatusCreated {
-		t.Fatalf("first issue: status = %d", w.Code)
+	first := issueRequest(t, s, runID, nil)
+	if first.Code != http.StatusCreated {
+		t.Fatalf("first issue: status = %d", first.Code)
 	}
-	w := issueRequest(t, s, runID, nil)
-	if w.Code != http.StatusConflict {
-		t.Errorf("second issue: status = %d, want 409", w.Code)
+	var firstResp map[string]string
+	_ = json.NewDecoder(first.Body).Decode(&firstResp)
+
+	second := issueRequest(t, s, runID, nil)
+	if second.Code != http.StatusCreated {
+		t.Errorf("second issue: status = %d, want 201", second.Code)
 	}
-	if !strings.Contains(w.Body.String(), `"signing_key_already_issued"`) {
-		t.Errorf("body missing code: %s", w.Body.String())
+	var secondResp map[string]string
+	_ = json.NewDecoder(second.Body).Decode(&secondResp)
+	if firstResp["public_key"] == secondResp["public_key"] {
+		t.Error("second issue should yield a new public_key, got the same")
 	}
 }
 

--- a/backend/internal/signing/db/models.go
+++ b/backend/internal/signing/db/models.go
@@ -83,6 +83,7 @@ type SigningKey struct {
 	PublicKey []byte             `json:"public_key"`
 	IssuedAt  pgtype.Timestamptz `json:"issued_at"`
 	ExpiresAt pgtype.Timestamptz `json:"expires_at"`
+	ID        uuid.UUID          `json:"id"`
 }
 
 type Stage struct {

--- a/backend/internal/signing/db/queries.sql.go
+++ b/backend/internal/signing/db/queries.sql.go
@@ -12,18 +12,22 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
-const getSigningKey = `-- name: GetSigningKey :one
-SELECT run_id, public_key, issued_at, expires_at FROM signing_keys WHERE run_id = $1
+const getLatestSigningKey = `-- name: GetLatestSigningKey :one
+SELECT run_id, public_key, issued_at, expires_at, id FROM signing_keys
+WHERE run_id = $1
+ORDER BY issued_at DESC
+LIMIT 1
 `
 
-func (q *Queries) GetSigningKey(ctx context.Context, runID uuid.UUID) (SigningKey, error) {
-	row := q.db.QueryRow(ctx, getSigningKey, runID)
+func (q *Queries) GetLatestSigningKey(ctx context.Context, runID uuid.UUID) (SigningKey, error) {
+	row := q.db.QueryRow(ctx, getLatestSigningKey, runID)
 	var i SigningKey
 	err := row.Scan(
 		&i.RunID,
 		&i.PublicKey,
 		&i.IssuedAt,
 		&i.ExpiresAt,
+		&i.ID,
 	)
 	return i, err
 }
@@ -32,7 +36,7 @@ const issueSigningKey = `-- name: IssueSigningKey :one
 
 INSERT INTO signing_keys (run_id, public_key, issued_at, expires_at)
 VALUES ($1, $2, $3, $4)
-RETURNING run_id, public_key, issued_at, expires_at
+RETURNING run_id, public_key, issued_at, expires_at, id
 `
 
 type IssueSigningKeyParams struct {
@@ -45,6 +49,12 @@ type IssueSigningKeyParams struct {
 // Signing-key queries consumed by the postgres adapter for the
 // signing.Repository interface (E2.3 / #24). Append-only — no Update
 // or Delete queries; the schema's triggers backstop that.
+//
+// Migration 0012 dropped the (run_id) PRIMARY KEY constraint so
+// multiple keys can exist per run (one per Issue call from a fresh
+// Actions-runner process). GetLatestSigningKey returns the most
+// recently issued key — Verify uses this so the runner doesn't have
+// to track which key signed which payload across stages.
 func (q *Queries) IssueSigningKey(ctx context.Context, arg IssueSigningKeyParams) (SigningKey, error) {
 	row := q.db.QueryRow(ctx, issueSigningKey,
 		arg.RunID,
@@ -58,6 +68,42 @@ func (q *Queries) IssueSigningKey(ctx context.Context, arg IssueSigningKeyParams
 		&i.PublicKey,
 		&i.IssuedAt,
 		&i.ExpiresAt,
+		&i.ID,
 	)
 	return i, err
+}
+
+const listSigningKeysForRun = `-- name: ListSigningKeysForRun :many
+SELECT run_id, public_key, issued_at, expires_at, id FROM signing_keys
+WHERE run_id = $1
+ORDER BY issued_at ASC
+`
+
+// Used by the standalone verifier to walk every key that was
+// active during a run's lifetime, since a single run may have
+// shipped traces signed by different keys at different stages.
+func (q *Queries) ListSigningKeysForRun(ctx context.Context, runID uuid.UUID) ([]SigningKey, error) {
+	rows, err := q.db.Query(ctx, listSigningKeysForRun, runID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []SigningKey
+	for rows.Next() {
+		var i SigningKey
+		if err := rows.Scan(
+			&i.RunID,
+			&i.PublicKey,
+			&i.IssuedAt,
+			&i.ExpiresAt,
+			&i.ID,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }

--- a/backend/internal/signing/postgres.go
+++ b/backend/internal/signing/postgres.go
@@ -6,7 +6,6 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -41,6 +40,13 @@ func NewPostgresRepositoryWithClock(pool *pgxpool.Pool, now func() time.Time) Re
 	return &postgresRepo{pool: pool, now: now}
 }
 
+// Issue mints a new signing key for the run. Multi-call:
+// each invocation appends a new row (per migration 0012), so each
+// stage's GitHub Actions runner can issue its own private key
+// without coordinating with prior stages. Verify always uses the
+// latest unexpired key; older rows remain in the table so the
+// standalone verifier can replay any signature that was valid at
+// upload time.
 func (r *postgresRepo) Issue(ctx context.Context, runID uuid.UUID, ttl time.Duration) (*IssuedKey, error) {
 	if ttl <= 0 {
 		return nil, fmt.Errorf("signing: ttl must be positive")
@@ -61,11 +67,6 @@ func (r *postgresRepo) Issue(ctx context.Context, runID uuid.UUID, ttl time.Dura
 		ExpiresAt: pgtype.Timestamptz{Time: expiresAt, Valid: true},
 	})
 	if err != nil {
-		// Primary key conflict surfaces as a Postgres unique-
-		// violation. Map to ErrAlreadyIssued for callers.
-		if isUniqueViolation(err) {
-			return nil, ErrAlreadyIssued
-		}
 		return nil, fmt.Errorf("signing: issue: %w", err)
 	}
 	return &IssuedKey{
@@ -77,9 +78,14 @@ func (r *postgresRepo) Issue(ctx context.Context, runID uuid.UUID, ttl time.Dura
 	}, nil
 }
 
+// Get returns the latest signing key issued for the run. Used by
+// Verify; external callers (e.g. the standalone verifier) that
+// need the full history should use a different query — Get is
+// intentionally narrow because every uploader path wants the
+// "current" key.
 func (r *postgresRepo) Get(ctx context.Context, runID uuid.UUID) (*Key, error) {
 	q := signingdb.New(r.pool)
-	row, err := q.GetSigningKey(ctx, runID)
+	row, err := q.GetLatestSigningKey(ctx, runID)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, ErrNotFound
 	}
@@ -103,20 +109,6 @@ func (r *postgresRepo) Verify(ctx context.Context, runID uuid.UUID, message, sig
 		return ErrExpired
 	}
 	return VerifyWith(key.PublicKey, message, signature)
-}
-
-// isUniqueViolation reports whether err is a Postgres
-// "unique_violation" (SQLSTATE 23505), which fires when Issue is
-// called twice for the same run_id (the table's PRIMARY KEY
-// constraint).
-func isUniqueViolation(err error) bool {
-	if err == nil {
-		return false
-	}
-	// pgx wraps SQLSTATE codes in *pgconn.PgError. Avoiding the
-	// import keeps the dependency surface tight; string-match is
-	// fine for the small set of codes we care about.
-	return strings.Contains(err.Error(), "SQLSTATE 23505")
 }
 
 // Compile-time check that postgresRepo implements Repository.

--- a/backend/internal/signing/postgres_test.go
+++ b/backend/internal/signing/postgres_test.go
@@ -189,17 +189,32 @@ func TestPostgres_Issue_RejectsZeroTTL(t *testing.T) {
 	}
 }
 
-func TestPostgres_Issue_RejectsRepeated(t *testing.T) {
+func TestPostgres_Issue_AllowsRotation(t *testing.T) {
+	// Per migration 0012 each Issue call inserts a new row so a
+	// later stage's runner process can sign with its own key. The
+	// second key's public half must differ from the first, and Get
+	// returns the latest.
 	pool := startContainer(t)
 	repo := signing.NewPostgresRepository(pool)
 	runID := makeRun(t, pool)
 
-	if _, err := repo.Issue(context.Background(), runID, signing.DefaultTTL); err != nil {
+	first, err := repo.Issue(context.Background(), runID, signing.DefaultTTL)
+	if err != nil {
 		t.Fatalf("first Issue: %v", err)
 	}
-	_, err := repo.Issue(context.Background(), runID, signing.DefaultTTL)
-	if !errors.Is(err, signing.ErrAlreadyIssued) {
-		t.Errorf("err = %v, want ErrAlreadyIssued", err)
+	second, err := repo.Issue(context.Background(), runID, signing.DefaultTTL)
+	if err != nil {
+		t.Fatalf("second Issue: %v", err)
+	}
+	if string(first.PublicKey) == string(second.PublicKey) {
+		t.Error("rotation should yield a fresh public key, got the same as the first")
+	}
+	got, err := repo.Get(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if string(got.PublicKey) != string(second.PublicKey) {
+		t.Error("Get should return the latest issued key")
 	}
 }
 
@@ -207,14 +222,11 @@ func TestPostgres_Issue_RunNotFound(t *testing.T) {
 	pool := startContainer(t)
 	repo := signing.NewPostgresRepository(pool)
 
-	// Run row does not exist; FK violation should bubble up as
-	// some non-nil error (not specifically ErrAlreadyIssued).
+	// Run row does not exist; FK violation should bubble up as a
+	// non-nil error.
 	_, err := repo.Issue(context.Background(), uuid.New(), signing.DefaultTTL)
 	if err == nil {
 		t.Fatal("Issue against missing run should error")
-	}
-	if errors.Is(err, signing.ErrAlreadyIssued) {
-		t.Errorf("err = %v, should not classify FK violation as already-issued", err)
 	}
 }
 

--- a/backend/internal/signing/queries.sql
+++ b/backend/internal/signing/queries.sql
@@ -1,11 +1,28 @@
 -- Signing-key queries consumed by the postgres adapter for the
 -- signing.Repository interface (E2.3 / #24). Append-only — no Update
 -- or Delete queries; the schema's triggers backstop that.
+--
+-- Migration 0012 dropped the (run_id) PRIMARY KEY constraint so
+-- multiple keys can exist per run (one per Issue call from a fresh
+-- Actions-runner process). GetLatestSigningKey returns the most
+-- recently issued key — Verify uses this so the runner doesn't have
+-- to track which key signed which payload across stages.
 
 -- name: IssueSigningKey :one
 INSERT INTO signing_keys (run_id, public_key, issued_at, expires_at)
 VALUES ($1, $2, $3, $4)
 RETURNING *;
 
--- name: GetSigningKey :one
-SELECT * FROM signing_keys WHERE run_id = $1;
+-- name: GetLatestSigningKey :one
+SELECT * FROM signing_keys
+WHERE run_id = $1
+ORDER BY issued_at DESC
+LIMIT 1;
+
+-- name: ListSigningKeysForRun :many
+-- Used by the standalone verifier to walk every key that was
+-- active during a run's lifetime, since a single run may have
+-- shipped traces signed by different keys at different stages.
+SELECT * FROM signing_keys
+WHERE run_id = $1
+ORDER BY issued_at ASC;

--- a/backend/internal/signing/repository.go
+++ b/backend/internal/signing/repository.go
@@ -13,9 +13,10 @@ import (
 type Repository interface {
 	// Issue mints a fresh Ed25519 keypair, stores the public half
 	// keyed by runID with the given TTL window, and returns both
-	// halves plus the timestamps. Returns ErrAlreadyIssued if a key
-	// already exists for the run; in v0 each run gets exactly one
-	// key.
+	// halves plus the timestamps. Multi-call: every Issue inserts a
+	// new row (per migration 0012), so each stage's GitHub Actions
+	// runner can issue its own private key independently. Verify
+	// uses the latest unexpired key for the run.
 	//
 	// The caller is responsible for delivering IssuedKey.PrivateKey
 	// to the runner (typically over the response body of the

--- a/backend/internal/signing/signing.go
+++ b/backend/internal/signing/signing.go
@@ -52,8 +52,14 @@ var (
 	// ErrNotFound means no signing key exists for the given run.
 	ErrNotFound = errors.New("signing key not found")
 
-	// ErrAlreadyIssued means a key was already issued for this run.
-	// Re-issuance is not supported in v0; a run gets exactly one key.
+	// ErrAlreadyIssued was returned from Issue() prior to migration
+	// 0012 when a row already existed for the run. Kept for
+	// backwards compatibility with callers that still test for it
+	// (notably runner/internal/upload), but the postgres adapter
+	// no longer returns it — Issue is multi-call, each invocation
+	// inserts a new row, and Verify uses the latest unexpired key.
+	//
+	// Deprecated: never returned by the production repository.
 	ErrAlreadyIssued = errors.New("signing key already issued for this run")
 
 	// ErrExpired means the stored key's expires_at is in the past.

--- a/backend/internal/webhook/db/models.go
+++ b/backend/internal/webhook/db/models.go
@@ -82,6 +82,7 @@ type SigningKey struct {
 	PublicKey []byte             `json:"public_key"`
 	IssuedAt  pgtype.Timestamptz `json:"issued_at"`
 	ExpiresAt pgtype.Timestamptz `json:"expires_at"`
+	ID        pgtype.UUID        `json:"id"`
 }
 
 type Stage struct {

--- a/docs/api/v0.openapi.yaml
+++ b/docs/api/v0.openapi.yaml
@@ -1041,11 +1041,19 @@ paths:
       summary: Issue a per-run Ed25519 signing key
       description: |
         Called by the runner at job start. The backend mints a fresh
-        Ed25519 keypair, persists the public half in `signing_keys`,
-        and returns the private half in the response body. The private
-        key is never persisted server-side and never returned to anyone
+        Ed25519 keypair, appends a new row in `signing_keys`, and
+        returns the private half in the response body. The private key
+        is never persisted server-side and never returned to anyone
         else. Auth is GitHub Actions OIDC token, verified per request.
         See ADR-008 (#72).
+
+        Multi-call: each invocation appends a new row so each stage's
+        fresh GitHub Actions runner process can issue its own key
+        without coordinating with prior stages. `Verify` (used by the
+        trace and plan upload endpoints) picks the latest unexpired
+        key for the run; older rows remain so the standalone audit
+        verifier can replay any signature that was valid at upload
+        time. Migration 0012.
       tags: [runner]
       security:
         - githubOIDC: []
@@ -1093,11 +1101,6 @@ paths:
         '401': { $ref: '#/components/responses/Unauthorized' }
         '404':
           description: Run does not exist.
-          content:
-            application/json:
-              schema: { $ref: '#/components/schemas/Error' }
-        '409':
-          description: A signing key has already been issued for this run.
           content:
             application/json:
               schema: { $ref: '#/components/schemas/Error' }

--- a/runner/internal/upload/upload.go
+++ b/runner/internal/upload/upload.go
@@ -110,9 +110,14 @@ type signingKeyResponse struct {
 // IssueKey calls POST /v0/runs/{run_id}/signing-key and returns the
 // decoded key material.
 //
-// Single-attempt: signing-key issuance is not idempotent (a second
-// call returns 409 ErrAlreadyIssued), so a transient failure here
-// must be surfaced rather than silently retried.
+// Multi-call against backends with migration 0012+: each call inserts
+// a new row, every stage's fresh runner process gets its own private
+// key, the backend's Verify uses the latest unexpired key. Older
+// backends return 409 ErrAlreadyIssued for the second call; we keep
+// that mapping as a defensive shim (callers shouldn't see it in
+// practice). Single-attempt either way — IssueKey doesn't retry on
+// transient errors so the caller can decide whether to abort or
+// surface them.
 func (c *Client) IssueKey(ctx context.Context, runID string, ttl time.Duration) (*IssuedKey, error) {
 	body := struct {
 		TTLSeconds int `json:"ttl_seconds,omitempty"`


### PR DESCRIPTION
## Summary

Plan worked → approved → orchestrator dispatched implement → implement-stage runner died:

```
{"event":"runner_failed","reason":"issue_key","detail":"upload: signing key already issued for this run"}
```

Migration 0003 modeled `signing_keys.run_id` as PRIMARY KEY, "one immutable key per run forever," matching ADR-008's externally-verifiable-record property. That model assumed the runner ran in one process for the whole run lifetime. v0's multi-stage workflows break that assumption: each stage is a separate GitHub Actions runner invocation with no shared in-memory state, so the implement-stage runner has no way to obtain the plan-stage's private key.

**Fix**: migration 0012 drops `run_id` as PK and adds a synthetic `id UUID PRIMARY KEY DEFAULT gen_random_uuid()`. Each `Issue` call appends a new row. `Verify` reads the latest unexpired key for the run; older rows remain so the standalone audit verifier can walk every key that was active at upload time. Append-only triggers stay — rotation is additive INSERT, not mutation.

## What changed

- **Migration** — `0012_signing_keys_allow_rotation.{up,down}.sql`. Up drops the run_id PK, adds synthetic id, indexes (run_id, issued_at DESC). Down restores; pre-flight dedup query in the comment for operators rolling back post-rotation production data.
- **SQL** — replaces `GetSigningKey` with `GetLatestSigningKey` (used by `Verify`) and adds `ListSigningKeysForRun` (for the verifier).
- **Repository** — `signing.postgresRepo.Issue` no longer maps unique-violation to `ErrAlreadyIssued`. `Get` returns the latest. Sentinel kept exported as `Deprecated`.
- **Server** — drops the 409 mapping on `/v0/runs/{run_id}/signing-key`.
- **Runner** — no functional change; `ErrAlreadyIssued` + the 409 mapping in `upload.go` remain as a defensive shim for older backends with a comment explaining the v0.x migration boundary.
- **OpenAPI** — signing-key endpoint description updated, 409 response removed.

## Test plan

- [x] `(cd backend && go test -race ./...)` passes; coverage gate 82.0%.
- [x] `(cd backend && golangci-lint run ./...)` clean.
- [x] `(cd runner && go test -race ./...)` clean.
- [x] `TestPostgres_Issue_AllowsRotation` (renamed from `_RejectsRepeated`) asserts second `Issue` yields a fresh public key and `Get` returns the latest.
- [x] `TestIssueSigningKey_RotatesOnSecondCall` (renamed) asserts the HTTP handler returns 201 with a different public_key on the second call.
- [x] `TestMigrateDown_RemovesTables` updated: now asserts the most-recent migration (0012) rolled back, with 0011's column still present.
- [ ] End-to-end against #184: implement stage's runner now issues its own key, signs trace + the eventual PR-artifact upload successfully, lands the next stage past `pending`.

## Notes

`sqlc` regen picked up the new `id` column in every `db/models.go`'s `SigningKey` struct. Expected — sqlc generates per-package copies of shared models and the migration affects all of them. No semantic change to packages other than `signing/`.

This unblocks the implement → review chain. The next thing to land after this is whatever the implement-stage runner produces — its trace will land cleanly, but `pull_request` artifact persistence is its own story (mirrors the plan-upload chain in #192).