### PR TITLE
cli: fishhawk audit list <run-id> (E18.4 / #335)

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -13,7 +13,7 @@ This directory is its own Go module (`github.com/kuhlman-labs/fishhawk/cli`) so 
 
 ## Status
 
-E6.1 (#55), E6.2 (#33), E6.3 (#34), E6.4 (#35), E6.5 (#36) shipped: scaffold + `run start`, `run status`, `run list`, `run cancel`, `run open`, `validate`. E18.1 (#332), E18.2 (#333), E18.3 (#334) added `plan approve`, `plan reject`, `run retry`.
+E6.1 (#55), E6.2 (#33), E6.3 (#34), E6.4 (#35), E6.5 (#36) shipped: scaffold + `run start`, `run status`, `run list`, `run cancel`, `run open`, `validate`. E18.1 (#332), E18.2 (#333), E18.3 (#334), E18.4 (#335) added `plan approve`, `plan reject`, `run retry`, `audit list`.
 
 ## Subcommands
 
@@ -26,11 +26,14 @@ fishhawk run open     <run-id> [--print-url]
 fishhawk run retry    <stage-id> [--output text|json]
 fishhawk plan approve <run-id> [--reason R] [--output text|json]
 fishhawk plan reject  <run-id> [--reason R] [--output text|json]
+fishhawk audit list   <run-id> [--category C] [--stage UUID] [--limit N] [--cursor X] [--output text|json]
 fishhawk validate     [path]                   # default: .fishhawk/workflows.yaml
 fishhawk version
 ```
 
 `run retry` takes a **stage** id, not a run id — retry is stage-scoped per the state machine. Pick the failed stage from `fishhawk run status <run-id> --output json` (`.stages[].id`).
+
+`audit list` outputs NDJSON (one entry per line) when `--output json` is set so a long page can be piped through `head`/`tail` without breaking the parser.
 
 ## Global flags
 
@@ -77,6 +80,10 @@ Or from this directory directly:
 
     # Reject — recording a reason is encouraged but not required
     fishhawk plan reject <run-id> --reason "scope too wide; split the migration"
+
+    # Inspect the audit log without leaving the terminal
+    fishhawk audit list <run-id>
+    fishhawk audit list <run-id> --category approval_submitted --output json | jq .
 
 ## See also
 

--- a/cli/cmd/fishhawk/audit.go
+++ b/cli/cmd/fishhawk/audit.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/kuhlman-labs/fishhawk/cli/internal/httpclient"
+)
+
+// runAudit dispatches `fishhawk audit <subcommand>`. The audit log
+// has been SPA-only until now (per ADR-019 / #320, every dashboard
+// surface needs a terminal equivalent so operators don't have to
+// alt-tab to inspect a run).
+func runAudit(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		_, _ = fmt.Fprintln(stderr, `fishhawk audit: subcommand required (list)`)
+		return exitUsage
+	}
+	sub, rest := args[0], args[1:]
+	switch sub {
+	case "list":
+		return auditList(rest, stdout, stderr)
+	default:
+		_, _ = fmt.Fprintf(stderr, "fishhawk audit: unknown subcommand %q\n", sub)
+		return exitUsage
+	}
+}
+
+// auditList implements `fishhawk audit list <run-id> [--category C] [--stage UUID] [--limit N] [--cursor X] [--output text|json]`.
+//
+// Text output is a four-column table: `seq | category | actor | when
+// | summary`. The summary column is best-effort: payloads vary by
+// category, so the renderer picks a few well-known fields when they
+// exist and falls back to a compact JSON one-liner otherwise.
+//
+// JSON output is NDJSON (one entry per line) rather than a single
+// JSON array — friendlier for jq pipelines and lets the user pipe
+// large pages through `head` without breaking the parser.
+func auditList(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("fishhawk audit list", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	cf := bindCommonFlags(fs)
+	category := fs.String("category", "", "filter by audit category (e.g. plan_generated)")
+	stage := fs.String("stage", "", "filter by stage id (UUID)")
+	limit := fs.Int("limit", 0, "max items per page (server default 50, max 500)")
+	cursor := fs.String("cursor", "", "pagination cursor from a prior list response")
+	outputFmt := fs.String("output", "text", "output format: text | json (ndjson)")
+	fs.StringVar(outputFmt, "o", "text", "output format: text | json (shorthand)")
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+	if err := validateOutputFormat(*outputFmt); err != nil {
+		_, _ = fmt.Fprintf(stderr, "fishhawk audit list: %v\n", err)
+		return exitUsage
+	}
+	if fs.NArg() != 1 {
+		_, _ = fmt.Fprintln(stderr, "fishhawk audit list: <run-id> required")
+		return exitUsage
+	}
+	runID, err := uuid.Parse(fs.Arg(0))
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "fishhawk audit list: %q is not a UUID: %v\n", fs.Arg(0), err)
+		return exitUsage
+	}
+	// --stage is a UUID too; surface a clear local error before the
+	// network round-trip so the operator doesn't get a generic
+	// "validation_failed" from the backend.
+	if *stage != "" {
+		if _, err := uuid.Parse(*stage); err != nil {
+			_, _ = fmt.Fprintf(stderr, "fishhawk audit list: --stage %q is not a UUID: %v\n", *stage, err)
+			return exitUsage
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), *cf.timeout)
+	defer cancel()
+	res, err := newClient(cf).ListRunAudit(ctx, runID, httpclient.ListRunAuditFilter{
+		Category: *category,
+		StageID:  *stage,
+		Limit:    *limit,
+		Cursor:   *cursor,
+	})
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "fishhawk audit list: %v\n", err)
+		return exitOnAPIError(err)
+	}
+
+	switch *outputFmt {
+	case "json":
+		enc := json.NewEncoder(stdout)
+		for i := range res.Items {
+			if err := enc.Encode(res.Items[i]); err != nil {
+				_, _ = fmt.Fprintf(stderr, "fishhawk audit list: encode: %v\n", err)
+				return exitFailure
+			}
+		}
+	default:
+		printAuditTable(stdout, res.Items)
+	}
+	if res.NextCursor != "" {
+		_, _ = fmt.Fprintf(stdout, "\nMore: --cursor %s\n", res.NextCursor)
+	}
+	return exitOK
+}
+
+// printAuditTable renders an audit page as a four-column table. The
+// "summary" column is a best-effort one-liner pulled from the
+// payload; columns are padded to fixed widths so a small page is
+// readable without piping through column(1).
+func printAuditTable(w io.Writer, entries []httpclient.AuditEntry) {
+	if len(entries) == 0 {
+		_, _ = fmt.Fprintln(w, "(no audit entries)")
+		return
+	}
+	_, _ = fmt.Fprintf(w, "%-6s  %-30s  %-15s  %-20s  %s\n", "SEQ", "CATEGORY", "ACTOR", "WHEN", "SUMMARY")
+	for i := range entries {
+		e := &entries[i]
+		actor := "system"
+		if e.ActorSubject != nil && *e.ActorSubject != "" {
+			actor = *e.ActorSubject
+		}
+		when := e.Timestamp.UTC().Format(time.RFC3339)
+		_, _ = fmt.Fprintf(w, "%-6d  %-30s  %-15s  %-20s  %s\n",
+			e.Sequence, truncateColumn(e.Category, 30), truncateColumn(actor, 15),
+			when, summarizePayload(e.Payload))
+	}
+}
+
+// truncateColumn caps s at max with a trailing ellipsis when over
+// budget. Keeps the table aligned on long category / actor strings.
+func truncateColumn(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	if max <= 1 {
+		return s[:max]
+	}
+	return s[:max-1] + "…"
+}
+
+// summarizePayload picks one operator-relevant field out of an
+// audit payload when present, falling back to a compact JSON
+// one-liner. Payloads vary by category — this is best-effort; the
+// JSON / `--output json` path always carries the full body.
+func summarizePayload(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var p map[string]any
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return strings.TrimSpace(string(raw))
+	}
+	// The closed set below tracks the audit categories the SPA
+	// surfaces today. Order matters — earlier keys win.
+	for _, k := range []string{
+		"summary", "message", "reason", "decision",
+		"check_name", "retry_attempt", "kind",
+		"pr_url", "issue_number", "head_sha",
+	} {
+		if v, ok := p[k]; ok && v != nil {
+			s := fmt.Sprint(v)
+			if s != "" {
+				return truncateColumn(s, 64)
+			}
+		}
+	}
+	// Fall back to the compact JSON if no recognized field exists.
+	compact, _ := json.Marshal(p)
+	return truncateColumn(string(compact), 64)
+}

--- a/cli/cmd/fishhawk/main.go
+++ b/cli/cmd/fishhawk/main.go
@@ -11,6 +11,7 @@
 //	fishhawk run retry    <stage-id> [--output text|json]
 //	fishhawk plan approve <run-id> [--reason ...] [--output text|json]
 //	fishhawk plan reject  <run-id> [--reason ...] [--output text|json]
+//	fishhawk audit list   <run-id> [--category C] [--stage UUID] [--limit N] [--cursor X] [--output text|json]
 //
 // Auth is the same `bearerToken` scheme defined in the OpenAPI:
 // CLI sends `Authorization: Bearer <token>` from --token /
@@ -55,6 +56,8 @@ func run(args []string, stdout, stderr io.Writer) int {
 		return runRun(rest, stdout, stderr)
 	case "plan":
 		return runPlan(rest, stdout, stderr)
+	case "audit":
+		return runAudit(rest, stdout, stderr)
 	case "validate":
 		return runValidate(rest, stdout, stderr)
 	case "version", "--version":
@@ -97,6 +100,7 @@ func printUsage(w io.Writer) {
 		"  run retry    Retry a failed stage (takes a stage id, not a run id).",
 		"  plan approve Approve the plan stage on a run.",
 		"  plan reject  Reject the plan stage on a run (category-D failure).",
+		"  audit list   List audit entries for a run.",
 		"  validate     Validate a workflow spec file locally.",
 		"  version      Print the CLI version and exit.",
 		"  help         Show this help.",

--- a/cli/cmd/fishhawk/main_test.go
+++ b/cli/cmd/fishhawk/main_test.go
@@ -86,6 +86,12 @@ type fakeBackend struct {
 	// E18.3 / #334 — captures the last retry request.
 	retriedID string
 
+	// E18.4 / #335 — captures the last audit-list request.
+	auditQuery  string
+	auditRunID  string
+	auditResp   httpclient.ListRunAuditResult
+	auditStatus int
+
 	startResp Run
 	getResp   Run
 	listResp  ListResp
@@ -120,6 +126,7 @@ func newFakeBackend(t *testing.T) (*fakeBackend, *httptest.Server) {
 		stagesStatus:   http.StatusOK,
 		approvalStatus: http.StatusOK,
 		retryStatus:    http.StatusOK,
+		auditStatus:    http.StatusOK,
 		stagesForRun:   map[uuid.UUID][]httpclient.Stage{},
 	}
 	mux := http.NewServeMux()
@@ -167,6 +174,24 @@ func newFakeBackend(t *testing.T) (*fakeBackend, *httptest.Server) {
 		items := fb.stagesForRun[id]
 		fb.mu.Unlock()
 		_ = json.NewEncoder(w).Encode(httpclient.ListStagesResult{Items: items})
+	})
+	mux.HandleFunc("GET /v0/runs/{run_id}/audit", func(w http.ResponseWriter, r *http.Request) {
+		fb.mu.Lock()
+		fb.auditRunID = r.PathValue("run_id")
+		fb.auditQuery = r.URL.RawQuery
+		fb.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(fb.auditStatus)
+		if fb.auditStatus >= 400 {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]any{
+					"code":    "internal_error",
+					"message": "boom",
+				},
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(fb.auditResp)
 	})
 	mux.HandleFunc("POST /v0/stages/{stage_id}/retry", func(w http.ResponseWriter, r *http.Request) {
 		fb.mu.Lock()
@@ -521,6 +546,250 @@ func TestRun_UnknownRunSubcommand(t *testing.T) {
 	got := run([]string{"run", "frobnicate"}, io.Discard, &stderr)
 	if got != exitUsage {
 		t.Errorf("status = %d, want exitUsage", got)
+	}
+}
+
+// --- audit list (E18.4 / #335) ---
+
+func auditEntryFixture(seq int64, runID uuid.UUID, category, actor string, payload map[string]any) httpclient.AuditEntry {
+	body, _ := json.Marshal(payload)
+	var actorPtr *string
+	if actor != "" {
+		s := actor
+		actorPtr = &s
+	}
+	return httpclient.AuditEntry{
+		ID: uuid.New(), Sequence: seq, RunID: runID,
+		Timestamp:    time.Date(2026, 5, 14, 12, 0, int(seq), 0, time.UTC),
+		Category:     category,
+		ActorSubject: actorPtr,
+		Payload:      body,
+		EntryHash:    fmt.Sprintf("hash-%d", seq),
+	}
+}
+
+func TestAuditList_HappyPath_TextOutput(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	withBackend(t, srv)
+	runID := uuid.New()
+	fb.auditResp = httpclient.ListRunAuditResult{
+		Items: []httpclient.AuditEntry{
+			auditEntryFixture(1, runID, "run_dispatched", "", map[string]any{"kind": "issue"}),
+			auditEntryFixture(2, runID, "plan_generated", "system", map[string]any{"summary": "add a feature"}),
+			auditEntryFixture(3, runID, "approval_submitted", "alice", map[string]any{"decision": "approve"}),
+		},
+	}
+
+	var stdout strings.Builder
+	got := run([]string{"audit", "list", runID.String()}, &stdout, io.Discard)
+	if got != exitOK {
+		t.Fatalf("status = %d, want exitOK", got)
+	}
+	if fb.auditRunID != runID.String() {
+		t.Errorf("audit ran against %s, want %s", fb.auditRunID, runID)
+	}
+	out := stdout.String()
+	for _, want := range []string{"SEQ", "CATEGORY", "ACTOR", "WHEN", "SUMMARY",
+		"run_dispatched", "plan_generated", "approval_submitted",
+		"system", "alice", "approve", "add a feature"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stdout missing %q\n---\n%s", want, out)
+		}
+	}
+}
+
+func TestAuditList_FiltersForwarded(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	withBackend(t, srv)
+	runID := uuid.New()
+	stageID := uuid.New()
+	fb.auditResp = httpclient.ListRunAuditResult{Items: nil}
+
+	got := run([]string{
+		"audit", "list",
+		"--category", "approval_submitted",
+		"--stage", stageID.String(),
+		"--limit", "25",
+		"--cursor", "abc",
+		runID.String(),
+	}, io.Discard, io.Discard)
+	if got != exitOK {
+		t.Fatalf("status = %d, want exitOK", got)
+	}
+	q := fb.auditQuery
+	for _, want := range []string{
+		"category=approval_submitted",
+		"stage_id=" + stageID.String(),
+		"limit=25",
+		"cursor=abc",
+	} {
+		if !strings.Contains(q, want) {
+			t.Errorf("query missing %q: %s", want, q)
+		}
+	}
+}
+
+func TestAuditList_EmptyPage(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	withBackend(t, srv)
+	fb.auditResp = httpclient.ListRunAuditResult{Items: nil}
+
+	var stdout strings.Builder
+	got := run([]string{"audit", "list", uuid.New().String()}, &stdout, io.Discard)
+	if got != exitOK {
+		t.Fatalf("status = %d", got)
+	}
+	if !strings.Contains(stdout.String(), "(no audit entries)") {
+		t.Errorf("stdout missing empty-page placeholder: %s", stdout.String())
+	}
+}
+
+func TestAuditList_NextCursorRendered(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	withBackend(t, srv)
+	runID := uuid.New()
+	fb.auditResp = httpclient.ListRunAuditResult{
+		Items:      []httpclient.AuditEntry{auditEntryFixture(1, runID, "run_dispatched", "", nil)},
+		NextCursor: "tok-42",
+	}
+
+	var stdout strings.Builder
+	got := run([]string{"audit", "list", runID.String()}, &stdout, io.Discard)
+	if got != exitOK {
+		t.Fatalf("status = %d", got)
+	}
+	if !strings.Contains(stdout.String(), "--cursor tok-42") {
+		t.Errorf("stdout missing cursor hint: %s", stdout.String())
+	}
+}
+
+func TestAuditList_JSONOutputIsNDJSON(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	withBackend(t, srv)
+	runID := uuid.New()
+	fb.auditResp = httpclient.ListRunAuditResult{
+		Items: []httpclient.AuditEntry{
+			auditEntryFixture(1, runID, "run_dispatched", "system", map[string]any{"kind": "issue"}),
+			auditEntryFixture(2, runID, "plan_generated", "system", map[string]any{"summary": "x"}),
+		},
+	}
+
+	var stdout strings.Builder
+	got := run([]string{"audit", "list", "--output", "json", runID.String()}, &stdout, io.Discard)
+	if got != exitOK {
+		t.Fatalf("status = %d", got)
+	}
+	lines := strings.Split(strings.TrimSpace(stdout.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 NDJSON lines; got %d\n%s", len(lines), stdout.String())
+	}
+	// Each line must round-trip through the AuditEntry shape.
+	for i, line := range lines {
+		var e httpclient.AuditEntry
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			t.Fatalf("line %d not valid AuditEntry json: %v\n%s", i, err, line)
+		}
+		if e.RunID != runID {
+			t.Errorf("line %d run_id = %s, want %s", i, e.RunID, runID)
+		}
+	}
+}
+
+func TestAuditList_BadUUID(t *testing.T) {
+	_, srv := newFakeBackend(t)
+	withBackend(t, srv)
+	var stderr strings.Builder
+	got := run([]string{"audit", "list", "not-a-uuid"}, io.Discard, &stderr)
+	if got != exitUsage {
+		t.Errorf("status = %d, want exitUsage", got)
+	}
+	if !strings.Contains(stderr.String(), "not a UUID") {
+		t.Errorf("stderr missing 'not a UUID': %s", stderr.String())
+	}
+}
+
+func TestAuditList_BadStageUUID(t *testing.T) {
+	// --stage parses locally; surface a clean error without hitting
+	// the backend.
+	fb, srv := newFakeBackend(t)
+	withBackend(t, srv)
+	var stderr strings.Builder
+	got := run([]string{
+		"audit", "list",
+		"--stage", "nope",
+		uuid.New().String(),
+	}, io.Discard, &stderr)
+	if got != exitUsage {
+		t.Errorf("status = %d, want exitUsage", got)
+	}
+	if !strings.Contains(stderr.String(), "--stage") {
+		t.Errorf("stderr missing --stage diagnostic: %s", stderr.String())
+	}
+	if fb.auditRunID != "" {
+		t.Errorf("backend hit despite local --stage validation failure")
+	}
+}
+
+func TestAuditList_MissingArg(t *testing.T) {
+	_, srv := newFakeBackend(t)
+	withBackend(t, srv)
+	var stderr strings.Builder
+	got := run([]string{"audit", "list"}, io.Discard, &stderr)
+	if got != exitUsage {
+		t.Errorf("status = %d, want exitUsage", got)
+	}
+	if !strings.Contains(stderr.String(), "<run-id> required") {
+		t.Errorf("stderr missing diagnostic: %s", stderr.String())
+	}
+}
+
+func TestAuditList_ServerError(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	withBackend(t, srv)
+	fb.auditStatus = http.StatusInternalServerError
+
+	var stderr strings.Builder
+	got := run([]string{"audit", "list", uuid.New().String()}, io.Discard, &stderr)
+	if got != exitFailure {
+		t.Errorf("status = %d, want exitFailure", got)
+	}
+	if !strings.Contains(stderr.String(), "internal_error") {
+		t.Errorf("stderr missing api code: %s", stderr.String())
+	}
+}
+
+func TestAuditList_BadOutputValue(t *testing.T) {
+	_, srv := newFakeBackend(t)
+	withBackend(t, srv)
+	var stderr strings.Builder
+	got := run([]string{"audit", "list", "--output", "xml", uuid.New().String()}, io.Discard, &stderr)
+	if got != exitUsage {
+		t.Errorf("status = %d, want exitUsage", got)
+	}
+	if !strings.Contains(stderr.String(), "invalid --output") {
+		t.Errorf("stderr missing diagnostic: %s", stderr.String())
+	}
+}
+
+func TestAudit_UnknownSubcommand(t *testing.T) {
+	var stderr strings.Builder
+	got := run([]string{"audit", "frobnicate"}, io.Discard, &stderr)
+	if got != exitUsage {
+		t.Errorf("status = %d, want exitUsage", got)
+	}
+	if !strings.Contains(stderr.String(), "unknown subcommand") {
+		t.Errorf("stderr missing diagnostic: %s", stderr.String())
+	}
+}
+
+func TestAudit_NoSubcommand(t *testing.T) {
+	var stderr strings.Builder
+	got := run([]string{"audit"}, io.Discard, &stderr)
+	if got != exitUsage {
+		t.Errorf("status = %d, want exitUsage", got)
+	}
+	if !strings.Contains(stderr.String(), "subcommand required") {
+		t.Errorf("stderr missing diagnostic: %s", stderr.String())
 	}
 }
 

--- a/cli/internal/httpclient/httpclient.go
+++ b/cli/internal/httpclient/httpclient.go
@@ -240,6 +240,69 @@ func (c *Client) SubmitApproval(ctx context.Context, stageID uuid.UUID, in Submi
 	return &stage, nil
 }
 
+// AuditEntry is the CLI-side projection of the OpenAPI AuditEntry
+// schema. Payload is left as raw JSON so the CLI can render or pass
+// through whatever shape a given category emits — categories grow
+// over time and the CLI shouldn't need to track each one.
+type AuditEntry struct {
+	ID           uuid.UUID       `json:"id"`
+	Sequence     int64           `json:"sequence"`
+	RunID        uuid.UUID       `json:"run_id"`
+	StageID      *uuid.UUID      `json:"stage_id"`
+	Timestamp    time.Time       `json:"ts"`
+	Category     string          `json:"category"`
+	ActorKind    *string         `json:"actor_kind"`
+	ActorSubject *string         `json:"actor_subject"`
+	Payload      json.RawMessage `json:"payload"`
+	PrevHash     *string         `json:"prev_hash"`
+	EntryHash    string          `json:"entry_hash"`
+}
+
+// ListRunAuditFilter scopes a ListRunAudit call. Empty values are
+// dropped from the query string; zero Limit lets the server pick its
+// default (50, per the OpenAPI default; 500 max).
+type ListRunAuditFilter struct {
+	Category string
+	StageID  string
+	Limit    int
+	Cursor   string
+}
+
+// ListRunAuditResult is the paginated response envelope.
+type ListRunAuditResult struct {
+	Items      []AuditEntry `json:"items"`
+	NextCursor string       `json:"next_cursor"`
+}
+
+// ListRunAudit calls GET /v0/runs/{run_id}/audit with optional
+// category / stage / pagination filters. Entries come back
+// sequence-ascending; the cursor stays opaque to the CLI — the
+// server defines its encoding.
+func (c *Client) ListRunAudit(ctx context.Context, runID uuid.UUID, f ListRunAuditFilter) (*ListRunAuditResult, error) {
+	q := url.Values{}
+	if f.Category != "" {
+		q.Set("category", f.Category)
+	}
+	if f.StageID != "" {
+		q.Set("stage_id", f.StageID)
+	}
+	if f.Limit > 0 {
+		q.Set("limit", strconv.Itoa(f.Limit))
+	}
+	if f.Cursor != "" {
+		q.Set("cursor", f.Cursor)
+	}
+	path := "/v0/runs/" + runID.String() + "/audit"
+	if encoded := q.Encode(); encoded != "" {
+		path = path + "?" + encoded
+	}
+	var res ListRunAuditResult
+	if err := c.do(ctx, http.MethodGet, path, nil, &res); err != nil {
+		return nil, err
+	}
+	return &res, nil
+}
+
 // RetryStage calls POST /v0/stages/{stage_id}/retry. The response is
 // the post-retry Stage — typically `dispatched` after orchestrator
 // handoff for category A/C, or `awaiting_approval` for the


### PR DESCRIPTION
## Summary

Adds `fishhawk audit list <run-id> [--category C] [--stage UUID] [--limit N] [--cursor X] [--output text|json]` — closes the SPA-only inspection gap per ADR-019 / #320.

- `httpclient` gains `AuditEntry`, `ListRunAuditFilter`, `ListRunAuditResult`, and `ListRunAudit` wrapping `GET /v0/runs/{id}/audit`. `AuditEntry.Payload` stays as `json.RawMessage` so the CLI doesn't need to track each category's payload shape as the vocabulary grows.
- **Text output**: 5-column table (`SEQ | CATEGORY | ACTOR | WHEN | SUMMARY`). The summary column is best-effort, extracted from the payload via a closed set of well-known fields (`summary`, `message`, `reason`, `decision`, `check_name`, `retry_attempt`, `kind`, `pr_url`, `issue_number`, `head_sha`). Falls back to a compact JSON rendering for shapes that don't match. Empty page → `(no audit entries)`.
- **JSON output**: NDJSON (one entry per line). Friendlier for `jq` and lets users pipe through `head`/`tail` without breaking the parser.
- `NextCursor` lands as a `--cursor <tok>` hint after the page so the operator can paginate without re-typing the run id.
- Local `--stage` UUID parse happens before the network round-trip — a bad stage id surfaces a clean usage error instead of waiting for the backend's generic `validation_failed`.

## Test plan

- [x] `go test -race ./cli/...`
- [x] `golangci-lint run ./cli/...`
- [x] Coverage gate: 82.2% aggregate (≥ 80% threshold)
- [x] Twelve auditList cases: happy path text output, filters forwarded (every flag in the query string), empty page placeholder, next-cursor pagination hint, NDJSON one-line-per-entry round-trip, bad run-id UUID, bad `--stage` UUID (asserts the backend is NOT hit), missing arg, server error, bad output value, unknown audit subcommand, no audit subcommand

## Notes

- Per-run only (per the issue's "out of scope"). Cross-run audit search is SPA-only / future work.
- The `tail` verb is E18.5 / #336.
- `cli/README.md` updated with the new verb + the NDJSON detail (the gotcha most likely to confuse jq users).

Closes #335