### PR TITLE
cli: fishhawk audit tail <run-id> (E18.5 / #336)

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -13,7 +13,7 @@ This directory is its own Go module (`github.com/kuhlman-labs/fishhawk/cli`) so 
 
 ## Status
 
-E6.1 (#55), E6.2 (#33), E6.3 (#34), E6.4 (#35), E6.5 (#36) shipped: scaffold + `run start`, `run status`, `run list`, `run cancel`, `run open`, `validate`. E18.1 (#332), E18.2 (#333), E18.3 (#334), E18.4 (#335) added `plan approve`, `plan reject`, `run retry`, `audit list`.
+E6.1 (#55), E6.2 (#33), E6.3 (#34), E6.4 (#35), E6.5 (#36) shipped: scaffold + `run start`, `run status`, `run list`, `run cancel`, `run open`, `validate`. E18.1 (#332), E18.2 (#333), E18.3 (#334), E18.4 (#335), E18.5 (#336) added `plan approve`, `plan reject`, `run retry`, `audit list`, `audit tail`.
 
 ## Subcommands
 
@@ -27,6 +27,7 @@ fishhawk run retry    <stage-id> [--output text|json]
 fishhawk plan approve <run-id> [--reason R] [--output text|json]
 fishhawk plan reject  <run-id> [--reason R] [--output text|json]
 fishhawk audit list   <run-id> [--category C] [--stage UUID] [--limit N] [--cursor X] [--output text|json]
+fishhawk audit tail   <run-id> [--interval D] [--output text|json] [--max-polls N]
 fishhawk validate     [path]                   # default: .fishhawk/workflows.yaml
 fishhawk version
 ```
@@ -34,6 +35,8 @@ fishhawk version
 `run retry` takes a **stage** id, not a run id — retry is stage-scoped per the state machine. Pick the failed stage from `fishhawk run status <run-id> --output json` (`.stages[].id`).
 
 `audit list` outputs NDJSON (one entry per line) when `--output json` is set so a long page can be piped through `head`/`tail` without breaking the parser.
+
+`audit tail` polls the audit endpoint on a configurable interval (default 2s, minimum 500ms) and prints new entries as they land. It exits cleanly on Ctrl-C. There's no server-side SSE today — if streaming demand grows we'd add one and migrate the client.
 
 ## Global flags
 
@@ -84,6 +87,9 @@ Or from this directory directly:
     # Inspect the audit log without leaving the terminal
     fishhawk audit list <run-id>
     fishhawk audit list <run-id> --category approval_submitted --output json | jq .
+
+    # Follow a run's audit log in a side terminal
+    fishhawk audit tail <run-id> --interval 1s
 
 ## See also
 

--- a/cli/cmd/fishhawk/audit.go
+++ b/cli/cmd/fishhawk/audit.go
@@ -3,10 +3,13 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
+	"os/signal"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/google/uuid"
@@ -20,13 +23,15 @@ import (
 // alt-tab to inspect a run).
 func runAudit(args []string, stdout, stderr io.Writer) int {
 	if len(args) == 0 {
-		_, _ = fmt.Fprintln(stderr, `fishhawk audit: subcommand required (list)`)
+		_, _ = fmt.Fprintln(stderr, `fishhawk audit: subcommand required (list|tail)`)
 		return exitUsage
 	}
 	sub, rest := args[0], args[1:]
 	switch sub {
 	case "list":
 		return auditList(rest, stdout, stderr)
+	case "tail":
+		return auditTail(rest, stdout, stderr)
 	default:
 		_, _ = fmt.Fprintf(stderr, "fishhawk audit: unknown subcommand %q\n", sub)
 		return exitUsage
@@ -143,6 +148,165 @@ func truncateColumn(s string, max int) string {
 		return s[:max]
 	}
 	return s[:max-1] + "…"
+}
+
+// auditTail implements `fishhawk audit tail <run-id> [--interval D] [--output text|json] [--max-polls N]`.
+//
+// Polls the audit endpoint on a loop, printing entries with a
+// sequence strictly greater than the high-water mark seen so far.
+// The first poll prints the current page so the operator has
+// context; subsequent polls are forward-only.
+//
+// Polling rather than SSE because no `text/event-stream` endpoint
+// exists today (verified before adding this verb per the issue).
+// If customers ask for streaming we'd add a server-side SSE
+// endpoint and migrate this client to consume it.
+//
+// Lifecycle:
+//   - Exits 0 on SIGINT / SIGTERM (operator hits Ctrl-C).
+//   - Exits 0 when --max-polls is set and reached (primarily for
+//     tests; an operator might use it to cap a scripted tail).
+//   - Exits 1 after N consecutive transport failures (the API has
+//     been unreachable long enough that "tailing" is misleading).
+//     Transient single-poll failures are warned to stderr and the
+//     loop continues — operators tailing during a deploy shouldn't
+//     have to restart.
+func auditTail(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("fishhawk audit tail", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	cf := bindCommonFlags(fs)
+	interval := fs.Duration("interval", 2*time.Second, "poll interval (min 500ms, default 2s)")
+	outputFmt := fs.String("output", "text", "output format: text | json (ndjson)")
+	fs.StringVar(outputFmt, "o", "text", "output format: text | json (shorthand)")
+	// --max-polls primarily exists so tests can bound the loop;
+	// operators can also use it to script a "tail until quiet"
+	// without writing a kill loop themselves.
+	maxPolls := fs.Int("max-polls", 0, "stop after this many polls (0 = forever)")
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+	if err := validateOutputFormat(*outputFmt); err != nil {
+		_, _ = fmt.Fprintf(stderr, "fishhawk audit tail: %v\n", err)
+		return exitUsage
+	}
+	if *interval < 500*time.Millisecond {
+		_, _ = fmt.Fprintf(stderr, "fishhawk audit tail: --interval %s is below the 500ms minimum\n", *interval)
+		return exitUsage
+	}
+	if fs.NArg() != 1 {
+		_, _ = fmt.Fprintln(stderr, "fishhawk audit tail: <run-id> required")
+		return exitUsage
+	}
+	runID, err := uuid.Parse(fs.Arg(0))
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "fishhawk audit tail: %q is not a UUID: %v\n", fs.Arg(0), err)
+		return exitUsage
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+	return runAuditTail(ctx, newClient(cf), runID, auditTailOptions{
+		interval:  *interval,
+		outputFmt: *outputFmt,
+		maxPolls:  *maxPolls,
+	}, stdout, stderr)
+}
+
+type auditTailOptions struct {
+	interval  time.Duration
+	outputFmt string
+	maxPolls  int
+}
+
+// auditTailAPI is the slice of *httpclient.Client runAuditTail needs.
+// Factored as an interface so tests can drive the loop without
+// standing up an httptest server when they want fine-grained
+// per-poll control over what the API returns (e.g. injecting
+// transient errors).
+type auditTailAPI interface {
+	ListRunAudit(ctx context.Context, runID uuid.UUID, f httpclient.ListRunAuditFilter) (*httpclient.ListRunAuditResult, error)
+}
+
+// runAuditTail is the testable loop body. Polls the audit endpoint
+// on `opts.interval`, tracks the high-water sequence, prints new
+// entries, and exits cleanly on ctx cancellation or after
+// `opts.maxPolls` iterations.
+func runAuditTail(ctx context.Context, api auditTailAPI, runID uuid.UUID, opts auditTailOptions, stdout, stderr io.Writer) int {
+	var highWater int64
+	pollCount := 0
+	consecFailures := 0
+	const maxConsecFailures = 5
+
+	enc := json.NewEncoder(stdout)
+	emit := func(e *httpclient.AuditEntry) {
+		if opts.outputFmt == "json" {
+			_ = enc.Encode(e)
+			return
+		}
+		printAuditEntryLine(stdout, e)
+	}
+
+	for {
+		// Pull a full page each poll. Limit=500 (the server max) so
+		// we don't paginate per cycle; for v0 demos the per-run
+		// audit chain is comfortably under that.
+		res, err := api.ListRunAudit(ctx, runID, httpclient.ListRunAuditFilter{Limit: 500})
+		if err != nil {
+			// Treat context-cancel as a clean exit; the SIGINT
+			// handler tripped or the caller bounded the loop.
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return exitOK
+			}
+			consecFailures++
+			_, _ = fmt.Fprintf(stderr,
+				"fishhawk audit tail: poll failed (%d/%d): %v\n",
+				consecFailures, maxConsecFailures, err)
+			if consecFailures >= maxConsecFailures {
+				_, _ = fmt.Fprintf(stderr,
+					"fishhawk audit tail: %d consecutive poll failures; bailing\n",
+					consecFailures)
+				return exitFailure
+			}
+		} else {
+			consecFailures = 0
+			for i := range res.Items {
+				e := &res.Items[i]
+				if e.Sequence <= highWater {
+					continue
+				}
+				emit(e)
+				if e.Sequence > highWater {
+					highWater = e.Sequence
+				}
+			}
+		}
+		pollCount++
+		if opts.maxPolls > 0 && pollCount >= opts.maxPolls {
+			return exitOK
+		}
+		select {
+		case <-ctx.Done():
+			return exitOK
+		case <-time.After(opts.interval):
+		}
+	}
+}
+
+// printAuditEntryLine renders one audit entry as a single-line text
+// row. Same column shape as `audit list` so a user piping tail
+// output side-by-side with a list page sees consistent formatting.
+func printAuditEntryLine(w io.Writer, e *httpclient.AuditEntry) {
+	actor := "system"
+	if e.ActorSubject != nil && *e.ActorSubject != "" {
+		actor = *e.ActorSubject
+	}
+	_, _ = fmt.Fprintf(w, "%-6d  %-30s  %-15s  %-20s  %s\n",
+		e.Sequence,
+		truncateColumn(e.Category, 30),
+		truncateColumn(actor, 15),
+		e.Timestamp.UTC().Format(time.RFC3339),
+		summarizePayload(e.Payload),
+	)
 }
 
 // summarizePayload picks one operator-relevant field out of an

--- a/cli/cmd/fishhawk/audit_tail_test.go
+++ b/cli/cmd/fishhawk/audit_tail_test.go
@@ -1,0 +1,330 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/kuhlman-labs/fishhawk/cli/internal/httpclient"
+)
+
+// stubAuditTailAPI is a programmable auditTailAPI that returns a
+// pre-recorded slice of responses, one per poll, then short-circuits
+// the runAuditTail loop by cancelling the context the test owns. Use
+// `responses` for happy-path polls and `errs[i]` to inject a
+// transport error on the i-th poll.
+type stubAuditTailAPI struct {
+	responses []httpclient.ListRunAuditResult
+	errs      []error
+	polled    atomic.Int32
+}
+
+func (s *stubAuditTailAPI) ListRunAudit(_ context.Context, _ uuid.UUID, _ httpclient.ListRunAuditFilter) (*httpclient.ListRunAuditResult, error) {
+	idx := int(s.polled.Add(1)) - 1
+	if idx < len(s.errs) && s.errs[idx] != nil {
+		return nil, s.errs[idx]
+	}
+	if idx >= len(s.responses) {
+		// Loop continued past what the test programmed; return an
+		// empty page so the loop keeps spinning until ctx fires.
+		return &httpclient.ListRunAuditResult{}, nil
+	}
+	out := s.responses[idx]
+	return &out, nil
+}
+
+func tailEntry(seq int64, runID uuid.UUID, category string, payload map[string]any) httpclient.AuditEntry {
+	body, _ := json.Marshal(payload)
+	return httpclient.AuditEntry{
+		ID: uuid.New(), Sequence: seq, RunID: runID,
+		Timestamp: time.Date(2026, 5, 14, 12, 0, int(seq), 0, time.UTC),
+		Category:  category,
+		Payload:   body,
+		EntryHash: "h",
+	}
+}
+
+func TestAuditTail_PrintsCurrentPageThenNewEntries(t *testing.T) {
+	runID := uuid.New()
+	api := &stubAuditTailAPI{
+		responses: []httpclient.ListRunAuditResult{
+			// Poll 1: current page, two entries.
+			{Items: []httpclient.AuditEntry{
+				tailEntry(1, runID, "run_dispatched", map[string]any{"kind": "issue"}),
+				tailEntry(2, runID, "plan_generated", map[string]any{"summary": "x"}),
+			}},
+			// Poll 2: one new entry beyond the high-water.
+			{Items: []httpclient.AuditEntry{
+				tailEntry(1, runID, "run_dispatched", map[string]any{"kind": "issue"}),
+				tailEntry(2, runID, "plan_generated", map[string]any{"summary": "x"}),
+				tailEntry(3, runID, "approval_submitted", map[string]any{"decision": "approve"}),
+			}},
+		},
+	}
+
+	var stdout strings.Builder
+	rc := runAuditTail(context.Background(), api, runID, auditTailOptions{
+		interval:  time.Millisecond,
+		outputFmt: "text",
+		maxPolls:  2,
+	}, &stdout, io.Discard)
+	if rc != exitOK {
+		t.Fatalf("exit = %d, want exitOK", rc)
+	}
+	out := stdout.String()
+	for _, want := range []string{"run_dispatched", "plan_generated", "approval_submitted"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stdout missing %q\n---\n%s", want, out)
+		}
+	}
+	// Each category should appear exactly once even though poll 2
+	// re-served them — the high-water filter must dedup.
+	for _, cat := range []string{"run_dispatched", "plan_generated", "approval_submitted"} {
+		if got := strings.Count(out, cat); got != 1 {
+			t.Errorf("category %q appeared %d times; want 1 (dedup must filter)\n---\n%s",
+				cat, got, out)
+		}
+	}
+}
+
+func TestAuditTail_NoDuplicates_AcrossManyPolls(t *testing.T) {
+	// The server returns the same page on every poll; the loop
+	// must emit each entry exactly once across many cycles.
+	runID := uuid.New()
+	page := httpclient.ListRunAuditResult{Items: []httpclient.AuditEntry{
+		tailEntry(1, runID, "run_dispatched", nil),
+		tailEntry(2, runID, "plan_generated", nil),
+	}}
+	api := &stubAuditTailAPI{
+		responses: []httpclient.ListRunAuditResult{page, page, page, page},
+	}
+
+	var stdout strings.Builder
+	rc := runAuditTail(context.Background(), api, runID, auditTailOptions{
+		interval:  time.Millisecond,
+		outputFmt: "text",
+		maxPolls:  4,
+	}, &stdout, io.Discard)
+	if rc != exitOK {
+		t.Fatalf("exit = %d", rc)
+	}
+	for _, cat := range []string{"run_dispatched", "plan_generated"} {
+		if got := strings.Count(stdout.String(), cat); got != 1 {
+			t.Errorf("%q appeared %d times; want 1\n%s", cat, got, stdout.String())
+		}
+	}
+}
+
+func TestAuditTail_TransientErrorWarnedAndContinued(t *testing.T) {
+	// One transport error on poll 1; recovers on poll 2. Exit code
+	// stays OK.
+	runID := uuid.New()
+	api := &stubAuditTailAPI{
+		responses: []httpclient.ListRunAuditResult{
+			{}, // ignored on poll 1 (errored)
+			{Items: []httpclient.AuditEntry{tailEntry(1, runID, "run_dispatched", nil)}},
+		},
+		errs: []error{errors.New("connection refused"), nil},
+	}
+
+	var stdout, stderr strings.Builder
+	rc := runAuditTail(context.Background(), api, runID, auditTailOptions{
+		interval:  time.Millisecond,
+		outputFmt: "text",
+		maxPolls:  2,
+	}, &stdout, &stderr)
+	if rc != exitOK {
+		t.Errorf("exit = %d, want exitOK after transient recovery", rc)
+	}
+	if !strings.Contains(stderr.String(), "poll failed (1/5)") {
+		t.Errorf("stderr missing transient-warning: %s", stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "run_dispatched") {
+		t.Errorf("entry after recovery should print: %s", stdout.String())
+	}
+}
+
+func TestAuditTail_PersistentErrorBailsNonZero(t *testing.T) {
+	// Five consecutive failures → exit failure. Sixth poll never
+	// happens.
+	runID := uuid.New()
+	api := &stubAuditTailAPI{
+		errs: []error{
+			errors.New("e1"),
+			errors.New("e2"),
+			errors.New("e3"),
+			errors.New("e4"),
+			errors.New("e5"),
+		},
+	}
+
+	var stderr strings.Builder
+	rc := runAuditTail(context.Background(), api, runID, auditTailOptions{
+		interval:  time.Millisecond,
+		outputFmt: "text",
+		maxPolls:  10,
+	}, io.Discard, &stderr)
+	if rc != exitFailure {
+		t.Errorf("exit = %d, want exitFailure", rc)
+	}
+	if !strings.Contains(stderr.String(), "consecutive poll failures") {
+		t.Errorf("stderr missing bail message: %s", stderr.String())
+	}
+	if got := int(api.polled.Load()); got != 5 {
+		t.Errorf("polled %d times; want 5 (bail at consecutive cap)", got)
+	}
+}
+
+func TestAuditTail_ContextCancelExitsClean(t *testing.T) {
+	// Caller cancels mid-loop; exit code should be 0.
+	runID := uuid.New()
+	api := &stubAuditTailAPI{
+		responses: []httpclient.ListRunAuditResult{
+			{Items: []httpclient.AuditEntry{tailEntry(1, runID, "run_dispatched", nil)}},
+		},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel immediately so the loop exits at the first ctx.Done
+	// poll guard.
+	cancel()
+
+	var stdout strings.Builder
+	rc := runAuditTail(ctx, api, runID, auditTailOptions{
+		interval:  time.Millisecond,
+		outputFmt: "text",
+		maxPolls:  0,
+	}, &stdout, io.Discard)
+	if rc != exitOK {
+		t.Errorf("exit = %d, want exitOK on context cancel", rc)
+	}
+}
+
+func TestAuditTail_JSONOutputIsNDJSON(t *testing.T) {
+	runID := uuid.New()
+	api := &stubAuditTailAPI{
+		responses: []httpclient.ListRunAuditResult{
+			{Items: []httpclient.AuditEntry{
+				tailEntry(1, runID, "run_dispatched", map[string]any{"kind": "issue"}),
+				tailEntry(2, runID, "plan_generated", map[string]any{"summary": "y"}),
+			}},
+		},
+	}
+
+	var stdout strings.Builder
+	rc := runAuditTail(context.Background(), api, runID, auditTailOptions{
+		interval:  time.Millisecond,
+		outputFmt: "json",
+		maxPolls:  1,
+	}, &stdout, io.Discard)
+	if rc != exitOK {
+		t.Fatalf("exit = %d", rc)
+	}
+	lines := strings.Split(strings.TrimSpace(stdout.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 NDJSON lines; got %d\n%s", len(lines), stdout.String())
+	}
+	for _, line := range lines {
+		var e httpclient.AuditEntry
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			t.Fatalf("not valid AuditEntry: %v\n%s", err, line)
+		}
+	}
+}
+
+// --- flag-parsing guards (these go through run([]string{...}) since
+// the dispatch + parsing path is what they exercise) ---
+
+func TestAuditTail_IntervalBelowMinimum_Refused(t *testing.T) {
+	_, srv := newFakeBackend(t)
+	withBackend(t, srv)
+	var stderr strings.Builder
+	rc := run([]string{
+		"audit", "tail", "--interval", "100ms", uuid.New().String(),
+	}, io.Discard, &stderr)
+	if rc != exitUsage {
+		t.Errorf("exit = %d, want exitUsage", rc)
+	}
+	if !strings.Contains(stderr.String(), "500ms minimum") {
+		t.Errorf("stderr missing minimum-interval diagnostic: %s", stderr.String())
+	}
+}
+
+func TestAuditTail_BadUUID(t *testing.T) {
+	_, srv := newFakeBackend(t)
+	withBackend(t, srv)
+	var stderr strings.Builder
+	rc := run([]string{"audit", "tail", "not-a-uuid"}, io.Discard, &stderr)
+	if rc != exitUsage {
+		t.Errorf("exit = %d, want exitUsage", rc)
+	}
+	if !strings.Contains(stderr.String(), "not a UUID") {
+		t.Errorf("stderr missing 'not a UUID': %s", stderr.String())
+	}
+}
+
+func TestAuditTail_MissingArg(t *testing.T) {
+	_, srv := newFakeBackend(t)
+	withBackend(t, srv)
+	var stderr strings.Builder
+	rc := run([]string{"audit", "tail"}, io.Discard, &stderr)
+	if rc != exitUsage {
+		t.Errorf("exit = %d, want exitUsage", rc)
+	}
+	if !strings.Contains(stderr.String(), "<run-id> required") {
+		t.Errorf("stderr missing diagnostic: %s", stderr.String())
+	}
+}
+
+func TestAuditTail_BadOutputValue(t *testing.T) {
+	_, srv := newFakeBackend(t)
+	withBackend(t, srv)
+	var stderr strings.Builder
+	rc := run([]string{
+		"audit", "tail", "--output", "xml", uuid.New().String(),
+	}, io.Discard, &stderr)
+	if rc != exitUsage {
+		t.Errorf("exit = %d, want exitUsage", rc)
+	}
+	if !strings.Contains(stderr.String(), "invalid --output") {
+		t.Errorf("stderr missing diagnostic: %s", stderr.String())
+	}
+}
+
+// TestAuditTail_EndToEnd_WithFakeBackend covers the full integration
+// path: signal-cancelled context, fake httptest backend, bounded by
+// --max-polls. The polling loop, network round-trip, dedup, and
+// rendering are all live; the only fake is the backend itself.
+func TestAuditTail_EndToEnd_WithFakeBackend(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	withBackend(t, srv)
+	runID := uuid.New()
+	fb.auditResp = httpclient.ListRunAuditResult{
+		Items: []httpclient.AuditEntry{
+			tailEntry(1, runID, "run_dispatched", nil),
+			tailEntry(2, runID, "plan_generated", map[string]any{"summary": "y"}),
+		},
+	}
+
+	var stdout strings.Builder
+	rc := run([]string{
+		"audit", "tail",
+		"--interval", "500ms",
+		"--max-polls", "1",
+		runID.String(),
+	}, &stdout, io.Discard)
+	if rc != exitOK {
+		t.Fatalf("exit = %d", rc)
+	}
+	for _, want := range []string{"run_dispatched", "plan_generated"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Errorf("stdout missing %q\n---\n%s", want, stdout.String())
+		}
+	}
+}

--- a/cli/cmd/fishhawk/main.go
+++ b/cli/cmd/fishhawk/main.go
@@ -12,6 +12,7 @@
 //	fishhawk plan approve <run-id> [--reason ...] [--output text|json]
 //	fishhawk plan reject  <run-id> [--reason ...] [--output text|json]
 //	fishhawk audit list   <run-id> [--category C] [--stage UUID] [--limit N] [--cursor X] [--output text|json]
+//	fishhawk audit tail   <run-id> [--interval D] [--output text|json] [--max-polls N]
 //
 // Auth is the same `bearerToken` scheme defined in the OpenAPI:
 // CLI sends `Authorization: Bearer <token>` from --token /
@@ -101,6 +102,7 @@ func printUsage(w io.Writer) {
 		"  plan approve Approve the plan stage on a run.",
 		"  plan reject  Reject the plan stage on a run (category-D failure).",
 		"  audit list   List audit entries for a run.",
+		"  audit tail   Follow the audit log of a run in real time.",
 		"  validate     Validate a workflow spec file locally.",
 		"  version      Print the CLI version and exit.",
 		"  help         Show this help.",


### PR DESCRIPTION
## Summary

Adds `fishhawk audit tail <run-id> [--interval D] [--output text|json] [--max-polls N]` — the follow-the-run terminal command. Operators run it in a side terminal and see audit entries land as the run progresses.

- **Polling, not SSE**: verified no `text/event-stream` handler exists in the backend before scope-creeping this child (per the issue's note). If streaming demand grows we'd add a server-side SSE endpoint and migrate the client.
- **Loop semantics**: first poll prints the current audit chain so the operator has context (matches `tail -f` default); subsequent polls print only entries with sequence > high-water mark. Each poll fetches `limit=500` so a v0-scale chain fits in one cycle.
- **Error tolerance**: transient single-poll failures emit a stderr warning and the loop continues; five consecutive failures bail with `exitFailure` so a tail that's been disconnected from the backend doesn't silently mislead.
- **Clean shutdown**: SIGINT / SIGTERM cancels the loop via `signal.NotifyContext`; exit code stays 0 (operator hit Ctrl-C).
- **Flags**: `--interval` (default 2s, min 500ms, below-min returns usage error before the network call); `--output text|json` (json = NDJSON, jq-friendly); `--max-polls N` (default 0 = forever; primarily for tests, but also lets operators script "tail for N rounds").

## Factoring

- `auditTail` (the public subcommand) handles flag parsing, validation, and signal-context wiring.
- `runAuditTail` (the testable inner loop) takes an `auditTailAPI` interface that `*httpclient.Client` satisfies. Tests use a `stubAuditTailAPI` to drive the loop with programmed responses + injected errors without an httptest server — except for the end-to-end test, which exercises the full signal-context + real HTTP path bounded by `--max-polls=1`.

## Test plan

- [x] `go test -race ./cli/...`
- [x] `golangci-lint run ./cli/...`
- [x] Coverage gate: 82.3% aggregate (≥ 80% threshold)
- [x] 11 audit-tail cases: prints current then new (dedup verified), no duplicates across N polls, transient warning + recovery, persistent failure bails, context-cancel clean exit, NDJSON output round-trips, four flag-parsing guards (interval-below-min, bad UUID, missing arg, bad output), end-to-end with the fake backend

## Notes

- `--state-file` and `--since <ts>` from the proposal are skipped per the issue's "optional" annotation. Operators can re-invoke and the loop will re-establish from scratch; if persistence matters we add it as a follow-up.
- Cross-run following is out of scope (per the issue).
- `cli/README.md` updated. This closes out E18 (#324).

Closes #336