### PR TITLE
cli: fishhawk plan approve <run-id> (E18.1 / #332)

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -13,17 +13,18 @@ This directory is its own Go module (`github.com/kuhlman-labs/fishhawk/cli`) so 
 
 ## Status
 
-E6.1 (#55), E6.2 (#33), E6.3 (#34), E6.4 (#35), E6.5 (#36) shipped: scaffold + `run start`, `run status`, `run list`, `run cancel`, `run open`, `validate`.
+E6.1 (#55), E6.2 (#33), E6.3 (#34), E6.4 (#35), E6.5 (#36) shipped: scaffold + `run start`, `run status`, `run list`, `run cancel`, `run open`, `validate`. E18.1 (#332) added `plan approve`.
 
 ## Subcommands
 
 ```
-fishhawk run start  --repo R --workflow W --workflow-sha S [--trigger-ref REF]
-fishhawk run status <run-id> [--output text|json]
-fishhawk run list   [--repo R] [--workflow W] [--state S] [--limit N] [--cursor C]
-fishhawk run cancel <run-id>
-fishhawk run open   <run-id> [--print-url]
-fishhawk validate   [path]                   # default: .fishhawk/workflows.yaml
+fishhawk run start    --repo R --workflow W --workflow-sha S [--trigger-ref REF]
+fishhawk run status   <run-id> [--output text|json]
+fishhawk run list     [--repo R] [--workflow W] [--state S] [--limit N] [--cursor C]
+fishhawk run cancel   <run-id>
+fishhawk run open     <run-id> [--print-url]
+fishhawk plan approve <run-id> [--reason R] [--output text|json]
+fishhawk validate     [path]                   # default: .fishhawk/workflows.yaml
 fishhawk version
 ```
 
@@ -66,6 +67,9 @@ Or from this directory directly:
 
     # List recent runs
     fishhawk run list --state running --limit 25
+
+    # Approve the plan stage on a run from the terminal (ADR-019 / #320)
+    fishhawk plan approve <run-id> --reason "scope looks right"
 
 ## See also
 

--- a/cli/cmd/fishhawk/main.go
+++ b/cli/cmd/fishhawk/main.go
@@ -3,11 +3,12 @@
 //
 // Subcommands:
 //
-//	fishhawk run start  --repo R --workflow W --workflow-sha S [--trigger-ref REF]
-//	fishhawk run status <run-id> [--output text|json]
-//	fishhawk run list   [--repo R] [--workflow W] [--state S] [--limit N]
-//	fishhawk run cancel <run-id>
-//	fishhawk run open   <run-id>
+//	fishhawk run start    --repo R --workflow W --workflow-sha S [--trigger-ref REF]
+//	fishhawk run status   <run-id> [--output text|json]
+//	fishhawk run list     [--repo R] [--workflow W] [--state S] [--limit N]
+//	fishhawk run cancel   <run-id>
+//	fishhawk run open     <run-id>
+//	fishhawk plan approve <run-id> [--reason ...] [--output text|json]
 //
 // Auth is the same `bearerToken` scheme defined in the OpenAPI:
 // CLI sends `Authorization: Bearer <token>` from --token /
@@ -50,6 +51,8 @@ func run(args []string, stdout, stderr io.Writer) int {
 		return exitUsage
 	case "run":
 		return runRun(rest, stdout, stderr)
+	case "plan":
+		return runPlan(rest, stdout, stderr)
 	case "validate":
 		return runValidate(rest, stdout, stderr)
 	case "version", "--version":
@@ -89,6 +92,7 @@ func printUsage(w io.Writer) {
 		"  run list     List runs with optional filters.",
 		"  run cancel   Cancel an in-flight run.",
 		"  run open     Open a run's detail page in the browser.",
+		"  plan approve Approve the plan stage on a run.",
 		"  validate     Validate a workflow spec file locally.",
 		"  version      Print the CLI version and exit.",
 		"  help         Show this help.",

--- a/cli/cmd/fishhawk/main_test.go
+++ b/cli/cmd/fishhawk/main_test.go
@@ -78,13 +78,23 @@ type fakeBackend struct {
 	cancelledID string
 	listQuery   string
 
+	// E18.1 / #332 — captures the last plan-approve request.
+	stagesForRun map[uuid.UUID][]httpclient.Stage
+	approvedID   string
+	approvalBody httpclient.SubmitApprovalInput
+
 	startResp Run
 	getResp   Run
 	listResp  ListResp
 
-	startStatus int
-	getStatus   int
-	listStatus  int
+	// approvalResp returned by POST /v0/stages/{id}/approvals
+	approvalResp httpclient.Stage
+
+	startStatus    int
+	getStatus      int
+	listStatus     int
+	stagesStatus   int
+	approvalStatus int
 }
 
 // Local copies — main.go doesn't import these from the httpclient
@@ -95,9 +105,12 @@ type ListResp = httpclient.ListRunsResult
 func newFakeBackend(t *testing.T) (*fakeBackend, *httptest.Server) {
 	t.Helper()
 	fb := &fakeBackend{
-		startStatus: http.StatusCreated,
-		getStatus:   http.StatusOK,
-		listStatus:  http.StatusOK,
+		startStatus:    http.StatusCreated,
+		getStatus:      http.StatusOK,
+		listStatus:     http.StatusOK,
+		stagesStatus:   http.StatusOK,
+		approvalStatus: http.StatusOK,
+		stagesForRun:   map[uuid.UUID][]httpclient.Stage{},
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /v0/runs", func(w http.ResponseWriter, r *http.Request) {
@@ -130,6 +143,40 @@ func newFakeBackend(t *testing.T) (*fakeBackend, *httptest.Server) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_ = json.NewEncoder(w).Encode(httpclient.Run{ID: uuid.MustParse(r.PathValue("run_id")), State: "cancelled"})
+	})
+	mux.HandleFunc("GET /v0/runs/{run_id}/stages", func(w http.ResponseWriter, r *http.Request) {
+		id, err := uuid.Parse(r.PathValue("run_id"))
+		w.Header().Set("Content-Type", "application/json")
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]any{"error": map[string]any{"code": "validation_failed"}})
+			return
+		}
+		w.WriteHeader(fb.stagesStatus)
+		fb.mu.Lock()
+		items := fb.stagesForRun[id]
+		fb.mu.Unlock()
+		_ = json.NewEncoder(w).Encode(httpclient.ListStagesResult{Items: items})
+	})
+	mux.HandleFunc("POST /v0/stages/{stage_id}/approvals", func(w http.ResponseWriter, r *http.Request) {
+		var in httpclient.SubmitApprovalInput
+		_ = json.NewDecoder(r.Body).Decode(&in)
+		fb.mu.Lock()
+		fb.approvedID = r.PathValue("stage_id")
+		fb.approvalBody = in
+		fb.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(fb.approvalStatus)
+		if fb.approvalStatus >= 400 {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]any{
+					"code":    "invalid_state_transition",
+					"message": "stage is not awaiting_approval",
+				},
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(fb.approvalResp)
 	})
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
@@ -443,6 +490,187 @@ func TestRun_UnknownRunSubcommand(t *testing.T) {
 	got := run([]string{"run", "frobnicate"}, io.Discard, &stderr)
 	if got != exitUsage {
 		t.Errorf("status = %d, want exitUsage", got)
+	}
+}
+
+// --- plan approve (E18.1 / #332) ---
+
+// planApproveStages builds a stage list with a plan stage in the
+// given state plus an implement stage at sequence 2 for shape.
+func planApproveStages(runID uuid.UUID, planState string) []httpclient.Stage {
+	return []httpclient.Stage{
+		{ID: uuid.New(), RunID: runID, Sequence: 1, Type: "plan", State: planState,
+			Executor: httpclient.StageExecutor{Kind: "agent", Ref: "claude-code"}},
+		{ID: uuid.New(), RunID: runID, Sequence: 2, Type: "implement", State: "pending",
+			Executor: httpclient.StageExecutor{Kind: "agent", Ref: "claude-code"}},
+	}
+}
+
+func TestPlanApprove_HappyPath(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	withBackend(t, srv)
+	runID := uuid.New()
+	stages := planApproveStages(runID, "awaiting_approval")
+	planStageID := stages[0].ID
+	fb.stagesForRun[runID] = stages
+	fb.approvalResp = httpclient.Stage{
+		ID: planStageID, RunID: runID, Sequence: 1, Type: "plan",
+		State:    "succeeded",
+		Executor: httpclient.StageExecutor{Kind: "agent", Ref: "claude-code"},
+	}
+
+	var stdout strings.Builder
+	got := run([]string{"plan", "approve", "--reason", "looks good", runID.String()}, &stdout, io.Discard)
+	if got != exitOK {
+		t.Fatalf("status = %d, want exitOK", got)
+	}
+	if fb.approvedID != planStageID.String() {
+		t.Errorf("approved stage_id = %s, want %s", fb.approvedID, planStageID)
+	}
+	if fb.approvalBody.Decision != httpclient.ApprovalApprove {
+		t.Errorf("decision = %q, want approve", fb.approvalBody.Decision)
+	}
+	if fb.approvalBody.Comment != "looks good" {
+		t.Errorf("comment = %q, want 'looks good'", fb.approvalBody.Comment)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, planStageID.String()) {
+		t.Errorf("stdout missing stage id: %s", out)
+	}
+	if !strings.Contains(out, "succeeded") {
+		t.Errorf("stdout missing post-approval state: %s", out)
+	}
+}
+
+func TestPlanApprove_NoAwaitingPlanStage(t *testing.T) {
+	// Plan stage already settled — the operator missed the window
+	// or someone else approved. Surface a clear, actionable message
+	// pointing back at run status.
+	fb, srv := newFakeBackend(t)
+	withBackend(t, srv)
+	runID := uuid.New()
+	fb.stagesForRun[runID] = planApproveStages(runID, "succeeded")
+
+	var stderr strings.Builder
+	got := run([]string{"plan", "approve", runID.String()}, io.Discard, &stderr)
+	if got != exitFailure {
+		t.Errorf("status = %d, want exitFailure", got)
+	}
+	if !strings.Contains(stderr.String(), "no plan stage awaiting approval") {
+		t.Errorf("stderr missing diagnostic: %s", stderr.String())
+	}
+	// Approval endpoint must not be reached.
+	if fb.approvedID != "" {
+		t.Errorf("approval endpoint reached with no awaiting plan stage; stage_id=%s", fb.approvedID)
+	}
+}
+
+func TestPlanApprove_BadUUID(t *testing.T) {
+	_, srv := newFakeBackend(t)
+	withBackend(t, srv)
+	var stderr strings.Builder
+	got := run([]string{"plan", "approve", "not-a-uuid"}, io.Discard, &stderr)
+	if got != exitUsage {
+		t.Errorf("status = %d, want exitUsage", got)
+	}
+	if !strings.Contains(stderr.String(), "not a UUID") {
+		t.Errorf("stderr missing 'not a UUID': %s", stderr.String())
+	}
+}
+
+func TestPlanApprove_MissingArg(t *testing.T) {
+	_, srv := newFakeBackend(t)
+	withBackend(t, srv)
+	var stderr strings.Builder
+	got := run([]string{"plan", "approve"}, io.Discard, &stderr)
+	if got != exitUsage {
+		t.Errorf("status = %d, want exitUsage", got)
+	}
+	if !strings.Contains(stderr.String(), "<run-id> required") {
+		t.Errorf("stderr missing diagnostic: %s", stderr.String())
+	}
+}
+
+func TestPlanApprove_ServerRejection(t *testing.T) {
+	// Server returns 409 invalid_state_transition (e.g. someone else
+	// just approved). The CLI surfaces the API error and exits non-zero.
+	fb, srv := newFakeBackend(t)
+	withBackend(t, srv)
+	runID := uuid.New()
+	fb.stagesForRun[runID] = planApproveStages(runID, "awaiting_approval")
+	fb.approvalStatus = http.StatusConflict
+
+	var stderr strings.Builder
+	got := run([]string{"plan", "approve", runID.String()}, io.Discard, &stderr)
+	if got != exitFailure {
+		t.Errorf("status = %d, want exitFailure", got)
+	}
+	if !strings.Contains(stderr.String(), "invalid_state_transition") {
+		t.Errorf("stderr missing api error code: %s", stderr.String())
+	}
+}
+
+func TestPlanApprove_JSONOutput(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	withBackend(t, srv)
+	runID := uuid.New()
+	stages := planApproveStages(runID, "awaiting_approval")
+	planStageID := stages[0].ID
+	fb.stagesForRun[runID] = stages
+	fb.approvalResp = httpclient.Stage{
+		ID: planStageID, RunID: runID, Sequence: 1, Type: "plan", State: "succeeded",
+		Executor: httpclient.StageExecutor{Kind: "agent", Ref: "claude-code"},
+	}
+
+	var stdout strings.Builder
+	got := run([]string{"plan", "approve", "--output", "json", runID.String()}, &stdout, io.Discard)
+	if got != exitOK {
+		t.Fatalf("status = %d", got)
+	}
+	var decoded httpclient.Stage
+	if err := json.NewDecoder(strings.NewReader(stdout.String())).Decode(&decoded); err != nil {
+		t.Fatalf("decode json: %v\nstdout: %s", err, stdout.String())
+	}
+	if decoded.ID != planStageID {
+		t.Errorf("ID = %s, want %s", decoded.ID, planStageID)
+	}
+	if decoded.State != "succeeded" {
+		t.Errorf("State = %q, want succeeded", decoded.State)
+	}
+}
+
+func TestPlanApprove_BadOutputValue(t *testing.T) {
+	_, srv := newFakeBackend(t)
+	withBackend(t, srv)
+	var stderr strings.Builder
+	got := run([]string{"plan", "approve", "--output", "xml", uuid.New().String()}, io.Discard, &stderr)
+	if got != exitUsage {
+		t.Errorf("status = %d, want exitUsage", got)
+	}
+	if !strings.Contains(stderr.String(), "invalid --output") {
+		t.Errorf("stderr missing diagnostic: %s", stderr.String())
+	}
+}
+
+func TestPlan_UnknownSubcommand(t *testing.T) {
+	var stderr strings.Builder
+	got := run([]string{"plan", "frobnicate"}, io.Discard, &stderr)
+	if got != exitUsage {
+		t.Errorf("status = %d, want exitUsage", got)
+	}
+	if !strings.Contains(stderr.String(), "unknown subcommand") {
+		t.Errorf("stderr missing diagnostic: %s", stderr.String())
+	}
+}
+
+func TestPlan_NoSubcommand(t *testing.T) {
+	var stderr strings.Builder
+	got := run([]string{"plan"}, io.Discard, &stderr)
+	if got != exitUsage {
+		t.Errorf("status = %d, want exitUsage", got)
+	}
+	if !strings.Contains(stderr.String(), "subcommand required") {
+		t.Errorf("stderr missing diagnostic: %s", stderr.String())
 	}
 }
 

--- a/cli/cmd/fishhawk/plan.go
+++ b/cli/cmd/fishhawk/plan.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+
+	"github.com/google/uuid"
+
+	"github.com/kuhlman-labs/fishhawk/cli/internal/httpclient"
+)
+
+// runPlan dispatches `fishhawk plan <subcommand>`. Closes the
+// SPA-only gap on plan review per ADR-019 / #320: every action the
+// SPA surfaces must also be reachable from the surfaces developers
+// already use, including the terminal.
+func runPlan(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		_, _ = fmt.Fprintln(stderr, `fishhawk plan: subcommand required (approve)`)
+		return exitUsage
+	}
+	sub, rest := args[0], args[1:]
+	switch sub {
+	case "approve":
+		return planApprove(rest, stdout, stderr)
+	default:
+		_, _ = fmt.Fprintf(stderr, "fishhawk plan: unknown subcommand %q\n", sub)
+		return exitUsage
+	}
+}
+
+// planApprove implements `fishhawk plan approve <run-id> [--reason ...] [--output text|json]`.
+// Resolves the plan stage from the run id (the operator-facing
+// identifier; the SPA exposes stages only as nested sub-routes), then
+// POSTs the approval. Mirrors the slash-command flow's resolution
+// logic so the same "no plan stage awaiting approval" condition
+// surfaces with the same error.
+func planApprove(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("fishhawk plan approve", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	cf := bindCommonFlags(fs)
+	reason := fs.String("reason", "", "optional approval comment recorded on the approval row")
+	outputFmt := fs.String("output", "text", "output format: text | json")
+	fs.StringVar(outputFmt, "o", "text", "output format: text | json (shorthand)")
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+	if err := validateOutputFormat(*outputFmt); err != nil {
+		_, _ = fmt.Fprintf(stderr, "fishhawk plan approve: %v\n", err)
+		return exitUsage
+	}
+	if fs.NArg() != 1 {
+		_, _ = fmt.Fprintln(stderr, "fishhawk plan approve: <run-id> required")
+		return exitUsage
+	}
+	runID, err := uuid.Parse(fs.Arg(0))
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "fishhawk plan approve: %q is not a UUID: %v\n", fs.Arg(0), err)
+		return exitUsage
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), *cf.timeout)
+	defer cancel()
+	client := newClient(cf)
+
+	stages, err := client.ListRunStages(ctx, runID)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "fishhawk plan approve: list stages: %v\n", err)
+		return exitOnAPIError(err)
+	}
+	planStage := findAwaitingApprovalPlanStage(stages.Items)
+	if planStage == nil {
+		_, _ = fmt.Fprintf(stderr,
+			"fishhawk plan approve: run %s has no plan stage awaiting approval (check `fishhawk run status %s`)\n",
+			runID, runID)
+		return exitFailure
+	}
+
+	stage, err := client.SubmitApproval(ctx, planStage.ID, httpclient.SubmitApprovalInput{
+		Decision: httpclient.ApprovalApprove,
+		Comment:  *reason,
+	})
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "fishhawk plan approve: %v\n", err)
+		return exitOnAPIError(err)
+	}
+
+	switch *outputFmt {
+	case "json":
+		if err := json.NewEncoder(stdout).Encode(stage); err != nil {
+			_, _ = fmt.Fprintf(stderr, "fishhawk plan approve: encode: %v\n", err)
+			return exitFailure
+		}
+	default:
+		printStage(stdout, stage)
+	}
+	return exitOK
+}
+
+// findAwaitingApprovalPlanStage walks the stage list (sequence
+// ascending) and returns the first plan stage in awaiting_approval.
+// Returns nil when no such stage exists — the caller surfaces a
+// help message naming the run.
+func findAwaitingApprovalPlanStage(stages []httpclient.Stage) *httpclient.Stage {
+	for i := range stages {
+		if stages[i].Type == "plan" && stages[i].State == "awaiting_approval" {
+			return &stages[i]
+		}
+	}
+	return nil
+}
+
+// validateOutputFormat enforces the text | json contract for
+// --output. Centralized so future subcommands can reuse the check
+// without diverging on the error wording.
+func validateOutputFormat(v string) error {
+	switch v {
+	case "text", "json":
+		return nil
+	}
+	return errors.New("invalid --output (want text|json)")
+}
+
+// printStage renders a Stage as a small block of human-readable
+// lines. Mirrors printRun's shape so the SPA's stage-detail and the
+// CLI's stage echo share field naming.
+func printStage(w io.Writer, s *httpclient.Stage) {
+	_, _ = fmt.Fprintf(w, "id:             %s\n", s.ID)
+	_, _ = fmt.Fprintf(w, "run_id:         %s\n", s.RunID)
+	_, _ = fmt.Fprintf(w, "sequence:       %d\n", s.Sequence)
+	_, _ = fmt.Fprintf(w, "type:           %s\n", s.Type)
+	_, _ = fmt.Fprintf(w, "executor:       %s:%s\n", s.Executor.Kind, s.Executor.Ref)
+	_, _ = fmt.Fprintf(w, "state:          %s\n", s.State)
+	if s.FailureCategory != nil {
+		_, _ = fmt.Fprintf(w, "failure_cat:    %s\n", *s.FailureCategory)
+	}
+	if s.FailureReason != nil {
+		_, _ = fmt.Fprintf(w, "failure_reason: %s\n", *s.FailureReason)
+	}
+}

--- a/cli/internal/httpclient/httpclient.go
+++ b/cli/internal/httpclient/httpclient.go
@@ -171,6 +171,75 @@ func (c *Client) CancelRun(ctx context.Context, id uuid.UUID) (*Run, error) {
 	return &run, nil
 }
 
+// Stage is the CLI-side projection of the OpenAPI Stage schema.
+// Field names + types match the wire shape verbatim. The pointer
+// fields mirror the OpenAPI `[string, "null"]` shape.
+type Stage struct {
+	ID              uuid.UUID     `json:"id"`
+	RunID           uuid.UUID     `json:"run_id"`
+	Sequence        int           `json:"sequence"`
+	Type            string        `json:"type"`
+	Executor        StageExecutor `json:"executor"`
+	State           string        `json:"state"`
+	StartedAt       *time.Time    `json:"started_at"`
+	EndedAt         *time.Time    `json:"ended_at"`
+	FailureCategory *string       `json:"failure_category"`
+	FailureReason   *string       `json:"failure_reason"`
+	CreatedAt       time.Time     `json:"created_at"`
+	UpdatedAt       time.Time     `json:"updated_at"`
+}
+
+// StageExecutor mirrors the OpenAPI executor sub-schema.
+type StageExecutor struct {
+	Kind string `json:"kind"`
+	Ref  string `json:"ref"`
+}
+
+// ListStagesResult is the response envelope for GET /v0/runs/{id}/stages.
+type ListStagesResult struct {
+	Items []Stage `json:"items"`
+}
+
+// ListRunStages calls GET /v0/runs/{run_id}/stages. Stages come back
+// ordered by sequence ascending.
+func (c *Client) ListRunStages(ctx context.Context, runID uuid.UUID) (*ListStagesResult, error) {
+	var res ListStagesResult
+	if err := c.do(ctx, http.MethodGet, "/v0/runs/"+runID.String()+"/stages", nil, &res); err != nil {
+		return nil, err
+	}
+	return &res, nil
+}
+
+// ApprovalDecision is the typed enum the approvals endpoint accepts.
+type ApprovalDecision string
+
+// Approval decisions.
+const (
+	ApprovalApprove ApprovalDecision = "approve"
+	ApprovalReject  ApprovalDecision = "reject"
+)
+
+// SubmitApprovalInput is the request body for POST /v0/stages/{id}/approvals.
+type SubmitApprovalInput struct {
+	Decision ApprovalDecision `json:"decision"`
+	Comment  string           `json:"comment,omitempty"`
+}
+
+// SubmitApproval calls POST /v0/stages/{stage_id}/approvals.
+// The response is the updated Stage with state transitioned to
+// succeeded (approve) or failed (reject).
+func (c *Client) SubmitApproval(ctx context.Context, stageID uuid.UUID, in SubmitApprovalInput) (*Stage, error) {
+	body, err := json.Marshal(in)
+	if err != nil {
+		return nil, fmt.Errorf("marshal: %w", err)
+	}
+	var stage Stage
+	if err := c.do(ctx, http.MethodPost, "/v0/stages/"+stageID.String()+"/approvals", body, &stage); err != nil {
+		return nil, err
+	}
+	return &stage, nil
+}
+
 // do performs the request and decodes the JSON body into out (or
 // reads the error envelope on non-2xx and returns *APIError).
 func (c *Client) do(ctx context.Context, method, path string, body []byte, out any) error {


### PR DESCRIPTION
## Summary

Adds `fishhawk plan approve <run-id> [--reason R] [--output text|json]` — closes the SPA-only gap on plan approval per ADR-019 / #320.

- CLI takes the run id (the operator-facing identifier), resolves the plan stage via `GET /v0/runs/{id}/stages`, and POSTs the approval to `/v0/stages/{plan-stage-id}/approvals`.
- httpclient gains typed wrappers for the new endpoints: `Stage` / `StageExecutor` / `ListStagesResult` types mirroring the OpenAPI Stage schema, `ListRunStages` and `SubmitApproval` methods, and an `ApprovalDecision` typed enum so callers can't typo the literal string.
- Output format mirrors `run status`'s pattern: key/value text by default, JSON when `--output json` is set. The bad-output-value check short-circuits before the network call (same posture as `run status`).
- When the plan stage has already settled (race with the slash command or the dashboard), the CLI surfaces a clear "no plan stage awaiting approval" error pointing back at `fishhawk run status`.

## Test plan

- [x] `go test -race ./cli/...`
- [x] `golangci-lint run ./...`
- [x] Coverage gate: 82.3% aggregate (≥ 80% threshold)
- [x] Seven planApprove cases: happy path, no-awaiting-stage, bad UUID, missing arg, server rejection (409 invalid_state_transition), JSON output, bad output value (short-circuits before network)
- [x] Two dispatch guards: TestPlan_UnknownSubcommand / TestPlan_NoSubcommand mirror their `run` equivalents

## Notes

- v0 takes a run UUID only (per the issue's "out of scope" note). `fishhawk plan approve issue:42` resolution is future work.
- `--reason` maps to the approval row's `comment` field — same wire shape the slash command uses.
- `cli/README.md` updated to list the new subcommand alongside `run *` and `validate`.

Closes #332