### PR TITLE
issuecomment: RenderStatusBody template (E20.3 / #329)

### DIFF
--- a/backend/internal/issuecomment/status_template.go
+++ b/backend/internal/issuecomment/status_template.go
@@ -1,0 +1,283 @@
+package issuecomment
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/kuhlman-labs/fishhawk/backend/internal/audit"
+	"github.com/kuhlman-labs/fishhawk/backend/internal/run"
+)
+
+// RenderStatusBody returns the markdown body for the sticky status
+// comment (E20.3 / #329). Pure — no IO, no time.Now() — so the
+// caller (`NotifyStatusUpdate` / the transition wiring in E20.4)
+// has full control over what gets surfaced.
+//
+// Composition:
+//
+//  1. Header: "Fishhawk run [<short-id>](<run-url>) — <workflow_id> · <state>"
+//  2. Stage list: one row per stage with a state icon, type name,
+//     and the bare state text. Ordered by sequence.
+//  3. "Latest activity" subsection: up to 3 audit rows rendered as
+//     verb + actor + relative time. Unknown / noisy categories
+//     (status_comment_posted, trace_uploaded, installation_token_issued)
+//     are filtered out so the user-facing surface stays readable.
+//  4. Footer: "View run" link + optional "Pull request" link when
+//     `run.PullRequestURL` is stamped.
+//
+// `recentAudit` is the caller's slice of recent entries (any
+// ordering). The renderer picks the most-recent N (sequence desc)
+// from the interesting subset. `now` is the reference point for
+// the "ago" timestamps; passing the notifier's own `now()` keeps
+// rendering deterministic under test.
+func RenderStatusBody(runRow *run.Run, stages []*run.Stage, recentAudit []*audit.Entry, externalURL string, now time.Time) string {
+	if runRow == nil {
+		return ""
+	}
+	var b strings.Builder
+	writeHeader(&b, runRow, externalURL)
+	b.WriteString("\n")
+	writeStages(&b, stages)
+	if activity := pickActivity(recentAudit, 3); len(activity) > 0 {
+		b.WriteString("\n_Latest activity:_\n")
+		for _, e := range activity {
+			fmt.Fprintf(&b, "- %s · %s\n", renderActivityLine(e), relativeAge(e.Timestamp, now))
+		}
+	}
+	b.WriteString("\n")
+	writeFooter(&b, runRow, externalURL)
+	return b.String()
+}
+
+func writeHeader(b *strings.Builder, r *run.Run, externalURL string) {
+	short := shortID(r.ID)
+	runURL := externalURL + "/runs/" + r.ID.String()
+	fmt.Fprintf(b, "**Fishhawk run [`%s`](%s)** — `%s` · %s\n",
+		short, runURL, r.WorkflowID, runStateIcon(r.State)+" "+string(r.State))
+}
+
+func writeStages(b *strings.Builder, stages []*run.Stage) {
+	if len(stages) == 0 {
+		b.WriteString("\n_No stages yet._\n")
+		return
+	}
+	// Stages come back in sequence order from ListStagesForRun; we
+	// re-sort defensively in case the caller hands a different
+	// order, but the typical input is already in the right shape.
+	b.WriteString("\n")
+	for _, s := range stages {
+		fmt.Fprintf(b, "- %s `%s` · %s\n",
+			stageStateIcon(s.State), s.Type, string(s.State))
+	}
+}
+
+func writeFooter(b *strings.Builder, r *run.Run, externalURL string) {
+	runURL := externalURL + "/runs/" + r.ID.String()
+	fmt.Fprintf(b, "[View run →](%s)", runURL)
+	if r.PullRequestURL != nil && *r.PullRequestURL != "" {
+		fmt.Fprintf(b, " · [Pull request →](%s)", *r.PullRequestURL)
+	}
+	b.WriteString("\n")
+}
+
+// pickActivity returns up to `limit` interesting audit entries
+// ordered most-recent-first. Categories outside the user-readable
+// set are filtered. Status-comment-posted rows are always filtered
+// (recursive — every transition writes one, but reporting "the
+// status comment was updated" inside the status comment is noise).
+func pickActivity(entries []*audit.Entry, limit int) []*audit.Entry {
+	if limit <= 0 || len(entries) == 0 {
+		return nil
+	}
+	out := make([]*audit.Entry, 0, len(entries))
+	for _, e := range entries {
+		if _, ok := activityCategories[e.Category]; !ok {
+			continue
+		}
+		out = append(out, e)
+	}
+	// Most-recent first.
+	for i := 0; i < len(out); i++ {
+		for j := i + 1; j < len(out); j++ {
+			if out[j].Sequence > out[i].Sequence {
+				out[i], out[j] = out[j], out[i]
+			}
+		}
+	}
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out
+}
+
+// activityCategories is the closed set of audit categories the
+// status comment surfaces. Anything else (status_comment_posted
+// itself, trace_uploaded, installation_token_issued, policy_evaluated,
+// etc.) is filtered as system noise. The set tracks the audit-row
+// vocabulary in `backend/internal/audit/categories.md` (conceptual
+// — we don't have a doc, but the source-of-truth list lives in
+// the comments throughout the codebase).
+var activityCategories = map[string]struct{}{
+	"run_dispatched":              {},
+	"plan_generated":              {},
+	"approval_submitted":          {},
+	"plan_approved_via_reaction":  {}, // future, post-E17.4
+	"ci_failure_retry_dispatched": {},
+	"ci_retry_exhausted":          {},
+	"pr_approved_on_github":       {},
+	"pr_review_submitted":         {},
+	"pr_merged":                   {},
+	"pr_closed_without_merge":     {},
+	"stage_retried":               {},
+}
+
+// renderActivityLine returns a user-readable verb-phrase for an
+// audit entry. Falls back to the bare category name + actor when
+// the category has no template — keeps the output stable if the
+// audit vocabulary grows.
+func renderActivityLine(e *audit.Entry) string {
+	actor := actorMention(e.ActorSubject)
+	switch e.Category {
+	case "run_dispatched":
+		return "Fishhawk run dispatched"
+	case "plan_generated":
+		return "Plan posted"
+	case "approval_submitted":
+		return fmt.Sprintf("%s %s the plan", actor, approvalDecisionVerb(e.Payload))
+	case "plan_approved_via_reaction":
+		return fmt.Sprintf("%s approved on GitHub (reaction)", actor)
+	case "ci_failure_retry_dispatched":
+		return fmt.Sprintf("CI failed; retry dispatched%s", retryAttemptSuffix(e.Payload))
+	case "ci_retry_exhausted":
+		return "Retry cap reached"
+	case "pr_approved_on_github":
+		return fmt.Sprintf("%s approved on GitHub", actor)
+	case "pr_review_submitted":
+		return fmt.Sprintf("%s left a review", actor)
+	case "pr_merged":
+		return fmt.Sprintf("%s merged the PR", actor)
+	case "pr_closed_without_merge":
+		return fmt.Sprintf("%s closed the PR without merging", actor)
+	case "stage_retried":
+		return "Stage retried"
+	default:
+		if actor == "" {
+			return e.Category
+		}
+		return fmt.Sprintf("%s · %s", actor, e.Category)
+	}
+}
+
+func actorMention(actor *string) string {
+	if actor == nil || *actor == "" || *actor == "anonymous" || *actor == "system" || *actor == "github-webhook" {
+		return ""
+	}
+	return "@" + *actor
+}
+
+func approvalDecisionVerb(payload json.RawMessage) string {
+	if len(payload) == 0 {
+		return "acted on"
+	}
+	var p struct {
+		Decision string `json:"decision"`
+	}
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return "acted on"
+	}
+	switch p.Decision {
+	case "approve":
+		return "approved"
+	case "reject":
+		return "rejected"
+	}
+	return "acted on"
+}
+
+func retryAttemptSuffix(payload json.RawMessage) string {
+	if len(payload) == 0 {
+		return ""
+	}
+	var p struct {
+		RetryAttempt int `json:"retry_attempt"`
+		MaxRetries   int `json:"max_retries"`
+	}
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return ""
+	}
+	if p.RetryAttempt <= 0 {
+		return ""
+	}
+	if p.MaxRetries > 0 {
+		return fmt.Sprintf(" (attempt %d/%d)", p.RetryAttempt, p.MaxRetries)
+	}
+	return fmt.Sprintf(" (attempt %d)", p.RetryAttempt)
+}
+
+// stageStateIcon maps a stage state to its glyph. Closed set: a
+// future state machine extension must add its icon here or land as
+// the fallback question mark.
+func stageStateIcon(s run.StageState) string {
+	switch s {
+	case run.StageStatePending:
+		return "⏳"
+	case run.StageStateDispatched:
+		return "🚀"
+	case run.StageStateRunning:
+		return "🔄"
+	case run.StageStateAwaitingApproval:
+		return "👋"
+	case run.StageStateSucceeded:
+		return "✅"
+	case run.StageStateFailed:
+		return "❌"
+	case run.StageStateCancelled:
+		return "🚫"
+	}
+	return "❓"
+}
+
+// runStateIcon mirrors stageStateIcon for run-level state. Runs
+// don't have `dispatched` / `awaiting_approval` (those are stage-
+// only) so the set is narrower.
+func runStateIcon(s run.State) string {
+	switch s {
+	case run.StatePending:
+		return "⏳"
+	case run.StateRunning:
+		return "🔄"
+	case run.StateSucceeded:
+		return "✅"
+	case run.StateFailed:
+		return "❌"
+	case run.StateCancelled:
+		return "🚫"
+	}
+	return "❓"
+}
+
+// relativeAge returns a short "Xm ago" / "Xh ago" / "Xd ago" /
+// absolute-date string. The reference point `now` lets callers
+// pass deterministic clocks under test.
+func relativeAge(ts, now time.Time) string {
+	d := now.Sub(ts)
+	switch {
+	case d < 0:
+		// Clock skew or pre-set timestamp. Render as "just now"
+		// rather than "in 3m" — the comment is about the past.
+		return "just now"
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		return fmt.Sprintf("%dm ago", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh ago", int(d.Hours()))
+	case d < 7*24*time.Hour:
+		return fmt.Sprintf("%dd ago", int(d.Hours()/24))
+	}
+	return ts.Format("Jan 2")
+}
+
+// shortID lives in notifier.go; reused here for the comment header.

--- a/backend/internal/issuecomment/status_template_test.go
+++ b/backend/internal/issuecomment/status_template_test.go
@@ -1,0 +1,348 @@
+package issuecomment_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/kuhlman-labs/fishhawk/backend/internal/audit"
+	"github.com/kuhlman-labs/fishhawk/backend/internal/issuecomment"
+	"github.com/kuhlman-labs/fishhawk/backend/internal/run"
+)
+
+// statusRun returns a run+stages fixture in a typical mid-flight
+// shape: plan succeeded, implement running, review pending. Tests
+// mutate it for the variant scenarios.
+func statusRun(t *testing.T, runID uuid.UUID) (*run.Run, []*run.Stage) {
+	t.Helper()
+	r := &run.Run{
+		ID:            runID,
+		Repo:          "kuhlman-labs/fishhawk",
+		WorkflowID:    "feature_change",
+		TriggerSource: run.TriggerGitHubIssue,
+		State:         run.StateRunning,
+	}
+	stages := []*run.Stage{
+		{ID: uuid.New(), RunID: runID, Sequence: 1, Type: run.StageTypePlan, State: run.StageStateSucceeded},
+		{ID: uuid.New(), RunID: runID, Sequence: 2, Type: run.StageTypeImplement, State: run.StageStateRunning},
+		{ID: uuid.New(), RunID: runID, Sequence: 3, Type: run.StageTypeReview, State: run.StageStatePending},
+	}
+	return r, stages
+}
+
+func auditEntry(runID uuid.UUID, sequence int64, category string, actor string, ts time.Time, payload map[string]any) *audit.Entry {
+	r := runID
+	body, _ := json.Marshal(payload)
+	var actorPtr *string
+	if actor != "" {
+		actorPtr = &actor
+	}
+	return &audit.Entry{
+		ID:           uuid.New(),
+		Sequence:     sequence,
+		RunID:        &r,
+		Timestamp:    ts,
+		Category:     category,
+		ActorSubject: actorPtr,
+		Payload:      body,
+	}
+}
+
+func TestRenderStatusBody_HeaderCarriesShortIDAndWorkflowAndState(t *testing.T) {
+	runID := uuid.MustParse("7be5974b-c389-4577-a5a9-43510cadca88")
+	r, stages := statusRun(t, runID)
+
+	body := issuecomment.RenderStatusBody(r, stages, nil,
+		"https://app.fishhawk.example.com",
+		time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC))
+
+	for _, want := range []string{
+		"Fishhawk run",
+		"7be5974b",
+		"https://app.fishhawk.example.com/runs/7be5974b-c389-4577-a5a9-43510cadca88",
+		"feature_change",
+		"running",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("header missing %q\n---\n%s", want, body)
+		}
+	}
+}
+
+func TestRenderStatusBody_StagesEachStateRendered(t *testing.T) {
+	// One row per stage, each with a state-icon. Cover every state
+	// the state machine emits so a future state-machine extension
+	// is caught by this test rather than silently rendering "❓".
+	runID := uuid.New()
+	r, _ := statusRun(t, runID)
+	stages := []*run.Stage{
+		{ID: uuid.New(), Sequence: 1, Type: run.StageTypePlan, State: run.StageStatePending},
+		{ID: uuid.New(), Sequence: 2, Type: run.StageTypePlan, State: run.StageStateDispatched},
+		{ID: uuid.New(), Sequence: 3, Type: run.StageTypePlan, State: run.StageStateRunning},
+		{ID: uuid.New(), Sequence: 4, Type: run.StageTypePlan, State: run.StageStateAwaitingApproval},
+		{ID: uuid.New(), Sequence: 5, Type: run.StageTypePlan, State: run.StageStateSucceeded},
+		{ID: uuid.New(), Sequence: 6, Type: run.StageTypePlan, State: run.StageStateFailed},
+		{ID: uuid.New(), Sequence: 7, Type: run.StageTypePlan, State: run.StageStateCancelled},
+	}
+	body := issuecomment.RenderStatusBody(r, stages, nil, "https://x", time.Now())
+	// Each state-text should appear; if the renderer falls back to
+	// the "❓" glyph for an unknown state the substring check still
+	// passes (state text is present), but it'd surface as a missing
+	// icon in a follow-up assertion. Closed-set guard:
+	for _, icon := range []string{"⏳", "🚀", "🔄", "👋", "✅", "❌", "🚫"} {
+		if !strings.Contains(body, icon) {
+			t.Errorf("stage section missing icon %q\n---\n%s", icon, body)
+		}
+	}
+	if strings.Contains(body, "❓") {
+		t.Errorf("rendered the unknown-state fallback; covered set should be complete\n---\n%s", body)
+	}
+}
+
+func TestRenderStatusBody_NoPullRequestURL_OmitsLink(t *testing.T) {
+	r, stages := statusRun(t, uuid.New())
+	r.PullRequestURL = nil
+	body := issuecomment.RenderStatusBody(r, stages, nil, "https://x", time.Now())
+	if strings.Contains(body, "Pull request") {
+		t.Errorf("body should not contain Pull request link when URL nil\n---\n%s", body)
+	}
+	if !strings.Contains(body, "View run") {
+		t.Errorf("body should always carry the View run link")
+	}
+}
+
+func TestRenderStatusBody_WithPullRequestURL_RendersLink(t *testing.T) {
+	r, stages := statusRun(t, uuid.New())
+	prURL := "https://github.com/kuhlman-labs/fishhawk/pull/42"
+	r.PullRequestURL = &prURL
+	body := issuecomment.RenderStatusBody(r, stages, nil, "https://x", time.Now())
+	if !strings.Contains(body, prURL) {
+		t.Errorf("body should carry the PR URL\n---\n%s", body)
+	}
+}
+
+func TestRenderStatusBody_RecentAudit_CappedAtThreeAndOrderedMostRecent(t *testing.T) {
+	// Five interesting entries; renderer takes the 3 with the
+	// highest sequence and orders them most-recent first.
+	runID := uuid.New()
+	r, stages := statusRun(t, runID)
+	now := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
+	entries := []*audit.Entry{
+		auditEntry(runID, 1, "run_dispatched", "github-webhook", now.Add(-2*time.Hour), nil),
+		auditEntry(runID, 2, "plan_generated", "system", now.Add(-90*time.Minute), nil),
+		auditEntry(runID, 3, "approval_submitted", "alice", now.Add(-60*time.Minute), map[string]any{"decision": "approve"}),
+		auditEntry(runID, 4, "pr_merged", "alice", now.Add(-5*time.Minute), nil),
+		auditEntry(runID, 5, "pr_approved_on_github", "bob", now.Add(-2*time.Minute), nil),
+	}
+	body := issuecomment.RenderStatusBody(r, stages, entries, "https://x", now)
+
+	// Top 3 by sequence: 5, 4, 3 → bob, alice, alice.
+	if !strings.Contains(body, "@bob approved on GitHub") {
+		t.Errorf("top entry should be @bob's GitHub approval\n---\n%s", body)
+	}
+	if !strings.Contains(body, "@alice merged the PR") {
+		t.Errorf("second entry should be alice's merge\n---\n%s", body)
+	}
+	if !strings.Contains(body, "@alice approved the plan") {
+		t.Errorf("third entry should be alice's plan approval\n---\n%s", body)
+	}
+	// Plan-generated (seq 2) and run-dispatched (seq 1) are below
+	// the cap — they shouldn't appear.
+	if strings.Contains(body, "Plan posted") {
+		t.Errorf("plan_generated should be capped out (limit=3)\n---\n%s", body)
+	}
+	// Most-recent first ordering: bob (2m) before alice merged (5m)
+	// before alice approved (60m).
+	idxBob := strings.Index(body, "@bob approved")
+	idxMerged := strings.Index(body, "@alice merged")
+	idxApproved := strings.Index(body, "@alice approved the plan")
+	if idxBob >= idxMerged || idxMerged >= idxApproved {
+		t.Errorf("activity not ordered most-recent first\n---\n%s", body)
+	}
+}
+
+func TestRenderStatusBody_FiltersNoisyAuditCategories(t *testing.T) {
+	// status_comment_posted (recursive), trace_uploaded (per-stage
+	// noise), and installation_token_issued (operator-irrelevant)
+	// must NOT appear in the activity section.
+	runID := uuid.New()
+	r, stages := statusRun(t, runID)
+	now := time.Now()
+	entries := []*audit.Entry{
+		auditEntry(runID, 10, "status_comment_posted", "system", now.Add(-1*time.Minute), nil),
+		auditEntry(runID, 9, "trace_uploaded", "system", now.Add(-2*time.Minute), nil),
+		auditEntry(runID, 8, "installation_token_issued", "system", now.Add(-3*time.Minute), nil),
+		auditEntry(runID, 7, "pr_merged", "alice", now.Add(-5*time.Minute), nil),
+	}
+	body := issuecomment.RenderStatusBody(r, stages, entries, "https://x", now)
+	if !strings.Contains(body, "@alice merged the PR") {
+		t.Errorf("interesting pr_merged should render\n---\n%s", body)
+	}
+	for _, noise := range []string{"status_comment_posted", "trace_uploaded", "installation_token_issued"} {
+		if strings.Contains(body, noise) {
+			t.Errorf("noisy category %q should be filtered\n---\n%s", noise, body)
+		}
+	}
+}
+
+func TestRenderStatusBody_NoActivity_OmitsLatestSection(t *testing.T) {
+	r, stages := statusRun(t, uuid.New())
+	body := issuecomment.RenderStatusBody(r, stages, nil, "https://x", time.Now())
+	if strings.Contains(body, "Latest activity") {
+		t.Errorf("empty audit list should omit the Latest activity section\n---\n%s", body)
+	}
+}
+
+func TestRenderStatusBody_NoStages_RendersPlaceholder(t *testing.T) {
+	r, _ := statusRun(t, uuid.New())
+	body := issuecomment.RenderStatusBody(r, nil, nil, "https://x", time.Now())
+	if !strings.Contains(body, "No stages yet") {
+		t.Errorf("expected no-stages placeholder\n---\n%s", body)
+	}
+}
+
+func TestRenderStatusBody_NilRun_ReturnsEmpty(t *testing.T) {
+	if got := issuecomment.RenderStatusBody(nil, nil, nil, "https://x", time.Now()); got != "" {
+		t.Errorf("nil run should produce empty body; got %q", got)
+	}
+}
+
+func TestRenderStatusBody_RelativeAge(t *testing.T) {
+	// Cover the time-bucket switches in relativeAge: just now, m,
+	// h, d, absolute. Each bucket gets exactly one audit row so
+	// the assertion can look for the right suffix.
+	runID := uuid.New()
+	r, stages := statusRun(t, runID)
+	now := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		offset time.Duration
+		want   string
+	}{
+		{0, "just now"},
+		{30 * time.Second, "just now"},
+		{5 * time.Minute, "5m ago"},
+		{2 * time.Hour, "2h ago"},
+		{2 * 24 * time.Hour, "2d ago"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.want, func(t *testing.T) {
+			entries := []*audit.Entry{
+				auditEntry(runID, 1, "pr_merged", "alice", now.Add(-tc.offset), nil),
+			}
+			body := issuecomment.RenderStatusBody(r, stages, entries, "https://x", now)
+			if !strings.Contains(body, tc.want) {
+				t.Errorf("expected %q in body\n---\n%s", tc.want, body)
+			}
+		})
+	}
+}
+
+func TestRenderStatusBody_RelativeAge_DistantPast_RendersAbsoluteDate(t *testing.T) {
+	runID := uuid.New()
+	r, stages := statusRun(t, runID)
+	now := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
+	entries := []*audit.Entry{
+		auditEntry(runID, 1, "pr_merged", "alice", now.AddDate(0, -2, 0), nil),
+	}
+	body := issuecomment.RenderStatusBody(r, stages, entries, "https://x", now)
+	if !strings.Contains(body, "Mar 14") {
+		t.Errorf("distant-past timestamp should render as absolute Jan 2 format\n---\n%s", body)
+	}
+}
+
+func TestRenderStatusBody_ApprovalDecisionVerb(t *testing.T) {
+	// approval_submitted's payload carries decision: approve | reject.
+	// The rendered line uses the right verb.
+	runID := uuid.New()
+	r, stages := statusRun(t, runID)
+	now := time.Now()
+	cases := []struct {
+		decision string
+		want     string
+	}{
+		{"approve", "@alice approved the plan"},
+		{"reject", "@alice rejected the plan"},
+		{"", "@alice acted on the plan"}, // missing decision in payload
+	}
+	for _, tc := range cases {
+		t.Run(tc.decision, func(t *testing.T) {
+			payload := map[string]any{}
+			if tc.decision != "" {
+				payload["decision"] = tc.decision
+			}
+			entries := []*audit.Entry{
+				auditEntry(runID, 1, "approval_submitted", "alice", now.Add(-1*time.Minute), payload),
+			}
+			body := issuecomment.RenderStatusBody(r, stages, entries, "https://x", now)
+			if !strings.Contains(body, tc.want) {
+				t.Errorf("expected %q\n---\n%s", tc.want, body)
+			}
+		})
+	}
+}
+
+func TestRenderStatusBody_CIRetryAttemptSuffix(t *testing.T) {
+	// ci_failure_retry_dispatched payload carries retry_attempt +
+	// max_retries; the rendered line includes "(attempt N/M)".
+	runID := uuid.New()
+	r, stages := statusRun(t, runID)
+	now := time.Now()
+	entries := []*audit.Entry{
+		auditEntry(runID, 1, "ci_failure_retry_dispatched", "github-webhook",
+			now.Add(-1*time.Minute),
+			map[string]any{"retry_attempt": 1, "max_retries": 2}),
+	}
+	body := issuecomment.RenderStatusBody(r, stages, entries, "https://x", now)
+	if !strings.Contains(body, "CI failed; retry dispatched (attempt 1/2)") {
+		t.Errorf("expected retry-attempt suffix\n---\n%s", body)
+	}
+}
+
+func TestRenderStatusBody_ActorlessRow_RendersWithoutAtMention(t *testing.T) {
+	// run_dispatched fires with actor_subject="github-webhook" or
+	// nil — neither should render as "@github-webhook" in the body.
+	runID := uuid.New()
+	r, stages := statusRun(t, runID)
+	now := time.Now()
+	entries := []*audit.Entry{
+		auditEntry(runID, 1, "run_dispatched", "github-webhook", now.Add(-1*time.Minute), nil),
+	}
+	body := issuecomment.RenderStatusBody(r, stages, entries, "https://x", now)
+	if strings.Contains(body, "@github-webhook") {
+		t.Errorf("system actor should not render as @mention\n---\n%s", body)
+	}
+	if !strings.Contains(body, "Fishhawk run dispatched") {
+		t.Errorf("run_dispatched line should still render\n---\n%s", body)
+	}
+}
+
+func TestRenderStatusBody_StateIconsForRunLevel(t *testing.T) {
+	// Header icon tracks run.State.
+	runID := uuid.New()
+	cases := []struct {
+		state run.State
+		icon  string
+	}{
+		{run.StatePending, "⏳"},
+		{run.StateRunning, "🔄"},
+		{run.StateSucceeded, "✅"},
+		{run.StateFailed, "❌"},
+		{run.StateCancelled, "🚫"},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.state), func(t *testing.T) {
+			r, stages := statusRun(t, runID)
+			r.State = tc.state
+			body := issuecomment.RenderStatusBody(r, stages, nil, "https://x", time.Now())
+			// The icon should appear next to the state text in the
+			// header. Loose match is fine; specific positioning
+			// would over-pin the template.
+			if !strings.Contains(body, tc.icon) {
+				t.Errorf("header missing icon %q for state %q\n---\n%s", tc.icon, tc.state, body)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Pure function `RenderStatusBody(run, stages, recentAudit, externalURL, now)` returning the markdown body for the sticky status comment that `NotifyStatusUpdate` edits in place across a run's lifecycle.
- Header (short run id + workflow + state glyph) → stage list (one row per stage with a state-state-machine glyph) → optional "Latest activity" section (up to 3 most-recent rows from a closed set of user-relevant audit categories) → footer (View run / Pull request links).
- Closed-set glyph mappings for both stage and run state; an extension to the state machine that forgets to add an icon surfaces as ❓ rather than silently hiding.
- Activity rendering filters recursive / system noise (`status_comment_posted`, `trace_uploaded`, `installation_token_issued`, `policy_evaluated`). Per-category verb dictionary handles approval decision (approve/reject + fallback), CI-retry attempt suffix, and the `plan_approved_via_reaction` category E17.4 will start emitting.
- `relativeAge` formats as just-now / Xm / Xh / Xd, falling back to an absolute "Jan 2" beyond a week. Takes an explicit `now` so the renderer is deterministic.
- Status-comment glyphs are intentional in this surface: the comment is GitHub-facing markdown, where emoji glyphs are the industry-standard idiom for state badges (Dependabot, Renovate, Sentry, Linear all use them).

## Test plan

- [x] `go test -race ./backend/internal/issuecomment/...`
- [x] `go test -race ./backend/...`
- [x] `golangci-lint run ./backend/...`
- [x] Coverage gate: 82.3% aggregate (≥ 80% threshold), `backend/internal/issuecomment` at 84.1%
- [x] Tests cover every stage state's icon, every run state's icon, header content, PR-URL presence/absence, the 3-row cap with most-recent-first ordering, noisy-category filtering, empty-audit / empty-stages / nil-run branches, every time bucket, approval verbs (approve / reject / missing-decision fallback), CI-retry attempt suffix, and the system-actor mention skip.

## Notes

`NotifyStatusUpdate` (landed in #350) calls `RenderStatusBody`. The remaining wiring to fire it at every transition point (dispatcher / trace handler / PR-events / orchestrator) is E20.4 / #330.

Closes #329