### PR TITLE
Document FISHHAWKD_EXTERNAL_URL in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,15 @@ FISHHAWKD_DATABASE_URL=postgres://fishhawk:fishhawk@localhost:5432/fishhawk?sslm
 # FISHHAWKD_OAUTH_CALLBACK_URL=http://localhost:8080/v0/auth/github/callback
 # FISHHAWKD_OAUTH_REDIRECT_AFTER_LOGIN=http://localhost:5173/
 
+# --- SPA root for back-links (#231) ---
+# Used as `details_url` on the published `fishhawk_audit_complete`
+# GitHub Check Run so a reviewer who clicks the check on github.com
+# lands on the run page in Fishhawk. Vite serves the SPA on :5173 in
+# local dev. Empty disables the publish-to-GitHub path cleanly; the
+# in-Fishhawk gate enforcement still works.
+
+# FISHHAWKD_EXTERNAL_URL=http://localhost:5173
+
 # --- runner OIDC (only when iterating on the signing-key endpoint) ---
 # Off by default — endpoint accepts any caller (v0 self-execution
 # posture). Set to a non-empty audience to enforce verification.


### PR DESCRIPTION
## Summary
Doc-only follow-up to #235. Adds the new \`FISHHAWKD_EXTERNAL_URL\` env var to \`.env.example\` so fresh contributors see the slot alongside the other Mode B/C config knobs. Commented out by default since the in-Fishhawk gate works without it.

## Test plan
- [x] No code change; just \`.env.example\`. Existing tests still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)