### PR TITLE
gitops: pass App token via -c extraheader, not URL embedding

### DIFF
--- a/runner/internal/gitops/commit.go
+++ b/runner/internal/gitops/commit.go
@@ -16,6 +16,7 @@ package gitops
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"net/url"
@@ -160,11 +161,28 @@ func (p *Pusher) CommitAndPush(ctx context.Context, args CommitAndPushArgs) (*Co
 	}
 	headSHA = strings.TrimSpace(headSHA)
 
-	pushURL, err := tokenizedPushURL(args.RemoteURL, args.Token)
+	// actions/checkout sets a global `http.https://github.com/.extraheader`
+	// pointing at the workflow's GITHUB_TOKEN. That header wins over
+	// any URL-embedded credential on the push (any `Authorization`
+	// header on the request supersedes basic-auth via x-access-token
+	// in the URL). We replace the extraheader for THIS push only via
+	// `-c`, so the customer's other workflow steps still see the
+	// actions/checkout config they expect.
+	pushAuthHeader, headerHost, err := pushExtraHeader(args.RemoteURL, args.Token)
 	if err != nil {
-		return nil, fmt.Errorf("gitops: tokenize remote URL: %w", err)
+		return nil, fmt.Errorf("gitops: build push auth header: %w", err)
 	}
-	if err := p.run(ctx, args.RepoDir, "push", pushURL, fmt.Sprintf("HEAD:%s", args.Branch)); err != nil {
+	pushArgs := []string{}
+	if pushAuthHeader != "" {
+		// `-c http.<host>.extraheader=<header>` is per-invocation.
+		pushArgs = append(pushArgs,
+			"-c", "http."+headerHost+".extraheader="+pushAuthHeader,
+		)
+	}
+	pushArgs = append(pushArgs,
+		"push", args.RemoteURL, fmt.Sprintf("HEAD:%s", args.Branch),
+	)
+	if err := p.run(ctx, args.RepoDir, pushArgs...); err != nil {
 		return nil, fmt.Errorf("gitops: push %s: %w", remote, err)
 	}
 
@@ -174,23 +192,29 @@ func (p *Pusher) CommitAndPush(ctx context.Context, args CommitAndPushArgs) (*Co
 	}, nil
 }
 
-// tokenizedPushURL rewrites an HTTPS GitHub URL to embed the token
-// for basic auth. The `x-access-token` username is GitHub's public
-// convention for App / Actions tokens.
+// pushExtraHeader returns the `AUTHORIZATION: basic <base64>` value
+// suitable for `git -c http.<host>.extraheader=…` to authenticate
+// the push, plus the `<host>` (scheme://host[:port]) it scopes to.
+// Mirrors actions/checkout's auth model exactly so we override its
+// existing extraheader cleanly rather than racing it.
 //
-// Inputs that aren't HTTPS URLs (SSH remotes, local paths) round-
-// trip unchanged — we only authenticate HTTPS pushes; the customer's
-// SSH config is their concern.
-func tokenizedPushURL(remoteURL, token string) (string, error) {
+// Empty header + empty host → caller skips the `-c` and pushes
+// unauthenticated. We return (empty, empty) for non-HTTPS remotes
+// (SSH, local file paths) since those use their own auth model.
+func pushExtraHeader(remoteURL, token string) (header, host string, err error) {
 	if !strings.HasPrefix(remoteURL, "https://") {
-		return remoteURL, nil
+		return "", "", nil
 	}
 	u, err := url.Parse(remoteURL)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
-	u.User = url.UserPassword("x-access-token", token)
-	return u.String(), nil
+	// `<scheme>://<host>` — git config keys are scoped at the host
+	// level, e.g. `http.https://github.com/.extraheader`.
+	host = u.Scheme + "://" + u.Host + "/"
+	encoded := base64.StdEncoding.EncodeToString([]byte("x-access-token:" + token))
+	header = "AUTHORIZATION: basic " + encoded
+	return header, host, nil
 }
 
 // run invokes git with cwd=dir, returning a wrapped error including

--- a/runner/internal/gitops/commit_test.go
+++ b/runner/internal/gitops/commit_test.go
@@ -13,8 +13,8 @@ import (
 // runReal initializes a git repo on disk and exercises CommitAndPush
 // end-to-end, with origin pointed at a bare local repo so push
 // actually completes. Production code targets HTTPS origin URLs;
-// the tokenizedPushURL branch that handles that is unit-tested
-// separately below.
+// the pushExtraHeader branch that handles auth for HTTPS remotes is
+// unit-tested separately below.
 func TestCommitAndPush_RealRepo_HappyPath(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
@@ -148,41 +148,58 @@ func TestCommitAndPush_RejectsBadInputs(t *testing.T) {
 	}
 }
 
-func TestTokenizedPushURL(t *testing.T) {
+func TestPushExtraHeader(t *testing.T) {
+	// "AUTHORIZATION: basic " + base64("x-access-token:secret")
+	const wantAuth = "AUTHORIZATION: basic eC1hY2Nlc3MtdG9rZW46c2VjcmV0"
+
 	cases := []struct {
-		name string
-		in   string
-		want string
+		name       string
+		in         string
+		wantHeader string
+		wantHost   string
 	}{
 		{
-			name: "github https rewrite",
-			in:   "https://github.com/owner/repo",
-			want: "https://x-access-token:secret@github.com/owner/repo",
+			name:       "github https",
+			in:         "https://github.com/owner/repo",
+			wantHeader: wantAuth,
+			wantHost:   "https://github.com/",
 		},
 		{
-			name: "trailing .git preserved",
-			in:   "https://github.com/owner/repo.git",
-			want: "https://x-access-token:secret@github.com/owner/repo.git",
+			name:       "trailing .git preserved",
+			in:         "https://github.com/owner/repo.git",
+			wantHeader: wantAuth,
+			wantHost:   "https://github.com/",
 		},
 		{
-			name: "ssh remote untouched",
-			in:   "git@github.com:owner/repo.git",
-			want: "git@github.com:owner/repo.git",
+			name:       "GHES host",
+			in:         "https://ghe.example.com/owner/repo",
+			wantHeader: wantAuth,
+			wantHost:   "https://ghe.example.com/",
 		},
 		{
-			name: "local path untouched",
-			in:   "/tmp/origin.git",
-			want: "/tmp/origin.git",
+			name:       "ssh remote skips auth",
+			in:         "git@github.com:owner/repo.git",
+			wantHeader: "",
+			wantHost:   "",
+		},
+		{
+			name:       "local path skips auth",
+			in:         "/tmp/origin.git",
+			wantHeader: "",
+			wantHost:   "",
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := tokenizedPushURL(tc.in, "secret")
+			gotHeader, gotHost, err := pushExtraHeader(tc.in, "secret")
 			if err != nil {
 				t.Fatal(err)
 			}
-			if got != tc.want {
-				t.Errorf("got %q, want %q", got, tc.want)
+			if gotHeader != tc.wantHeader {
+				t.Errorf("header = %q, want %q", gotHeader, tc.wantHeader)
+			}
+			if gotHost != tc.wantHost {
+				t.Errorf("host = %q, want %q", gotHost, tc.wantHost)
 			}
 		})
 	}
@@ -201,3 +218,98 @@ func mustGit(t *testing.T, dir string, args ...string) {
 // Make sure `errors` is used so a refactor that drops the import
 // stays caught by go vet/imports tooling.
 var _ = errors.New
+
+// TestCommitAndPush_PushPassesExtraHeader replays the production
+// command path through a fake exec so we can assert the push goes
+// out with `-c http.<host>.extraheader=…`. This is the regression
+// guard for the issue where actions/checkout's extraheader was
+// winning over our URL-embedded credential and the runner was
+// pushing as github-actions[bot] instead of the App.
+func TestCommitAndPush_PushPassesExtraHeader(t *testing.T) {
+	// Use a fake exec hook so we capture every `git ...` invocation
+	// and can synthesize a succeeding HEAD-rev / status / etc.
+	// without touching disk.
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	repo := filepath.Join(dir, "src")
+	bare := filepath.Join(dir, "origin.git")
+	if err := os.Mkdir(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, repo, "init", "--initial-branch=main")
+	mustGit(t, repo, "config", "user.name", "init")
+	mustGit(t, repo, "config", "user.email", "init@example.com")
+	if err := os.WriteFile(filepath.Join(repo, "f"), []byte("a\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, repo, "add", "-A")
+	mustGit(t, repo, "commit", "-m", "init")
+	mustGit(t, repo, "init", "--bare", bare)
+
+	// Capture every command's args without changing behavior.
+	var captured [][]string
+	p := &Pusher{
+		Cmd: func(ctx context.Context, name string, args ...string) *exec.Cmd {
+			capturedArgs := append([]string{name}, args...)
+			captured = append(captured, capturedArgs)
+			return exec.CommandContext(ctx, name, args...)
+		},
+	}
+
+	// Modify the working tree so there's something to commit + push.
+	if err := os.WriteFile(filepath.Join(repo, "f"), []byte("b\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	httpsRemote := "https://github.com/owner/repo"
+	_, err := p.CommitAndPush(context.Background(), CommitAndPushArgs{
+		RepoDir:       repo,
+		Branch:        "fishhawk/test",
+		CommitMessage: "test",
+		Token:         "ghs_xyz",
+		RemoteURL:     httpsRemote, // not actually pushed; bare-repo test above covers real push
+	})
+	// We expect an error from the push (network call to github.com
+	// from a unit test would actually try to authenticate), but the
+	// args MUST have included our extraheader.
+	if err == nil {
+		t.Logf("CommitAndPush succeeded unexpectedly (no network?): captured=%v", captured)
+	}
+
+	// Find the push invocation.
+	var pushCmd []string
+	for _, c := range captured {
+		// `git -c ... push ...` — find the one with "push" in it.
+		for _, a := range c {
+			if a == "push" {
+				pushCmd = c
+				break
+			}
+		}
+	}
+	if pushCmd == nil {
+		t.Fatalf("push command not captured among %d invocations", len(captured))
+	}
+
+	// Expect: git -c http.https://github.com/.extraheader=AUTHORIZATION: basic <b64> push https://github.com/owner/repo HEAD:fishhawk/test
+	wantHeaderPrefix := "http.https://github.com/.extraheader=AUTHORIZATION: basic "
+	gotHeaderArg := false
+	for i, a := range pushCmd {
+		if a == "-c" && i+1 < len(pushCmd) && strings.HasPrefix(pushCmd[i+1], wantHeaderPrefix) {
+			gotHeaderArg = true
+			break
+		}
+	}
+	if !gotHeaderArg {
+		t.Errorf("push args did not include `-c %s…`: %v", wantHeaderPrefix, pushCmd)
+	}
+	// Remote URL must NOT have credentials embedded in it (we moved
+	// off the x-access-token-in-URL approach).
+	for _, a := range pushCmd {
+		if strings.Contains(a, "x-access-token:") {
+			t.Errorf("push command leaked credentials in URL: %q", a)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

#197 plumbed the App installation token from the backend through to the runner — but pushes still went out as `github-actions[bot]` and got 403'd:

```
remote: Permission to kuhlman-labs/fishhawk.git denied to github-actions[bot].
fatal: ... 'https://github.com/.../': The requested URL returned error: 403
```

actions/checkout sets a **global** gitconfig value:

```
http.https://github.com/.extraheader = AUTHORIZATION: basic <base64(x-access-token:GHA_TOKEN)>
```

So subsequent git operations in the workflow authenticate as the workflow's `GITHUB_TOKEN`. When we pushed to a URL with `x-access-token:<APP_TOKEN>` embedded, the extraheader's `Authorization` HTTP header still won on the request, and our App token was dropped on the floor.

**Fix:** stop embedding credentials in the push URL and instead pass

```
-c http.<host>.extraheader="AUTHORIZATION: basic <base64(x-access-token:APP_TOKEN)>"
```

on the push command itself. Per-invocation `-c` overrides the existing config for that single git call, so the customer's subsequent workflow steps still see the actions/checkout extraheader they expect.

Replaced `tokenizedPushURL` with `pushExtraHeader` (returns the auth header + host scope) and routed it through the push step. `RemoteURL` is now passed plain to `git push`.

## Test plan

- [x] `(cd runner && go test -race ./internal/gitops/)` passes — including a new `TestCommitAndPush_PushPassesExtraHeader` regression that captures every git invocation through the fake `Cmd` hook and asserts (a) the push command carries `-c http.https://github.com/.extraheader=...` and (b) the URL doesn't leak credentials.
- [x] `TestPushExtraHeader` covers github.com / GHES / SSH / local-path branches.
- [x] `(cd runner && go test -race ./...)` clean.
- [x] `(cd runner && golangci-lint run ./...)` clean.
- [ ] End-to-end against #184: implement-stage push now succeeds as `fishhawk-local-dev[bot]` instead of getting 403'd as `github-actions[bot]`.

## Notes

This is a small fix for a specific failure mode #197 didn't anticipate (interaction with actions/checkout's auth setup). The core architecture from #197 — fetch App token from backend, use it for push + PR — is unchanged; this is just how the token gets to git.