### PR TITLE
githubclient: add UpdateIssueComment (E20.1 / #327)

### DIFF
--- a/backend/internal/githubclient/client.go
+++ b/backend/internal/githubclient/client.go
@@ -979,6 +979,76 @@ func (c *Client) CreateIssueComment(ctx context.Context, installationID int64, r
 	return classifyStatus("create issue comment", resp)
 }
 
+// IssueComment is the subset of GitHub's issue-comment shape Fishhawk
+// reads back from PATCH responses. The wire shape carries more fields
+// (user, reactions, timing); we surface only what callers verify.
+type IssueComment struct {
+	ID      int64  `json:"id"`
+	Body    string `json:"body"`
+	HTMLURL string `json:"html_url"`
+}
+
+// UpdateIssueComment edits an existing issue comment in place. ADR-019
+// / #320 (Fishhawk as coordination layer) leans on this for the
+// sticky status comment (E20 / #326) and `update_on_change` plan
+// comments (E17.2 / #337) — both flows need to mutate a previously-
+// posted comment instead of spamming new ones.
+//
+//	PATCH /repos/{owner}/{repo}/issues/comments/{comment_id}
+//
+// Returns ErrNotFound when the comment was deleted by the operator or
+// isn't visible to the installation, ErrForbidden when the App lacks
+// `issues:write`. Same permission scope as CreateIssueComment, so no
+// new manifest entry needed.
+//
+// Caller is responsible for finding the comment id (typically via
+// the run's audit log — the existing `issue_commented` rows record
+// the id for sticky-comment lookups).
+func (c *Client) UpdateIssueComment(ctx context.Context, installationID int64, repo RepoRef, commentID int64, body string) (*IssueComment, error) {
+	if c.Tokens == nil {
+		return nil, errors.New("githubclient: client missing TokenProvider")
+	}
+	if repo.Owner == "" || repo.Name == "" {
+		return nil, errors.New("githubclient: repo owner and name required")
+	}
+	if commentID <= 0 {
+		return nil, errors.New("githubclient: comment id must be > 0")
+	}
+	if body == "" {
+		return nil, errors.New("githubclient: comment body must be non-empty")
+	}
+
+	raw, err := json.Marshal(map[string]string{"body": body})
+	if err != nil {
+		return nil, fmt.Errorf("githubclient: marshal issue comment: %w", err)
+	}
+
+	endpoint := c.endpoint("/repos/" + url.PathEscape(repo.Owner) +
+		"/" + url.PathEscape(repo.Name) +
+		"/issues/comments/" + url.PathEscape(fmt.Sprintf("%d", commentID)))
+
+	req, err := c.buildRequest(ctx, http.MethodPatch, endpoint, bytes.NewReader(raw), installationID)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("githubclient: update issue comment: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if err := classifyStatus("update issue comment", resp); err != nil {
+		return nil, err
+	}
+	var out IssueComment
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("githubclient: decode update issue comment: %w", err)
+	}
+	return &out, nil
+}
+
 // CheckRunStatus is the GitHub Checks API `status` enum.
 // Closed set; passing anything else returns ErrValidation.
 type CheckRunStatus string

--- a/backend/internal/githubclient/client_test.go
+++ b/backend/internal/githubclient/client_test.go
@@ -54,6 +54,9 @@ type fakeGitHub struct {
 	createIssueCommentStatus int
 	createIssueCommentBody   string
 
+	updateIssueCommentStatus int
+	updateIssueCommentBody   string
+
 	getWorkflowRunStatus int
 	getWorkflowRunBody   string
 
@@ -92,6 +95,8 @@ func newFakeGitHub(t *testing.T) (*fakeGitHub, *httptest.Server) {
 		createCheckRunBody:        `{"id":987654,"html_url":"https://github.com/x/y/runs/987654"}`,
 		createIssueCommentStatus:  http.StatusCreated,
 		createIssueCommentBody:    `{"id":11111}`,
+		updateIssueCommentStatus:  http.StatusOK,
+		updateIssueCommentBody:    `{"id":11111,"body":"edited body","html_url":"https://github.com/x/y/issues/17#issuecomment-11111"}`,
 		getWorkflowRunStatus:      http.StatusOK,
 		getWorkflowRunBody:        `{"id":987654321,"html_url":"https://github.com/x/y/actions/runs/987654321","conclusion":"failure","status":"completed","event":"workflow_dispatch","head_branch":"main","head_sha":"abc","inputs":{"stage_id":"22222222-2222-2222-2222-222222222222","run_id":"11111111-1111-1111-1111-111111111111"}}`,
 		getBranchProtectionStatus: http.StatusOK,
@@ -164,6 +169,16 @@ func newFakeGitHub(t *testing.T) (*fakeGitHub, *httptest.Server) {
 			w.WriteHeader(fg.createIssueCommentStatus)
 			if fg.createIssueCommentBody != "" {
 				_, _ = io.WriteString(w, fg.createIssueCommentBody)
+			}
+		})
+
+	mux.HandleFunc("PATCH /repos/{owner}/{repo}/issues/comments/{comment_id}",
+		func(w http.ResponseWriter, r *http.Request) {
+			capture(r)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(fg.updateIssueCommentStatus)
+			if fg.updateIssueCommentBody != "" {
+				_, _ = io.WriteString(w, fg.updateIssueCommentBody)
 			}
 		})
 
@@ -868,6 +883,95 @@ func TestCreateIssueComment_GitHubError(t *testing.T) {
 	c, _ := newTestClient(t, srv, nil)
 
 	err := c.CreateIssueComment(context.Background(), 1,
+		RepoRef{Owner: "x", Name: "y"}, 1, "hi")
+	if err == nil || !errors.Is(err, ErrForbidden) {
+		t.Errorf("err = %v want ErrForbidden", err)
+	}
+}
+
+// --- UpdateIssueComment (E20.1 / #327, ADR-019) ---
+
+func TestUpdateIssueComment_HappyPath(t *testing.T) {
+	fg, srv := newFakeGitHub(t)
+	c, _ := newTestClient(t, srv, nil)
+
+	got, err := c.UpdateIssueComment(context.Background(), 42,
+		RepoRef{Owner: "x", Name: "y"}, 11111, "edited body")
+	if err != nil {
+		t.Fatalf("UpdateIssueComment: %v", err)
+	}
+	if fg.gotMethod != http.MethodPatch {
+		t.Errorf("method = %q want PATCH", fg.gotMethod)
+	}
+	if fg.gotPath != "/repos/x/y/issues/comments/11111" {
+		t.Errorf("path = %q", fg.gotPath)
+	}
+	if fg.gotContentType != "application/json" {
+		t.Errorf("content-type = %q", fg.gotContentType)
+	}
+	var body map[string]string
+	if err := json.Unmarshal(fg.gotBody, &body); err != nil {
+		t.Fatalf("decode request body: %v", err)
+	}
+	if body["body"] != "edited body" {
+		t.Errorf("request body[\"body\"] = %q", body["body"])
+	}
+	// Returned struct mirrors the PATCH response body so callers can
+	// verify the edit landed (e.g., assert html_url matches the
+	// original comment).
+	if got == nil || got.ID != 11111 || got.Body != "edited body" ||
+		got.HTMLURL != "https://github.com/x/y/issues/17#issuecomment-11111" {
+		t.Errorf("returned IssueComment = %+v", got)
+	}
+}
+
+func TestUpdateIssueComment_ValidationErrors(t *testing.T) {
+	c := &Client{Tokens: &stubTokens{}}
+	cases := []struct {
+		name      string
+		repo      RepoRef
+		commentID int64
+		body      string
+		wantSubst string
+	}{
+		{"missing owner", RepoRef{Name: "y"}, 1, "x", "owner and name"},
+		{"missing name", RepoRef{Owner: "x"}, 1, "x", "owner and name"},
+		{"zero comment id", RepoRef{Owner: "x", Name: "y"}, 0, "x", "comment id must be"},
+		{"empty body", RepoRef{Owner: "x", Name: "y"}, 1, "", "body must be non-empty"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := c.UpdateIssueComment(context.Background(), 1, tc.repo, tc.commentID, tc.body)
+			if err == nil || !strings.Contains(err.Error(), tc.wantSubst) {
+				t.Errorf("err = %v, want substring %q", err, tc.wantSubst)
+			}
+		})
+	}
+}
+
+func TestUpdateIssueComment_NotFound(t *testing.T) {
+	// Operator deleted the comment between Create and Update. The
+	// 404 maps to ErrNotFound so the caller (E20.2's NotifyStatusUpdate)
+	// can fall back to creating a fresh comment.
+	fg, srv := newFakeGitHub(t)
+	fg.updateIssueCommentStatus = http.StatusNotFound
+	fg.updateIssueCommentBody = `{"message":"Not Found"}`
+	c, _ := newTestClient(t, srv, nil)
+
+	_, err := c.UpdateIssueComment(context.Background(), 1,
+		RepoRef{Owner: "x", Name: "y"}, 9999, "edited")
+	if err == nil || !errors.Is(err, ErrNotFound) {
+		t.Errorf("err = %v want ErrNotFound", err)
+	}
+}
+
+func TestUpdateIssueComment_Forbidden(t *testing.T) {
+	fg, srv := newFakeGitHub(t)
+	fg.updateIssueCommentStatus = http.StatusForbidden
+	fg.updateIssueCommentBody = `{"message":"Resource not accessible by integration"}`
+	c, _ := newTestClient(t, srv, nil)
+
+	_, err := c.UpdateIssueComment(context.Background(), 1,
 		RepoRef{Owner: "x", Name: "y"}, 1, "hi")
 	if err == nil || !errors.Is(err, ErrForbidden) {
 		t.Errorf("err = %v want ErrForbidden", err)


### PR DESCRIPTION
## Summary

Foundation for the coordination-layer epics that need to mutate a previously-posted comment instead of spamming new ones:

- **E20** (#326) — sticky status comment that edits in place as a run progresses
- **E17** (#323) — plan-as-canonical-review-on-the-issue, where spec's `update_on_change: true` edits the plan comment on re-upload

New `Client.UpdateIssueComment(ctx, installationID, repo, commentID, body) (*IssueComment, error)` hits `PATCH /repos/{owner}/{repo}/issues/comments/{comment_id}`. Mirrors `CreateIssueComment`'s validation + error mapping; returns the updated comment (id, body, html_url) so callers can verify the edit landed. Same permission scope as `CreateIssueComment` (`issues:write`) — no manifest change needed.

## Test plan

- [x] `go test -race ./backend/...` — full suite passes; four new test cases (happy path, validation errors, 404 → ErrNotFound, 403 → ErrForbidden).
- [x] `golangci-lint run ./backend/...` — clean.
- [x] Coverage gate: 82.3%.

## Notes

- 404 → ErrNotFound is load-bearing for E20.2: if an operator deletes the status comment, the notifier falls back to creating a fresh one. The mapping comes for free via the existing `classifyStatus` helper.
- Return shape is `(*IssueComment, error)` — slightly richer than `CreateIssueComment`'s `error` only. The asymmetry is intentional: the issue body explicitly asked for "id + body so callers can verify"; PATCH responses carry the full updated object on the wire.
- No call sites yet — added in E20.2 (#328) and E17.2 (#337).

Closes #327