### PR TITLE
issuecomment: post full plan on the originating issue + update_on_change (E17.2 / #337)

### DIFF
--- a/backend/internal/issuecomment/notifier.go
+++ b/backend/internal/issuecomment/notifier.go
@@ -45,6 +45,7 @@ import (
 	"github.com/kuhlman-labs/fishhawk/backend/internal/githubclient"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/plan"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/run"
+	"github.com/kuhlman-labs/fishhawk/backend/internal/spec"
 )
 
 // CategoryIssueCommented is the audit-log category the notifier writes
@@ -92,6 +93,19 @@ const (
 	// answer "how many status updates fired per run" without
 	// scanning payload kinds.
 	KindStatusUpdate Kind = "status_update"
+	// KindPlanFull tags the full-plan-document post (E17.2 / #337).
+	// Distinct from KindPlan (the legacy summary post) because the
+	// payload carries github_comment_id and the comment is editable
+	// via UpdateIssueComment on subsequent plan re-uploads when the
+	// spec opts in to `update_on_change`. Audit-log dedup uses this
+	// kind plus KindPlanUpdated to find the most-recent comment id
+	// for a run.
+	KindPlanFull Kind = "plan_full"
+	// KindPlanUpdated tags an edit-in-place of the full-plan
+	// comment. Each re-upload that lands a UpdateIssueComment call
+	// appends one row carrying the (unchanged) github_comment_id so
+	// the audit chain records every revision.
+	KindPlanUpdated Kind = "plan_updated"
 )
 
 // IssueCommenter is the slice of githubclient.Client this package
@@ -189,6 +203,22 @@ func (n *Notifier) NotifyPickup(ctx context.Context, runID uuid.UUID, senderLogi
 // `planArtifact` is the typed `*plan.Plan` from its standard_v1
 // artifact. Both are required — if either is nil the call skips.
 //
+// Two surfaces today (E17.2 / #337):
+//
+//   - **Full-plan-as-comment**: when the workflow spec declares the
+//     plan stage's `produces.persistence` with
+//     `target: originating_issue, mode: rendered_comment`, the call
+//     renders the whole standard_v1 plan as a markdown document and
+//     posts it on the issue. If `update_on_change: true` is also set
+//     and a prior full-plan comment exists for the run, the call
+//     edits the existing comment in place via UpdateIssueComment.
+//     Per ADR-020 / #321 this is the canonical plan-review surface.
+//
+//   - **Summary-only**: when the spec opts out (no
+//     originating_issue persistence), the legacy path posts a short
+//     summary comment that links to the SPA's plan-document page.
+//     Behavior unchanged from #234.
+//
 // The comment routes to the approval-surface URL when the plan
 // stage requires approval (v0's typical workflow); to the run page
 // otherwise (`routine_change`-style flows).
@@ -196,12 +226,263 @@ func (n *Notifier) NotifyPlanReady(ctx context.Context, runID uuid.UUID, planSta
 	if n == nil || planStage == nil || planArtifact == nil {
 		return nil
 	}
+	runRow, err := n.runs.GetRun(ctx, runID)
+	if err != nil {
+		return fmt.Errorf("issuecomment: get run: %w", err)
+	}
+	// Per-stage persistence config lives on the cached workflow
+	// spec (the dispatcher snapshotted it onto the run row per
+	// #283). Read once; nil means "use the legacy summary path".
+	persistence := planOriginatingIssuePersistence(runRow.WorkflowSpec, runRow.WorkflowID, planStage)
+	if persistence != nil && persistence.Mode == spec.ModeRenderedComment {
+		return n.notifyFullPlan(ctx, runID, planStage, planArtifact, *persistence)
+	}
+	// Legacy path: summary post with audit-log dedup.
 	ctxv, ok, err := n.contextFor(ctx, runID, KindPlan)
 	if err != nil || !ok {
 		return err
 	}
 	body := renderPlanBody(ctxv, planStage, planArtifact, n.externalURL)
 	return n.post(ctx, ctxv, KindPlan, body)
+}
+
+// MaxIssueCommentBodyBytes mirrors GitHub's per-comment body cap.
+// Render output that exceeds this is truncated with a "View full
+// plan →" link to the SPA's plan-document page. Documented at
+// https://docs.github.com/en/rest/issues/comments — the practical
+// cap is 65,536 characters; we treat the limit as bytes since UTF-8
+// payloads can be longer than rune counts.
+const MaxIssueCommentBodyBytes = 65_536
+
+// notifyFullPlan is the post-or-edit path for the full-plan-on-issue
+// surface (E17.2 / #337). Resolves the plan-comment id from the
+// audit log; CreateIssueComment when none exists, UpdateIssueComment
+// when one does AND update_on_change is set, no-op when one exists
+// but update_on_change is unset (the post is one-shot in that mode).
+func (n *Notifier) notifyFullPlan(ctx context.Context, runID uuid.UUID, planStage *run.Stage, planArtifact *plan.Plan, persistence spec.Persistence) error {
+	ctxv, ok, err := n.contextForStatus(ctx, runID)
+	if err != nil || !ok {
+		return err
+	}
+
+	existingID, err := n.findPlanCommentID(ctx, runID)
+	if err != nil {
+		return fmt.Errorf("issuecomment: lookup plan comment: %w", err)
+	}
+
+	body := renderFullPlanBody(ctxv, planStage, planArtifact, n.externalURL)
+
+	if existingID > 0 {
+		if !persistence.UpdateOnChange {
+			// First plan post is the final post for this surface;
+			// re-fires shouldn't re-edit. Skip silently.
+			return nil
+		}
+		got, updErr := n.github.UpdateIssueComment(ctx, *ctxv.run.InstallationID,
+			ctxv.repo, existingID, body)
+		switch {
+		case updErr == nil:
+			return n.appendPlanCommentAudit(ctx, ctxv, got.ID, KindPlanUpdated)
+		case errors.Is(updErr, githubclient.ErrNotFound):
+			// Operator deleted the comment; fall through to create.
+		default:
+			return fmt.Errorf("issuecomment: update plan comment: %w", updErr)
+		}
+	}
+
+	created, err := n.github.CreateIssueComment(ctx, *ctxv.run.InstallationID,
+		ctxv.repo, ctxv.issueNumber, body)
+	if err != nil {
+		return fmt.Errorf("issuecomment: create plan comment: %w", err)
+	}
+	return n.appendPlanCommentAudit(ctx, ctxv, created.ID, KindPlanFull)
+}
+
+// findPlanCommentID returns the most-recent github_comment_id from
+// the run's audit log across KindPlanFull and KindPlanUpdated rows.
+// Returns 0 when none exists (the first-post case).
+func (n *Notifier) findPlanCommentID(ctx context.Context, runID uuid.UUID) (int64, error) {
+	entries, err := n.audit.ListForRunByCategory(ctx, runID, CategoryIssueCommented)
+	if err != nil {
+		return 0, err
+	}
+	// ListForRunByCategory returns ascending-by-sequence; walk from
+	// the end so the latest comment id wins.
+	for i := len(entries) - 1; i >= 0; i-- {
+		k := extractKind(entries[i].Payload)
+		if k != KindPlanFull && k != KindPlanUpdated {
+			continue
+		}
+		if id := extractGithubCommentID(entries[i].Payload); id > 0 {
+			return id, nil
+		}
+	}
+	return 0, nil
+}
+
+// appendPlanCommentAudit records a full-plan create/update on the
+// issue_commented category. Payload carries the kind + comment id +
+// issue/repo for compliance consumers that index on intent.
+func (n *Notifier) appendPlanCommentAudit(ctx context.Context, ctxv commentContext, commentID int64, kind Kind) error {
+	systemKind := audit.ActorSystem
+	payload, _ := json.Marshal(map[string]any{
+		"kind":              string(kind),
+		"issue_number":      ctxv.issueNumber,
+		"repo":              ctxv.repo.String(),
+		"github_comment_id": commentID,
+	})
+	if _, err := n.audit.AppendChained(ctx, audit.ChainAppendParams{
+		RunID:     ctxv.run.ID,
+		Timestamp: n.now().UTC(),
+		Category:  CategoryIssueCommented,
+		ActorKind: &systemKind,
+		Payload:   payload,
+	}); err != nil {
+		return fmt.Errorf("issuecomment: audit append: %w", err)
+	}
+	return nil
+}
+
+// planOriginatingIssuePersistence pulls the plan stage's
+// originating_issue persistence config out of the cached workflow
+// spec. Returns nil when the spec opts out — that's the signal for
+// NotifyPlanReady to use the legacy summary-post path.
+//
+// The lookup walks the workflow named by `workflowID` (the run's
+// WorkflowID column, which is the dispatcher-resolved key into the
+// spec's Workflows map) and finds the first stage of type plan.
+// v0 workflows have at most one plan stage per workflow.
+//
+// Best-effort: a parse failure falls through to the legacy path.
+// The spec was validated at dispatch time per #283, so this is
+// defensive against future shape drift.
+func planOriginatingIssuePersistence(workflowSpec []byte, workflowID string, planStage *run.Stage) *spec.Persistence {
+	if len(workflowSpec) == 0 || planStage == nil || workflowID == "" {
+		return nil
+	}
+	parsed, err := spec.ParseBytes(workflowSpec)
+	if err != nil {
+		return nil
+	}
+	wf, ok := parsed.Workflows[workflowID]
+	if !ok {
+		return nil
+	}
+	for i := range wf.Stages {
+		if string(wf.Stages[i].Type) != string(planStage.Type) {
+			continue
+		}
+		for _, p := range wf.Stages[i].Produces {
+			if p.Artifact != spec.ArtifactPlan {
+				continue
+			}
+			for _, ps := range p.Persistence {
+				if ps.Target == spec.PersistenceOriginatingIssue {
+					pp := ps
+					return &pp
+				}
+			}
+		}
+		// First plan stage wins; later plan stages (if a future
+		// workflow shape allows them) would need a more specific
+		// match — file a follow-up if that happens.
+		return nil
+	}
+	return nil
+}
+
+// renderFullPlanBody renders the entire standard_v1 plan as a
+// markdown document for the issue thread (E17.2 / #337). Sections:
+//
+//	**Fishhawk plan** (header + run + workflow link)
+//	**Summary**: <plan.Summary>
+//	**Scope**: bullet list of plan.Scope.Files
+//	**Approach**:
+//	  1. step 1
+//	  2. step 2
+//	**Verification**:
+//	  Test strategy: ...
+//	  Rollback plan: ...
+//	**Risks & assumptions**: bullets
+//	[Approve in the dashboard →](url) | [Reject →](url)
+//
+// When the rendered body exceeds MaxIssueCommentBodyBytes the
+// renderer truncates at a safe rune boundary and appends a
+// "View full plan →" link to the SPA's plan-document page so the
+// reviewer can see the untruncated body.
+func renderFullPlanBody(c commentContext, planStage *run.Stage, p *plan.Plan, externalURL string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "**Fishhawk plan** for Run [`%s`](%s)\n\n", shortID(c.run.ID), c.runURL)
+	fmt.Fprintf(&b, "Workflow: `%s`\n\n", c.run.WorkflowID)
+
+	if p.Summary != "" {
+		fmt.Fprintf(&b, "**Summary**\n\n%s\n\n", p.Summary)
+	}
+	if files := renderFileList(p.Scope.Files, len(p.Scope.Files)); files != "" {
+		b.WriteString("**Scope**\n\n")
+		b.WriteString(files)
+		b.WriteString("\n")
+	}
+	if len(p.Approach) > 0 {
+		b.WriteString("**Approach**\n\n")
+		for _, s := range p.Approach {
+			fmt.Fprintf(&b, "%d. %s\n", s.Step, s.Description)
+		}
+		b.WriteString("\n")
+	}
+	if p.Verification.TestStrategy != "" || p.Verification.RollbackPlan != "" {
+		b.WriteString("**Verification**\n\n")
+		if p.Verification.TestStrategy != "" {
+			fmt.Fprintf(&b, "- **Test strategy**: %s\n", p.Verification.TestStrategy)
+		}
+		if p.Verification.RollbackPlan != "" {
+			fmt.Fprintf(&b, "- **Rollback plan**: %s\n", p.Verification.RollbackPlan)
+		}
+		b.WriteString("\n")
+	}
+	if len(p.RisksAndAssumptions) > 0 {
+		b.WriteString("**Risks & assumptions**\n\n")
+		for _, r := range p.RisksAndAssumptions {
+			fmt.Fprintf(&b, "- %s\n", r)
+		}
+		b.WriteString("\n")
+	}
+
+	if planStage.RequiresApproval {
+		fmt.Fprintf(&b, "[Approve in the dashboard →](%s/runs/%s/stages/%s)\n",
+			externalURL, c.run.ID.String(), planStage.ID.String())
+	} else {
+		fmt.Fprintf(&b, "[View run →](%s)\n", c.runURL)
+	}
+	return truncateForGitHubComment(b.String(), c.runURL, planStage.ID.String(), externalURL, c.run.ID.String())
+}
+
+// truncateForGitHubComment caps body at MaxIssueCommentBodyBytes,
+// dropping bytes from the end and appending a "View full plan →"
+// link to the SPA so the reviewer can see the rest. Pure function;
+// safe to call when the body is already short — returns body
+// unchanged.
+func truncateForGitHubComment(body, runURL, stageID, externalURL, runID string) string {
+	if len(body) <= MaxIssueCommentBodyBytes {
+		return body
+	}
+	tail := fmt.Sprintf("\n\n_…truncated — [view full plan →](%s/runs/%s/stages/%s)_\n",
+		externalURL, runID, stageID)
+	// Reserve room for the tail; trim conservatively.
+	budget := MaxIssueCommentBodyBytes - len(tail)
+	if budget < 0 {
+		// Tail itself exceeds the cap (would be a very long URL).
+		// Render only the bare run URL as a fallback so the
+		// reviewer can navigate without leaving the comment.
+		return fmt.Sprintf("_Plan exceeds GitHub's comment size; view at %s_\n", runURL)
+	}
+	cut := budget
+	// Back off any UTF-8 continuation bytes so we land on a rune
+	// boundary — same defense the summary path's truncate uses.
+	for cut > 0 && (body[cut]&0xC0) == 0x80 {
+		cut--
+	}
+	return strings.TrimRight(body[:cut], " \n") + tail
 }
 
 // NotifyPlanApproved posts the "plan approved → implementing now"

--- a/backend/internal/issuecomment/notifier_test.go
+++ b/backend/internal/issuecomment/notifier_test.go
@@ -262,6 +262,381 @@ func TestNotifyPlanReady_TruncatesLongSummaryAndFiles(t *testing.T) {
 	}
 }
 
+// fullPlanSpecYAML returns a minimal but valid workflow spec where
+// the plan stage's `produces.persistence` opts into the
+// originating_issue / rendered_comment surface (E17.2 / #337). The
+// `update_on_change` flag is toggled by the caller via a sprintf
+// param so tests can flip behavior without forking the YAML.
+func fullPlanSpecYAML(updateOnChange bool) []byte {
+	return []byte(fmt.Sprintf(`version: "0.3"
+roles:
+  tech_lead:
+    members: ["@org/leads"]
+workflows:
+  feature_change:
+    stages:
+      - id: plan
+        type: plan
+        executor:
+          agent: claude-code
+        inputs:
+          - source: github_issue
+            required: true
+        produces:
+          - artifact: plan
+            schema: standard_v1
+            persistence:
+              - target: originating_issue
+                mode: rendered_comment
+                update_on_change: %t
+        gates:
+          - type: approval
+            approvers:
+              any_of: [tech_lead]
+      - id: implement
+        type: implement
+        executor:
+          agent: claude-code
+`, updateOnChange))
+}
+
+// summaryOnlySpecYAML returns a workflow spec whose plan stage does
+// NOT declare originating_issue persistence — the legacy summary
+// path should fire.
+func summaryOnlySpecYAML() []byte {
+	return []byte(`version: "0.3"
+workflows:
+  feature_change:
+    stages:
+      - id: plan
+        type: plan
+        executor:
+          agent: claude-code
+        inputs:
+          - source: github_issue
+            required: true
+        produces:
+          - artifact: plan
+            schema: standard_v1
+        gates:
+          - type: approval
+            approvers:
+              any_of: ["@org/leads"]
+      - id: implement
+        type: implement
+        executor:
+          agent: claude-code
+`)
+}
+
+// fullPlanFixture returns a plan with every field populated so the
+// rendered-comment body covers all sections.
+func fullPlanFixture() *plan.Plan {
+	return &plan.Plan{
+		Summary: "Refactor the dispatcher to skip the watchdog timer in dry-run mode.",
+		Scope: plan.Scope{
+			Files: []plan.ScopeFile{
+				{Path: "backend/internal/webhook/dispatcher.go", Operation: plan.FileOpModify},
+				{Path: "backend/internal/webhook/dispatcher_test.go", Operation: plan.FileOpModify},
+			},
+		},
+		Approach: []plan.ApproachStep{
+			{Step: 1, Description: "Add a dryRun field to dispatchOptions."},
+			{Step: 2, Description: "Skip the watchdog when dryRun is true."},
+			{Step: 3, Description: "Add a unit test covering the new branch."},
+		},
+		Verification: plan.Verification{
+			TestStrategy: "Run the dispatcher test suite plus the new dry-run case.",
+			RollbackPlan: "Revert the PR; the dispatcher returns to its prior shape.",
+		},
+		RisksAndAssumptions: []string{
+			"Operators set dryRun via a feature flag — no env var landed yet.",
+		},
+	}
+}
+
+func TestNotifyPlanReady_FullPlanSpec_PostsFullDocument(t *testing.T) {
+	// Spec opts into originating_issue + rendered_comment; the
+	// notifier renders the full plan doc and posts it. The legacy
+	// "Plan ready" summary phrase should NOT appear.
+	runID := uuid.New()
+	gh := &fakeGitHub{}
+	au := &fakeAudit{}
+	runs := map[uuid.UUID]*run.Run{runID: {
+		ID:             runID,
+		Repo:           "x/y",
+		WorkflowID:     "feature_change",
+		TriggerSource:  run.TriggerGitHubIssue,
+		TriggerRef:     ptrStr("issue:42"),
+		InstallationID: int64Ptr(99),
+		WorkflowSpec:   fullPlanSpecYAML(true),
+	}}
+	n := issuecomment.New(issuecomment.Deps{
+		GitHub:      gh,
+		Runs:        &fakeRuns{runs: runs},
+		Audit:       au,
+		ExternalURL: "https://app.fishhawk.example.com",
+		Now:         func() time.Time { return time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC) },
+	})
+
+	planStage := &run.Stage{ID: uuid.New(), Type: run.StageTypePlan, RunID: runID, RequiresApproval: true}
+	p := fullPlanFixture()
+
+	if err := n.NotifyPlanReady(context.Background(), runID, planStage, p); err != nil {
+		t.Fatalf("NotifyPlanReady: %v", err)
+	}
+	if len(gh.calls) != 1 {
+		t.Fatalf("expected 1 create call; got %d", len(gh.calls))
+	}
+	body := gh.calls[0].body
+	// The full-plan path doesn't use the "Plan ready" phrase — its
+	// header is "Fishhawk plan for Run …".
+	if strings.Contains(body, "Plan ready") {
+		t.Errorf("body should not use the legacy summary phrase: %q", body)
+	}
+	for _, want := range []string{
+		"Fishhawk plan",
+		"feature_change",
+		p.Summary,
+		"Scope",
+		"Approach",
+		"Refactor the dispatcher",
+		"Verification",
+		"Test strategy",
+		"Rollback plan",
+		"Risks & assumptions",
+		"Approve in the dashboard",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q\n---\n%s", want, body)
+		}
+	}
+
+	// Audit row records the kind + comment id (the latter so the
+	// next post can edit).
+	if len(au.appended) != 1 {
+		t.Fatalf("expected 1 audit row; got %d", len(au.appended))
+	}
+	var pl map[string]any
+	_ = json.Unmarshal(au.appended[0].Payload, &pl)
+	if pl["kind"] != string(issuecomment.KindPlanFull) {
+		t.Errorf("audit kind = %v, want plan_full", pl["kind"])
+	}
+	if id, _ := pl["github_comment_id"].(float64); int64(id) != 1 {
+		t.Errorf("audit github_comment_id = %v, want 1", pl["github_comment_id"])
+	}
+}
+
+func TestNotifyPlanReady_FullPlanSpec_UpdateOnChange_EditsExistingComment(t *testing.T) {
+	// Pre-seed a KindPlanFull audit row so the second post finds
+	// the comment id and takes the edit-in-place path. update_on_
+	// change=true is on in the spec.
+	runID := uuid.New()
+	gh := &fakeGitHub{}
+	au := &fakeAudit{}
+	au.preSeed(runID, issuecomment.CategoryIssueCommented, map[string]any{
+		"kind":              string(issuecomment.KindPlanFull),
+		"issue_number":      42,
+		"repo":              "x/y",
+		"github_comment_id": 7777,
+	})
+	runs := map[uuid.UUID]*run.Run{runID: {
+		ID:             runID,
+		Repo:           "x/y",
+		WorkflowID:     "feature_change",
+		TriggerSource:  run.TriggerGitHubIssue,
+		TriggerRef:     ptrStr("issue:42"),
+		InstallationID: int64Ptr(99),
+		WorkflowSpec:   fullPlanSpecYAML(true),
+	}}
+	n := issuecomment.New(issuecomment.Deps{
+		GitHub:      gh,
+		Runs:        &fakeRuns{runs: runs},
+		Audit:       au,
+		ExternalURL: "https://app.fishhawk.example.com",
+		Now:         func() time.Time { return time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC) },
+	})
+
+	planStage := &run.Stage{ID: uuid.New(), Type: run.StageTypePlan, RunID: runID, RequiresApproval: true}
+	if err := n.NotifyPlanReady(context.Background(), runID, planStage, fullPlanFixture()); err != nil {
+		t.Fatalf("NotifyPlanReady: %v", err)
+	}
+	if len(gh.calls) != 0 {
+		t.Errorf("expected 0 create calls; got %d", len(gh.calls))
+	}
+	if len(gh.updateCalls) != 1 {
+		t.Fatalf("expected 1 update call; got %d", len(gh.updateCalls))
+	}
+	if gh.updateCalls[0].commentID != 7777 {
+		t.Errorf("edit commentID = %d, want 7777 (seeded)", gh.updateCalls[0].commentID)
+	}
+	// Fresh audit row for the update.
+	if len(au.appended) != 1 {
+		t.Fatalf("expected 1 new audit row; got %d", len(au.appended))
+	}
+	var pl map[string]any
+	_ = json.Unmarshal(au.appended[0].Payload, &pl)
+	if pl["kind"] != string(issuecomment.KindPlanUpdated) {
+		t.Errorf("audit kind = %v, want plan_updated", pl["kind"])
+	}
+}
+
+func TestNotifyPlanReady_FullPlanSpec_NoUpdateOnChange_SkipsOnSecondCall(t *testing.T) {
+	// update_on_change=false: the post is one-shot. A second call
+	// after the first lands the audit row should silently skip.
+	runID := uuid.New()
+	gh := &fakeGitHub{}
+	au := &fakeAudit{}
+	au.preSeed(runID, issuecomment.CategoryIssueCommented, map[string]any{
+		"kind":              string(issuecomment.KindPlanFull),
+		"issue_number":      42,
+		"repo":              "x/y",
+		"github_comment_id": 5555,
+	})
+	runs := map[uuid.UUID]*run.Run{runID: {
+		ID: runID, Repo: "x/y", WorkflowID: "feature_change",
+		TriggerSource: run.TriggerGitHubIssue, TriggerRef: ptrStr("issue:42"),
+		InstallationID: int64Ptr(99),
+		WorkflowSpec:   fullPlanSpecYAML(false), // update_on_change=false
+	}}
+	n := issuecomment.New(issuecomment.Deps{
+		GitHub: gh, Runs: &fakeRuns{runs: runs}, Audit: au,
+		ExternalURL: "https://app.fishhawk.example.com",
+	})
+
+	planStage := &run.Stage{ID: uuid.New(), Type: run.StageTypePlan, RunID: runID, RequiresApproval: true}
+	if err := n.NotifyPlanReady(context.Background(), runID, planStage, fullPlanFixture()); err != nil {
+		t.Fatal(err)
+	}
+	if len(gh.calls)+len(gh.updateCalls) != 0 {
+		t.Errorf("expected no GitHub calls when update_on_change=false; got %d creates + %d updates",
+			len(gh.calls), len(gh.updateCalls))
+	}
+	if len(au.appended) != 0 {
+		t.Errorf("no audit append expected on skip; got %d", len(au.appended))
+	}
+}
+
+func TestNotifyPlanReady_SummaryOnlySpec_UsesLegacyPath(t *testing.T) {
+	// Spec lacks originating_issue persistence; the legacy summary
+	// path posts a KindPlan row with the "Plan ready" phrase.
+	runID := uuid.New()
+	gh := &fakeGitHub{}
+	au := &fakeAudit{}
+	runs := map[uuid.UUID]*run.Run{runID: {
+		ID: runID, Repo: "x/y", WorkflowID: "feature_change",
+		TriggerSource: run.TriggerGitHubIssue, TriggerRef: ptrStr("issue:42"),
+		InstallationID: int64Ptr(99),
+		WorkflowSpec:   summaryOnlySpecYAML(),
+	}}
+	n := issuecomment.New(issuecomment.Deps{
+		GitHub: gh, Runs: &fakeRuns{runs: runs}, Audit: au,
+		ExternalURL: "https://app.fishhawk.example.com",
+	})
+
+	planStage := &run.Stage{ID: uuid.New(), Type: run.StageTypePlan, RunID: runID, RequiresApproval: true}
+	if err := n.NotifyPlanReady(context.Background(), runID, planStage, fullPlanFixture()); err != nil {
+		t.Fatal(err)
+	}
+	if len(gh.calls) != 1 {
+		t.Fatalf("expected 1 create call (legacy summary); got %d", len(gh.calls))
+	}
+	if !strings.Contains(gh.calls[0].body, "Plan ready") {
+		t.Errorf("legacy path should use 'Plan ready' phrase: %q", gh.calls[0].body)
+	}
+	// Legacy audit row stays KindPlan, no github_comment_id.
+	if len(au.appended) != 1 {
+		t.Fatalf("expected 1 audit row; got %d", len(au.appended))
+	}
+	var pl map[string]any
+	_ = json.Unmarshal(au.appended[0].Payload, &pl)
+	if pl["kind"] != string(issuecomment.KindPlan) {
+		t.Errorf("legacy audit kind = %v, want plan", pl["kind"])
+	}
+	if _, ok := pl["github_comment_id"]; ok {
+		t.Errorf("legacy summary should not record github_comment_id: %+v", pl)
+	}
+}
+
+func TestNotifyPlanReady_FullPlanSpec_OperatorDeletedComment_FallsBackToCreate(t *testing.T) {
+	// Pre-seed a KindPlanFull row; GitHub returns ErrNotFound on
+	// UpdateIssueComment (operator manually deleted the comment).
+	// The notifier creates a fresh comment + appends a KindPlanFull
+	// audit row carrying the new id.
+	runID := uuid.New()
+	gh := &fakeGitHub{updateErr: githubclient.ErrNotFound}
+	au := &fakeAudit{}
+	au.preSeed(runID, issuecomment.CategoryIssueCommented, map[string]any{
+		"kind":              string(issuecomment.KindPlanFull),
+		"issue_number":      42,
+		"repo":              "x/y",
+		"github_comment_id": 4242,
+	})
+	runs := map[uuid.UUID]*run.Run{runID: {
+		ID: runID, Repo: "x/y", WorkflowID: "feature_change",
+		TriggerSource: run.TriggerGitHubIssue, TriggerRef: ptrStr("issue:42"),
+		InstallationID: int64Ptr(99),
+		WorkflowSpec:   fullPlanSpecYAML(true),
+	}}
+	n := issuecomment.New(issuecomment.Deps{
+		GitHub: gh, Runs: &fakeRuns{runs: runs}, Audit: au,
+		ExternalURL: "https://app.fishhawk.example.com",
+	})
+
+	planStage := &run.Stage{ID: uuid.New(), Type: run.StageTypePlan, RunID: runID, RequiresApproval: true}
+	if err := n.NotifyPlanReady(context.Background(), runID, planStage, fullPlanFixture()); err != nil {
+		t.Fatal(err)
+	}
+	if len(gh.updateCalls) != 1 {
+		t.Errorf("expected 1 update attempt (404'd); got %d", len(gh.updateCalls))
+	}
+	if len(gh.calls) != 1 {
+		t.Fatalf("expected 1 fresh create after 404; got %d", len(gh.calls))
+	}
+}
+
+func TestNotifyPlanReady_FullPlanSpec_TruncatesAtGitHubLimit(t *testing.T) {
+	// Build a plan whose rendered body exceeds the 65,536-byte
+	// cap; the renderer truncates with a "view full plan" link.
+	runID := uuid.New()
+	gh := &fakeGitHub{}
+	au := &fakeAudit{}
+	runs := map[uuid.UUID]*run.Run{runID: {
+		ID: runID, Repo: "x/y", WorkflowID: "feature_change",
+		TriggerSource: run.TriggerGitHubIssue, TriggerRef: ptrStr("issue:42"),
+		InstallationID: int64Ptr(99),
+		WorkflowSpec:   fullPlanSpecYAML(true),
+	}}
+	n := issuecomment.New(issuecomment.Deps{
+		GitHub: gh, Runs: &fakeRuns{runs: runs}, Audit: au,
+		ExternalURL: "https://app.fishhawk.example.com",
+	})
+
+	// One 100KB risk pushes the body well past the cap.
+	huge := strings.Repeat("a", 100_000)
+	p := &plan.Plan{
+		Summary:             "x",
+		RisksAndAssumptions: []string{huge},
+	}
+	planStage := &run.Stage{ID: uuid.New(), Type: run.StageTypePlan, RunID: runID, RequiresApproval: true}
+	if err := n.NotifyPlanReady(context.Background(), runID, planStage, p); err != nil {
+		t.Fatal(err)
+	}
+	if len(gh.calls) != 1 {
+		t.Fatalf("expected 1 create call; got %d", len(gh.calls))
+	}
+	body := gh.calls[0].body
+	if got := len(body); got > issuecomment.MaxIssueCommentBodyBytes {
+		t.Errorf("body length %d exceeds cap %d", got, issuecomment.MaxIssueCommentBodyBytes)
+	}
+	if !strings.Contains(body, "truncated") {
+		t.Errorf("body should carry truncation marker: %q", body[len(body)-200:])
+	}
+	if !strings.Contains(body, "view full plan") {
+		t.Errorf("body should link to the SPA plan view: %q", body[len(body)-200:])
+	}
+}
+
 func TestNotifyPlanReady_DedupsViaAuditLog(t *testing.T) {
 	runID, gh, au, n := happyDeps(t)
 	au.preSeed(runID, issuecomment.CategoryIssueCommented, map[string]any{"kind": "plan"})
@@ -1136,6 +1511,7 @@ func TestNotifyPlanApproved_NilReceiver_NoOp(t *testing.T) {
 // --- helpers ---
 
 func int64Ptr(v int64) *int64 { return &v }
+func ptrStr(s string) *string { return &s }
 
 // --- fakes ---
 


### PR DESCRIPTION
## Summary

Per **ADR-020 / #321** (resolved this turn), the originating issue is the canonical plan-review surface. This PR makes `NotifyPlanReady` honor the workflow spec's `produces.persistence` config so the full plan document posts on the issue when the spec opts in, and edits in place on re-uploads when `update_on_change: true` is set.

- **Branching**: spec opts in → full-plan path; spec opts out → legacy summary-only path (existing #234 / #274 behavior preserved).
- **New audit kinds**: `KindPlanFull` (first full-plan create) + `KindPlanUpdated` (each edit-in-place). Payload carries `github_comment_id` so subsequent calls find the comment via audit-log lookup. `KindPlan` (legacy summary) is unchanged.
- **Body**: header → Summary → Scope → Approach → Verification (test strategy + rollback) → Risks & assumptions → footer link. Truncates at GitHub's 65,536-byte cap with a "view full plan →" link to the SPA so reviewers can read the rest if it spills.
- **Operator-deleted comment**: `UpdateIssueComment` returning `ErrNotFound` falls back to a fresh `CreateIssueComment` + a new `KindPlanFull` audit row.

## Test plan

- [x] `go test -race ./backend/...`
- [x] `golangci-lint run backend/...`
- [x] Coverage gate: 82.3% aggregate (≥ 80% threshold)
- [x] Six acceptance cases (every bullet from the issue):
  - spec-flag-on posts the full document; all sections render; legacy phrase absent; KindPlanFull + github_comment_id stored
  - `update_on_change: true` with pre-seeded audit row → UpdateIssueComment with seeded id; KindPlanUpdated appended
  - `update_on_change: false` re-fire skips silently (no GitHub call, no audit row)
  - spec-flag-off → legacy summary path (KindPlan, no comment id, "Plan ready" phrase)
  - operator-deleted comment (404 on update) → fresh create + new KindPlanFull row
  - body truncation: 100KB risk pushes body past cap; truncation marker + view-full-plan link surface

## Notes

- ADR-020 / #321 closed in the same task — the Decision section in the issue body is final ("Adopt option A: plan-as-issue-comment-thread"). E17 impl track is now unblocked.
- Reaction-as-approval ingestion is the next ticket pair (E17.3 / #338 reaction webhook + E17.4 / #339 reaction → approval path).
- Frontend read-only flip is E17.5 / #340; spec doc update is E17.6 / #341.

Closes #337