### PR TITLE
Fix plan-ready 'Approve in the dashboard' link 404 (#273)

### DIFF
--- a/backend/internal/issuecomment/notifier.go
+++ b/backend/internal/issuecomment/notifier.go
@@ -378,8 +378,11 @@ func renderPlanBody(c commentContext, planStage *run.Stage, p *plan.Plan, extern
 	}
 
 	if planStage.RequiresApproval {
-		fmt.Fprintf(&b, "\n[Approve in the dashboard →](%s/stages/%s)\n",
-			externalURL, planStage.ID.String())
+		// SPA route is /runs/:runId/stages/:stageId — there's no
+		// top-level /stages/<id> route, so pre-#273 this URL 404'd
+		// for every plan-ready comment that landed (#273).
+		fmt.Fprintf(&b, "\n[Approve in the dashboard →](%s/runs/%s/stages/%s)\n",
+			externalURL, c.run.ID.String(), planStage.ID.String())
 	} else {
 		fmt.Fprintf(&b, "\n[View run →](%s)\n", c.runURL)
 	}

--- a/backend/internal/issuecomment/notifier_test.go
+++ b/backend/internal/issuecomment/notifier_test.go
@@ -207,8 +207,14 @@ func TestNotifyPlanReady_GatedRun_LinksToApprovalSurface(t *testing.T) {
 	if !strings.Contains(body, "`x.go`") || !strings.Contains(body, "`y.go`") {
 		t.Errorf("body should include file paths: %q", body)
 	}
-	if !strings.Contains(body, "/stages/"+planStage.ID.String()) {
-		t.Errorf("body should link to approval surface for gated run: %q", body)
+	// The approval link must include the /runs/<run_id> prefix
+	// before the /stages/<stage_id> segment — the SPA route is
+	// /runs/:runId/stages/:stageId; pre-#273 this asserted only on
+	// the trailing /stages/<id> shape, which pinned a broken URL
+	// in place (every plan-ready comment 404'd).
+	wantURL := "/runs/" + runID.String() + "/stages/" + planStage.ID.String()
+	if !strings.Contains(body, wantURL) {
+		t.Errorf("body should link to %q (run-scoped stage URL): %q", wantURL, body)
 	}
 }
 


### PR DESCRIPTION
## Summary

Pre-#273 \`renderPlanBody\` built the gated-stage approval link as \`<external>/stages/<stage_id>\`. But the SPA route declared in \`frontend/src/App.tsx\` is \`runs/:runId/stages/:stageId\` — there's no top-level \`/stages/<id>\` route. Every plan-ready comment that landed in production carried a link that 404'd; the user confirmed it live by clicking through.

- \`renderPlanBody\` template gains the missing \`/runs/<run_id>\` segment. \`c.run.ID\` is already in scope on the \`commentContext\`, so the fix is a one-line edit.
- The matching test asserted only on the trailing \`/stages/<id>\` shape (no anchor on the run id), which is how the bug stayed green in CI. Flipped to assert the full run-scoped URL.

## Test plan

- [ ] \`go test -race ./backend/...\` — touched: \`internal/issuecomment\`.
- [ ] \`golangci-lint run ./backend/...\`
- [ ] Manual: trigger an issue-driven \`feature_change\` run, wait for the plan-ready comment, click \"Approve in the dashboard →\". The SPA loads the stage page (not a 404).

## Notes

The fix doesn't change the gateless arm's URL (it already uses \`c.runURL\` which builds the right shape).

Closes #273