### PR TITLE
Match the actual GitHub check name in workflow spec blocking_checks

### DIFF
--- a/.fishhawk/workflows.yaml
+++ b/.fishhawk/workflows.yaml
@@ -89,7 +89,7 @@ workflows:
             approvers:
               any_of: [founder]
             blocking_checks:
-              - ci_pass
+              - "CI Pass"
               - fishhawk_audit_complete
 
   # Low autonomy — human-led work.
@@ -115,7 +115,7 @@ workflows:
             approvers:
               any_of: [founder]
             blocking_checks:
-              - ci_pass
+              - "CI Pass"
 
   # High autonomy — agent implements and merges if gates pass.
   # Reserved for low-risk, high-volume work where the cost of a mistake
@@ -150,5 +150,5 @@ workflows:
         gates:
           - type: check
             blocking_checks:
-              - ci_pass
+              - "CI Pass"
               - fishhawk_audit_complete


### PR DESCRIPTION
## Summary
The repo's CI rollup job has \`name: CI Pass\` (\`.github/workflows/ci.yml\` line 204). GitHub fires \`check_run\` events with that display name verbatim, and the backend's check ingester (#228) does verbatim string matching. The spec's \`blocking_checks\` was \`ci_pass\` (snake_case), so the names never matched — \`stage_checks\` never got rows for the rollup, the synthetic \`ci_pass\` row stayed at \`not_tracked\`, and the review-stage gate refused approval even when CI was green.

Updates all three \`blocking_checks\` entries in \`.fishhawk/workflows.yaml\` (\`feature_change\`, \`human_led_change\`, \`routine_change\`) from \`ci_pass\` to \`"CI Pass"\` (quoted because of the space).

Surfaced by the Day 21 dogfooding pass.

## Test plan
- [x] \`check-jsonschema --schemafile docs/spec/workflow-v0.schema.json .fishhawk/workflows.yaml\` — schema-valid.
- [x] \`go test -race ./internal/spec/...\` — parser tests still green (the spec is YAML; check name is just a string).

## Notes
- \`ci_pass\` references in the test files (\`frontend/src/components/blocking-checks-panel.test.tsx\`, \`frontend/src/review/review-document.test.tsx\`, \`backend/internal/webhook/dispatcher_test.go\`) stay as-is — those use \`ci_pass\` as a synthetic name to exercise the blocking-check machinery, not as the production check name.
- The customer-side branch-protection guide (\`docs/github-app/README.md:214\`) keeps \`ci_pass\` as a generic example since per-customer CI names vary. The point of this change is just to match Fishhawk's own deployment.
- A future cleanup: standardize on either the snake_case spec convention or the human-readable display name. For now, defer to whatever the GitHub side actually emits — that's what the gate has to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)