### PR TITLE
Wire NotifyStatusUpdate at transition points (E20.4 / #330)

### DIFF
--- a/backend/internal/issuecomment/notifier.go
+++ b/backend/internal/issuecomment/notifier.go
@@ -445,6 +445,40 @@ func (n *Notifier) NotifyStatusUpdate(ctx context.Context, runID uuid.UUID, body
 	return n.appendStatusAudit(ctx, ctxv, created.ID)
 }
 
+// NotifyStatusUpdateForRun is the convenience entry point transition-
+// point callers use (E20.4 / #330). It loads the run, its stages, and
+// the audit chain for the run, renders the body via RenderStatusBody,
+// and dispatches to NotifyStatusUpdate. Returns nil silently for
+// non-issue triggers so callers at every transition point don't need
+// to branch on TriggerSource.
+//
+// Best-effort: load failures return wrapped errors the caller can
+// log; the post itself follows NotifyStatusUpdate's own best-effort
+// posture (operator-deleted comment → fresh create, idempotent on
+// redelivery, etc.).
+func (n *Notifier) NotifyStatusUpdateForRun(ctx context.Context, runID uuid.UUID) error {
+	if n == nil {
+		return nil
+	}
+	runRow, err := n.runs.GetRun(ctx, runID)
+	if err != nil {
+		return fmt.Errorf("issuecomment: get run: %w", err)
+	}
+	if runRow.TriggerSource != run.TriggerGitHubIssue {
+		return nil
+	}
+	stages, err := n.runs.ListStagesForRun(ctx, runID)
+	if err != nil {
+		return fmt.Errorf("issuecomment: list stages: %w", err)
+	}
+	entries, err := n.audit.ListForRun(ctx, runID)
+	if err != nil {
+		return fmt.Errorf("issuecomment: list audit: %w", err)
+	}
+	body := RenderStatusBody(runRow, stages, entries, n.externalURL, n.now())
+	return n.NotifyStatusUpdate(ctx, runID, body)
+}
+
 // contextForStatus is the status-comment variant of contextFor — it
 // resolves run + repo + issue without the per-kind dedup check that
 // contextFor enforces. The status comment's "dedup" is "use the

--- a/backend/internal/issuecomment/notifier_test.go
+++ b/backend/internal/issuecomment/notifier_test.go
@@ -551,6 +551,112 @@ func TestNotifyPickup_AndPlan_ShareCategoryButDistinctKinds(t *testing.T) {
 	}
 }
 
+// happyDepsWithStages returns the happyDeps fixtures plus a stage
+// list so NotifyStatusUpdateForRun has something to render against.
+func happyDepsWithStages(t *testing.T) (uuid.UUID, *fakeGitHub, *fakeAudit, *fakeRuns, *issuecomment.Notifier) {
+	t.Helper()
+	runID := uuid.New()
+	triggerRef := "issue:42"
+	stages := []*run.Stage{
+		{ID: uuid.New(), RunID: runID, Sequence: 1, Type: run.StageTypePlan, State: run.StageStateSucceeded},
+		{ID: uuid.New(), RunID: runID, Sequence: 2, Type: run.StageTypeImplement, State: run.StageStateRunning},
+	}
+	repoRuns := &fakeRuns{
+		runs: map[uuid.UUID]*run.Run{runID: {
+			ID:             runID,
+			Repo:           "x/y",
+			WorkflowID:     "feature_change",
+			TriggerSource:  run.TriggerGitHubIssue,
+			TriggerRef:     &triggerRef,
+			InstallationID: int64Ptr(99),
+			State:          run.StateRunning,
+		}},
+		stages: map[uuid.UUID][]*run.Stage{runID: stages},
+	}
+	gh := &fakeGitHub{}
+	au := &fakeAudit{}
+	n := issuecomment.New(issuecomment.Deps{
+		GitHub:      gh,
+		Runs:        repoRuns,
+		Audit:       au,
+		ExternalURL: "https://app.fishhawk.example.com",
+		Now:         func() time.Time { return time.Date(2026, 5, 8, 12, 0, 0, 0, time.UTC) },
+	})
+	if n == nil {
+		t.Fatal("notifier nil")
+	}
+	return runID, gh, au, repoRuns, n
+}
+
+func TestNotifyStatusUpdateForRun_FirstCall_CreatesAndRenders(t *testing.T) {
+	runID, gh, au, _, n := happyDepsWithStages(t)
+	if err := n.NotifyStatusUpdateForRun(context.Background(), runID); err != nil {
+		t.Fatalf("NotifyStatusUpdateForRun: %v", err)
+	}
+	if len(gh.calls) != 1 {
+		t.Fatalf("expected 1 create call; got %d", len(gh.calls))
+	}
+	body := gh.calls[0].body
+	// Should carry the rendered header + stage list.
+	for _, want := range []string{"Fishhawk run", "feature_change", "plan", "implement"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q\n---\n%s", want, body)
+		}
+	}
+	if len(au.appended) != 1 {
+		t.Fatalf("expected 1 audit row; got %d", len(au.appended))
+	}
+	if au.appended[0].Category != issuecomment.CategoryStatusCommentPosted {
+		t.Errorf("audit category = %q", au.appended[0].Category)
+	}
+}
+
+func TestNotifyStatusUpdateForRun_SubsequentCall_EditsSameComment(t *testing.T) {
+	// Pre-seed an existing status comment audit row; the convenience
+	// method should resolve to UpdateIssueComment with that id.
+	runID, gh, au, _, n := happyDepsWithStages(t)
+	au.preSeed(runID, issuecomment.CategoryStatusCommentPosted, map[string]any{
+		"kind":              string(issuecomment.KindStatusUpdate),
+		"issue_number":      42,
+		"repo":              "x/y",
+		"github_comment_id": 4242,
+	})
+	if err := n.NotifyStatusUpdateForRun(context.Background(), runID); err != nil {
+		t.Fatalf("NotifyStatusUpdateForRun: %v", err)
+	}
+	if len(gh.calls) != 0 {
+		t.Errorf("expected 0 create calls on edit path; got %d", len(gh.calls))
+	}
+	if len(gh.updateCalls) != 1 {
+		t.Fatalf("expected 1 update call; got %d", len(gh.updateCalls))
+	}
+	if gh.updateCalls[0].commentID != 4242 {
+		t.Errorf("update.commentID = %d, want 4242", gh.updateCalls[0].commentID)
+	}
+}
+
+func TestNotifyStatusUpdateForRun_NonIssueTrigger_SkipsSilently(t *testing.T) {
+	runID, gh, au, runs, n := happyDepsWithStages(t)
+	runs.runs[runID].TriggerSource = run.TriggerCLI
+	if err := n.NotifyStatusUpdateForRun(context.Background(), runID); err != nil {
+		t.Fatalf("NotifyStatusUpdateForRun: %v", err)
+	}
+	if len(gh.calls)+len(gh.updateCalls) != 0 {
+		t.Errorf("non-issue trigger should skip; got %d creates + %d updates",
+			len(gh.calls), len(gh.updateCalls))
+	}
+	if len(au.appended) != 0 {
+		t.Errorf("non-issue trigger should not append audit rows; got %d", len(au.appended))
+	}
+}
+
+func TestNotifyStatusUpdateForRun_NilReceiver_NoOp(t *testing.T) {
+	var n *issuecomment.Notifier
+	if err := n.NotifyStatusUpdateForRun(context.Background(), uuid.New()); err != nil {
+		t.Errorf("nil receiver should be a no-op; got %v", err)
+	}
+}
+
 func TestNew_NilDepsReturnsNilNotifier(t *testing.T) {
 	cases := []struct {
 		name string
@@ -881,7 +987,8 @@ func (f *fakeGitHub) UpdateIssueComment(_ context.Context, installationID int64,
 
 type fakeRuns struct {
 	run.Repository
-	runs map[uuid.UUID]*run.Run
+	runs   map[uuid.UUID]*run.Run
+	stages map[uuid.UUID][]*run.Stage
 }
 
 func (f *fakeRuns) GetRun(_ context.Context, id uuid.UUID) (*run.Run, error) {
@@ -890,6 +997,13 @@ func (f *fakeRuns) GetRun(_ context.Context, id uuid.UUID) (*run.Run, error) {
 		return nil, run.ErrNotFound
 	}
 	return r, nil
+}
+
+func (f *fakeRuns) ListStagesForRun(_ context.Context, id uuid.UUID) ([]*run.Stage, error) {
+	if f.stages == nil {
+		return nil, nil
+	}
+	return f.stages[id], nil
 }
 
 type fakeAudit struct {
@@ -923,6 +1037,18 @@ func (f *fakeAudit) ListForRunByCategory(_ context.Context, runID uuid.UUID, cat
 	out := []*audit.Entry{}
 	for _, e := range f.preSeeds {
 		if e.RunID != nil && *e.RunID == runID && e.Category == category {
+			out = append(out, e)
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeAudit) ListForRun(_ context.Context, runID uuid.UUID) ([]*audit.Entry, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := []*audit.Entry{}
+	for _, e := range f.preSeeds {
+		if e.RunID != nil && *e.RunID == runID {
 			out = append(out, e)
 		}
 	}

--- a/backend/internal/server/approvals.go
+++ b/backend/internal/server/approvals.go
@@ -210,6 +210,12 @@ func (s *Server) handleSubmitApproval(w http.ResponseWriter, r *http.Request) {
 				)
 			}
 		}
+
+		// Sticky status comment (E20.4 / #330). Every approval —
+		// approve or reject, plan stage or otherwise — changes the
+		// run's surface state and is worth surfacing in the issue
+		// thread.
+		s.notifyStatusUpdate(r.Context(), stage.RunID, "approval_submit")
 	}
 
 	s.writeJSON(w, r, http.StatusOK, toStageResponse(stage))

--- a/backend/internal/server/issue_approval.go
+++ b/backend/internal/server/issue_approval.go
@@ -161,6 +161,11 @@ func (s *Server) HandleApprovalCommand(ctx context.Context, p webhook.ApprovalCo
 	} else {
 		s.replyApproval(ctx, p, formatSuccessReply(decision, subject, runRow.ID, advanced))
 	}
+
+	// Sticky status comment (E20.4 / #330). Mirrors the HTTP
+	// approval path: every approval (approve / reject, any stage
+	// type) updates the sticky comment.
+	s.notifyStatusUpdate(ctx, advanced.RunID, "slash_approval")
 	return nil
 }
 

--- a/backend/internal/server/issue_approval_test.go
+++ b/backend/internal/server/issue_approval_test.go
@@ -77,25 +77,27 @@ func TestHandleApprovalCommand_PlanApprove_PostsOnlyBroadcast(t *testing.T) {
 		t.Errorf("approver = %q, want alice", ar.all[0].ApproverSubject)
 	}
 
-	// Exactly one comment expected: the plan-approved broadcast
-	// (#274). The redundant slash reply is suppressed on the plan-
-	// approve path (#304) so the issue thread sees a single canonical
-	// confirmation.
+	// Two comments expected: the plan-approved broadcast (#274) and
+	// the sticky-status seed (E20.4 / #330). The redundant slash
+	// reply is suppressed on the plan-approve path (#304) so the
+	// issue thread sees a single canonical broadcast confirmation
+	// plus the live-status comment.
 	got := gh.calls()
-	if len(got) != 1 {
-		t.Fatalf("expected 1 comment (plan-approved broadcast only); got %d", len(got))
+	broadcast, status := splitBroadcastAndStatus(got)
+	if broadcast == "" {
+		t.Fatalf("expected a plan-approved broadcast comment; got bodies %v", commentBodies(got))
 	}
-	if !strings.Contains(got[0].body, "Plan approved by") {
-		t.Errorf("broadcast should announce plan approval: %q", got[0].body)
+	if status == "" {
+		t.Fatalf("expected a sticky-status comment; got bodies %v", commentBodies(got))
 	}
-	if !strings.Contains(got[0].body, "@alice") {
-		t.Errorf("plan-approved broadcast should mention approver: %q", got[0].body)
+	if !strings.Contains(broadcast, "@alice") {
+		t.Errorf("plan-approved broadcast should mention approver: %q", broadcast)
 	}
 	// Regression guard for #305: the @login must NOT be wrapped in
 	// backticks — GitHub only fires a mention notification when the
 	// handle is bare.
-	if strings.Contains(got[0].body, "`@") {
-		t.Errorf("plan-approved broadcast must not backtick-wrap the @mention (breaks GitHub notification): %q", got[0].body)
+	if strings.Contains(broadcast, "`@") {
+		t.Errorf("plan-approved broadcast must not backtick-wrap the @mention (breaks GitHub notification): %q", broadcast)
 	}
 }
 
@@ -196,12 +198,24 @@ func TestHandleApprovalCommand_PlanReject_StillPostsSlashReply(t *testing.T) {
 	if stage.State != run.StageStateFailed {
 		t.Errorf("stage state = %q, want failed", stage.State)
 	}
+	// Two comments expected: the slash reply on plan-reject (the
+	// only path that doesn't suppress it in favor of a broadcast)
+	// and the sticky-status update (E20.4 / #330).
 	got := gh.calls()
-	if len(got) != 1 {
-		t.Fatalf("expected exactly 1 comment (slash reply on plan-reject); got %d: %+v", len(got), got)
+	var reply, status string
+	for _, c := range got {
+		switch {
+		case strings.HasPrefix(c.body, "Rejected by "):
+			reply = c.body
+		case strings.Contains(c.body, "Fishhawk run"):
+			status = c.body
+		}
 	}
-	if !strings.HasPrefix(got[0].body, "Rejected by ") {
-		t.Errorf("slash reply should start with 'Rejected by ': %q", got[0].body)
+	if reply == "" {
+		t.Fatalf("expected a 'Rejected by ' slash reply; got bodies %v", commentBodies(got))
+	}
+	if status == "" {
+		t.Fatalf("expected a sticky-status comment; got bodies %v", commentBodies(got))
 	}
 }
 
@@ -450,17 +464,18 @@ func TestHandleApprovalCommand_RepeatAfterAdvance_RepliesNoAwaitingStage(t *test
 	if len(ar.all) != 1 {
 		t.Errorf("approval repo should have one row; got %d", len(ar.all))
 	}
-	// Two comments expected: the first attempt's plan-approved
-	// broadcast (#274), plus the second attempt's "no awaiting
-	// stage" slash reply. The slash reply on the plan-approve path
-	// is suppressed in favor of the broadcast (#304), so the first
-	// attempt posts only one comment.
+	// Three comments expected: the first attempt's plan-approved
+	// broadcast (#274), the first attempt's sticky-status seed
+	// (E20.4 / #330), and the second attempt's "no awaiting stage"
+	// slash reply. The slash reply on the plan-approve path is
+	// suppressed in favor of the broadcast (#304), so the first
+	// attempt posts the broadcast + status; the second never
+	// reaches the status hook because it returns early on the
+	// missing-awaiting-stage branch.
 	calls := gh.calls()
-	if len(calls) != 2 {
-		t.Fatalf("expected 2 comments (1st: broadcast, 2nd: reply); got %d", len(calls))
+	if len(calls) != 3 {
+		t.Fatalf("expected 3 comments (broadcast + status seed + 2nd-attempt reply); got %d: %v", len(calls), commentBodies(calls))
 	}
-	// Order-independent body scan — the second-attempt's reply
-	// must explain that no awaiting stage exists.
 	var noAwaitingReply string
 	for _, c := range calls {
 		if strings.Contains(c.body, "No stage on this issue's run is awaiting approval") {
@@ -468,14 +483,7 @@ func TestHandleApprovalCommand_RepeatAfterAdvance_RepliesNoAwaitingStage(t *test
 		}
 	}
 	if noAwaitingReply == "" {
-		t.Errorf("expected one comment explaining 'no awaiting stage'; got bodies %v",
-			func() []string {
-				out := []string{}
-				for _, c := range calls {
-					out = append(out, c.body)
-				}
-				return out
-			}())
+		t.Errorf("expected one comment explaining 'no awaiting stage'; got bodies %v", commentBodies(calls))
 	}
 }
 
@@ -537,6 +545,32 @@ func TestHandleApprovalCommand_RepoLookupFailure_RepliesGracefully(t *testing.T)
 }
 
 // --- helpers ---
+
+// splitBroadcastAndStatus picks the plan-approved broadcast (the
+// "Plan approved by" comment) and the sticky-status comment (the
+// "Fishhawk run" header) out of a recorded call list. Returns the
+// matched bodies, or empty strings when not found.
+func splitBroadcastAndStatus(calls []slashCommentCall) (broadcast, status string) {
+	for _, c := range calls {
+		switch {
+		case strings.Contains(c.body, "Plan approved by"):
+			broadcast = c.body
+		case strings.Contains(c.body, "Fishhawk run"):
+			status = c.body
+		}
+	}
+	return broadcast, status
+}
+
+// commentBodies returns just the body slice for diagnostics in
+// failed assertions.
+func commentBodies(calls []slashCommentCall) []string {
+	out := make([]string, 0, len(calls))
+	for _, c := range calls {
+		out = append(out, c.body)
+	}
+	return out
+}
 
 type slashCommentCall struct {
 	repo        string

--- a/backend/internal/server/pullrequest.go
+++ b/backend/internal/server/pullrequest.go
@@ -245,6 +245,12 @@ func (s *Server) handleShipPullRequest(w http.ResponseWriter, r *http.Request) {
 		)
 	}
 
+	// Sticky status comment (E20.4 / #330). The PR-opened transition
+	// adds the PR URL to the run; the status comment's footer now
+	// surfaces the "Pull request →" link, so an update here is the
+	// signal that lets operators jump to the PR from the issue thread.
+	s.notifyStatusUpdate(r.Context(), runID, "pr_opened")
+
 	s.writeJSON(w, r, http.StatusCreated, pullRequestResponse{
 		ID:          created.ID,
 		StageID:     created.StageID,

--- a/backend/internal/server/pullrequest_review_events.go
+++ b/backend/internal/server/pullrequest_review_events.go
@@ -138,6 +138,9 @@ func (s *Server) handlePullRequestClosed(ctx context.Context, raw []byte) {
 			"pull_request.closed: no review stage on run; audit-only",
 			slog.String("pr_url", prURL),
 			slog.String("run_id", target.ID.String()))
+		// Sticky status comment (E20.4 / #330) — the audit row
+		// reflects the merge; the comment should too.
+		s.notifyStatusUpdate(ctx, target.ID, "pr_merged_no_review")
 		return
 	}
 
@@ -163,6 +166,11 @@ func (s *Server) handlePullRequestClosed(ctx context.Context, raw []byte) {
 		slog.String("stage_id", reviewStage.ID.String()),
 		slog.String("merger", mergerLogin(p)),
 	)
+
+	// Sticky status comment (E20.4 / #330). The PR merging is the
+	// terminal state for review-gated workflows; this is one of the
+	// most operator-visible moments of the run lifecycle.
+	s.notifyStatusUpdate(ctx, target.ID, "pr_merged")
 }
 
 // handlePullRequestReviewSubmitted handles
@@ -307,6 +315,9 @@ func (s *Server) handlePullRequestClosedWithoutMerge(ctx context.Context, target
 			slog.String("pr_url", p.PullRequest.HTMLURL),
 			slog.String("run_id", target.ID.String()),
 			slog.String("closer", p.Sender.Login))
+		// Sticky status comment (E20.4 / #330) — audit row is in;
+		// surface the close in the issue thread.
+		s.notifyStatusUpdate(ctx, target.ID, "pr_closed_no_review")
 		return
 	}
 	if _, err := s.cfg.RunRepo.TransitionStage(ctx,
@@ -325,6 +336,11 @@ func (s *Server) handlePullRequestClosedWithoutMerge(ctx context.Context, target
 		slog.String("stage_id", reviewStage.ID.String()),
 		slog.String("closer", p.Sender.Login),
 	)
+
+	// Sticky status comment (E20.4 / #330). Review stage cancelled
+	// is a terminal-ish surface state — the user should see the
+	// run's review row flip to cancelled in the comment.
+	s.notifyStatusUpdate(ctx, target.ID, "pr_closed_without_merge")
 }
 
 // writePRClosedWithoutMergeAudit appends a pr_closed_without_merge

--- a/backend/internal/server/retry.go
+++ b/backend/internal/server/retry.go
@@ -117,6 +117,11 @@ func (s *Server) handleRetryStage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Sticky status comment (E20.4 / #330). A retry flips a failed
+	// stage back to pending / dispatched / awaiting_approval; the
+	// status comment should reflect the new shape.
+	s.notifyStatusUpdate(r.Context(), dec.Stage.RunID, "stage_retry")
+
 	s.writeJSON(w, r, http.StatusOK, toStageResponse(dec.Stage))
 }
 

--- a/backend/internal/server/trace.go
+++ b/backend/internal/server/trace.go
@@ -328,6 +328,13 @@ func (s *Server) advanceStageAfterTrace(r *http.Request, runID, stageID uuid.UUI
 	if stage.Type == run.StageTypePlan {
 		s.notifyPlanReady(r, runID, stage)
 	}
+
+	// Sticky status comment (E20.4 / #330). Every terminal stage
+	// transition is a state change worth surfacing — plan terminal,
+	// implement terminal, review terminal, etc. The notifier itself
+	// short-circuits for non-issue triggers; for issue triggers it
+	// edits the seeded comment in place.
+	s.notifyStatusUpdate(r.Context(), runID, "trace_handler")
 }
 
 // notifyPlanReady fires the plan-ready comment-back hook after a
@@ -379,6 +386,30 @@ func (s *Server) notifyPlanReady(r *http.Request, runID uuid.UUID, stage *run.St
 			"plan-ready notify: comment-back failed",
 			slog.String("run_id", runID.String()),
 			slog.String("stage_id", stage.ID.String()),
+			slog.String("error", err.Error()),
+		)
+	}
+}
+
+// notifyStatusUpdate is the best-effort sticky-comment hook called
+// from every meaningful transition (E20.4 / #330). The notifier
+// short-circuits for non-issue triggers + handles its own dedup +
+// 404-recovery; here we just call it and log on failure. The state
+// machine is authoritative; the comment is a UI mirror.
+//
+// `source` is a short tag identifying the call site (e.g.
+// "trace_handler", "approval_submit", "pr_merged"). It lands in the
+// log line as a slog attribute so operators tailing logs can pinpoint
+// which transition tripped a notify failure.
+func (s *Server) notifyStatusUpdate(ctx context.Context, runID uuid.UUID, source string) {
+	if s.issueNotifier == nil {
+		return
+	}
+	if err := s.issueNotifier.NotifyStatusUpdateForRun(ctx, runID); err != nil {
+		s.cfg.Logger.LogAttrs(ctx, slog.LevelWarn,
+			"status comment update failed",
+			slog.String("source", source),
+			slog.String("run_id", runID.String()),
 			slog.String("error", err.Error()),
 		)
 	}

--- a/backend/internal/webhook/dispatcher.go
+++ b/backend/internal/webhook/dispatcher.go
@@ -530,6 +530,10 @@ type IssueNotifier interface {
 	// Per-attempt dedup via the audit log; failures log but don't
 	// unwind the dispatch.
 	NotifyCIRetry(ctx context.Context, runID uuid.UUID, parentRunID uuid.UUID, checkName string, attempt, max int) error
+	// NotifyStatusUpdateForRun creates-or-edits the run's sticky
+	// status comment (E20.4 / #330). Best-effort; failures here
+	// don't unwind the calling transition.
+	NotifyStatusUpdateForRun(ctx context.Context, runID uuid.UUID) error
 }
 
 // ApprovalCommandHandler executes a slash-command approval / reject
@@ -804,6 +808,20 @@ func (d *Dispatcher) Handle(ctx context.Context, ev Event) error {
 			d.logger().LogAttrs(ctx, slog.LevelWarn,
 				"pickup comment-back failed",
 				slog.String("delivery_id", ev.DeliveryID),
+				slog.String("run_id", created.ID.String()),
+				slog.String("error", err.Error()),
+			)
+		}
+		// Sticky-status seed (E20.4 / #330): post the initial
+		// status comment so the operator sees current stage/state
+		// in the issue thread. Subsequent transitions edit this
+		// comment in place. Best-effort, separate from the pickup
+		// post: pickup is a one-shot acknowledgment; the status
+		// comment is the durable live view.
+		if err := d.IssueNotifier.NotifyStatusUpdateForRun(ctx, created.ID); err != nil {
+			d.logger().LogAttrs(ctx, slog.LevelWarn,
+				"status comment update failed",
+				slog.String("source", "dispatcher.create_run"),
 				slog.String("run_id", created.ID.String()),
 				slog.String("error", err.Error()),
 			)

--- a/backend/internal/webhook/dispatcher_test.go
+++ b/backend/internal/webhook/dispatcher_test.go
@@ -1880,10 +1880,11 @@ workflows:
 // dispatcher's pickup-ack hook can be asserted on without standing
 // up the full issuecomment package wiring.
 type stubIssueNotifier struct {
-	mu         sync.Mutex
-	calls      []stubNotifyCall
-	retryCalls []stubCIRetryCall
-	err        error
+	mu          sync.Mutex
+	calls       []stubNotifyCall
+	retryCalls  []stubCIRetryCall
+	statusCalls []uuid.UUID
+	err         error
 }
 
 type stubNotifyCall struct {
@@ -1917,6 +1918,13 @@ func (s *stubIssueNotifier) NotifyCIRetry(_ context.Context, runID, parentRunID 
 		runID: runID, parentRunID: parentRunID,
 		checkName: checkName, attempt: attempt, max: max,
 	})
+	return s.err
+}
+
+func (s *stubIssueNotifier) NotifyStatusUpdateForRun(_ context.Context, runID uuid.UUID) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.statusCalls = append(s.statusCalls, runID)
 	return s.err
 }
 
@@ -1964,6 +1972,65 @@ func TestHandle_NotifyPickupError_DoesntFailDispatch(t *testing.T) {
 	}
 	if len(notifier.calls) != 1 {
 		t.Errorf("notifier should still be called once; got %d", len(notifier.calls))
+	}
+}
+
+// TestHandle_IssueTrigger_FiresStatusUpdate is the dispatcher-side
+// integration test for E20.4 / #330. After CreateRun succeeds, the
+// dispatcher seeds the sticky status comment so the operator sees
+// the run's initial stage list in the issue thread without needing
+// to wait for the first trace upload.
+func TestHandle_IssueTrigger_FiresStatusUpdate(t *testing.T) {
+	d, _, runs, _ := newDispatcherWithStubs(t)
+	notifier := &stubIssueNotifier{}
+	d.IssueNotifier = notifier
+
+	if err := d.Handle(context.Background(), issueLabeledEvent(t)); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if len(notifier.statusCalls) != 1 {
+		t.Fatalf("expected 1 NotifyStatusUpdateForRun call; got %d", len(notifier.statusCalls))
+	}
+	created := runs.created[0]
+	if notifier.statusCalls[0] != created.ID {
+		t.Errorf("status-update runID = %s, want %s", notifier.statusCalls[0], created.ID)
+	}
+}
+
+// TestHandle_DispatchFailure_SuppressesStatusUpdate locks the
+// failure-path behavior in: the dispatcher only seeds the sticky
+// status comment when the workflow_dispatch call succeeded —
+// commenting "Plan stage: dispatched" on a run whose dispatch
+// returned 422 would be misleading. Mirrors the pickup-comment
+// gate at the same call site.
+func TestHandle_DispatchFailure_SuppressesStatusUpdate(t *testing.T) {
+	d, gh, _, _ := newDispatcherWithStubs(t)
+	gh.dispatchErr = errors.New("422 invalid ref")
+	notifier := &stubIssueNotifier{}
+	d.IssueNotifier = notifier
+
+	if err := d.Handle(context.Background(), issueLabeledEvent(t)); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if len(notifier.statusCalls) != 0 {
+		t.Errorf("status update should not fire when dispatch failed; got %d calls", len(notifier.statusCalls))
+	}
+}
+
+// TestHandle_StatusUpdateError_DoesntFailDispatch covers the
+// best-effort posture: a status-comment write failure logs but
+// never unwinds the dispatch. The run is already in the DB; the
+// status comment is operator UI, not state.
+func TestHandle_StatusUpdateError_DoesntFailDispatch(t *testing.T) {
+	d, _, _, _ := newDispatcherWithStubs(t)
+	notifier := &stubIssueNotifier{err: errors.New("403 forbidden")}
+	d.IssueNotifier = notifier
+
+	if err := d.Handle(context.Background(), issueLabeledEvent(t)); err != nil {
+		t.Errorf("Handle should swallow status-update errors; got %v", err)
+	}
+	if len(notifier.statusCalls) != 1 {
+		t.Errorf("notifier should still be called once; got %d", len(notifier.statusCalls))
 	}
 }
 


### PR DESCRIPTION
## Summary

- Wires `NotifyStatusUpdateForRun` at every transition listed in #330: dispatcher (run-create), trace handler (any terminal stage), HTTP + slash-command approval handlers, PR-artifact landing, PR closed (merge / no-merge, with / without a review stage), and the retry endpoint.
- Adds `NotifyStatusUpdateForRun(ctx, runID)` on `issuecomment.Notifier` — the convenience method transition-point callers use. It loads the run, stages, and audit chain, renders via `RenderStatusBody` (E20.3 / #329), and dispatches to the existing `NotifyStatusUpdate(ctx, runID, body)`. Skips silently for non-issue triggers.
- Adds `Server.notifyStatusUpdate(ctx, runID, source)` — a helper that handles the nil-notifier case and logs at WARN on failure. `source` is a short tag (e.g. `"trace_handler"`, `"approval_submit"`, `"pr_merged"`) that lands in the slog attribute so operators can attribute a notify failure to a specific transition.
- Extends `webhook.IssueNotifier` interface with `NotifyStatusUpdateForRun` so the dispatcher seam doesn't need the concrete notifier type.

## Test plan

- [x] `go test -race ./backend/...`
- [x] `golangci-lint run ./backend/...`
- [x] Coverage gate: 82.3% aggregate (≥ 80% threshold)
- [x] Dispatcher integration tests covering: happy path (1 status call after CreateRun), dispatch-failure suppresses the status call, notify error doesn't unwind Handle
- [x] Unit tests for `NotifyStatusUpdateForRun`: first-call creates, second-call edits same comment, non-issue trigger skips, nil-receiver no-op
- [x] Existing plan-approve broadcast tests updated for the new two-comment expectation (broadcast + sticky-status seed); replaced exact-count assertions with body-content matchers (`splitBroadcastAndStatus`, `commentBodies`) so future additions to the comment surface don't break unrelated tests

## Notes

- Best-effort throughout: every call site catches the notifier error and continues. The state machine is authoritative; the comment is a UI mirror.
- The dispatcher seam is gated behind `dispatchErr == nil && m.TriggerSource == run.TriggerGitHubIssue` (mirrors the existing pickup-comment gate). Commenting "Plan stage: dispatched" on a run whose `workflow_dispatch` returned 422 would be misleading.
- The convenience method's category-filtering for the activity section happens inside `RenderStatusBody`; this PR doesn't change which audit categories the comment surfaces.
- The PR-merged path fires the status update twice when there's a review stage (once on the audit-only no-review branch which doesn't apply, once on the post-transition success path). The dedup is intentional: the same comment id is the target both times.

E20.5 (#331) — integration tests for the full status-comment lifecycle — is the next ticket in E20.

Closes #330