### PR TITLE
Verify audit-complete + Check Run publication across retry chains (#281)

### DIFF
--- a/backend/internal/auditcheckpublisher/publisher_test.go
+++ b/backend/internal/auditcheckpublisher/publisher_test.go
@@ -256,6 +256,135 @@ func TestPublish_GitHubError_Returned(t *testing.T) {
 	}
 }
 
+// --- Retry chain (#281 / E16.5) ---
+
+// TestCheckRunPublisher_RetryHeadSHA_PublishesIndependently asserts
+// that publishing audit-complete state for a parent run + a retry
+// run on the same PR (distinct head_shas, as the runner commits
+// fresh each attempt) results in two independent CreateCheckRun
+// calls — one against each head_sha. Branch protection re-evaluates
+// against whatever sha is currently the PR's HEAD; if the publisher
+// ever conflated the two head_shas, GitHub would receive the wrong
+// (or no) signal for the retry's commit and the PR would stay
+// merge-blocked even after the retry succeeded.
+func TestCheckRunPublisher_RetryHeadSHA_PublishesIndependently(t *testing.T) {
+	parentID := uuid.New()
+	retryID := uuid.New()
+	parentImplID := uuid.New()
+	retryImplID := uuid.New()
+	const parentSHA = "p1p1p1p1p1p1p1p1p1p1p1p1p1p1p1p1p1p1p1p1"
+	const retrySHA = "r2r2r2r2r2r2r2r2r2r2r2r2r2r2r2r2r2r2r2r2"
+
+	repoRuns := &fakeRuns{
+		runs: map[uuid.UUID]*run.Run{
+			parentID: {ID: parentID, Repo: "x/y", InstallationID: int64Ptr(42)},
+			retryID:  {ID: retryID, Repo: "x/y", InstallationID: int64Ptr(42), ParentRunID: &parentID, RetryAttempt: 1},
+		},
+		stages: map[uuid.UUID][]*run.Stage{
+			parentID: {{ID: parentImplID, Type: run.StageTypeImplement, RunID: parentID}},
+			retryID:  {{ID: retryImplID, Type: run.StageTypeImplement, RunID: retryID}},
+		},
+	}
+	repoArts := &fakeArtifacts{byStage: map[uuid.UUID][]*artifact.Artifact{
+		parentImplID: {prArtifact(parentImplID, parentSHA)},
+		retryImplID:  {prArtifact(retryImplID, retrySHA)},
+	}}
+	gh := &fakeGitHub{}
+	pub := auditcheckpublisher.New(auditcheckpublisher.Deps{
+		GitHub: gh, Runs: repoRuns, Artifacts: repoArts,
+		ExternalURL: "https://app.fishhawk.example.com",
+	})
+
+	if _, err := pub.Publish(context.Background(), parentID, stagecheck.StatePass, nil); err != nil {
+		t.Fatalf("Publish(parent): %v", err)
+	}
+	if _, err := pub.Publish(context.Background(), retryID, stagecheck.StatePass, nil); err != nil {
+		t.Fatalf("Publish(retry): %v", err)
+	}
+	if len(gh.calls) != 2 {
+		t.Fatalf("expected 2 CreateCheckRun calls, got %d", len(gh.calls))
+	}
+	// Each call carries its own head_sha — the publisher is keyed
+	// off the implement-stage artifact, not the run's lineage, so
+	// the retry's call must name retrySHA and the parent's must
+	// name parentSHA.
+	if gh.calls[0].params.HeadSHA != parentSHA {
+		t.Errorf("first call head_sha = %q, want %q", gh.calls[0].params.HeadSHA, parentSHA)
+	}
+	if gh.calls[1].params.HeadSHA != retrySHA {
+		t.Errorf("second call head_sha = %q, want %q", gh.calls[1].params.HeadSHA, retrySHA)
+	}
+	// Details URLs route to the correct run page on each call too —
+	// reviewers clicking through from GitHub get the right run.
+	if !strings.Contains(gh.calls[0].params.DetailsURL, parentID.String()) {
+		t.Errorf("parent details_url should reference parent run id: %q", gh.calls[0].params.DetailsURL)
+	}
+	if !strings.Contains(gh.calls[1].params.DetailsURL, retryID.String()) {
+		t.Errorf("retry details_url should reference retry run id: %q", gh.calls[1].params.DetailsURL)
+	}
+}
+
+// TestCheckRunPublisher_DoesNotRepublishParentOnRetry covers the
+// case where a retry exists and the publisher is later invoked
+// again on the *parent* run — e.g. an audit-log read triggers a
+// re-compute on the parent for some reason. The publisher must
+// still post against the parent's own head_sha rather than trying
+// to be clever about "latest on PR." If it tried to publish the
+// retry's sha for the parent's run id, the details_url would point
+// at the wrong run page and reviewers chasing the GitHub link
+// would see mismatched audit context.
+func TestCheckRunPublisher_DoesNotRepublishParentOnRetry(t *testing.T) {
+	parentID := uuid.New()
+	retryID := uuid.New()
+	parentImplID := uuid.New()
+	retryImplID := uuid.New()
+	const parentSHA = "p1p1p1p1p1p1p1p1p1p1p1p1p1p1p1p1p1p1p1p1"
+	const retrySHA = "r2r2r2r2r2r2r2r2r2r2r2r2r2r2r2r2r2r2r2r2"
+
+	repoRuns := &fakeRuns{
+		runs: map[uuid.UUID]*run.Run{
+			parentID: {ID: parentID, Repo: "x/y", InstallationID: int64Ptr(42)},
+			retryID:  {ID: retryID, Repo: "x/y", InstallationID: int64Ptr(42), ParentRunID: &parentID, RetryAttempt: 1},
+		},
+		stages: map[uuid.UUID][]*run.Stage{
+			parentID: {{ID: parentImplID, Type: run.StageTypeImplement, RunID: parentID}},
+			retryID:  {{ID: retryImplID, Type: run.StageTypeImplement, RunID: retryID}},
+		},
+	}
+	repoArts := &fakeArtifacts{byStage: map[uuid.UUID][]*artifact.Artifact{
+		parentImplID: {prArtifact(parentImplID, parentSHA)},
+		retryImplID:  {prArtifact(retryImplID, retrySHA)},
+	}}
+	gh := &fakeGitHub{}
+	pub := auditcheckpublisher.New(auditcheckpublisher.Deps{
+		GitHub: gh, Runs: repoRuns, Artifacts: repoArts,
+		ExternalURL: "https://app.fishhawk.example.com",
+	})
+
+	// Publish retry first — simulates the most-recent retry
+	// finishing and being audit-complete.
+	if _, err := pub.Publish(context.Background(), retryID, stagecheck.StatePass, nil); err != nil {
+		t.Fatalf("Publish(retry): %v", err)
+	}
+	// Now publish parent — a second audit read on the older run
+	// must still route through parent's own head_sha.
+	if _, err := pub.Publish(context.Background(), parentID, stagecheck.StatePass, nil); err != nil {
+		t.Fatalf("Publish(parent): %v", err)
+	}
+	if len(gh.calls) != 2 {
+		t.Fatalf("expected 2 CreateCheckRun calls; got %d", len(gh.calls))
+	}
+	// First call (retry) used retrySHA; second call (parent) must
+	// use parentSHA — the publisher reads the artifact for the run
+	// being published, not whichever was most recently published.
+	if gh.calls[0].params.HeadSHA != retrySHA {
+		t.Errorf("first call (retry) head_sha = %q, want %q", gh.calls[0].params.HeadSHA, retrySHA)
+	}
+	if gh.calls[1].params.HeadSHA != parentSHA {
+		t.Errorf("second call (parent) head_sha = %q, want %q", gh.calls[1].params.HeadSHA, parentSHA)
+	}
+}
+
 func TestNew_NilDepsReturnsNilPublisher(t *testing.T) {
 	cases := []struct {
 		name string

--- a/backend/internal/auditcomplete/auditcomplete_test.go
+++ b/backend/internal/auditcomplete/auditcomplete_test.go
@@ -354,6 +354,175 @@ func stubPRHead(t *testing.T, headSHA string, err error) auditcomplete.PRHeadFet
 	}
 }
 
+// --- Retry chain (#281 / E16.5) ---
+
+// retryChainSetup seeds a parent run + a retry run that follows it,
+// each with its own plan + implement + review stages, distinct
+// head_shas on their pull_request artifacts, and complete
+// trace_uploaded chains. Mirrors the on-the-wire shape produced by
+// the dispatcher's auto-retry path (#279): retry.ParentRunID =
+// parent.ID, retry.RetryAttempt = parent.RetryAttempt + 1,
+// distinct head_shas because the runner commits fresh on each
+// attempt.
+//
+// Returns both run IDs + the fakes so individual tests can mutate a
+// single run's audit story to assert the parent / child boundary
+// holds.
+func retryChainSetup(t *testing.T) (parentID, retryID uuid.UUID, runs *fakeRuns, arts *fakeArtifacts, ar *fakeAudit) {
+	t.Helper()
+	parentID = uuid.New()
+	retryID = uuid.New()
+
+	parentImpl := mkStage(parentID, 2, run.StageTypeImplement, run.StageStateSucceeded)
+	retryImpl := mkStage(retryID, 1, run.StageTypeImplement, run.StageStateSucceeded)
+	// Variant A from the issue body: retry runs skip the plan stage —
+	// only the parent has one. Adding a retry-side plan would
+	// over-state the rig: real retries never get one.
+	parentPlan := mkStage(parentID, 1, run.StageTypePlan, run.StageStateSucceeded)
+	parentReview := mkStage(parentID, 3, run.StageTypeReview, run.StageStateAwaitingApproval)
+	retryReview := mkStage(retryID, 2, run.StageTypeReview, run.StageStateAwaitingApproval)
+
+	installID := int64(99)
+	parentRow := &run.Run{
+		ID: parentID, Repo: "kuhlman-labs/fishhawk", WorkflowID: "feature_change",
+		InstallationID: &installID, RetryAttempt: 0, MaxRetriesSnapshot: 1,
+	}
+	retryRow := &run.Run{
+		ID: retryID, Repo: "kuhlman-labs/fishhawk", WorkflowID: "feature_change",
+		InstallationID: &installID, ParentRunID: &parentID,
+		RetryAttempt: 1, MaxRetriesSnapshot: 1,
+	}
+
+	runs = &fakeRuns{
+		stages: []*run.Stage{parentPlan, parentImpl, parentReview, retryImpl, retryReview},
+		runs: map[uuid.UUID]*run.Run{
+			parentID: parentRow,
+			retryID:  retryRow,
+		},
+	}
+	arts = &fakeArtifacts{
+		byStage: map[uuid.UUID][]*artifact.Artifact{
+			parentPlan.ID: {planArtifact(parentPlan.ID, "standard_v1")},
+			// Distinct head_shas — the runner commits fresh on each
+			// attempt and the foreign-commit rule reads these to
+			// build the known-set.
+			parentImpl.ID: {pullRequestArtifactWithBody(parentImpl.ID, "p1p1p1p1p1p1p1p1p1p1p1p1p1p1p1p1p1p1p1p1", 275)},
+			retryImpl.ID:  {pullRequestArtifactWithBody(retryImpl.ID, "r2r2r2r2r2r2r2r2r2r2r2r2r2r2r2r2r2r2r2r2", 275)},
+		},
+	}
+
+	ar = &fakeAudit{}
+	// Parent's chain: dispatch + traces on plan & implement.
+	ar.appendChained(t, parentID, &parentPlan.ID, "stage_dispatched", nil)
+	ar.appendChained(t, parentID, &parentPlan.ID, "trace_uploaded", traceVariantPayload("raw"))
+	ar.appendChained(t, parentID, &parentPlan.ID, "trace_uploaded", traceVariantPayload("redacted"))
+	ar.appendChained(t, parentID, &parentImpl.ID, "trace_uploaded", traceVariantPayload("raw"))
+	ar.appendChained(t, parentID, &parentImpl.ID, "trace_uploaded", traceVariantPayload("redacted"))
+	// Retry's chain: traces on its own implement stage. Independent
+	// chain — prev_hash threading is per-run, so the retry's first
+	// entry has prev_hash=nil just like the parent's first did.
+	ar.appendChainedReset(t, retryID, &retryImpl.ID, "trace_uploaded", traceVariantPayload("raw"))
+	ar.appendChained(t, retryID, &retryImpl.ID, "trace_uploaded", traceVariantPayload("redacted"))
+	return parentID, retryID, runs, arts, ar
+}
+
+func TestRetryChain_AuditComplete_PassesPerRun(t *testing.T) {
+	// Parent and retry each carry their own complete audit story.
+	// Compute is run-scoped: both IDs return pass independently,
+	// proving the implementation doesn't smear state across the
+	// retry boundary.
+	parentID, retryID, runs, arts, ar := retryChainSetup(t)
+	d := deps(runs, arts, ar)
+	parentState, parentMissing, err := auditcomplete.Compute(context.Background(), parentID, d)
+	if err != nil {
+		t.Fatalf("Compute(parent): %v", err)
+	}
+	if parentState != stagecheck.StatePass {
+		t.Errorf("parent state = %s, want pass; missing=%+v", parentState, parentMissing)
+	}
+	retryState, retryMissing, err := auditcomplete.Compute(context.Background(), retryID, d)
+	if err != nil {
+		t.Fatalf("Compute(retry): %v", err)
+	}
+	if retryState != stagecheck.StatePass {
+		t.Errorf("retry state = %s, want pass; missing=%+v", retryState, retryMissing)
+	}
+}
+
+func TestRetryChain_AuditComplete_RetryGapsDontInfectParent(t *testing.T) {
+	// Drop the retry's redacted trace entry — the retry's audit story
+	// is now broken, but the parent's is untouched. Compute(parent)
+	// must still pass; Compute(retry) must fail with trace_missing.
+	// This is what proves the per-run scoping actually works: a
+	// regression that read all entries regardless of run_id would
+	// false-positive a pass on the retry (since the parent's traces
+	// are present) AND a false-fail on the parent if the gap-detection
+	// ever leaked across run boundaries.
+	parentID, retryID, runs, arts, ar := retryChainSetup(t)
+	retryImplID := runs.stages[3].ID // see retryChainSetup ordering
+	ar.dropEntry(func(e *audit.Entry) bool {
+		if e.StageID == nil || *e.StageID != retryImplID {
+			return false
+		}
+		if e.Category != "trace_uploaded" {
+			return false
+		}
+		return string(e.Payload) == string(traceVariantPayload("redacted"))
+	})
+
+	d := deps(runs, arts, ar)
+	parentState, parentMissing, err := auditcomplete.Compute(context.Background(), parentID, d)
+	if err != nil {
+		t.Fatalf("Compute(parent): %v", err)
+	}
+	if parentState != stagecheck.StatePass {
+		t.Errorf("parent state = %s, want pass (gap on retry must not infect parent); missing=%+v",
+			parentState, parentMissing)
+	}
+	retryState, retryMissing, err := auditcomplete.Compute(context.Background(), retryID, d)
+	if err != nil {
+		t.Fatalf("Compute(retry): %v", err)
+	}
+	if retryState != stagecheck.StateFail {
+		t.Fatalf("retry state = %s, want fail; missing=%+v", retryState, retryMissing)
+	}
+	if !containsKind(retryMissing, auditcomplete.MissingTrace) {
+		t.Errorf("retry missing should include trace_missing: %+v", retryMissing)
+	}
+}
+
+func TestRetryChain_AuditLogChain_VerifiesAcrossRuns(t *testing.T) {
+	// The per-run chain integrity rule (rule 4 of Compute) MUST hold
+	// for each run in a retry chain. Both parent and retry have
+	// their own chains; both must verify. A regression that broke
+	// linkage between successive entries on either side would surface
+	// here as a chain_invalid missing item.
+	parentID, retryID, runs, arts, ar := retryChainSetup(t)
+	d := deps(runs, arts, ar)
+
+	for _, tc := range []struct {
+		name  string
+		runID uuid.UUID
+	}{
+		{"parent", parentID},
+		{"retry", retryID},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			state, missing, err := auditcomplete.Compute(context.Background(), tc.runID, d)
+			if err != nil {
+				t.Fatalf("Compute: %v", err)
+			}
+			if state != stagecheck.StatePass {
+				t.Errorf("state = %s, want pass; missing=%+v", state, missing)
+			}
+			if containsKind(missing, auditcomplete.MissingChain) ||
+				containsKind(missing, auditcomplete.MissingChainBroken) {
+				t.Errorf("chain integrity check produced an issue: %+v", missing)
+			}
+		})
+	}
+}
+
 // --- helpers ---
 
 func deps(r *fakeRuns, a *fakeArtifacts, au *fakeAudit) auditcomplete.Deps {
@@ -482,17 +651,26 @@ type fakeAudit struct {
 
 // appendChained mirrors what the real audit.Repository.AppendChained
 // does at the integrity layer: compute the canonical hash, link
-// prev → entry. Tests use this so the synthetic chain is identical
-// in shape to the production one and verifyChain agrees.
+// prev → entry within the run's chain. Per-run scoping mirrors
+// production — each run has its own chain, prev_hash threads only
+// within that run. Tests use this so the synthetic chain is
+// identical in shape to the production one and verifyChain agrees.
 func (f *fakeAudit) appendChained(t *testing.T, runID uuid.UUID, stageID *uuid.UUID, category string, payload json.RawMessage) {
 	t.Helper()
 	if payload == nil {
 		payload = json.RawMessage(`{}`)
 	}
+	// Find the last entry that belongs to THIS run — that's the
+	// prev_hash anchor. Entries on other runs (siblings in a retry
+	// chain, etc.) don't link in.
 	var prev *string
-	if n := len(f.entries); n > 0 {
-		ph := f.entries[n-1].EntryHash
-		prev = &ph
+	for i := len(f.entries) - 1; i >= 0; i-- {
+		e := f.entries[i]
+		if e.RunID != nil && *e.RunID == runID {
+			ph := e.EntryHash
+			prev = &ph
+			break
+		}
 	}
 	r := runID
 	ts := time.Date(2026, 5, 7, 12, 0, int(len(f.entries)), 0, time.UTC)
@@ -522,6 +700,15 @@ func (f *fakeAudit) appendChained(t *testing.T, runID uuid.UUID, stageID *uuid.U
 	})
 }
 
+// appendChainedReset is appendChained's alias; the per-run scoping
+// in appendChained already gives a fresh chain for a new run_id.
+// Kept as a named entry point in tests so the intent ("start a new
+// run's chain") is explicit at the call site.
+func (f *fakeAudit) appendChainedReset(t *testing.T, runID uuid.UUID, stageID *uuid.UUID, category string, payload json.RawMessage) {
+	t.Helper()
+	f.appendChained(t, runID, stageID, category, payload)
+}
+
 func (f *fakeAudit) dropEntry(pred func(*audit.Entry) bool) {
 	out := f.entries[:0]
 	for _, e := range f.entries {
@@ -532,16 +719,31 @@ func (f *fakeAudit) dropEntry(pred func(*audit.Entry) bool) {
 	f.entries = out
 }
 
-func (f *fakeAudit) ListForRun(_ context.Context, _ uuid.UUID) ([]*audit.Entry, error) {
-	return f.entries, nil
-}
-
-func (f *fakeAudit) ListForRunByCategory(_ context.Context, _ uuid.UUID, category string) ([]*audit.Entry, error) {
+func (f *fakeAudit) ListForRun(_ context.Context, runID uuid.UUID) ([]*audit.Entry, error) {
 	out := []*audit.Entry{}
 	for _, e := range f.entries {
-		if e.Category == category {
+		// Scope by runID so retry-chain tests (#281) can seed parent
+		// + child chains side by side and have each verifyChain call
+		// see only its own entries. Single-run tests are unaffected:
+		// their entries all carry the one runID, so the filter is a
+		// no-op for them.
+		if e.RunID != nil && *e.RunID == runID {
 			out = append(out, e)
 		}
+	}
+	return out, nil
+}
+
+func (f *fakeAudit) ListForRunByCategory(_ context.Context, runID uuid.UUID, category string) ([]*audit.Entry, error) {
+	out := []*audit.Entry{}
+	for _, e := range f.entries {
+		if e.Category != category {
+			continue
+		}
+		if e.RunID != nil && *e.RunID != runID {
+			continue
+		}
+		out = append(out, e)
 	}
 	return out, nil
 }

--- a/verifier/internal/audit/verify_test.go
+++ b/verifier/internal/audit/verify_test.go
@@ -272,6 +272,36 @@ func TestVerify_BadRunIDInExport(t *testing.T) {
 	}
 }
 
+// TestRetryChain_VerifierTool_AcceptsRetryRuns asserts that an
+// export carrying both a parent run's chain and a CI-failure retry
+// run's chain verifies cleanly (#281 / E16.5). Each run owns its
+// own per-run chain in the Export.Runs map; the verifier walks
+// them independently, so a retry chain that uses a fresh prev=nil
+// anchor on its first entry must pass alongside the parent's
+// chain without any cross-run linkage.
+func TestRetryChain_VerifierTool_AcceptsRetryRuns(t *testing.T) {
+	parentID := uuid.MustParse("00000000-0000-0000-0000-0000000000a1")
+	retryID := uuid.MustParse("00000000-0000-0000-0000-0000000000a2")
+	ex := &audit.Export{
+		Schema:     audit.ExportSchemaV1,
+		ExportedAt: time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC),
+		Runs: map[string]audit.RunData{
+			parentID.String(): {AuditEntries: makeChain(t, parentID)},
+			retryID.String():  {AuditEntries: makeChain(t, retryID)},
+		},
+	}
+	res := audit.VerifyExport(ex)
+	if !res.OK() {
+		t.Fatalf("expected verify OK across parent+retry chains; got issues=%+v", res.Issues)
+	}
+	if res.RunsVerified != 2 {
+		t.Errorf("RunsVerified = %d, want 2", res.RunsVerified)
+	}
+	if res.EntriesChecked != 6 {
+		t.Errorf("EntriesChecked = %d, want 6 (3 per run)", res.EntriesChecked)
+	}
+}
+
 // --- VerifyBundleSignature ---
 
 func TestVerifyBundleSignature_HappyPath(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds the integration tests that confirm the audit-complete derivation (#229) and the Check Run publisher (#231) hold end-to-end across a CI-failure auto-retry chain (#279). No production-code changes — the per-run scoping that the chain relies on was already in place; this PR is the explicit verification the issue body asked for.

- `TestRetryChain_AuditComplete_PassesPerRun` — parent + retry with distinct head_shas + complete plan/trace/PR artifacts; `Compute` returns `pass` for both independently.
- `TestRetryChain_AuditComplete_RetryGapsDontInfectParent` — drop the retry's redacted trace; parent still passes, retry fails with `trace_missing`. Proves the per-run scoping is real, not coincidental from single-run fixtures.
- `TestRetryChain_AuditLogChain_VerifiesAcrossRuns` — per-run chain integrity (rule 4 of `Compute`) holds for both runs side-by-side.
- `TestCheckRunPublisher_RetryHeadSHA_PublishesIndependently` — publishing parent + retry fires two `CreateCheckRun` calls, each against its own head_sha, with details_urls routing to the correct run page.
- `TestCheckRunPublisher_DoesNotRepublishParentOnRetry` — a later publish on the parent (after the retry already published) still routes through the parent's own head_sha; the publisher reads the artifact for the run being published, not whichever sha was most recently posted.
- `TestRetryChain_VerifierTool_AcceptsRetryRuns` — an export with both runs' chains verifies cleanly (`RunsVerified=2`, `EntriesChecked=6`).

## Test plan

- [x] `go test -race ./backend/internal/auditcomplete/... ./backend/internal/auditcheckpublisher/...` — pass
- [x] `cd verifier && go test -race ./internal/audit/...` — pass
- [x] `golangci-lint run` across all three modules — clean
- [x] Coverage gate: 82.6% aggregate

## Notes

- Tightened the `auditcomplete` package's `fakeAudit` so `ListForRun` / `ListForRunByCategory` / `appendChained` scope by `run_id` rather than returning the full entry slice. Mirrors production's per-run chain shape; single-run tests are unaffected because their entries all carry the one runID.
- The issue body framed task 5 around an "audit chain that spans parent + retry," but the production chain is per-run (`audit.Repository.ListForRun(runID)`). The test confirms both per-run chains verify side-by-side, which is the closest interpretation that matches the current implementation. The cross-run global chain (`AppendGlobalChained`) has its own coverage and isn't load-bearing for E16.
- E16 (#276) is now fully covered end-to-end. Closing this PR closes the epic's last open child.

Closes #281