### PR TITLE
gitops: unset stale extraheader before push to avoid duplicate Authorization

### DIFF
--- a/runner/internal/gitops/commit.go
+++ b/runner/internal/gitops/commit.go
@@ -161,20 +161,29 @@ func (p *Pusher) CommitAndPush(ctx context.Context, args CommitAndPushArgs) (*Co
 	}
 	headSHA = strings.TrimSpace(headSHA)
 
-	// actions/checkout sets a global `http.https://github.com/.extraheader`
-	// pointing at the workflow's GITHUB_TOKEN. That header wins over
-	// any URL-embedded credential on the push (any `Authorization`
-	// header on the request supersedes basic-auth via x-access-token
-	// in the URL). We replace the extraheader for THIS push only via
-	// `-c`, so the customer's other workflow steps still see the
-	// actions/checkout config they expect.
+	// actions/checkout sets a `http.https://github.com/.extraheader` at
+	// LOCAL scope pointing at the workflow's GITHUB_TOKEN. That header
+	// wins over any URL-embedded credential on the push.
+	//
+	// `extraheader` is a multi-valued config key — `-c` ADDS an entry
+	// rather than replacing the existing one, which gets us two
+	// `Authorization` headers on the request and a 400 "Duplicate
+	// header" from GitHub. So we have to clear the existing local
+	// entry first, then `-c` ours on the push call.
+	//
+	// Unset is best-effort: returns non-zero when no value matches,
+	// which is fine for non-Actions environments where the setting
+	// was never there to begin with.
 	pushAuthHeader, headerHost, err := pushExtraHeader(args.RemoteURL, args.Token)
 	if err != nil {
 		return nil, fmt.Errorf("gitops: build push auth header: %w", err)
 	}
+	if pushAuthHeader != "" {
+		_ = p.run(ctx, args.RepoDir, "config", "--local", "--unset-all",
+			"http."+headerHost+".extraheader")
+	}
 	pushArgs := []string{}
 	if pushAuthHeader != "" {
-		// `-c http.<host>.extraheader=<header>` is per-invocation.
 		pushArgs = append(pushArgs,
 			"-c", "http."+headerHost+".extraheader="+pushAuthHeader,
 		)

--- a/runner/internal/gitops/commit_test.go
+++ b/runner/internal/gitops/commit_test.go
@@ -313,3 +313,98 @@ func TestCommitAndPush_PushPassesExtraHeader(t *testing.T) {
 		}
 	}
 }
+
+// TestCommitAndPush_UnsetsStaleExtraHeaderBeforePush replays the
+// failure mode from production: actions/checkout sets a --local
+// http.<host>.extraheader pointing at the workflow's GITHUB_TOKEN,
+// our `-c` override stacks rather than replaces, and GitHub
+// rejects with "Duplicate header: Authorization". The fix unsets
+// the existing local entry first; this test asserts the unset
+// call happens BEFORE the push.
+func TestCommitAndPush_UnsetsStaleExtraHeaderBeforePush(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	repo := filepath.Join(dir, "src")
+	if err := os.Mkdir(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, repo, "init", "--initial-branch=main")
+	mustGit(t, repo, "config", "user.name", "init")
+	mustGit(t, repo, "config", "user.email", "init@example.com")
+	if err := os.WriteFile(filepath.Join(repo, "f"), []byte("a\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, repo, "add", "-A")
+	mustGit(t, repo, "commit", "-m", "init")
+
+	// Simulate actions/checkout setting the local extraheader.
+	mustGit(t, repo, "config", "--local",
+		"http.https://github.com/.extraheader",
+		"AUTHORIZATION: basic stale-token-value")
+
+	// Capture every command's args without changing behavior.
+	var captured [][]string
+	p := &Pusher{
+		Cmd: func(ctx context.Context, name string, args ...string) *exec.Cmd {
+			capturedArgs := append([]string{name}, args...)
+			captured = append(captured, capturedArgs)
+			return exec.CommandContext(ctx, name, args...)
+		},
+	}
+
+	if err := os.WriteFile(filepath.Join(repo, "f"), []byte("b\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Push will fail (no real remote); we only care about the
+	// invocation order before the push.
+	_, _ = p.CommitAndPush(context.Background(), CommitAndPushArgs{
+		RepoDir:       repo,
+		Branch:        "fishhawk/test",
+		CommitMessage: "test",
+		Token:         "ghs_xyz",
+		RemoteURL:     "https://github.com/owner/repo",
+	})
+
+	// Find the first push invocation and the unset invocation.
+	pushIdx, unsetIdx := -1, -1
+	for i, c := range captured {
+		// Skip past `git`, look at the rest.
+		args := c[1:]
+		// Push has "push" as a top-level (post `-c` flags) arg.
+		for j, a := range args {
+			if a == "push" {
+				pushIdx = i
+				_ = j
+				break
+			}
+		}
+		// Unset matches `config --local --unset-all
+		// http.<host>.extraheader`.
+		if len(args) >= 4 && args[0] == "config" && args[1] == "--local" &&
+			args[2] == "--unset-all" && strings.HasPrefix(args[3], "http.") &&
+			strings.HasSuffix(args[3], ".extraheader") {
+			unsetIdx = i
+		}
+	}
+
+	if unsetIdx < 0 {
+		t.Errorf("expected an `unset-all extraheader` call before push, none found:\n%v", captured)
+	}
+	if pushIdx < 0 {
+		t.Fatalf("push command not captured:\n%v", captured)
+	}
+	if unsetIdx >= pushIdx {
+		t.Errorf("unset must precede push: unsetIdx=%d, pushIdx=%d", unsetIdx, pushIdx)
+	}
+
+	// Final repo state: actions/checkout's stale extraheader should
+	// be gone (the unset took effect on disk).
+	out, _ := exec.Command("git", "-C", repo, "config", "--local", "--get-all",
+		"http.https://github.com/.extraheader").Output()
+	if strings.TrimSpace(string(out)) != "" {
+		t.Errorf("stale extraheader still present after CommitAndPush: %q", out)
+	}
+}


### PR DESCRIPTION
## Summary

Sequel to #199. That PR switched the implement-stage push from URL-embedded credentials to `git -c http.<host>.extraheader=…`, which was supposed to override the value actions/checkout sets. It didn't:

```
remote: Duplicate header: "Authorization"
fatal: ... 'https://github.com/.../': The requested URL returned error: 400
```

git's `extraheader` is a **multi-valued** config key. Adding a value via `-c` *appends* an entry rather than replacing the existing one — both flow through as separate `Authorization` headers on the HTTP request, GitHub's frontend rejects.

actions/checkout sets the stale entry at `--local` scope (per its source). Fix: unset the local entry before pushing, then `-c` ours as the sole authorization signal.

## Mechanism

```go
// Best-effort: returns non-zero when no value matches (fine for
// non-Actions environments where actions/checkout never ran).
git config --local --unset-all http.<host>.extraheader
git -c http.<host>.extraheader=<our auth> push <plain URL> HEAD:branch
```

The unset is scoped to the host the push targets, so we don't disturb extraheaders for other remotes the customer's workflow may have set.

## Test plan

- [x] `(cd runner && go test -race ./...)` passes — including a new `TestCommitAndPush_UnsetsStaleExtraHeaderBeforePush` regression that:
  1. Seeds a stale extraheader the way actions/checkout would.
  2. Captures every git invocation through the fake `Cmd` hook.
  3. Asserts an `--unset-all extraheader` call happened, that it happened **before** push, and that the on-disk repo no longer has the stale entry afterward.
- [x] `(cd runner && golangci-lint run ./...)` clean.
- [ ] End-to-end against #184: implement-stage push succeeds as `fishhawk-local-dev[bot]` rather than 400'ing on duplicate `Authorization`.

## Notes

This is the third take on the App-token push path (#197 → #199 → here). Each iteration uncovered a deeper layer of actions/checkout's auth shim. The regression test should make this stable: any future "swap to a different auth approach" change has to either keep the unset step or break a test that explicitly captures the failure mode.