### PR TITLE
Fix runs stuck in pending; complete via Advance on every terminal path

### DIFF
--- a/backend/cmd/fishhawkd/serve.go
+++ b/backend/cmd/fishhawkd/serve.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/kuhlman-labs/fishhawk/backend/internal/apitoken"
@@ -326,6 +327,7 @@ func runServe(args []string, logSink io.Writer) int {
 			ticker := &slaTickerConfig{
 				Repo:     cfg.RunRepo,
 				Audit:    cfg.AuditRepo,
+				Advance:  advanceFuncFor(cfg.Orchestrator),
 				Logger:   logger,
 				Interval: *slaInterval,
 			}
@@ -345,6 +347,7 @@ func runServe(args []string, logSink io.Writer) int {
 			ticker := &dispatchwatchdog.Ticker{
 				Repo:     cfg.RunRepo,
 				Audit:    cfg.AuditRepo,
+				Advance:  advanceFuncFor(cfg.Orchestrator),
 				Logger:   logger,
 				Interval: *dispatchWatchdogInterval,
 				Timeout:  *dispatchWatchdogTimeout,
@@ -448,6 +451,7 @@ func runWebhookEvictor(ctx context.Context, logger *slog.Logger, store *webhook.
 type slaTickerConfig struct {
 	Repo     runpkg.Repository
 	Audit    audit.Repository
+	Advance  func(ctx context.Context, runID uuid.UUID) error
 	Logger   *slog.Logger
 	Interval time.Duration
 }
@@ -456,11 +460,28 @@ func (c *slaTickerConfig) Start(ctx context.Context) {
 	t := &slapkg.Ticker{
 		Repo:     c.Repo,
 		Audit:    c.Audit,
+		Advance:  c.Advance,
 		Logger:   c.Logger,
 		Interval: c.Interval,
 	}
 	if err := t.Run(ctx); err != nil {
 		c.Logger.Error("sla ticker exited with error", slog.String("error", err.Error()))
+	}
+}
+
+// advanceFuncFor wraps the orchestrator's Advance method as a plain
+// `func(ctx, runID) error` so the SLA + dispatch-watchdog tickers
+// can depend on the behaviour without forcing their packages to
+// import orchestrator.Outcome. Returns nil when the orchestrator
+// is unconfigured — the tickers tolerate a nil Advance and fall
+// back to "fail the stage and log the run-state gap."
+func advanceFuncFor(o *orchestrator.Orchestrator) func(ctx context.Context, runID uuid.UUID) error {
+	if o == nil {
+		return nil
+	}
+	return func(ctx context.Context, runID uuid.UUID) error {
+		_, err := o.Advance(ctx, runID)
+		return err
 	}
 }
 

--- a/backend/internal/dispatchwatchdog/dispatchwatchdog.go
+++ b/backend/internal/dispatchwatchdog/dispatchwatchdog.go
@@ -25,6 +25,8 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/kuhlman-labs/fishhawk/backend/internal/audit"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/run"
 )
@@ -34,6 +36,12 @@ import (
 // to failed-C. Stable so log scrapers and the compliance export
 // can index on it.
 const CategoryDispatchWatchdogElapsed = "dispatch_watchdog_elapsed"
+
+// (Ticker.Advance is a plain `func(ctx, runID) error` rather than
+// a named type so any caller can satisfy the dependency without a
+// typed conversion. Production wires
+// `orchestrator.Orchestrator.Advance` here via a small closure that
+// drops the Outcome return value.)
 
 // Ticker scans for stages stuck in dispatched state past Timeout
 // and transitions them to failed with category C. Run() blocks
@@ -47,6 +55,12 @@ type Ticker struct {
 	// Audit appends the dispatch_watchdog_elapsed entry per
 	// timeout. Required.
 	Audit audit.Repository
+
+	// Advance walks the run's state machine after the stage
+	// transitions to failed-C. Without this the run sits in
+	// pending forever once its dispatched stage times out.
+	// Optional; nil skips the advancement and logs the gap.
+	Advance func(ctx context.Context, runID uuid.UUID) error
 
 	// Logger receives structured warnings about transient transition
 	// errors. nil → slog.Default().
@@ -177,5 +191,19 @@ func (t *Ticker) handleStage(ctx context.Context, logger *slog.Logger, now time.
 			slog.String("run_id", s.RunID.String()),
 			slog.String("error", err.Error()),
 		)
+	}
+
+	// Walk the run's state machine. Without this, runs whose only
+	// dispatched stage is now category-C-failed sit in pending
+	// forever; the watchdog is the only path that produces this
+	// failure, so the orchestrator never gets called otherwise.
+	if t.Advance != nil {
+		if err := t.Advance(ctx, s.RunID); err != nil {
+			logger.LogAttrs(ctx, slog.LevelWarn, "dispatchwatchdog: orchestrator advance failed",
+				slog.String("run_id", s.RunID.String()),
+				slog.String("stage_id", stageID.String()),
+				slog.String("error", err.Error()),
+			)
+		}
 	}
 }

--- a/backend/internal/orchestrator/orchestrator.go
+++ b/backend/internal/orchestrator/orchestrator.go
@@ -95,11 +95,34 @@ func (o *Orchestrator) Advance(ctx context.Context, runID uuid.UUID) (Outcome, e
 		return OutcomeNoOp, fmt.Errorf("orchestrator: list stages: %w", err)
 	}
 
+	// Walk pending → running before any stage transitions so the
+	// terminal target (succeeded / failed) is reachable. The state
+	// machine rejects pending → terminal directly; without this
+	// step every run that completes its stages stays stuck in
+	// pending. Idempotent on subsequent Advance calls (same-state
+	// transitions are no-ops at the repo layer).
+	if r.State == run.StatePending {
+		updated, err := o.Runs.TransitionRun(ctx, r.ID, run.StateRunning)
+		if err != nil {
+			return OutcomeNoOp, fmt.Errorf("orchestrator: transition run to running: %w", err)
+		}
+		r = updated
+	}
+
 	// Find the next pending stage in sequence order. The
 	// repository returns stages ordered by sequence ascending, so
 	// we walk and pick the first non-terminal pending one.
+	//
+	// If we hit a failed or cancelled stage before finding a
+	// pending one, the run is over — completing as failed (or
+	// cancelled) is correct, and dispatching downstream stages
+	// would be wrong because the upstream output they depended on
+	// never landed.
 	var next *run.Stage
 	for _, s := range stages {
+		if s.State == run.StageStateFailed || s.State == run.StageStateCancelled {
+			return o.completeRun(ctx, r, stages)
+		}
 		if s.State == run.StageStatePending {
 			next = s
 			break
@@ -107,10 +130,8 @@ func (o *Orchestrator) Advance(ctx context.Context, runID uuid.UUID) (Outcome, e
 	}
 
 	if next == nil {
-		// Every stage has terminated. If at least one failed, the
-		// run was already transitioned to failed by whoever
-		// transitioned the stage. If they all succeeded, mark the
-		// run succeeded.
+		// Every stage has terminated successfully. completeRun
+		// transitions the run to succeeded.
 		return o.completeRun(ctx, r, stages)
 	}
 

--- a/backend/internal/orchestrator/orchestrator_test.go
+++ b/backend/internal/orchestrator/orchestrator_test.go
@@ -484,3 +484,80 @@ func TestParseRepo(t *testing.T) {
 		}
 	}
 }
+
+func TestAdvance_PendingRun_WalksToRunningBeforeProcessingStages(t *testing.T) {
+	// Regression for the "runs stuck in pending" bug: every run
+	// is created in StatePending, but the state machine rejects
+	// pending → terminal directly. Without an explicit pending →
+	// running step in Advance, completeRun fails and the run is
+	// stuck forever.
+	//
+	// All-stages-succeeded path: Advance must walk pending →
+	// running → succeeded.
+	o, rs, _ := newOrchestrator(t)
+	r, _ := rs.seed(t, "x/y", int64Ptr(42), []stageSeed{
+		{Type: run.StageTypePlan, ExecutorKind: run.ExecutorAgent, State: run.StageStateSucceeded},
+		{Type: run.StageTypeImplement, ExecutorKind: run.ExecutorAgent, State: run.StageStateSucceeded},
+	})
+	rs.runs[r.ID].State = run.StatePending // override the helper's default Running
+
+	out, err := o.Advance(context.Background(), r.ID)
+	if err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	if out != OutcomeRunCompleted {
+		t.Errorf("Outcome = %q, want run_completed", out)
+	}
+	if rs.runs[r.ID].State != run.StateSucceeded {
+		t.Errorf("run state = %q, want succeeded (pending → running → succeeded)", rs.runs[r.ID].State)
+	}
+}
+
+func TestAdvance_PendingRun_WithFailedStage_WalksToFailed(t *testing.T) {
+	// The all-failures variant of the regression: a stage failed
+	// while the run was still in pending. Advance must walk
+	// pending → running → failed; without that, every run with a
+	// failed stage stays stuck in pending too.
+	o, rs, _ := newOrchestrator(t)
+	r, _ := rs.seed(t, "x/y", int64Ptr(42), []stageSeed{
+		{Type: run.StageTypePlan, ExecutorKind: run.ExecutorAgent, State: run.StageStateFailed},
+		{Type: run.StageTypeImplement, ExecutorKind: run.ExecutorAgent, State: run.StageStatePending},
+	})
+	rs.runs[r.ID].State = run.StatePending
+
+	out, err := o.Advance(context.Background(), r.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != OutcomeRunCompleted {
+		t.Errorf("Outcome = %q, want run_completed", out)
+	}
+	if rs.runs[r.ID].State != run.StateFailed {
+		t.Errorf("run state = %q, want failed (pending → running → failed)", rs.runs[r.ID].State)
+	}
+}
+
+func TestAdvance_FailedStageBeforePending_DoesNotDispatchDownstream(t *testing.T) {
+	// When stage 0 has failed and stage 1 is still pending, the
+	// orchestrator must not dispatch stage 1 — its upstream
+	// output never landed. The run completes as failed instead.
+	// Without this short-circuit, a rejected gate or
+	// constraint-violation failure on stage 0 would still fire
+	// the implement stage's runner, wasting the run and leaving
+	// the audit log telling two contradictory stories.
+	o, rs, gh := newOrchestrator(t)
+	r, _ := rs.seed(t, "x/y", int64Ptr(42), []stageSeed{
+		{Type: run.StageTypePlan, ExecutorKind: run.ExecutorAgent, State: run.StageStateFailed},
+		{Type: run.StageTypeImplement, ExecutorKind: run.ExecutorAgent, State: run.StageStatePending},
+	})
+
+	if _, err := o.Advance(context.Background(), r.ID); err != nil {
+		t.Fatal(err)
+	}
+	if rs.runs[r.ID].State != run.StateFailed {
+		t.Errorf("run state = %q, want failed", rs.runs[r.ID].State)
+	}
+	if len(gh.calls) != 0 {
+		t.Errorf("orchestrator dispatched a stage past the failure: %d calls", len(gh.calls))
+	}
+}

--- a/backend/internal/server/approvals.go
+++ b/backend/internal/server/approvals.go
@@ -141,16 +141,16 @@ func (s *Server) handleSubmitApproval(w http.ResponseWriter, r *http.Request) {
 
 		s.writeApprovalAudit(r, stage, res.Approval)
 
-		// On approve, hand off to the orchestrator to dispatch
-		// the next stage (or transition the run to succeeded if
-		// this was the last stage). On reject we don't advance —
-		// the run is over and the orchestrator would no-op
-		// against the now-terminal state anyway.
-		if decision == approval.DecisionApprove && s.cfg.Orchestrator != nil {
+		// Hand off to the orchestrator on both approve AND reject
+		// — approve dispatches the next stage; reject walks the
+		// run's state machine to terminal (pending → running →
+		// failed). Without the reject path the run would stay in
+		// pending forever once an approver rejected.
+		if s.cfg.Orchestrator != nil {
 			if _, err := s.cfg.Orchestrator.Advance(r.Context(), stage.RunID); err != nil {
-				// Don't fail the approval: the gate did pass,
-				// the audit row is in place. Surface the
-				// orchestration failure in logs and let a
+				// Don't fail the approval: the gate did pass /
+				// reject, the audit row is in place. Surface
+				// the orchestration failure in logs and let a
 				// follow-up call recover.
 				s.cfg.Logger.LogAttrs(r.Context(), slog.LevelError,
 					"orchestrator advance failed",

--- a/backend/internal/server/approvals_test.go
+++ b/backend/internal/server/approvals_test.go
@@ -702,7 +702,13 @@ func TestSubmitApproval_NoOrchestrator_LeavesNextStagePending(t *testing.T) {
 	}
 }
 
-func TestSubmitApproval_Reject_DoesntTriggerOrchestrator(t *testing.T) {
+func TestSubmitApproval_Reject_AdvancesRunToFailed(t *testing.T) {
+	// Reject must hand off to the orchestrator so the run walks
+	// pending → running → failed. Without that the run stays
+	// stuck in pending forever once an approver rejects (the bug
+	// that drove this fix). Downstream stages stay pending — the
+	// orchestrator short-circuits on the failed first stage rather
+	// than dispatching anything past it.
 	rr := newOrchestratorRepo()
 	r := rr.seedRun()
 	first := rr.seedStage(r.ID, 0, run.StageStateAwaitingApproval)
@@ -725,7 +731,14 @@ func TestSubmitApproval_Reject_DoesntTriggerOrchestrator(t *testing.T) {
 		t.Errorf("first.State = %q, want failed", first.State)
 	}
 	if second.State != run.StageStatePending {
-		t.Errorf("second.State = %q, want pending (reject shouldn't advance)", second.State)
+		t.Errorf("second.State = %q, want pending (orchestrator shouldn't dispatch past a failed stage)", second.State)
+	}
+	got, err := rr.GetRun(t.Context(), r.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.State != run.StateFailed {
+		t.Errorf("run.State = %q, want failed (reject should walk pending → running → failed)", got.State)
 	}
 }
 

--- a/backend/internal/server/trace.go
+++ b/backend/internal/server/trace.go
@@ -219,6 +219,12 @@ func (s *Server) handleShipTrace(w http.ResponseWriter, r *http.Request) {
 					slog.String("stage_id", stageID.String()),
 					slog.String("error", err.Error()))
 			}
+			// Advance so the orchestrator walks the run to its
+			// terminal state — without this the run stays in
+			// pending forever once a stage fails. Best-effort:
+			// the audit row for the failed stage is the canonical
+			// signal; a stuck run is recoverable.
+			s.advanceAfterFailure(r, runID, stageID)
 			s.writeJSON(w, r, http.StatusAccepted, traceUploadResponse{
 				RunID:       runID,
 				StageID:     stageID,
@@ -497,6 +503,10 @@ func isEmptyConstraints(c policy.Constraints) bool {
 // failed if needed. Failures are logged but don't unwind — the
 // policy_evaluated audit entry is the primary signal; a stuck stage
 // is recoverable.
+//
+// After the stage transitions to failed, advance the run so the
+// orchestrator walks pending → running → failed. Without this the
+// run stays in pending forever once any stage fails.
 func (s *Server) failStageCategoryB(r *http.Request, runID, stageID uuid.UUID, reason string) {
 	if _, err := run.FailStage(r.Context(), s.cfg.RunRepo, stageID, run.FailureB, reason); err != nil {
 		s.cfg.Logger.LogAttrs(r.Context(), slog.LevelWarn,
@@ -504,6 +514,27 @@ func (s *Server) failStageCategoryB(r *http.Request, runID, stageID uuid.UUID, r
 			slog.String("run_id", runID.String()),
 			slog.String("stage_id", stageID.String()),
 			slog.String("error", err.Error()))
+	}
+	s.advanceAfterFailure(r, runID, stageID)
+}
+
+// advanceAfterFailure invokes the orchestrator to walk the run's
+// state machine after a stage has transitioned terminally. Errors
+// are logged but never unwind the caller — the audit log is the
+// canonical signal that the stage failed; a stuck run is the kind
+// of bug we want surfaced via /v0/runs (state != pending) rather
+// than via a 500 on the upload that already wrote the audit row.
+func (s *Server) advanceAfterFailure(r *http.Request, runID, stageID uuid.UUID) {
+	if s.cfg.Orchestrator == nil {
+		return
+	}
+	if _, err := s.cfg.Orchestrator.Advance(r.Context(), runID); err != nil {
+		s.cfg.Logger.LogAttrs(r.Context(), slog.LevelWarn,
+			"trace upload: orchestrator advance after stage failure failed",
+			slog.String("run_id", runID.String()),
+			slog.String("stage_id", stageID.String()),
+			slog.String("error", err.Error()),
+		)
 	}
 }
 

--- a/backend/internal/sla/sla.go
+++ b/backend/internal/sla/sla.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/kuhlman-labs/fishhawk/backend/internal/audit"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/run"
 )
@@ -76,6 +78,12 @@ func Parse(s string) (time.Duration, error) {
 	}
 }
 
+// (No named function type — the ticker's Advance field is a
+// plain `func(ctx, runID) error` so any package can satisfy it
+// without conversion. Defining it as a named type would force
+// callers to wrap their advancer in a typed conversion at every
+// call site.)
+
 // Ticker scans for awaiting_approval stages whose SLA has elapsed
 // and transitions them to failed with category D. Run() blocks
 // until ctx is done; for production wiring start it on its own
@@ -88,6 +96,15 @@ type Ticker struct {
 	// Audit appends the approval_sla_elapsed entry per timeout.
 	// Required.
 	Audit audit.Repository
+
+	// Advance walks the run's state machine after the stage
+	// transitions to failed-D — without this, runs whose only
+	// stages have all timed out stay stuck in pending. Optional;
+	// nil skips the advancement and logs the gap (the run can
+	// still be advanced via a follow-up event). Production wires
+	// `orchestrator.Orchestrator.Advance` here via a small
+	// closure that drops its Outcome return value.
+	Advance func(ctx context.Context, runID uuid.UUID) error
 
 	// Logger receives structured warnings about parse failures and
 	// transient transition errors. nil → slog.Default().
@@ -246,4 +263,18 @@ func (t *Ticker) handleStage(ctx context.Context, logger *slog.Logger, now time.
 		slog.String("sla", *s.GateSLA),
 		slog.Duration("elapsed", elapsed),
 	)
+
+	// Walk the run's state machine. Without this the run sits in
+	// pending forever once its only awaiting_approval stage times
+	// out. The advancer's GitHub-dispatch path won't fire (the
+	// stage is terminal), so this is a pure state transition.
+	if t.Advance != nil {
+		if err := t.Advance(ctx, s.RunID); err != nil {
+			logger.LogAttrs(ctx, slog.LevelWarn, "sla: orchestrator advance failed",
+				slog.String("run_id", s.RunID.String()),
+				slog.String("stage_id", s.ID.String()),
+				slog.String("error", err.Error()),
+			)
+		}
+	}
 }


### PR DESCRIPTION
## Summary

- Every run was stuck in \`pending\` regardless of stage state. Root cause: nothing transitions runs from \`pending → running\`, so the state machine (which requires \`running\` in between) rejected \`completeRun\`'s \`pending → succeeded\` and the run sat forever. The /runs page showed every run as pending.
- Two halves of the fix: \`orchestrator.Advance\` now walks \`pending → running\` once per run as the first step (idempotent on subsequent calls), and every terminal-stage path now calls \`Advance\` so the run-state machine actually progresses.
- Companion bug fixed in the same change: the orchestrator dispatched downstream stages past a failed stage (\`reject\` → \`failed\` → "next stage" was \`pending\` → dispatched). \`Advance\` now short-circuits on the first failed/cancelled stage in the walk and completes the run as failed instead.

## What was broken

| Path | Before | After |
|---|---|---|
| All stages succeed | \`completeRun\` rejected by state machine, run stuck | Advance walks pending → running → succeeded ✓ |
| Trace-upload category-A failure | Stage failed, \`Advance\` never called, run stuck | \`advanceAfterFailure\` walks run to failed |
| Trace-upload category-B failure | Same | Same |
| Approval reject (category-D) | "Don't advance, run is over" — but it wasn't terminal | Advance walks run to failed |
| SLA D-timeout | Background ticker had no orchestrator dep | New \`Advance func\` field; serve.go wires it |
| Dispatch watchdog (category-C) | Same | Same |
| Stage 0 fails, stage 1 pending | Orchestrator dispatches stage 1 anyway | Short-circuit on failure → completeRun |

## Test plan

- [x] \`TestAdvance_PendingRun_WalksToRunningBeforeProcessingStages\` — explicit regression for the success path; seeds the run in pending and asserts it ends in succeeded.
- [x] \`TestAdvance_PendingRun_WithFailedStage_WalksToFailed\` — failure path mirror.
- [x] \`TestAdvance_FailedStageBeforePending_DoesNotDispatchDownstream\` — guard for the short-circuit.
- [x] \`TestSubmitApproval_Reject_AdvancesRunToFailed\` — replaces the now-wrong \"reject doesn't trigger orchestrator\" test; asserts reject walks the run to failed and downstream stages stay pending.
- [x] \`go test -race ./...\` clean across all backend modules; \`golangci-lint\` clean. Coverage gate 83.0% (threshold 80%).
- [x] No frontend changes — the /runs page picks up the corrected run states automatically.

## Notes

- Tickers (SLA + dispatch-watchdog) gain an \`Advance func(ctx, runID) error\` field rather than an interface so callers can wire any source without a typed conversion. serve.go's \`advanceFuncFor\` wraps \`orchestrator.Orchestrator.Advance\` and drops the Outcome return.
- Existing runs that are already stuck in \`pending\` won't auto-recover from this PR — they need a follow-up Advance trigger (cancel + recreate, or a manual Advance via a future operator endpoint). Filing a follow-up if recovery becomes a problem; the immediate fix prevents new runs from getting stuck.
- The "advance on every terminal path" pattern is a maintenance burden — every new failure path needs to remember to call Advance. Considered moving the advancement into \`run.FailStage\` itself (single touchpoint) but rejected for now: \`run\` would need to know about the orchestrator, reversing the dependency direction. v0.x can revisit if more failure paths land.