### PR TITLE
Bump GitHub App manifest: administration:read for branch protection

### DIFF
--- a/backend/internal/server/manifest.go
+++ b/backend/internal/server/manifest.go
@@ -228,6 +228,12 @@ func buildManifest(backendURL, webhookURL, name string) map[string]any {
 			"workflows":     "write",
 			"members":       "read",
 			"metadata":      "read",
+			// administration:read lets the backend read branch
+			// protection + rulesets to derive the required-checks
+			// list at run-create time (ADR-017 / #249, consumed by
+			// #251). Read-only — we don't manage protection from
+			// Fishhawk.
+			"administration": "read",
 		},
 		"default_events": []string{
 			"issues",

--- a/backend/internal/server/manifest_test.go
+++ b/backend/internal/server/manifest_test.go
@@ -304,6 +304,53 @@ func TestManifestCallback_Unconfigured_503(t *testing.T) {
 	}
 }
 
+// TestBuildManifest_DefaultPermissions asserts the rendered manifest
+// carries the permissions Fishhawk depends on. The contract here is
+// load-bearing for the install flow — a missing scope means the App
+// gets installed without the API access the backend assumes, and the
+// failure surfaces later as a 403 from a totally unrelated handler.
+//
+// The permissions listed below are the closed set required for v0;
+// each one has a load-bearing call site in the backend or runner.
+// Bumping a permission here requires a re-install, which is documented
+// in docs/github-app/README.md "Re-installing after a permissions
+// bump".
+func TestBuildManifest_DefaultPermissions(t *testing.T) {
+	m := buildManifest("http://localhost:8080", "https://smee.io/abc", "")
+	perms, ok := m["default_permissions"].(map[string]string)
+	if !ok {
+		t.Fatalf("default_permissions missing or wrong type: %T", m["default_permissions"])
+	}
+	want := map[string]string{
+		"actions":       "write",
+		"contents":      "write",
+		"issues":        "write",
+		"pull_requests": "write",
+		"checks":        "write",
+		"workflows":     "write",
+		"members":       "read",
+		"metadata":      "read",
+		// administration:read for ADR-017 / #249: backend reads
+		// branch protection + rulesets at run-create time to derive
+		// the required-checks list (consumed by #251).
+		"administration": "read",
+	}
+	if len(perms) != len(want) {
+		t.Errorf("permission count = %d, want %d:\n got: %v\nwant: %v",
+			len(perms), len(want), perms, want)
+	}
+	for k, v := range want {
+		got, ok := perms[k]
+		if !ok {
+			t.Errorf("permission %q missing", k)
+			continue
+		}
+		if got != v {
+			t.Errorf("permission %q = %q, want %q", k, got, v)
+		}
+	}
+}
+
 func TestDeriveOAuthCallbackURL(t *testing.T) {
 	cases := []struct {
 		name string

--- a/docs/github-app/README.md
+++ b/docs/github-app/README.md
@@ -25,6 +25,7 @@ Per `MVP_SPEC.md` §5.1.5:
 | `workflows` | w | Edit `.github/workflows/*.yml` (e.g. install-time provisioning of the customer's `fishhawk.yml`). Does NOT cover the dispatch endpoint — see `actions` above. |
 | `members` | r | Resolve `@org/team` references in role definitions to GitHub-login allowlists for approver checks (E4.4 / #50). |
 | `metadata` | r | Always granted; required for any read access. |
+| `administration` | r | Read branch protection + rulesets to derive the required-checks list (ADR-017 / #249). |
 
 Webhook events:
 
@@ -219,6 +220,8 @@ From this point, GitHub itself refuses the merge until Fishhawk reports `success
 ### Re-installing after a permissions bump
 
 When the App's permission set changes (e.g. a new `checks: write` requirement), GitHub flags the installation as needing review and existing installations fall back to the old permission set until the customer accepts the new ones. Reinstall via the App's installation page (**Configure** → **Save**) to pick up the new permissions.
+
+The most recent bump (ADR-017 / #249) added `administration: read` so the backend can read branch protection + rulesets at run-create time. Existing installs must re-accept before required-checks derivation will work; the run will fall back to an empty required-checks list otherwise.
 
 **Installing the App is the only repo-side dependency.** Specifically, customers do **not** need to:
 

--- a/docs/github-app/manifest.template.json
+++ b/docs/github-app/manifest.template.json
@@ -21,7 +21,8 @@
     "checks": "write",
     "workflows": "write",
     "members": "read",
-    "metadata": "read"
+    "metadata": "read",
+    "administration": "read"
   },
   "default_events": [
     "issues",


### PR DESCRIPTION
## Summary

- Add `administration: read` to the App's default permissions in both `docs/github-app/manifest.template.json` and `backend/internal/server/manifest.go::buildManifest`. The two have to stay in lockstep — the template is what the operator pastes into GitHub during the manifest flow; `buildManifest` is what the backend renders for the embedded form.
- New `TestBuildManifest_DefaultPermissions` asserts the closed permission set (counts + values), so a future scope bump that touches only one of the two files fails CI.
- `docs/github-app/README.md` Permissions table gains a row for `administration` and the "Re-installing after a permissions bump" section gets a callout pointing at this specific change.

The new scope is consumed by #251 (read branch protection at run-create time, snapshot on the run). It's read-only — Fishhawk doesn't manage protection.

## Test plan

- [ ] `go test -race ./backend/internal/server/...` — manifest tests pass, including the new `TestBuildManifest_DefaultPermissions`.
- [ ] `golangci-lint run ./backend/...`
- [ ] `diff <(jq -S .default_permissions docs/github-app/manifest.template.json) <(echo '{"actions":"write","contents":"write","issues":"write","pull_requests":"write","checks":"write","workflows":"write","members":"read","metadata":"read","administration":"read"}' | jq -S .)` — template and the test's expected map match.
- [ ] Re-install the dev App via the manifest flow and confirm the GitHub App settings page now lists "Administration: Read" under permissions.

## Notes

Existing installs must re-accept the new permission set before the backend can read branch protection. The fallback (#251) will be: empty required-checks list + a one-time audit entry flagging the missing scope, so the run still proceeds with degraded gating rather than 500ing.

Closes #252