### PR TITLE
cli: fishhawk run retry <stage-id> (E18.3 / #334)

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -13,7 +13,7 @@ This directory is its own Go module (`github.com/kuhlman-labs/fishhawk/cli`) so 
 
 ## Status
 
-E6.1 (#55), E6.2 (#33), E6.3 (#34), E6.4 (#35), E6.5 (#36) shipped: scaffold + `run start`, `run status`, `run list`, `run cancel`, `run open`, `validate`. E18.1 (#332) and E18.2 (#333) added `plan approve` and `plan reject`.
+E6.1 (#55), E6.2 (#33), E6.3 (#34), E6.4 (#35), E6.5 (#36) shipped: scaffold + `run start`, `run status`, `run list`, `run cancel`, `run open`, `validate`. E18.1 (#332), E18.2 (#333), E18.3 (#334) added `plan approve`, `plan reject`, `run retry`.
 
 ## Subcommands
 
@@ -23,11 +23,14 @@ fishhawk run status   <run-id> [--output text|json]
 fishhawk run list     [--repo R] [--workflow W] [--state S] [--limit N] [--cursor C]
 fishhawk run cancel   <run-id>
 fishhawk run open     <run-id> [--print-url]
+fishhawk run retry    <stage-id> [--output text|json]
 fishhawk plan approve <run-id> [--reason R] [--output text|json]
 fishhawk plan reject  <run-id> [--reason R] [--output text|json]
 fishhawk validate     [path]                   # default: .fishhawk/workflows.yaml
 fishhawk version
 ```
+
+`run retry` takes a **stage** id, not a run id — retry is stage-scoped per the state machine. Pick the failed stage from `fishhawk run status <run-id> --output json` (`.stages[].id`).
 
 ## Global flags
 

--- a/cli/cmd/fishhawk/main.go
+++ b/cli/cmd/fishhawk/main.go
@@ -8,6 +8,7 @@
 //	fishhawk run list     [--repo R] [--workflow W] [--state S] [--limit N]
 //	fishhawk run cancel   <run-id>
 //	fishhawk run open     <run-id>
+//	fishhawk run retry    <stage-id> [--output text|json]
 //	fishhawk plan approve <run-id> [--reason ...] [--output text|json]
 //	fishhawk plan reject  <run-id> [--reason ...] [--output text|json]
 //
@@ -93,6 +94,7 @@ func printUsage(w io.Writer) {
 		"  run list     List runs with optional filters.",
 		"  run cancel   Cancel an in-flight run.",
 		"  run open     Open a run's detail page in the browser.",
+		"  run retry    Retry a failed stage (takes a stage id, not a run id).",
 		"  plan approve Approve the plan stage on a run.",
 		"  plan reject  Reject the plan stage on a run (category-D failure).",
 		"  validate     Validate a workflow spec file locally.",

--- a/cli/cmd/fishhawk/main_test.go
+++ b/cli/cmd/fishhawk/main_test.go
@@ -83,18 +83,27 @@ type fakeBackend struct {
 	approvedID   string
 	approvalBody httpclient.SubmitApprovalInput
 
+	// E18.3 / #334 — captures the last retry request.
+	retriedID string
+
 	startResp Run
 	getResp   Run
 	listResp  ListResp
 
 	// approvalResp returned by POST /v0/stages/{id}/approvals
 	approvalResp httpclient.Stage
+	// retryResp returned by POST /v0/stages/{id}/retry
+	retryResp httpclient.Stage
+	// retryErrCode lets a test request a 4xx response with a typed
+	// API code; empty + retryStatus<400 → happy path.
+	retryErrCode string
 
 	startStatus    int
 	getStatus      int
 	listStatus     int
 	stagesStatus   int
 	approvalStatus int
+	retryStatus    int
 }
 
 // Local copies — main.go doesn't import these from the httpclient
@@ -110,6 +119,7 @@ func newFakeBackend(t *testing.T) (*fakeBackend, *httptest.Server) {
 		listStatus:     http.StatusOK,
 		stagesStatus:   http.StatusOK,
 		approvalStatus: http.StatusOK,
+		retryStatus:    http.StatusOK,
 		stagesForRun:   map[uuid.UUID][]httpclient.Stage{},
 	}
 	mux := http.NewServeMux()
@@ -157,6 +167,27 @@ func newFakeBackend(t *testing.T) (*fakeBackend, *httptest.Server) {
 		items := fb.stagesForRun[id]
 		fb.mu.Unlock()
 		_ = json.NewEncoder(w).Encode(httpclient.ListStagesResult{Items: items})
+	})
+	mux.HandleFunc("POST /v0/stages/{stage_id}/retry", func(w http.ResponseWriter, r *http.Request) {
+		fb.mu.Lock()
+		fb.retriedID = r.PathValue("stage_id")
+		fb.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(fb.retryStatus)
+		if fb.retryStatus >= 400 {
+			code := fb.retryErrCode
+			if code == "" {
+				code = "internal_error"
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]any{
+					"code":    code,
+					"message": "retry rejected",
+				},
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(fb.retryResp)
 	})
 	mux.HandleFunc("POST /v0/stages/{stage_id}/approvals", func(w http.ResponseWriter, r *http.Request) {
 		var in httpclient.SubmitApprovalInput
@@ -490,6 +521,140 @@ func TestRun_UnknownRunSubcommand(t *testing.T) {
 	got := run([]string{"run", "frobnicate"}, io.Discard, &stderr)
 	if got != exitUsage {
 		t.Errorf("status = %d, want exitUsage", got)
+	}
+}
+
+// --- run retry (E18.3 / #334) ---
+
+func TestRunRetry_HappyPath(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	withBackend(t, srv)
+	stageID := uuid.New()
+	runID := uuid.New()
+	// Category-A retry path: state flips to dispatched once the
+	// orchestrator hands off workflow_dispatch.
+	fb.retryResp = httpclient.Stage{
+		ID: stageID, RunID: runID, Sequence: 2, Type: "implement",
+		State:    "dispatched",
+		Executor: httpclient.StageExecutor{Kind: "agent", Ref: "claude-code"},
+	}
+
+	var stdout strings.Builder
+	got := run([]string{"run", "retry", stageID.String()}, &stdout, io.Discard)
+	if got != exitOK {
+		t.Fatalf("status = %d, want exitOK", got)
+	}
+	if fb.retriedID != stageID.String() {
+		t.Errorf("retried stage_id = %s, want %s", fb.retriedID, stageID)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, stageID.String()) {
+		t.Errorf("stdout missing stage id: %s", out)
+	}
+	if !strings.Contains(out, "dispatched") {
+		t.Errorf("stdout missing post-retry state: %s", out)
+	}
+}
+
+func TestRunRetry_NotApplicable_409(t *testing.T) {
+	// retry_not_applicable (e.g. category B or gate-rejected D).
+	// The CLI surfaces the API error code verbatim so operators
+	// can switch on it.
+	fb, srv := newFakeBackend(t)
+	withBackend(t, srv)
+	fb.retryStatus = http.StatusUnprocessableEntity
+	fb.retryErrCode = "retry_not_applicable"
+
+	var stderr strings.Builder
+	got := run([]string{"run", "retry", uuid.New().String()}, io.Discard, &stderr)
+	if got != exitFailure {
+		t.Errorf("status = %d, want exitFailure", got)
+	}
+	if !strings.Contains(stderr.String(), "retry_not_applicable") {
+		t.Errorf("stderr missing api code: %s", stderr.String())
+	}
+}
+
+func TestRunRetry_StageNotFound_404(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	withBackend(t, srv)
+	fb.retryStatus = http.StatusNotFound
+	fb.retryErrCode = "stage_not_found"
+
+	var stderr strings.Builder
+	got := run([]string{"run", "retry", uuid.New().String()}, io.Discard, &stderr)
+	if got != exitFailure {
+		t.Errorf("status = %d, want exitFailure", got)
+	}
+	if !strings.Contains(stderr.String(), "stage_not_found") {
+		t.Errorf("stderr missing api code: %s", stderr.String())
+	}
+}
+
+func TestRunRetry_BadUUID(t *testing.T) {
+	_, srv := newFakeBackend(t)
+	withBackend(t, srv)
+	var stderr strings.Builder
+	got := run([]string{"run", "retry", "not-a-uuid"}, io.Discard, &stderr)
+	if got != exitUsage {
+		t.Errorf("status = %d, want exitUsage", got)
+	}
+	if !strings.Contains(stderr.String(), "not a UUID") {
+		t.Errorf("stderr missing 'not a UUID': %s", stderr.String())
+	}
+}
+
+func TestRunRetry_MissingArg(t *testing.T) {
+	_, srv := newFakeBackend(t)
+	withBackend(t, srv)
+	var stderr strings.Builder
+	got := run([]string{"run", "retry"}, io.Discard, &stderr)
+	if got != exitUsage {
+		t.Errorf("status = %d, want exitUsage", got)
+	}
+	if !strings.Contains(stderr.String(), "<stage-id> required") {
+		t.Errorf("stderr missing diagnostic: %s", stderr.String())
+	}
+}
+
+func TestRunRetry_JSONOutput(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	withBackend(t, srv)
+	stageID := uuid.New()
+	runID := uuid.New()
+	fb.retryResp = httpclient.Stage{
+		ID: stageID, RunID: runID, Sequence: 2, Type: "implement",
+		State:    "dispatched",
+		Executor: httpclient.StageExecutor{Kind: "agent", Ref: "claude-code"},
+	}
+
+	var stdout strings.Builder
+	got := run([]string{"run", "retry", "--output", "json", stageID.String()}, &stdout, io.Discard)
+	if got != exitOK {
+		t.Fatalf("status = %d", got)
+	}
+	var decoded httpclient.Stage
+	if err := json.NewDecoder(strings.NewReader(stdout.String())).Decode(&decoded); err != nil {
+		t.Fatalf("decode json: %v\nstdout: %s", err, stdout.String())
+	}
+	if decoded.ID != stageID {
+		t.Errorf("ID = %s, want %s", decoded.ID, stageID)
+	}
+	if decoded.State != "dispatched" {
+		t.Errorf("State = %q", decoded.State)
+	}
+}
+
+func TestRunRetry_BadOutputValue(t *testing.T) {
+	_, srv := newFakeBackend(t)
+	withBackend(t, srv)
+	var stderr strings.Builder
+	got := run([]string{"run", "retry", "--output", "xml", uuid.New().String()}, io.Discard, &stderr)
+	if got != exitUsage {
+		t.Errorf("status = %d, want exitUsage", got)
+	}
+	if !strings.Contains(stderr.String(), "invalid --output") {
+		t.Errorf("stderr missing 'invalid --output': %s", stderr.String())
 	}
 }
 

--- a/cli/cmd/fishhawk/run.go
+++ b/cli/cmd/fishhawk/run.go
@@ -22,7 +22,7 @@ import (
 // token) live in newClient and are consumed by every subcommand.
 func runRun(args []string, stdout, stderr io.Writer) int {
 	if len(args) == 0 {
-		_, _ = fmt.Fprintln(stderr, `fishhawk run: subcommand required (start|status|list|cancel|open)`)
+		_, _ = fmt.Fprintln(stderr, `fishhawk run: subcommand required (start|status|list|cancel|open|retry)`)
 		return exitUsage
 	}
 	sub, rest := args[0], args[1:]
@@ -37,6 +37,8 @@ func runRun(args []string, stdout, stderr io.Writer) int {
 		return runCancel(rest, stdout, stderr)
 	case "open":
 		return runOpen(rest, stdout, stderr)
+	case "retry":
+		return runRetry(rest, stdout, stderr)
 	default:
 		_, _ = fmt.Fprintf(stderr, "fishhawk run: unknown subcommand %q\n", sub)
 		return exitUsage
@@ -252,6 +254,56 @@ func runOpen(args []string, stdout, stderr io.Writer) int {
 		return exitFailure
 	}
 	_, _ = fmt.Fprintln(stdout, url)
+	return exitOK
+}
+
+// runRetry implements `fishhawk run retry <stage-id> [--output text|json]`.
+// Takes a STAGE id, not a run id: retry is stage-scoped per
+// docs/MVP_SPEC §6 (only failed stages are retryable, and the
+// retryable failure categories differ). The CLI doesn't try to
+// resolve which stage the user means — they pass the failed stage's
+// id directly. Server-side rejections (non-failed stage,
+// non-retryable failure category) come back as *APIError with the
+// envelope's code (e.g. `retry_not_applicable`); the CLI surfaces
+// the API error message verbatim.
+func runRetry(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("fishhawk run retry", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	cf := bindCommonFlags(fs)
+	outputFmt := fs.String("output", "text", "output format: text | json")
+	fs.StringVar(outputFmt, "o", "text", "output format: text | json (shorthand)")
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+	if err := validateOutputFormat(*outputFmt); err != nil {
+		_, _ = fmt.Fprintf(stderr, "fishhawk run retry: %v\n", err)
+		return exitUsage
+	}
+	if fs.NArg() != 1 {
+		_, _ = fmt.Fprintln(stderr, "fishhawk run retry: <stage-id> required")
+		return exitUsage
+	}
+	stageID, err := uuid.Parse(fs.Arg(0))
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "fishhawk run retry: %q is not a UUID: %v\n", fs.Arg(0), err)
+		return exitUsage
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), *cf.timeout)
+	defer cancel()
+	stage, err := newClient(cf).RetryStage(ctx, stageID)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "fishhawk run retry: %v\n", err)
+		return exitOnAPIError(err)
+	}
+	switch *outputFmt {
+	case "json":
+		if err := json.NewEncoder(stdout).Encode(stage); err != nil {
+			_, _ = fmt.Fprintf(stderr, "fishhawk run retry: encode: %v\n", err)
+			return exitFailure
+		}
+	default:
+		printStage(stdout, stage)
+	}
 	return exitOK
 }
 

--- a/cli/internal/httpclient/httpclient.go
+++ b/cli/internal/httpclient/httpclient.go
@@ -240,6 +240,20 @@ func (c *Client) SubmitApproval(ctx context.Context, stageID uuid.UUID, in Submi
 	return &stage, nil
 }
 
+// RetryStage calls POST /v0/stages/{stage_id}/retry. The response is
+// the post-retry Stage — typically `dispatched` after orchestrator
+// handoff for category A/C, or `awaiting_approval` for the
+// D-timeout path. Server-side rejections (non-failed stage,
+// non-retryable failure category) surface as *APIError with the
+// envelope's code (e.g. `retry_not_applicable`).
+func (c *Client) RetryStage(ctx context.Context, stageID uuid.UUID) (*Stage, error) {
+	var stage Stage
+	if err := c.do(ctx, http.MethodPost, "/v0/stages/"+stageID.String()+"/retry", nil, &stage); err != nil {
+		return nil, err
+	}
+	return &stage, nil
+}
+
 // do performs the request and decodes the JSON body into out (or
 // reads the error envelope on non-2xx and returns *APIError).
 func (c *Client) do(ctx context.Context, method, path string, body []byte, out any) error {


### PR DESCRIPTION
## Summary

Adds `fishhawk run retry <stage-id> [--output text|json]` — closes the SPA-only gap on stage retry per ADR-019 / #320.

- Takes a **stage** id, not a run id: retry is stage-scoped per MVP_SPEC §6 (the retryable failure categories — A, C, D-timeout — differ from non-retryable B and D-gate-rejected). The CLI doesn't try to resolve which stage to retry; operators who only know the run id can look up the stage with `fishhawk run status <run-id> --output json`.
- `httpclient.RetryStage(ctx, stageID)` wraps `POST /v0/stages/{id}/retry`. Server rejections (`retry_not_applicable`, `stage_not_found`, `validation_failed`) come back as `*APIError` with the envelope code; the CLI surfaces the API error message verbatim.
- Output mirrors the rest of the CLI: text key/value by default, JSON with `--output json`. Bad output values short-circuit before the network call.

## Test plan

- [x] `go test -race ./cli/...`
- [x] `golangci-lint run ./cli/...`
- [x] Coverage gate: 82.3% aggregate (≥ 80% threshold)
- [x] Seven runRetry cases: happy path (dispatched), 422 retry_not_applicable, 404 stage_not_found, bad UUID, missing arg, JSON output, bad output value

## Notes

- v0 stays stage-scoped (per the issue's "out of scope" note). Run-level retry — "retry whichever stage in this run last failed" — is a separate future verb if needed.
- `cli/README.md` updated and explicitly notes the stage-id-not-run-id detail (the gotcha most likely to confuse new users).

Closes #334