### PR TITLE
Spec on_ci_failure.max_retries; bump to v0.3 (#277)

### DIFF
--- a/.fishhawk/workflows.yaml
+++ b/.fishhawk/workflows.yaml
@@ -11,7 +11,7 @@
 # When the product can execute this spec, the syntax may be revised to
 # match the frozen v0 schema. The intent expressed here will not change.
 
-version: "0.2"
+version: "0.3"
 
 roles:
   founder:
@@ -26,6 +26,11 @@ workflows:
     description: >-
       Default workflow for feature work and non-trivial changes.
       Human approves plan and PR; agent does the implementation.
+    # Auto-retry once on CI failure (#276). The human approves the
+    # plan; the agent should self-heal on a routine test or lint
+    # regression without forcing the reviewer back into the loop.
+    on_ci_failure:
+      max_retries: 1
 
     stages:
       - id: plan
@@ -119,6 +124,13 @@ workflows:
     description: >-
       Workflow for documentation, dependency bumps, lint/format fixes,
       and tests for existing behavior. Agent may merge if all gates pass.
+    # High-autonomy auto-retry (#276). Routine_change is the
+    # canonical case for self-healing: the human never approved
+    # anything; the agent's job is to keep the change merging
+    # cleanly. One retry strikes the balance between resilience to
+    # flaky CI and not spinning forever on a real bug.
+    on_ci_failure:
+      max_retries: 1
 
     stages:
       - id: implement

--- a/backend/internal/server/approvals_role_test.go
+++ b/backend/internal/server/approvals_role_test.go
@@ -99,7 +99,7 @@ func (s *stubTeamLister) ListTeamMembers(_ context.Context, _ int64, org, slug s
 }
 
 const approvalGateSpec = `
-version: "0.2"
+version: "0.3"
 roles:
   eng_team:
     members: ["@acme/eng"]

--- a/backend/internal/server/trace_policy_test.go
+++ b/backend/internal/server/trace_policy_test.go
@@ -157,7 +157,7 @@ func makeTestBundle(t *testing.T, files []map[string]string) []byte {
 }
 
 const testWorkflowSpec = `
-version: "0.2"
+version: "0.3"
 roles:
   eng_team:
     members: ["@org/eng"]

--- a/backend/internal/spec/schemas/workflow-v0.schema.json
+++ b/backend/internal/spec/schemas/workflow-v0.schema.json
@@ -11,8 +11,8 @@
   "properties": {
     "version": {
       "type": "string",
-      "enum": ["0.2"],
-      "description": "Spec syntax version. 0.2 dropped gate.blocking_checks (ADR-017 / #249); required CI checks are derived from GitHub branch protection at run-create time. 0.1 specs that still declare the field fail validation — the field has no consumer left."
+      "enum": ["0.3"],
+      "description": "Spec syntax version. 0.3 adds workflow.on_ci_failure.max_retries for the auto-retry epic (#276 / #277). 0.2 dropped gate.blocking_checks (ADR-017 / #249); 0.1 is rejected. Old specs in the audit log remain readable forever via the historical schemas; this enum gates *new* specs only."
     },
     "roles": {
       "type": "object",
@@ -63,6 +63,21 @@
           "type": "array",
           "minItems": 1,
           "items": { "$ref": "#/$defs/stage" }
+        },
+        "on_ci_failure": { "$ref": "#/$defs/on_ci_failure" }
+      }
+    },
+
+    "on_ci_failure": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Auto-retry policy when a required CI check fails on the implement stage's PR (#276 / E16). The dispatcher fires a fresh implement workflow_dispatch up to `max_retries` times, threading the new run via `parent_run_id` (#216). Only the closed set of failing conclusions in stagecheck.DeriveState triggers a retry; `fishhawk_audit_complete` failures are explicitly excluded — retrying won't fix Fishhawk's own audit gaps.",
+      "properties": {
+        "max_retries": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 5,
+          "description": "Bound on the retry chain length. 1 (the default when the field is absent) means \"on CI failure, dispatch one more run, total agent-touch count 2.\" 0 disables auto-retries — useful for low-autonomy workflows that prefer a human re-trigger. Capped at 5 to keep runaway loops contained in v0."
         }
       }
     },

--- a/backend/internal/spec/spec.go
+++ b/backend/internal/spec/spec.go
@@ -37,9 +37,31 @@ type Role struct {
 // Workflow is one named pipeline (e.g. "feature_change") with an
 // ordered list of stages.
 type Workflow struct {
-	Description string  `json:"description,omitempty" yaml:"description,omitempty"`
-	Stages      []Stage `json:"stages" yaml:"stages"`
+	Description string       `json:"description,omitempty" yaml:"description,omitempty"`
+	Stages      []Stage      `json:"stages" yaml:"stages"`
+	OnCIFailure *OnCIFailure `json:"on_ci_failure,omitempty" yaml:"on_ci_failure,omitempty"`
 }
+
+// OnCIFailure is the per-workflow auto-retry policy (#276 / #277).
+// When set, the dispatcher fires a fresh implement workflow_dispatch
+// on a required-check failure (#251 / branch protection snapshot)
+// up to MaxRetries times, chaining each retry via `parent_run_id`.
+//
+// Nil-vs-zero distinction matters: a nil pointer means the workflow
+// doesn't declare a policy at all (use the documented default of 1
+// retry — `DefaultMaxRetries`). An explicit `max_retries: 0` is the
+// opt-out signal — useful for low-autonomy workflows that prefer a
+// human re-trigger. The consumer (dispatcher) reads MaxRetries
+// directly when the pointer is non-nil; resolves to
+// DefaultMaxRetries otherwise.
+type OnCIFailure struct {
+	MaxRetries int `json:"max_retries,omitempty" yaml:"max_retries,omitempty"`
+}
+
+// DefaultMaxRetries is the value the dispatcher uses when a
+// workflow doesn't declare an `on_ci_failure` block. Centralized
+// here so the consumer side has a single source of truth.
+const DefaultMaxRetries = 1
 
 // Stage is one unit of work in a workflow. The closed set of types
 // (plan / implement / review) is enforced by the schema.

--- a/backend/internal/spec/spec_test.go
+++ b/backend/internal/spec/spec_test.go
@@ -26,8 +26,8 @@ func TestParse_CanonicalFeatureChange(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Parse: %v", err)
 	}
-	if s.Version != "0.2" {
-		t.Errorf("version = %q, want 0.2", s.Version)
+	if s.Version != "0.3" {
+		t.Errorf("version = %q, want 0.3", s.Version)
 	}
 	if got, want := len(s.Workflows), 1; got != want {
 		t.Errorf("workflows count = %d, want %d", got, want)
@@ -62,6 +62,125 @@ func TestParse_Minimal(t *testing.T) {
 	}
 	if len(s.Roles) != 0 {
 		t.Errorf("roles should be empty, got %v", s.Roles)
+	}
+}
+
+// --- on_ci_failure / retry policy (#277) ---
+
+func TestParse_OnCIFailure_Absent_NilPointer(t *testing.T) {
+	// No `on_ci_failure` block → Workflow.OnCIFailure is nil. The
+	// nil-vs-zero distinction is load-bearing: nil = "use the
+	// default of 1 retry"; an explicit `max_retries: 0` = "opt out
+	// of auto-retries." The dispatcher reads these differently.
+	s, err := spec.ParseBytes(readFixture(t, "valid/minimal.yaml"))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	wf, ok := s.Workflows["trivial"]
+	if !ok {
+		t.Fatal("trivial workflow missing from parsed spec")
+	}
+	if wf.OnCIFailure != nil {
+		t.Errorf("OnCIFailure = %+v, want nil for an unset block", wf.OnCIFailure)
+	}
+}
+
+func TestParse_OnCIFailure_Default(t *testing.T) {
+	// `max_retries: 1` round-trips cleanly. Same shape the
+	// dispatcher will read at run-create time when evaluating
+	// whether to fire a follow-up implement workflow_dispatch on
+	// CI failure (#276).
+	yml := []byte(`
+version: "0.3"
+workflows:
+  feature_change:
+    description: "x"
+    on_ci_failure:
+      max_retries: 1
+    stages:
+      - id: implement
+        type: implement
+        executor:
+          agent: claude-code
+        produces:
+          - artifact: pull_request
+`)
+	s, err := spec.ParseBytes(yml)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	wf := s.Workflows["feature_change"]
+	if wf.OnCIFailure == nil {
+		t.Fatal("OnCIFailure should round-trip non-nil")
+	}
+	if wf.OnCIFailure.MaxRetries != 1 {
+		t.Errorf("MaxRetries = %d, want 1", wf.OnCIFailure.MaxRetries)
+	}
+}
+
+func TestParse_OnCIFailure_ExplicitZero_OptsOut(t *testing.T) {
+	// `max_retries: 0` is the explicit opt-out — the dispatcher
+	// won't fire any auto-retries even on CI failure. Distinct
+	// from the absent-block case (nil pointer → DefaultMaxRetries).
+	yml := []byte(`
+version: "0.3"
+workflows:
+  human_led_change:
+    description: "x"
+    on_ci_failure:
+      max_retries: 0
+    stages:
+      - id: review
+        type: review
+        executor:
+          human: true
+        inputs:
+          - source: pull_request
+            required: true
+`)
+	s, err := spec.ParseBytes(yml)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	wf := s.Workflows["human_led_change"]
+	if wf.OnCIFailure == nil {
+		t.Fatal("OnCIFailure should round-trip non-nil even when value=0")
+	}
+	if wf.OnCIFailure.MaxRetries != 0 {
+		t.Errorf("MaxRetries = %d, want 0", wf.OnCIFailure.MaxRetries)
+	}
+}
+
+func TestParse_OnCIFailure_ExceedsCap_Rejected(t *testing.T) {
+	// max_retries: 6 violates the schema's maximum: 5. The schema-
+	// validation pass surfaces it as a ValidationError naming the
+	// failing field — the dispatcher never gets a chance to fire
+	// six retries because we refuse the spec before it lands on a
+	// run row.
+	yml := []byte(`
+version: "0.3"
+workflows:
+  feature_change:
+    description: "x"
+    on_ci_failure:
+      max_retries: 6
+    stages:
+      - id: implement
+        type: implement
+        executor:
+          agent: claude-code
+        produces:
+          - artifact: pull_request
+`)
+	_, err := spec.ParseBytes(yml)
+	var se *spec.SchemaError
+	if !errors.As(err, &se) {
+		t.Fatalf("err = %v, want *SchemaError", err)
+	}
+	// The error trail names the offending field so a customer can
+	// fix their spec without grepping the schema source.
+	if !strings.Contains(se.Path, "max_retries") && !strings.Contains(se.Message, "maximum") {
+		t.Errorf("error should name the offending field / constraint: %s", se.Error())
 	}
 }
 
@@ -118,7 +237,7 @@ workflows:
 
 func TestParse_UnknownStageType(t *testing.T) {
 	_, err := spec.ParseBytes([]byte(`
-version: "0.2"
+version: "0.3"
 workflows:
   trivial:
     stages:
@@ -135,7 +254,7 @@ workflows:
 func TestParse_BothExecutorKinds(t *testing.T) {
 	// Schema's oneOf rejects {agent, human} together.
 	_, err := spec.ParseBytes([]byte(`
-version: "0.2"
+version: "0.3"
 workflows:
   trivial:
     stages:
@@ -154,7 +273,7 @@ workflows:
 func TestParse_StageIDPattern(t *testing.T) {
 	// Stage IDs must be snake_case (^[a-z][a-z0-9_]*$).
 	_, err := spec.ParseBytes([]byte(`
-version: "0.2"
+version: "0.3"
 workflows:
   trivial:
     stages:
@@ -170,7 +289,7 @@ workflows:
 
 func TestParse_UnknownArtifactKind(t *testing.T) {
 	_, err := spec.ParseBytes([]byte(`
-version: "0.2"
+version: "0.3"
 workflows:
   trivial:
     stages:
@@ -190,7 +309,7 @@ workflows:
 
 func TestParse_DuplicateStageIDs(t *testing.T) {
 	_, err := spec.ParseBytes([]byte(`
-version: "0.2"
+version: "0.3"
 workflows:
   trivial:
     stages:
@@ -217,7 +336,7 @@ workflows:
 
 func TestParse_DanglingFromStage(t *testing.T) {
 	_, err := spec.ParseBytes([]byte(`
-version: "0.2"
+version: "0.3"
 workflows:
   trivial:
     stages:
@@ -242,7 +361,7 @@ workflows:
 func TestParse_ForwardFromStage(t *testing.T) {
 	// from_stage may reference only earlier stages.
 	_, err := spec.ParseBytes([]byte(`
-version: "0.2"
+version: "0.3"
 workflows:
   trivial:
     stages:
@@ -266,7 +385,7 @@ workflows:
 
 func TestParse_UndefinedApproverRole(t *testing.T) {
 	_, err := spec.ParseBytes([]byte(`
-version: "0.2"
+version: "0.3"
 roles:
   founder:
     members: ["@kuhlman-labs"]
@@ -292,7 +411,7 @@ workflows:
 
 func TestParse_PlanMissingSchema(t *testing.T) {
 	_, err := spec.ParseBytes([]byte(`
-version: "0.2"
+version: "0.3"
 workflows:
   trivial:
     stages:
@@ -324,7 +443,7 @@ func TestValidate_BuiltProgrammatically(t *testing.T) {
 	// Confirms callers can build a Spec in-memory and run only the
 	// semantic layer without going through Parse.
 	s := &spec.Spec{
-		Version: "0.2",
+		Version: "0.3",
 		Roles: map[string]spec.Role{
 			"founder": {Members: []string{"@kuhlman-labs"}},
 		},
@@ -352,7 +471,7 @@ func TestValidate_BuiltProgrammatically(t *testing.T) {
 
 func TestParse_ReaderRoundTrip(t *testing.T) {
 	s, err := spec.Parse(strings.NewReader(`
-version: "0.2"
+version: "0.3"
 workflows:
   t:
     stages:

--- a/backend/internal/spec/testdata/valid/feature-change.yaml
+++ b/backend/internal/spec/testdata/valid/feature-change.yaml
@@ -2,7 +2,7 @@
 # Used as a regression fixture: any change to the parser must keep
 # this example parseable end-to-end.
 
-version: "0.2"
+version: "0.3"
 
 roles:
   tech_lead:

--- a/backend/internal/spec/testdata/valid/minimal.yaml
+++ b/backend/internal/spec/testdata/valid/minimal.yaml
@@ -2,7 +2,7 @@
 # gates, no constraints. Useful as a regression baseline that
 # nothing about the parser regressed for the bare-bones case.
 
-version: "0.2"
+version: "0.3"
 
 workflows:
   trivial:

--- a/backend/internal/webhook/dispatcher_test.go
+++ b/backend/internal/webhook/dispatcher_test.go
@@ -693,7 +693,7 @@ func (s *stubAudit) ListForRunByCategory(context.Context, uuid.UUID, string) ([]
 
 // validSpec is the canonical workflow YAML used in dispatcher
 // tests. Mirrors MVP_SPEC §4.2 in shape but with minimal content.
-const validSpec = `version: "0.2"
+const validSpec = `version: "0.3"
 roles:
   tech_lead:
     members: ["@kuhlman-labs"]
@@ -877,7 +877,7 @@ func TestHandle_HappyPath_CreatesStagesAndDispatchesFirst(t *testing.T) {
 
 func TestHandle_MultiStageSpec_OnlyFirstDispatched(t *testing.T) {
 	d, gh, runs, _ := newDispatcherWithStubs(t)
-	gh.specContent = []byte(`version: "0.2"
+	gh.specContent = []byte(`version: "0.3"
 roles:
   tech_lead:
     members: ["@x"]
@@ -960,7 +960,7 @@ func TestHandle_HumanStage_ExecutorRefIsConventional(t *testing.T) {
 	// stage's from_stage reference must resolve, so we keep both
 	// stages and assert the human one's executor mapping.
 	d, gh, runs, _ := newDispatcherWithStubs(t)
-	gh.specContent = []byte(`version: "0.2"
+	gh.specContent = []byte(`version: "0.3"
 roles:
   tech_lead:
     members: ["@x"]
@@ -1044,7 +1044,7 @@ func TestHandle_EmptyStagesSpec_NoRun(t *testing.T) {
 	// A workflow with no stages — schema requires at least one,
 	// but defense-in-depth: the dispatcher refuses rather than
 	// dispatching with no work to do.
-	gh.specContent = []byte(`version: "0.2"
+	gh.specContent = []byte(`version: "0.3"
 workflows:
   feature_change:
     description: empty
@@ -1320,7 +1320,7 @@ func TestHandle_SpecParseError_NoRun(t *testing.T) {
 func TestHandle_WorkflowIDNotInSpec_NoRun(t *testing.T) {
 	d, gh, runs, _ := newDispatcherWithStubs(t)
 	// Spec parses, but doesn't contain "feature_change".
-	gh.specContent = []byte(`version: "0.2"
+	gh.specContent = []byte(`version: "0.3"
 roles:
   tech_lead:
     members: ["@x"]
@@ -1448,7 +1448,7 @@ func TestHandle_PersistsRequiresApprovalPerStageGate(t *testing.T) {
 	// RequiresApproval=true at create time so the trace upload
 	// handler picks the right post-upload transition. Stages
 	// without an approval gate must have RequiresApproval=false.
-	const multiStageSpec = `version: "0.2"
+	const multiStageSpec = `version: "0.3"
 roles:
   founder:
     members: ["@kuhlman-labs"]
@@ -1526,7 +1526,7 @@ func TestHandle_PersistsGateShapePerStage(t *testing.T) {
 	// approval gate, else first check gate, else nil. The
 	// blocking_checks field was dropped in v0.2 (#254); required
 	// CI checks now live in branch protection (#251).
-	const spec = `version: "0.2"
+	const spec = `version: "0.3"
 roles:
   founder:
     members: ["@kuhlman-labs"]

--- a/cli/cmd/fishhawk/validate_test.go
+++ b/cli/cmd/fishhawk/validate_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 const validateValidYAML = `
-version: "0.2"
+version: "0.3"
 roles:
   tech_lead:
     members: ["@org/tech-leads"]
@@ -128,7 +128,7 @@ func TestValidate_EmptyFile_ReturnsParseError(t *testing.T) {
 }
 
 func TestValidate_SchemaError_ReturnsValidationError(t *testing.T) {
-	bad := strings.Replace(validateValidYAML, `version: "0.2"`, "", 1)
+	bad := strings.Replace(validateValidYAML, `version: "0.3"`, "", 1)
 	path := writeTempSpec(t, bad)
 	var stdout, stderr strings.Builder
 	got := runValidate([]string{path}, &stdout, &stderr)

--- a/cli/internal/spec/schemas/workflow-v0.schema.json
+++ b/cli/internal/spec/schemas/workflow-v0.schema.json
@@ -11,8 +11,8 @@
   "properties": {
     "version": {
       "type": "string",
-      "enum": ["0.2"],
-      "description": "Spec syntax version. 0.2 dropped gate.blocking_checks (ADR-017 / #249); required CI checks are derived from GitHub branch protection at run-create time. 0.1 specs that still declare the field fail validation — the field has no consumer left."
+      "enum": ["0.3"],
+      "description": "Spec syntax version. 0.3 adds workflow.on_ci_failure.max_retries for the auto-retry epic (#276 / #277). 0.2 dropped gate.blocking_checks (ADR-017 / #249); 0.1 is rejected. Old specs in the audit log remain readable forever via the historical schemas; this enum gates *new* specs only."
     },
     "roles": {
       "type": "object",
@@ -63,6 +63,21 @@
           "type": "array",
           "minItems": 1,
           "items": { "$ref": "#/$defs/stage" }
+        },
+        "on_ci_failure": { "$ref": "#/$defs/on_ci_failure" }
+      }
+    },
+
+    "on_ci_failure": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Auto-retry policy when a required CI check fails on the implement stage's PR (#276 / E16). The dispatcher fires a fresh implement workflow_dispatch up to `max_retries` times, threading the new run via `parent_run_id` (#216). Only the closed set of failing conclusions in stagecheck.DeriveState triggers a retry; `fishhawk_audit_complete` failures are explicitly excluded — retrying won't fix Fishhawk's own audit gaps.",
+      "properties": {
+        "max_retries": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 5,
+          "description": "Bound on the retry chain length. 1 (the default when the field is absent) means \"on CI failure, dispatch one more run, total agent-touch count 2.\" 0 disables auto-retries — useful for low-autonomy workflows that prefer a human re-trigger. Capped at 5 to keep runaway loops contained in v0."
         }
       }
     },

--- a/cli/internal/spec/spec_test.go
+++ b/cli/internal/spec/spec_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 const validSpec = `
-version: "0.2"
+version: "0.3"
 roles:
   tech_lead:
     members: ["@org/tech-leads"]
@@ -57,7 +57,7 @@ func TestValidateBytes_MalformedYAML(t *testing.T) {
 
 func TestValidateBytes_MissingRequiredFields(t *testing.T) {
 	// Missing `version` (required at the top level).
-	noVersion := strings.Replace(validSpec, `version: "0.2"`, "", 1)
+	noVersion := strings.Replace(validSpec, `version: "0.3"`, "", 1)
 	err := spec.ValidateBytes([]byte(noVersion))
 	var ve *spec.ValidationError
 	if !errors.As(err, &ve) {

--- a/docs/MVP_SPEC.md
+++ b/docs/MVP_SPEC.md
@@ -88,7 +88,7 @@ Lives in the customer's repo at `.fishhawk/workflows.yaml`. Declarative YAML. Ve
 ### 4.2 Workflow spec example (canonical reference)
 
 ```yaml
-version: "0.2"
+version: "0.3"
 
 roles:
   tech_lead:

--- a/docs/spec/examples/workflow-v0-feature-change.yaml
+++ b/docs/spec/examples/workflow-v0-feature-change.yaml
@@ -4,7 +4,7 @@
 # fixture: any change to the schema must keep this example valid, and
 # any change to this example must remain valid against the schema.
 
-version: "0.2"
+version: "0.3"
 
 roles:
   tech_lead:
@@ -17,6 +17,8 @@ roles:
 workflows:
   feature_change:
     description: "Default workflow for new features and non-trivial changes."
+    on_ci_failure:
+      max_retries: 1
 
     stages:
       - id: plan

--- a/docs/spec/examples/workflow-v0-routine-change.yaml
+++ b/docs/spec/examples/workflow-v0-routine-change.yaml
@@ -6,7 +6,7 @@
 # - executor on a review stage being an agent
 # - omitted optional sections (no inputs, no budget on either stage)
 
-version: "0.2"
+version: "0.3"
 
 roles:
   founder:
@@ -17,6 +17,8 @@ workflows:
     description: >-
       Workflow for documentation, dependency bumps, lint/format fixes,
       and tests for existing behavior. Agent may merge if all gates pass.
+    on_ci_failure:
+      max_retries: 1
 
     stages:
       - id: implement

--- a/docs/spec/workflow-v0.md
+++ b/docs/spec/workflow-v0.md
@@ -7,13 +7,15 @@ Reference for `.fishhawk/workflows.yaml`. The canonical schema is [`workflow-v0.
 ## Top-level shape
 
 ```yaml
-version: "0.2"          # required, exactly "0.2" in v0
+version: "0.3"          # required, exactly "0.3" in v0
 roles:                  # optional; named groups referenced by gates
   <role_id>:
     members: ["@org/team", "@user"]
 workflows:              # required; at least one workflow
   <workflow_id>:
     description: "..."
+    on_ci_failure:      # optional; auto-retry policy (#276)
+      max_retries: 1    # default when the block is absent
     stages: [...]
 ```
 
@@ -119,11 +121,28 @@ Two types:
 
 `blocking_checks` was removed in v0.2 (ADR-017 / #249). Required CI checks are now derived from GitHub branch protection / rulesets at run-create time and snapshotted onto the run row (#251). The `fishhawk_audit_complete` signal is still computed by Fishhawk (#229) and published as a Check Run on the PR (#231) so branch protection can enforce it.
 
+## On CI failure (auto-retry)
+
+```yaml
+workflows:
+  feature_change:
+    on_ci_failure:
+      max_retries: 1    # 0 disables; 1 (default) = retry once; max 5
+    stages: [ … ]
+```
+
+Per-workflow auto-retry policy (#276 / E16). When a required CI check fails on the implement stage's PR, the dispatcher fires a fresh implement workflow_dispatch up to `max_retries` times, threading each retry via `parent_run_id` (#216).
+
+- **`max_retries`** — integer, `0..5`, default `1`. A retry chain of length N means the agent is dispatched `N+1` times total (original + N retries). Set to `0` to disable auto-retry — useful for low-autonomy workflows where a human prefers to re-trigger after inspecting the failure.
+- **Trigger predicate**: only the closed set of failing conclusions in `stagecheck.DeriveState` (`failure`, `timed_out`, `cancelled`, `action_required`, `stale`, `startup_failure`) fires a retry. `success` / `neutral` / `skipped` are no-ops.
+- **`fishhawk_audit_complete` failures are excluded** from the retry trigger. Retrying won't fix Fishhawk's own audit gaps; that's #229's job.
+- **Required-check scoping**: only failures of checks in the run's branch-protection snapshot (#251) count. A failing third-party non-required check doesn't trigger retries.
+
 ## Identifier namespaces
 
 | Field | Pattern / values | Notes |
 |---|---|---|
-| `version` | `"0.2"` | current value; 0.1 was frozen briefly before ADR-017 dropped `blocking_checks` (#254) |
+| `version` | `"0.3"` | current value; 0.2 added v0.2's `blocking_checks` drop, 0.3 adds `on_ci_failure.max_retries` (#277) |
 | Role / workflow / stage IDs | `^[a-z][a-z0-9_]*$` | snake_case |
 | Member refs | `^@[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)?$` | GitHub user or team |
 | Stage `type` | `plan` \| `implement` \| `review` | closed set |

--- a/docs/spec/workflow-v0.schema.json
+++ b/docs/spec/workflow-v0.schema.json
@@ -11,8 +11,8 @@
   "properties": {
     "version": {
       "type": "string",
-      "enum": ["0.2"],
-      "description": "Spec syntax version. 0.2 dropped gate.blocking_checks (ADR-017 / #249); required CI checks are derived from GitHub branch protection at run-create time. 0.1 specs that still declare the field fail validation — the field has no consumer left."
+      "enum": ["0.3"],
+      "description": "Spec syntax version. 0.3 adds workflow.on_ci_failure.max_retries for the auto-retry epic (#276 / #277). 0.2 dropped gate.blocking_checks (ADR-017 / #249); 0.1 is rejected. Old specs in the audit log remain readable forever via the historical schemas; this enum gates *new* specs only."
     },
     "roles": {
       "type": "object",
@@ -63,6 +63,21 @@
           "type": "array",
           "minItems": 1,
           "items": { "$ref": "#/$defs/stage" }
+        },
+        "on_ci_failure": { "$ref": "#/$defs/on_ci_failure" }
+      }
+    },
+
+    "on_ci_failure": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Auto-retry policy when a required CI check fails on the implement stage's PR (#276 / E16). The dispatcher fires a fresh implement workflow_dispatch up to `max_retries` times, threading the new run via `parent_run_id` (#216). Only the closed set of failing conclusions in stagecheck.DeriveState triggers a retry; `fishhawk_audit_complete` failures are explicitly excluded — retrying won't fix Fishhawk's own audit gaps.",
+      "properties": {
+        "max_retries": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 5,
+          "description": "Bound on the retry chain length. 1 (the default when the field is absent) means \"on CI failure, dispatch one more run, total agent-touch count 2.\" 0 disables auto-retries — useful for low-autonomy workflows that prefer a human re-trigger. Capped at 5 to keep runaway loops contained in v0."
         }
       }
     },


### PR DESCRIPTION
## Summary

Foundational child of the auto-retry epic (#276 / E16). Adds the per-workflow `on_ci_failure.max_retries` knob the dispatcher will read in #279, and bumps the spec to v0.3.

- **`workflow.on_ci_failure.max_retries`** — integer, `0..5`. Default 1 when the block is absent; explicit `0` opts the workflow out of auto-retries — useful for low-autonomy workflows that prefer a human re-trigger.
- **Nil-vs-zero distinction is load-bearing**: a nil pointer means "use the documented default" (centralized as `spec.DefaultMaxRetries`); an explicit `0` means "never retry." The dispatcher (in #279) branches on the pointer.
- `.fishhawk/workflows.yaml` opts in for `feature_change` and `routine_change`. `human_led_change` stays without the block — there's no implement stage to retry against; the default never fires anywhere.

## Test plan

- [ ] `go test -race ./backend/... ./cli/...` — 4 new spec-parser tests (absent / explicit 1 / explicit 0 / cap-exceeded → SchemaError); all existing version-string fixtures bumped.
- [ ] `golangci-lint run ./backend/...`
- [ ] `check-jsonschema --schemafile docs/spec/workflow-v0.schema.json .fishhawk/workflows.yaml docs/spec/examples/workflow-v0-{feature,routine}-change.yaml`
- [ ] Aggregate coverage ≥ 80% (locally: 82.8%).
- [ ] Manual: a customer spec with `version: "0.2"` now fails validation with a clear error pointing at the version enum.

## Notes

**Trigger predicate** (documented in the markdown, enforced by the dispatcher in #278/#279, not this PR): only the closed set of failing conclusions in `stagecheck.DeriveState` fires a retry; `success`/`neutral`/`skipped` are no-ops; `fishhawk_audit_complete` failures are explicitly excluded (retrying won't fix Fishhawk's own audit gaps).

**Required-check scoping**: only failures of checks in the run's branch-protection snapshot (#251) count — the dispatcher won't retry on a flaky third-party non-required check.

**Schema-sync** is enforced by CI; both `backend/internal/spec/schemas/` and `cli/internal/spec/schemas/` are exact copies of `docs/spec/workflow-v0.schema.json` and stay byte-for-byte in lockstep.

Closes #277