### PR TITLE
webhook: reply-comment approval patterns (E17.3 / #338)

### DIFF
--- a/backend/internal/server/issue_approval.go
+++ b/backend/internal/server/issue_approval.go
@@ -55,6 +55,14 @@ func (s *Server) HandleApprovalCommand(ctx context.Context, p webhook.ApprovalCo
 		return nil
 	}
 
+	// Reply-comment approvals (E17.3 / #338) skip silently on every
+	// "no, this comment isn't an approval" branch — an operator who
+	// types "+1 yes I agree" on an issue thread that happens not to
+	// have a Fishhawk plan should not get an unsolicited reply.
+	// Slash-command approvals keep their explicit help replies; the
+	// reviewer typed a deliberate command.
+	silent := p.Source == webhook.ApprovalSourceReplyComment
+
 	runRow, stage, found, err := s.findAwaitingApprovalStage(ctx, p.Repo, p.IssueNumber)
 	if err != nil {
 		s.cfg.Logger.LogAttrs(ctx, slog.LevelWarn,
@@ -62,10 +70,16 @@ func (s *Server) HandleApprovalCommand(ctx context.Context, p webhook.ApprovalCo
 			slog.String("repo", p.Repo),
 			slog.Int("issue", p.IssueNumber),
 			slog.String("error", err.Error()))
+		if silent {
+			return nil
+		}
 		s.replyApproval(ctx, p, "Could not look up the run for this issue. Try the dashboard.")
 		return nil
 	}
 	if !found {
+		if silent {
+			return nil
+		}
 		s.replyApproval(ctx, p, fmt.Sprintf("No stage on this issue's run is awaiting approval. (Subject: @%s)", subject))
 		return nil
 	}
@@ -74,8 +88,13 @@ func (s *Server) HandleApprovalCommand(ctx context.Context, p webhook.ApprovalCo
 	// The PR merge event (#312) advances the stage; branch protection's
 	// required-reviewers enforces the approver list. Reply with a help
 	// message pointing at the PR rather than submitting an approval.
-	// Plan-stage slash approvals continue to work.
+	// Plan-stage slash approvals continue to work. Reply-comment
+	// approvals skip silently: the operator wasn't necessarily talking
+	// about the review stage either.
 	if stage.Type == run.StageTypeReview {
+		if silent {
+			return nil
+		}
 		s.replyApproval(ctx, p, reviewStageHelpReply(runRow, subject))
 		return nil
 	}

--- a/backend/internal/server/issue_approval_test.go
+++ b/backend/internal/server/issue_approval_test.go
@@ -544,6 +544,133 @@ func TestHandleApprovalCommand_RepoLookupFailure_RepliesGracefully(t *testing.T)
 	}
 }
 
+// --- reply-comment approval (E17.3 / #338) ---
+
+// TestHandleApprovalCommand_ReplyComment_NoAwaitingStage_SkipsSilently
+// locks in the core E17.3 contract: when source is ReplyComment, an
+// "issue has no awaiting-approval plan stage" condition does NOT
+// produce an unsolicited reply. The operator's "+1" might have been
+// agreeing with another comment unrelated to Fishhawk.
+func TestHandleApprovalCommand_ReplyComment_NoAwaitingStage_SkipsSilently(t *testing.T) {
+	rr := newOrchestratorRepo()
+	// No run for this issue — findAwaitingApprovalStage returns
+	// found=false.
+	ar := newFakeApprovalRepo()
+	au := newAuditCompleteAuditFake()
+	gh := newSlashGitHubRecorder()
+
+	s := New(Config{
+		Addr: "127.0.0.1:0", RunRepo: rr, ApprovalRepo: ar, AuditRepo: au,
+		ExternalURL: "https://app.fishhawk.example.com",
+	})
+	s.issueNotifier = issuecomment.New(issuecomment.Deps{
+		GitHub: gh, Runs: rr, Audit: au,
+		ExternalURL: "https://app.fishhawk.example.com",
+	})
+
+	if err := s.HandleApprovalCommand(context.Background(), webhook.ApprovalCommandParams{
+		Repo:           "x/y",
+		IssueNumber:    42,
+		InstallationID: 99,
+		SenderLogin:    "alice",
+		Decision:       webhook.MatchActionApprove,
+		Source:         webhook.ApprovalSourceReplyComment,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got := gh.calls(); len(got) != 0 {
+		t.Errorf("reply-comment with no awaiting stage should produce no reply; got %d: %v",
+			len(got), commentBodies(got))
+	}
+	if len(ar.all) != 0 {
+		t.Errorf("no approval row should be written; got %+v", ar.all)
+	}
+}
+
+// TestHandleApprovalCommand_ReplyComment_ReviewStage_SkipsSilently
+// covers the second silent-skip branch: when the awaiting stage is
+// a review (not plan), the reply-comment path skips rather than
+// posting the review-stage help reply. ADR-018 owns the review
+// approval surface; a generic "+1" on the issue thread isn't
+// scoped to that.
+func TestHandleApprovalCommand_ReplyComment_ReviewStage_SkipsSilently(t *testing.T) {
+	rr := newOrchestratorRepo()
+	r := rr.seedRun()
+	r.TriggerSource = run.TriggerGitHubIssue
+	triggerRef := "issue:42"
+	r.TriggerRef = &triggerRef
+	r.InstallationID = ptrInt64(99)
+	r.Repo = "x/y"
+	prURL := "https://github.com/x/y/pull/42"
+	r.PullRequestURL = &prURL
+
+	stage := rr.seedStage(r.ID, 0, run.StageStateAwaitingApproval)
+	stage.Type = run.StageTypeReview
+
+	ar := newFakeApprovalRepo()
+	au := newAuditCompleteAuditFake()
+	gh := newSlashGitHubRecorder()
+
+	s := New(Config{
+		Addr: "127.0.0.1:0", RunRepo: rr, ApprovalRepo: ar, AuditRepo: au,
+		ExternalURL: "https://app.fishhawk.example.com",
+	})
+	s.issueNotifier = issuecomment.New(issuecomment.Deps{
+		GitHub: gh, Runs: rr, Audit: au,
+		ExternalURL: "https://app.fishhawk.example.com",
+	})
+
+	if err := s.HandleApprovalCommand(context.Background(), webhook.ApprovalCommandParams{
+		Repo: "x/y", IssueNumber: 42, InstallationID: 99, SenderLogin: "alice",
+		Decision: webhook.MatchActionApprove,
+		Source:   webhook.ApprovalSourceReplyComment,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got := gh.calls(); len(got) != 0 {
+		t.Errorf("reply-comment on review stage should produce no reply; got %d: %v",
+			len(got), commentBodies(got))
+	}
+	if len(ar.all) != 0 {
+		t.Errorf("no approval row should be written; got %+v", ar.all)
+	}
+}
+
+// TestHandleApprovalCommand_SlashCommand_NoAwaitingStage_StillReplies
+// is the inverse regression: the silent-skip behavior is gated on
+// Source=ReplyComment, NOT a behavior change for the slash path.
+// Slash commands keep their explicit help replies.
+func TestHandleApprovalCommand_SlashCommand_NoAwaitingStage_StillReplies(t *testing.T) {
+	rr := newOrchestratorRepo()
+	ar := newFakeApprovalRepo()
+	au := newAuditCompleteAuditFake()
+	gh := newSlashGitHubRecorder()
+
+	s := New(Config{
+		Addr: "127.0.0.1:0", RunRepo: rr, ApprovalRepo: ar, AuditRepo: au,
+		ExternalURL: "https://app.fishhawk.example.com",
+	})
+	s.issueNotifier = issuecomment.New(issuecomment.Deps{
+		GitHub: gh, Runs: rr, Audit: au,
+		ExternalURL: "https://app.fishhawk.example.com",
+	})
+
+	if err := s.HandleApprovalCommand(context.Background(), webhook.ApprovalCommandParams{
+		Repo: "x/y", IssueNumber: 42, InstallationID: 99, SenderLogin: "alice",
+		Decision: webhook.MatchActionApprove,
+		Source:   webhook.ApprovalSourceSlash, // explicit slash → loud reply
+	}); err != nil {
+		t.Fatal(err)
+	}
+	got := gh.calls()
+	if len(got) != 1 {
+		t.Fatalf("slash path should still post an explicit reply; got %d", len(got))
+	}
+	if !strings.Contains(got[0].body, "No stage on this issue's run is awaiting approval") {
+		t.Errorf("reply should explain no-awaiting-stage: %q", got[0].body)
+	}
+}
+
 // --- helpers ---
 
 // splitBroadcastAndStatus picks the plan-approved broadcast (the

--- a/backend/internal/webhook/dispatcher.go
+++ b/backend/internal/webhook/dispatcher.go
@@ -27,6 +27,33 @@ const FishhawkLabel = "fishhawk"
 // from an issue or PR comment.
 const CommentTrigger = "/fishhawk run"
 
+// ApprovalSource identifies which `issue_comment` matcher produced
+// a MatchActionApprove. The downstream handler branches on this:
+// slash-command approvals error loudly when no awaiting plan stage
+// exists (the reviewer typed an explicit command); reply-comment
+// approvals skip silently (the reviewer may have been replying to
+// something else on the same issue thread).
+//
+// E17.3 / #338 introduced ApprovalSourceReplyComment after a
+// late-discovery during impl: GitHub does not fire webhooks for
+// reactions on issue comments (verified at
+// https://docs.github.com/en/webhooks/webhook-events-and-payloads).
+// ADR-020 / #321 pivoted to reply-comment patterns as the primary
+// "lightweight" approval surface; a polling worker (E17.3b / #360)
+// will catch the click-only-thumbs-up case as a follow-up.
+type ApprovalSource string
+
+// ApprovalSource values.
+const (
+	// ApprovalSourceSlash tags the explicit `/fishhawk approve` /
+	// `/fishhawk reject` slash-command path (E5.2 / #238).
+	ApprovalSourceSlash ApprovalSource = "slash"
+	// ApprovalSourceReplyComment tags the reply-pattern path
+	// (E17.3 / #338): `+1`, `👍`, `lgtm`, etc. as a fresh comment
+	// on the issue thread. No explicit slash, no required prefix.
+	ApprovalSourceReplyComment ApprovalSource = "reply_comment"
+)
+
 // CommentApprove and CommentReject are the chat-style commands that
 // submit a gate decision against an issue's currently-awaiting-
 // approval stage (#238). The reviewer can leave an optional comment
@@ -36,6 +63,25 @@ const (
 	CommentApprove = "/fishhawk approve"
 	CommentReject  = "/fishhawk reject"
 )
+
+// approvalReplyPatterns is the closed set of body prefixes that
+// approve a plan comment without requiring an explicit slash
+// command (E17.3 / #338). Matched case-insensitively against the
+// trimmed body's first token. ADR-020 / #321 picked these because
+// they are the conventions developers already use on GitHub PRs and
+// issues; nothing here is Fishhawk-specific.
+//
+// A pattern matches when the body's first whitespace-delimited
+// token equals one of these (case-insensitive). Trailing text
+// becomes the optional comment. Bodies that contain the token
+// elsewhere ("Should we lgtm this?") do NOT match — the pattern
+// must anchor the body, same posture as the slash-command matcher.
+var approvalReplyPatterns = []string{
+	"+1",
+	"👍",
+	":+1:",
+	"lgtm",
+}
 
 // MatchAction tags how a matched event should be handled. Run is
 // the historical default (create + workflow_dispatch); approve and
@@ -102,6 +148,15 @@ type Match struct {
 	// approve / reject so the approval row's `comment` column gets
 	// the reviewer's rationale.
 	CommentBody string
+
+	// ApprovalSource identifies which `issue_comment` matcher
+	// produced a MatchActionApprove (E17.3 / #338). Empty means the
+	// slash-command path (default; backwards-compat). The
+	// reply-comment path sets it to ApprovalSourceReplyComment so
+	// the downstream handler knows to skip silently when no
+	// awaiting plan stage exists (a generic `+1` reply isn't an
+	// error if the issue happens not to have a Fishhawk plan).
+	ApprovalSource ApprovalSource
 
 	// WorkflowRunID is the GitHub Actions run id from a
 	// `workflow_run.completed` event. Set for
@@ -250,19 +305,21 @@ func matchIssueComment(ev Event) Match {
 	switch {
 	case isCommand(body, CommentApprove):
 		return Match{
-			Action:        MatchActionApprove,
-			TriggerSource: run.TriggerGitHubIssue,
-			TriggerRef:    fmt.Sprintf("issue:%d", payload.Issue.Number),
-			IssueRef:      &IssueRef{Number: payload.Issue.Number, Body: payload.Comment.Body},
-			CommentBody:   trailingComment(body, CommentApprove),
+			Action:         MatchActionApprove,
+			ApprovalSource: ApprovalSourceSlash,
+			TriggerSource:  run.TriggerGitHubIssue,
+			TriggerRef:     fmt.Sprintf("issue:%d", payload.Issue.Number),
+			IssueRef:       &IssueRef{Number: payload.Issue.Number, Body: payload.Comment.Body},
+			CommentBody:    trailingComment(body, CommentApprove),
 		}
 	case isCommand(body, CommentReject):
 		return Match{
-			Action:        MatchActionReject,
-			TriggerSource: run.TriggerGitHubIssue,
-			TriggerRef:    fmt.Sprintf("issue:%d", payload.Issue.Number),
-			IssueRef:      &IssueRef{Number: payload.Issue.Number, Body: payload.Comment.Body},
-			CommentBody:   trailingComment(body, CommentReject),
+			Action:         MatchActionReject,
+			ApprovalSource: ApprovalSourceSlash,
+			TriggerSource:  run.TriggerGitHubIssue,
+			TriggerRef:     fmt.Sprintf("issue:%d", payload.Issue.Number),
+			IssueRef:       &IssueRef{Number: payload.Issue.Number, Body: payload.Comment.Body},
+			CommentBody:    trailingComment(body, CommentReject),
 		}
 	case isCommand(body, CommentTrigger):
 		return Match{
@@ -273,9 +330,63 @@ func matchIssueComment(ev Event) Match {
 			IssueRef:      &IssueRef{Number: payload.Issue.Number, Body: payload.Comment.Body},
 		}
 	}
+	// Reply-comment approval (E17.3 / #338). Tried after the slash
+	// matches so an explicit "/fishhawk approve lgtm" still routes
+	// through the slash path. Patterns are anchored at the start of
+	// the body, same shape as isCommand. Reject reply patterns are
+	// intentionally absent: the rejection conventions ("-1", "👎")
+	// have weaker industry consensus and a typed-reply reject lacks
+	// the slash command's explicit-confirmation property; reviewers
+	// wanting to reject use the slash command or the dashboard.
+	if pat, trailing, ok := matchApprovalReplyPattern(body); ok {
+		_ = pat
+		return Match{
+			Action:         MatchActionApprove,
+			ApprovalSource: ApprovalSourceReplyComment,
+			TriggerSource:  run.TriggerGitHubIssue,
+			TriggerRef:     fmt.Sprintf("issue:%d", payload.Issue.Number),
+			IssueRef:       &IssueRef{Number: payload.Issue.Number, Body: payload.Comment.Body},
+			CommentBody:    trailing,
+		}
+	}
 	return Match{Skip: true,
-		Reason: fmt.Sprintf("comment does not start with a Fishhawk command (recognized: %q, %q, %q)",
+		Reason: fmt.Sprintf("comment does not start with a Fishhawk command (recognized: %q, %q, %q) or an approval-reply pattern",
 			CommentTrigger, CommentApprove, CommentReject)}
+}
+
+// matchApprovalReplyPattern returns the matched pattern + trailing
+// text + ok when body's first token is one of approvalReplyPatterns.
+// Token matching is case-insensitive; only the literal token must
+// match — surrounding whitespace and trailing text are fine.
+//
+// Examples (all match):
+//   - "+1"            → pat="+1",  trailing=""
+//   - "+1 looks good" → pat="+1",  trailing="looks good"
+//   - "LGTM"          → pat="lgtm", trailing=""
+//   - "👍"             → pat="👍",  trailing=""
+//
+// Examples (no match):
+//   - "Should we lgtm this?"  → pattern is not the first token
+//   - "+10 percent improvement" → first token "+10" isn't in the
+//     pattern list (we don't substring-match)
+func matchApprovalReplyPattern(body string) (pattern, trailing string, ok bool) {
+	if body == "" {
+		return "", "", false
+	}
+	// Split on the first whitespace boundary; first chunk is the
+	// candidate token, second (if present) is the trailing comment.
+	first, rest, _ := strings.Cut(body, " ")
+	// Body might use \n / \t / etc. as the boundary; normalize.
+	if idx := strings.IndexAny(first, "\t\n\r"); idx >= 0 {
+		rest = strings.TrimLeft(first[idx:]+" "+rest, "\t\n\r ")
+		first = first[:idx]
+	}
+	for _, pat := range approvalReplyPatterns {
+		if strings.EqualFold(first, pat) {
+			return pat, strings.TrimSpace(rest), true
+		}
+	}
+	return "", "", false
 }
 
 // isCommand returns true when body starts with command followed by
@@ -563,6 +674,12 @@ type ApprovalCommandParams struct {
 	SenderLogin    string
 	Decision       MatchAction // approve | reject
 	Comment        string      // optional reviewer rationale (the trailing line on the slash command)
+	// Source identifies which matcher produced this. The handler
+	// branches on it: slash-command approvals surface a help reply
+	// when no awaiting plan stage exists; reply-comment approvals
+	// (E17.3 / #338) skip silently (the comment may have been
+	// unrelated to a Fishhawk plan).
+	Source ApprovalSource
 }
 
 // Dispatcher orchestrates the I/O side: it consumes a Match,
@@ -929,6 +1046,7 @@ func (d *Dispatcher) handleApprovalCommand(ctx context.Context, ev Event, m Matc
 		SenderLogin:    ev.Sender,
 		Decision:       m.Action,
 		Comment:        m.CommentBody,
+		Source:         m.ApprovalSource,
 	}); err != nil {
 		d.logger().LogAttrs(ctx, slog.LevelWarn,
 			"slash-command approval failed",

--- a/backend/internal/webhook/dispatcher_test.go
+++ b/backend/internal/webhook/dispatcher_test.go
@@ -238,6 +238,145 @@ func TestMatchEvent_IssueComment_NotMistakenForLongerCommandPrefix(t *testing.T)
 	}
 }
 
+// --- MatchEvent: issue_comment reply-pattern approvals (E17.3 / #338) ---
+
+func TestMatchEvent_IssueComment_ApproveCommand_TaggedSlashSource(t *testing.T) {
+	body := []byte(`{"comment":{"body":"/fishhawk approve"},"issue":{"number":42}}`)
+	ev := Event{Type: "issue_comment", Action: "created", InstallationID: 1, RawBody: body}
+	got := MatchEvent(ev)
+	if got.Skip {
+		t.Fatalf("got = %+v, want match", got)
+	}
+	if got.ApprovalSource != ApprovalSourceSlash {
+		t.Errorf("ApprovalSource = %q, want %q", got.ApprovalSource, ApprovalSourceSlash)
+	}
+}
+
+func TestMatchEvent_IssueComment_ReplyPatternApproval(t *testing.T) {
+	// Pattern matrix — each variant must classify as a reply-comment
+	// approval with the right Source tag. Trailing text becomes the
+	// optional comment.
+	cases := []struct {
+		name      string
+		body      string
+		wantTrail string
+	}{
+		{"plus-one-bare", "+1", ""},
+		{"plus-one-trailing", "+1 looks good", "looks good"},
+		{"thumbs-up-emoji", "👍", ""},
+		{"plus-one-emoji-shortcode", ":+1:", ""},
+		{"lgtm-lowercase", "lgtm", ""},
+		{"lgtm-uppercase", "LGTM", ""},
+		{"lgtm-trailing-multiline", "lgtm\n\nbut watch the retry cap", "but watch the retry cap"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, _ := json.Marshal(map[string]any{
+				"comment": map[string]any{"body": tc.body},
+				"issue":   map[string]any{"number": 42},
+			})
+			ev := Event{Type: "issue_comment", Action: "created", InstallationID: 1, RawBody: raw}
+			got := MatchEvent(ev)
+			if got.Skip {
+				t.Fatalf("got = %+v, want match", got)
+			}
+			if got.Action != MatchActionApprove {
+				t.Errorf("Action = %q, want approve", got.Action)
+			}
+			if got.ApprovalSource != ApprovalSourceReplyComment {
+				t.Errorf("ApprovalSource = %q, want %q", got.ApprovalSource, ApprovalSourceReplyComment)
+			}
+			if got.IssueRef == nil || got.IssueRef.Number != 42 {
+				t.Errorf("IssueRef = %+v", got.IssueRef)
+			}
+			if got.CommentBody != tc.wantTrail {
+				t.Errorf("CommentBody = %q, want %q", got.CommentBody, tc.wantTrail)
+			}
+		})
+	}
+}
+
+func TestMatchEvent_IssueComment_ReplyPattern_OnlyMatchesAtStart(t *testing.T) {
+	// "Should we lgtm this?" must NOT classify as a reply-pattern
+	// approval — the pattern must anchor the body. Same posture as
+	// the slash command's quoted-reply guard.
+	cases := []string{
+		"Should we lgtm this?",
+		"hmm, +1 maybe later",
+		"see https://example.com/+1",
+		"+10 percent improvement",
+	}
+	for _, body := range cases {
+		t.Run(body, func(t *testing.T) {
+			raw, _ := json.Marshal(map[string]any{
+				"comment": map[string]any{"body": body},
+				"issue":   map[string]any{"number": 1},
+			})
+			ev := Event{Type: "issue_comment", Action: "created", InstallationID: 1, RawBody: raw}
+			got := MatchEvent(ev)
+			if !got.Skip {
+				t.Errorf("body %q should not match approval-reply patterns; got %+v", body, got)
+			}
+		})
+	}
+}
+
+func TestMatchEvent_IssueComment_SlashCommandWinsOverReplyPattern(t *testing.T) {
+	// "/fishhawk approve lgtm" — the slash matcher fires first; the
+	// trailing "lgtm" goes into CommentBody rather than triggering
+	// the reply-pattern arm. Source is Slash.
+	body := []byte(`{"comment":{"body":"/fishhawk approve lgtm"},"issue":{"number":42}}`)
+	ev := Event{Type: "issue_comment", Action: "created", InstallationID: 1, RawBody: body}
+	got := MatchEvent(ev)
+	if got.Skip {
+		t.Fatalf("got = %+v, want match", got)
+	}
+	if got.Action != MatchActionApprove {
+		t.Errorf("Action = %q, want approve", got.Action)
+	}
+	if got.ApprovalSource != ApprovalSourceSlash {
+		t.Errorf("ApprovalSource = %q, want slash", got.ApprovalSource)
+	}
+	if got.CommentBody != "lgtm" {
+		t.Errorf("CommentBody = %q, want lgtm", got.CommentBody)
+	}
+}
+
+// TestHandle_ReplyPatternApprove_RoutesWithSource is the dispatch
+// integration: a reply-pattern comment lands on Handle, which
+// forwards an ApprovalCommandParams carrying Source=ReplyComment to
+// the handler. The handler's behavior for that source is server-
+// side (issue_approval.go) and tested separately.
+func TestHandle_ReplyPatternApprove_RoutesWithSource(t *testing.T) {
+	d, _, _, _ := newDispatcherWithStubs(t)
+	stub := &stubApprovalHandler{}
+	d.ApprovalHandler = stub
+
+	body := []byte(`{"comment":{"body":"+1"},"issue":{"number":42}}`)
+	if err := d.Handle(context.Background(), Event{
+		Type: "issue_comment", Action: "created", InstallationID: 99, Sender: "alice",
+		Repo: "x/y", RawBody: body,
+	}); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if len(stub.calls) != 1 {
+		t.Fatalf("expected 1 approval call; got %d", len(stub.calls))
+	}
+	got := stub.calls[0]
+	if got.Source != ApprovalSourceReplyComment {
+		t.Errorf("Source = %q, want reply_comment", got.Source)
+	}
+	if got.Decision != MatchActionApprove {
+		t.Errorf("Decision = %q", got.Decision)
+	}
+	if got.IssueNumber != 42 {
+		t.Errorf("IssueNumber = %d", got.IssueNumber)
+	}
+	if got.SenderLogin != "alice" {
+		t.Errorf("SenderLogin = %q", got.SenderLogin)
+	}
+}
+
 // --- MatchEvent: workflow_run ---
 
 func workflowRunBody(t *testing.T, fields map[string]any) []byte {


### PR DESCRIPTION
## Summary

ADR-020 / #321 picked reactions on the plan comment as the lightweight approval surface, but discovered during impl spike that **GitHub doesn't deliver webhook events for reactions on issue comments** (verified at https://docs.github.com/en/webhooks/webhook-events-and-payloads). The ADR's "Consequences" line about subscribing to reaction events is invalid.

Two-part response:

1. **This PR — typed-reply approval**. Operators type `+1`, `👍`, `:+1:`, or `lgtm` (case-insensitive) as a comment. The already-subscribed `issue_comment` event delivers it. Zero rate-limit cost, instant feedback.
2. **Follow-up #360** — adaptive reaction polling for the click-only-thumbs-up case. ~30s cadence for the first 10 min after the plan posts, ~5 min thereafter. Reuses the periodic-worker pattern from dispatchwatchdog / sla.

## Implementation

- **`ApprovalSource` enum** (`slash` vs `reply_comment`) on `Match` and `ApprovalCommandParams`. Slash matches tag `slash`; the new reply-pattern arm tags `reply_comment`.
- **`matchApprovalReplyPattern`** — splits on first whitespace; first token must equal a closed-set pattern (case-insensitive). Reject patterns are intentionally absent — typed-reply reject lacks the slash command's explicit-confirmation property; the slash path / dashboard stays the canonical rejection surface.
- **Slash tried first** — `/fishhawk approve lgtm` routes through slash with "lgtm" as the trailing rationale, not as a reply-pattern match.
- **Anchoring** — quoted-reply false positives ("Should we lgtm this?") don't match, same posture as the slash matcher.
- **Server-side silent skip** — `HandleApprovalCommand` branches on Source. Reply-comment skips silently when no run exists for the issue, no awaiting stage, or the awaiting stage is a review. Slash commands keep their explicit help replies — the reviewer typed a deliberate command.

## Test plan

- [x] `go test -race ./backend/...`
- [x] `golangci-lint run backend/...`
- [x] Coverage gate: 82.3% aggregate (≥ 80% threshold)
- [x] Existing slash matcher tagged Source=slash (regression guard)
- [x] Pattern matrix (`+1`, `+1 trailing`, `👍`, `:+1:`, `lgtm`, `LGTM`, `lgtm` multiline) all classify with Source=reply_comment
- [x] Quoted-reply guard: 4 false-positive shapes ("Should we lgtm this?", "hmm, +1 maybe later", "see https://...+1", "+10 percent")
- [x] Slash wins over reply pattern: "/fishhawk approve lgtm" stays Source=slash with `CommentBody="lgtm"`
- [x] Dispatch integration: stub approval handler receives ApprovalCommandParams with Source=reply_comment
- [x] Server silent-skip on (a) no awaiting stage and (b) review stage — for reply path only; slash path unchanged

## Notes

- **ADR-020 / #321 received an Amendment comment** documenting the webhook discovery + the amended approval-signal section. Issue stays closed.
- **E17.3b / #360 filed** for the adaptive polling follow-up.
- **No new webhook subscription needed** — `issue_comment` was already subscribed. The acceptance criteria's first bullet ("App manifest updated; new event listed") is N/A because the original premise didn't hold.
- **Surface mapping stays at `github_comment` for now** — E17.4 / #339 will introduce `SurfaceGitHubReplyComment` and branch on Source. This PR keeps the existing slash path's audit shape unchanged so E17.4 owns the schema change.

Closes #338