### PR TITLE
Prescribe ## Summary / ## Test plan / ## Notes in the implement prompt

### DIFF
--- a/backend/internal/prompt/prompt.go
+++ b/backend/internal/prompt/prompt.go
@@ -104,11 +104,15 @@ func buildImplement(t Trigger) string {
 	b.WriteString("\n")
 	b.WriteString("- The first line is the PR title. Write a task-specific summary of what you changed (e.g. `Add make minio-init target`). Keep it ≤72 characters and do not prefix it with `Fishhawk:` — the runner adds attribution separately.\n")
 	b.WriteString("- Leave one blank line.\n")
-	b.WriteString("- The rest is the PR body in markdown. Lead with the motivation, then describe what changed, then list anything a reviewer should test or watch for. Avoid restating the diff line by line.\n")
+	b.WriteString("- The rest is the PR body in markdown. Use these sections (and only these), in this order:\n")
+	b.WriteString("  - `## Summary` — 1–3 bullets covering the motivation and the load-bearing changes. Don't restate the diff line-by-line.\n")
+	b.WriteString("  - `## Test plan` — a checklist of how a reviewer should verify the change, written as `- [ ] …` items (unchecked; the reviewer ticks them).\n")
+	b.WriteString("  - `## Notes` — optional. Use only when there's something deferred, surprising, or non-obvious worth flagging.\n")
+	b.WriteString("- Don't add other top-level sections. Don't open the body with prose that floats above the first heading; everything narrative goes under `## Summary`.\n")
 
 	if t.IssueNumber > 0 {
 		fmt.Fprintf(&b,
-			"- Include the line `Closes #%d` somewhere in the body so merging the PR auto-closes the originating issue.\n",
+			"- End the body with `Closes #%d` on its own line so merging the PR auto-closes the originating issue.\n",
 			t.IssueNumber,
 		)
 	}

--- a/backend/internal/prompt/prompt_test.go
+++ b/backend/internal/prompt/prompt_test.go
@@ -25,6 +25,14 @@ func TestBuild_Implement_FullContext(t *testing.T) {
 		"smallest set of changes",
 		// PR description guidance + the path the runner reads (#206).
 		PullRequestDescriptionPath,
+		// PR body section structure (matches CLAUDE.md's hand-written
+		// PR convention). Without these the agent tends to write the
+		// summary as floating prose and only head up the Test plan
+		// section, producing an orphan-prose-then-H2 layout.
+		"## Summary",
+		"## Test plan",
+		"## Notes",
+		"`- [ ] …`",
 		// `Closes #N` instruction is conditional on a non-zero issue
 		// number — without it the merge wouldn't auto-close the
 		// originating issue.


### PR DESCRIPTION
## Summary

- Agent-authored PR bodies were rendering with floating prose at the top followed by a standalone \`## Test plan\` heading — the visually-orphaned-summary layout that surfaced on the audit-row PR's screenshot review. The prompt in \`backend/internal/prompt/prompt.go::buildImplement\` told the agent to "Lead with the motivation, then describe what changed, then list anything a reviewer should test or watch for" without prescribing the heading structure CLAUDE.md uses for hand-written PRs, so the agent treated the summary as heading-less prose and only headed up the section that obviously needed structure (the checklist).
- Tighten the prompt to spell out the three sections explicitly: \`## Summary\` (1–3 bullets, motivation + load-bearing changes), \`## Test plan\` (checklist as \`- [ ] …\` items the reviewer ticks), \`## Notes\` (optional, only when something's deferred or non-obvious). Order is fixed; no other top-level sections; nothing floats above the first heading.
- \`Closes #N\` moves to "end the body" / "on its own line" so it consistently lands at the bottom rather than being sprinkled mid-prose.

## Test plan

- [x] \`TestBuild_Implement_FullContext\` extended to assert \`## Summary\`, \`## Test plan\`, \`## Notes\`, and the \`- [ ] …\` checklist hint all appear in the constructed prompt.
- [x] \`TestBuild_Implement_NoIssueRef_OmitsClosesGuidance\` still passes — \`Closes #N\` stays gated on \`IssueNumber > 0\`.
- [x] \`go test -race ./...\` clean across all backend modules; \`golangci-lint\` clean; coverage gate at 83.0% (threshold 80%).

## Notes

- This is a prompt-only change. The runner contract on \`/tmp/fishhawk-pr.md\` (#206), the title-extraction code, and the runner-side fallback template are all unchanged. The first agent-authored PR after this lands will be the visible test of the new shape.
- Trade-off acknowledged: this removes a sliver of agent latitude on PR-body structure. The audit-log story benefits from consistent shape across agent-authored PRs, so the trade is fair — and the agent can still vary the bullet content freely within each section.