### PR TITLE
cli: fishhawk plan reject <run-id> (E18.2 / #333)

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -13,7 +13,7 @@ This directory is its own Go module (`github.com/kuhlman-labs/fishhawk/cli`) so 
 
 ## Status
 
-E6.1 (#55), E6.2 (#33), E6.3 (#34), E6.4 (#35), E6.5 (#36) shipped: scaffold + `run start`, `run status`, `run list`, `run cancel`, `run open`, `validate`. E18.1 (#332) added `plan approve`.
+E6.1 (#55), E6.2 (#33), E6.3 (#34), E6.4 (#35), E6.5 (#36) shipped: scaffold + `run start`, `run status`, `run list`, `run cancel`, `run open`, `validate`. E18.1 (#332) and E18.2 (#333) added `plan approve` and `plan reject`.
 
 ## Subcommands
 
@@ -24,6 +24,7 @@ fishhawk run list     [--repo R] [--workflow W] [--state S] [--limit N] [--curso
 fishhawk run cancel   <run-id>
 fishhawk run open     <run-id> [--print-url]
 fishhawk plan approve <run-id> [--reason R] [--output text|json]
+fishhawk plan reject  <run-id> [--reason R] [--output text|json]
 fishhawk validate     [path]                   # default: .fishhawk/workflows.yaml
 fishhawk version
 ```
@@ -70,6 +71,9 @@ Or from this directory directly:
 
     # Approve the plan stage on a run from the terminal (ADR-019 / #320)
     fishhawk plan approve <run-id> --reason "scope looks right"
+
+    # Reject — recording a reason is encouraged but not required
+    fishhawk plan reject <run-id> --reason "scope too wide; split the migration"
 
 ## See also
 

--- a/cli/cmd/fishhawk/main.go
+++ b/cli/cmd/fishhawk/main.go
@@ -9,6 +9,7 @@
 //	fishhawk run cancel   <run-id>
 //	fishhawk run open     <run-id>
 //	fishhawk plan approve <run-id> [--reason ...] [--output text|json]
+//	fishhawk plan reject  <run-id> [--reason ...] [--output text|json]
 //
 // Auth is the same `bearerToken` scheme defined in the OpenAPI:
 // CLI sends `Authorization: Bearer <token>` from --token /
@@ -93,6 +94,7 @@ func printUsage(w io.Writer) {
 		"  run cancel   Cancel an in-flight run.",
 		"  run open     Open a run's detail page in the browser.",
 		"  plan approve Approve the plan stage on a run.",
+		"  plan reject  Reject the plan stage on a run (category-D failure).",
 		"  validate     Validate a workflow spec file locally.",
 		"  version      Print the CLI version and exit.",
 		"  help         Show this help.",

--- a/cli/cmd/fishhawk/main_test.go
+++ b/cli/cmd/fishhawk/main_test.go
@@ -652,6 +652,114 @@ func TestPlanApprove_BadOutputValue(t *testing.T) {
 	}
 }
 
+// --- plan reject (E18.2 / #333) ---
+
+func TestPlanReject_HappyPath(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	withBackend(t, srv)
+	runID := uuid.New()
+	stages := planApproveStages(runID, "awaiting_approval")
+	planStageID := stages[0].ID
+	fb.stagesForRun[runID] = stages
+	cat := "D"
+	reason := "scope too wide"
+	fb.approvalResp = httpclient.Stage{
+		ID: planStageID, RunID: runID, Sequence: 1, Type: "plan", State: "failed",
+		FailureCategory: &cat,
+		FailureReason:   &reason,
+		Executor:        httpclient.StageExecutor{Kind: "agent", Ref: "claude-code"},
+	}
+
+	var stdout, stderr strings.Builder
+	got := run([]string{"plan", "reject", "--reason", "scope too wide", runID.String()}, &stdout, &stderr)
+	if got != exitOK {
+		t.Fatalf("status = %d, want exitOK; stderr=%s", got, stderr.String())
+	}
+	if fb.approvedID != planStageID.String() {
+		t.Errorf("approved stage_id = %s, want %s", fb.approvedID, planStageID)
+	}
+	if fb.approvalBody.Decision != httpclient.ApprovalReject {
+		t.Errorf("decision = %q, want reject", fb.approvalBody.Decision)
+	}
+	if fb.approvalBody.Comment != "scope too wide" {
+		t.Errorf("comment = %q", fb.approvalBody.Comment)
+	}
+	out := stdout.String()
+	// Output should reflect the failed-D state and the rejection
+	// reason, otherwise the user runs an extra `run status` to
+	// understand what happened.
+	if !strings.Contains(out, "failed") {
+		t.Errorf("stdout missing 'failed' state: %s", out)
+	}
+	if !strings.Contains(out, "D") {
+		t.Errorf("stdout missing failure category 'D': %s", out)
+	}
+	// --reason was provided so no warning should fire.
+	if strings.Contains(stderr.String(), "warning") {
+		t.Errorf("unexpected warning when --reason set: %s", stderr.String())
+	}
+}
+
+func TestPlanReject_NoReasonWarns(t *testing.T) {
+	// Reject without --reason is wire-legal but produces an empty
+	// audit comment. The CLI emits a soft warning to stderr and
+	// proceeds — exit code stays exitOK.
+	fb, srv := newFakeBackend(t)
+	withBackend(t, srv)
+	runID := uuid.New()
+	stages := planApproveStages(runID, "awaiting_approval")
+	planStageID := stages[0].ID
+	fb.stagesForRun[runID] = stages
+	fb.approvalResp = httpclient.Stage{
+		ID: planStageID, RunID: runID, Sequence: 1, Type: "plan", State: "failed",
+		Executor: httpclient.StageExecutor{Kind: "agent", Ref: "claude-code"},
+	}
+
+	var stdout, stderr strings.Builder
+	got := run([]string{"plan", "reject", runID.String()}, &stdout, &stderr)
+	if got != exitOK {
+		t.Fatalf("status = %d, want exitOK", got)
+	}
+	if !strings.Contains(stderr.String(), "--reason not provided") {
+		t.Errorf("stderr missing soft warning: %s", stderr.String())
+	}
+	if fb.approvalBody.Comment != "" {
+		t.Errorf("comment = %q, want empty", fb.approvalBody.Comment)
+	}
+}
+
+func TestPlanReject_NoAwaitingPlanStage(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	withBackend(t, srv)
+	runID := uuid.New()
+	fb.stagesForRun[runID] = planApproveStages(runID, "succeeded")
+
+	var stderr strings.Builder
+	got := run([]string{"plan", "reject", "--reason", "x", runID.String()}, io.Discard, &stderr)
+	if got != exitFailure {
+		t.Errorf("status = %d, want exitFailure", got)
+	}
+	if !strings.Contains(stderr.String(), "no plan stage awaiting approval") {
+		t.Errorf("stderr missing diagnostic: %s", stderr.String())
+	}
+	if fb.approvedID != "" {
+		t.Errorf("approval endpoint reached with no awaiting plan stage; stage_id=%s", fb.approvedID)
+	}
+}
+
+func TestPlanReject_BadUUID(t *testing.T) {
+	_, srv := newFakeBackend(t)
+	withBackend(t, srv)
+	var stderr strings.Builder
+	got := run([]string{"plan", "reject", "--reason", "x", "not-a-uuid"}, io.Discard, &stderr)
+	if got != exitUsage {
+		t.Errorf("status = %d, want exitUsage", got)
+	}
+	if !strings.Contains(stderr.String(), "not a UUID") {
+		t.Errorf("stderr missing 'not a UUID': %s", stderr.String())
+	}
+}
+
 func TestPlan_UnknownSubcommand(t *testing.T) {
 	var stderr strings.Builder
 	got := run([]string{"plan", "frobnicate"}, io.Discard, &stderr)

--- a/cli/cmd/fishhawk/plan.go
+++ b/cli/cmd/fishhawk/plan.go
@@ -19,13 +19,15 @@ import (
 // already use, including the terminal.
 func runPlan(args []string, stdout, stderr io.Writer) int {
 	if len(args) == 0 {
-		_, _ = fmt.Fprintln(stderr, `fishhawk plan: subcommand required (approve)`)
+		_, _ = fmt.Fprintln(stderr, `fishhawk plan: subcommand required (approve|reject)`)
 		return exitUsage
 	}
 	sub, rest := args[0], args[1:]
 	switch sub {
 	case "approve":
 		return planApprove(rest, stdout, stderr)
+	case "reject":
+		return planReject(rest, stdout, stderr)
 	default:
 		_, _ = fmt.Fprintf(stderr, "fishhawk plan: unknown subcommand %q\n", sub)
 		return exitUsage
@@ -33,71 +35,115 @@ func runPlan(args []string, stdout, stderr io.Writer) int {
 }
 
 // planApprove implements `fishhawk plan approve <run-id> [--reason ...] [--output text|json]`.
-// Resolves the plan stage from the run id (the operator-facing
-// identifier; the SPA exposes stages only as nested sub-routes), then
-// POSTs the approval. Mirrors the slash-command flow's resolution
-// logic so the same "no plan stage awaiting approval" condition
-// surfaces with the same error.
+// Resolves the plan stage from the run id and POSTs an approve
+// decision.
 func planApprove(args []string, stdout, stderr io.Writer) int {
-	fs := flag.NewFlagSet("fishhawk plan approve", flag.ContinueOnError)
+	return planDecision("fishhawk plan approve", httpclient.ApprovalApprove,
+		args, stdout, stderr)
+}
+
+// planReject implements `fishhawk plan reject <run-id> [--reason ...] [--output text|json]`.
+// Same flow as planApprove but submits a reject decision, which the
+// state machine resolves as a category-D stage failure.
+//
+// The CLI emits a soft warning (to stderr, doesn't change the exit
+// code) when --reason is omitted: rejection without a recorded
+// rationale is allowed but the audit row would have an empty
+// comment, which is unhelpful for the requester reading back what
+// changed.
+func planReject(args []string, stdout, stderr io.Writer) int {
+	return planDecision("fishhawk plan reject", httpclient.ApprovalReject,
+		args, stdout, stderr)
+}
+
+// planDecision is the shared body of `plan approve` / `plan reject`.
+// It owns flag parsing, run-id validation, plan-stage resolution,
+// the approvals POST, and output formatting. The two verbs differ
+// only in the decision passed to SubmitApproval and the soft-warning
+// behavior reject opts into for missing --reason.
+func planDecision(name string, decision httpclient.ApprovalDecision, args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet(name, flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	cf := bindCommonFlags(fs)
-	reason := fs.String("reason", "", "optional approval comment recorded on the approval row")
+	reason := fs.String("reason", "", "optional comment recorded on the approval row")
 	outputFmt := fs.String("output", "text", "output format: text | json")
 	fs.StringVar(outputFmt, "o", "text", "output format: text | json (shorthand)")
 	if err := fs.Parse(args); err != nil {
 		return exitUsage
 	}
 	if err := validateOutputFormat(*outputFmt); err != nil {
-		_, _ = fmt.Fprintf(stderr, "fishhawk plan approve: %v\n", err)
+		_, _ = fmt.Fprintf(stderr, "%s: %v\n", name, err)
 		return exitUsage
 	}
 	if fs.NArg() != 1 {
-		_, _ = fmt.Fprintln(stderr, "fishhawk plan approve: <run-id> required")
+		_, _ = fmt.Fprintf(stderr, "%s: <run-id> required\n", name)
 		return exitUsage
 	}
 	runID, err := uuid.Parse(fs.Arg(0))
 	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "fishhawk plan approve: %q is not a UUID: %v\n", fs.Arg(0), err)
+		_, _ = fmt.Fprintf(stderr, "%s: %q is not a UUID: %v\n", name, fs.Arg(0), err)
 		return exitUsage
+	}
+	if decision == httpclient.ApprovalReject && *reason == "" {
+		// Soft warning. Reject without a reason is wire-legal but
+		// produces an audit row whose comment is empty, leaving the
+		// requester guessing why the plan got blocked. Don't fail
+		// the command — operators sometimes legitimately want a
+		// silent reject (e.g. scripted clean-up) — but make the
+		// loss visible.
+		_, _ = fmt.Fprintf(stderr,
+			"%s: warning: --reason not provided; the approval row will record an empty comment\n", name)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), *cf.timeout)
 	defer cancel()
 	client := newClient(cf)
 
-	stages, err := client.ListRunStages(ctx, runID)
-	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "fishhawk plan approve: list stages: %v\n", err)
-		return exitOnAPIError(err)
-	}
-	planStage := findAwaitingApprovalPlanStage(stages.Items)
+	planStage, exitCode := resolvePlanStage(ctx, client, name, runID, stderr)
 	if planStage == nil {
-		_, _ = fmt.Fprintf(stderr,
-			"fishhawk plan approve: run %s has no plan stage awaiting approval (check `fishhawk run status %s`)\n",
-			runID, runID)
-		return exitFailure
+		return exitCode
 	}
 
 	stage, err := client.SubmitApproval(ctx, planStage.ID, httpclient.SubmitApprovalInput{
-		Decision: httpclient.ApprovalApprove,
+		Decision: decision,
 		Comment:  *reason,
 	})
 	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "fishhawk plan approve: %v\n", err)
+		_, _ = fmt.Fprintf(stderr, "%s: %v\n", name, err)
 		return exitOnAPIError(err)
 	}
 
 	switch *outputFmt {
 	case "json":
 		if err := json.NewEncoder(stdout).Encode(stage); err != nil {
-			_, _ = fmt.Fprintf(stderr, "fishhawk plan approve: encode: %v\n", err)
+			_, _ = fmt.Fprintf(stderr, "%s: encode: %v\n", name, err)
 			return exitFailure
 		}
 	default:
 		printStage(stdout, stage)
 	}
 	return exitOK
+}
+
+// resolvePlanStage finds the plan stage that's awaiting approval on
+// the given run. Returns (stage, exitOK) on success; (nil, exitCode)
+// when no awaiting-approval plan stage exists or the list call
+// failed. Centralized so plan approve / plan reject (and any future
+// plan-* verbs) share the same lookup + error wording.
+func resolvePlanStage(ctx context.Context, client *httpclient.Client, name string, runID uuid.UUID, stderr io.Writer) (*httpclient.Stage, int) {
+	stages, err := client.ListRunStages(ctx, runID)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "%s: list stages: %v\n", name, err)
+		return nil, exitOnAPIError(err)
+	}
+	planStage := findAwaitingApprovalPlanStage(stages.Items)
+	if planStage == nil {
+		_, _ = fmt.Fprintf(stderr,
+			"%s: run %s has no plan stage awaiting approval (check `fishhawk run status %s`)\n",
+			name, runID, runID)
+		return nil, exitFailure
+	}
+	return planStage, exitOK
 }
 
 // findAwaitingApprovalPlanStage walks the stage list (sequence


### PR DESCRIPTION
## Summary

Sibling of E18.1 / #332 — same flow, different decision. Adds `fishhawk plan reject <run-id> [--reason R] [--output text|json]`.

- The CLI resolves the awaiting-approval plan stage on the given run and POSTs `{decision: reject, comment: <reason>}` to `/v0/stages/{id}/approvals`. The state machine resolves a reject as a category-D stage failure; the response carries the `failed` state and category, which the CLI renders so the operator doesn't need to follow up with `run status`.
- **Shared resolution path** — refactored `planApprove` and `planReject` to both call a new `planDecision(name, decision, args, ...)`. The shared body owns flag parsing, run-id validation, plan-stage lookup, the approvals POST, and output formatting. `resolvePlanStage` is the shared helper the acceptance criteria called out; any future `plan-*` verb can reuse it.
- **Soft warning** when `--reason` is omitted on reject: wire-legal, but the audit row's comment ends up empty, leaving the requester guessing why the plan was blocked. The CLI prints a stderr warning and proceeds — exit code stays `exitOK` so scripted clean-up isn't broken.

## Test plan

- [x] `go test -race ./cli/...`
- [x] `golangci-lint run ./cli/...`
- [x] Coverage gate: 82.3% aggregate (≥ 80% threshold)
- [x] Happy path: reject with reason renders failed-D state + category, no warning fires
- [x] No-reason: stderr warning, exit stays OK, empty comment forwarded to the server
- [x] No-awaiting-stage: exitFailure + diagnostic; approval endpoint never reached
- [x] Bad UUID: exitUsage
- [x] Existing `planApprove` tests verified clean against the refactor (no behavior change for approve)

## Notes

- v0 takes a run UUID only (same out-of-scope as E18.1).
- The `--reason` flag maps to the approval row's `comment` field — same wire shape the HTTP approval handler and the slash command write.
- `cli/README.md` updated to list `plan reject` alongside `plan approve`.

Closes #333