### PR TITLE
approval: SurfaceGitHubReplyComment + reply-comment approval-write path (E17.4 / #339)

### DIFF
--- a/backend/internal/approval/approval.go
+++ b/backend/internal/approval/approval.go
@@ -46,12 +46,21 @@ const (
 	SurfaceUI            Surface = "ui"
 	SurfaceCLI           Surface = "cli"
 	SurfaceGitHubComment Surface = "github_comment"
+	// SurfaceGitHubReplyComment tags approvals submitted via a
+	// typed reply pattern (+1 / lgtm / 👍) on the originating
+	// issue thread (E17.4 / #339). Distinct from
+	// SurfaceGitHubComment (the explicit slash command) so the
+	// audit log can attribute the decision to the right UX
+	// affordance — slash commands carry a typed rationale and
+	// produce explicit replies on misuse; reply-pattern approvals
+	// have no rationale and silently skip on misuse.
+	SurfaceGitHubReplyComment Surface = "github_reply_comment"
 )
 
 // Valid reports whether s is one of the closed-set values.
 func (s Surface) Valid() bool {
 	switch s {
-	case SurfaceAPI, SurfaceUI, SurfaceCLI, SurfaceGitHubComment:
+	case SurfaceAPI, SurfaceUI, SurfaceCLI, SurfaceGitHubComment, SurfaceGitHubReplyComment:
 		return true
 	}
 	return false

--- a/backend/internal/postgres/migrations/0022_approvals_surface_reply_comment.down.sql
+++ b/backend/internal/postgres/migrations/0022_approvals_surface_reply_comment.down.sql
@@ -1,0 +1,11 @@
+-- 0022 (down): revert the approvals.surface CHECK constraint to the
+-- pre-E17.4 set. Drops rows whose surface is `github_reply_comment`
+-- by failing the constraint re-add — the operator should clear
+-- those rows manually before downgrading.
+
+ALTER TABLE approvals
+    DROP CONSTRAINT approvals_surface_check;
+
+ALTER TABLE approvals
+    ADD CONSTRAINT approvals_surface_check
+    CHECK (surface IN ('api', 'ui', 'cli', 'github_comment'));

--- a/backend/internal/postgres/migrations/0022_approvals_surface_reply_comment.up.sql
+++ b/backend/internal/postgres/migrations/0022_approvals_surface_reply_comment.up.sql
@@ -1,0 +1,29 @@
+-- 0022: extend the approvals.surface CHECK constraint with the
+-- `github_reply_comment` value (E17.4 / #339).
+--
+-- ADR-020 / #321 chose plan-as-issue-comment-thread as the canonical
+-- plan-review surface. The lightweight approval signal is a typed
+-- reply comment (`+1`, `lgtm`, `👍`, etc.) on the originating issue;
+-- E17.3 / #338 added the matcher, and this migration is what lets
+-- E17.4 / #339 record those approvals with a distinct Surface value
+-- so the audit log can tell a slash command apart from a reply.
+--
+-- Why not reuse `github_comment`: existing rows tagged
+-- `github_comment` came from explicit `/fishhawk approve` slash
+-- commands. The reply-comment path is a different operator action
+-- (no command word required) with different UX semantics (silent
+-- skip on missing context vs. explicit help reply). The Surface
+-- field is the discriminator a post-hoc reviewer / compliance
+-- consumer reads to attribute the decision; collapsing the two
+-- would lose that distinction.
+--
+-- A future `github_reaction` value will land alongside the polling
+-- worker in E17.3b / #360. Filing one migration per Surface value
+-- keeps the upgrade history obvious.
+
+ALTER TABLE approvals
+    DROP CONSTRAINT approvals_surface_check;
+
+ALTER TABLE approvals
+    ADD CONSTRAINT approvals_surface_check
+    CHECK (surface IN ('api', 'ui', 'cli', 'github_comment', 'github_reply_comment'));

--- a/backend/internal/postgres/postgres_test.go
+++ b/backend/internal/postgres/postgres_test.go
@@ -202,16 +202,28 @@ func TestMigrateDown_RemovesTables(t *testing.T) {
 	}
 	defer pool.Close()
 
-	// MigrateDown rolls back one step. 0021 added
-	// runs.max_retries_snapshot (#280); the down migration drops
-	// the column. Confirm: max_retries_snapshot is gone, but every
-	// prior migration's effect is still present (retry_attempt from
-	// 0020, workflow_spec from 0019, stages.gate_blocking_checks
-	// dropped by 0018, required_checks_snapshot from 0017,
-	// parent_run_id + pull_request_url from 0016, stage_checks table
-	// from 0015, stages.gate_type from 0014, stages.requires_approval
-	// from 0013, signing_keys.id from 0012, runs.idempotency_key from
-	// 0011, users + sessions from 0010, etc.).
+	// MigrateDown rolls back one step. 0022 (E17.4 / #339) extended
+	// approvals.surface_check with `github_reply_comment`; the down
+	// migration restores the pre-E17.4 CHECK set. Confirm: the new
+	// surface value is no longer permitted, but every prior
+	// migration's effect is still present (max_retries_snapshot
+	// from 0021, retry_attempt from 0020, workflow_spec from 0019,
+	// etc.).
+	var surfaceCheckRejectsReplyComment bool
+	if err := pool.QueryRow(context.Background(),
+		`SELECT consrc IS NOT NULL FROM (
+			SELECT pg_get_constraintdef(oid) AS consrc
+			FROM pg_constraint
+			WHERE conname = 'approvals_surface_check'
+		) c WHERE consrc LIKE '%github_reply_comment%'`,
+	).Scan(&surfaceCheckRejectsReplyComment); err != nil {
+		// No row → constraint doesn't mention the new value; that's
+		// the expected post-MigrateDown state.
+		surfaceCheckRejectsReplyComment = false
+	}
+	if surfaceCheckRejectsReplyComment {
+		t.Errorf("approvals_surface_check still references github_reply_comment after MigrateDown; 0022 down should have removed it")
+	}
 	var maxRetriesCol, retryAttemptCol, workflowSpecCol, gateBlockingChecksCol, requiredChecksCol, parentRunIDCol, pullRequestURLCol, stageChecksTable, gateTypeCol, requiresApprovalCol, signingIDCol, idempotencyCol, usersCount, sessionsCount, apiTokensCount, deliveriesCount, approvalsCount, runsCount int
 	if err := pool.QueryRow(context.Background(),
 		`SELECT count(*) FROM information_schema.columns
@@ -219,8 +231,8 @@ func TestMigrateDown_RemovesTables(t *testing.T) {
 	).Scan(&maxRetriesCol); err != nil {
 		t.Fatalf("query runs.max_retries_snapshot column: %v", err)
 	}
-	if maxRetriesCol != 0 {
-		t.Errorf("runs.max_retries_snapshot count after MigrateDown = %d, want 0 (0021 down dropped it)", maxRetriesCol)
+	if maxRetriesCol != 1 {
+		t.Errorf("runs.max_retries_snapshot count after MigrateDown = %d, want 1 (0021 still applied; only 0022 rolled back)", maxRetriesCol)
 	}
 	if err := pool.QueryRow(context.Background(),
 		`SELECT count(*) FROM information_schema.columns

--- a/backend/internal/server/issue_approval.go
+++ b/backend/internal/server/issue_approval.go
@@ -100,6 +100,19 @@ func (s *Server) HandleApprovalCommand(ctx context.Context, p webhook.ApprovalCo
 	}
 
 	if msg, allowed := s.authorizeSlashApprover(ctx, stage, subject); !allowed {
+		if silent {
+			// Reply-comment approvals (E17.4 / #339) from a
+			// non-approver are silently dropped: a random "+1"
+			// from a passerby shouldn't get a help reply explaining
+			// the role-resolution failure. The slash path keeps its
+			// help reply — the reviewer typed a deliberate command.
+			s.cfg.Logger.LogAttrs(ctx, slog.LevelDebug,
+				"reply-comment approval: unauthorized approver, skipping",
+				slog.String("repo", p.Repo),
+				slog.Int("issue", p.IssueNumber),
+				slog.String("subject", subject))
+			return nil
+		}
 		s.replyApproval(ctx, p, msg)
 		return nil
 	}
@@ -121,20 +134,30 @@ func (s *Server) HandleApprovalCommand(ctx context.Context, p webhook.ApprovalCo
 		ApproverSubject: subject,
 		Decision:        decision,
 		Comment:         commentPtr,
-		Surface:         approval.SurfaceGitHubComment,
+		Surface:         approvalSurfaceForSource(p.Source),
 	})
 	if err != nil {
 		s.cfg.Logger.LogAttrs(ctx, slog.LevelError,
 			"slash-command approval: submit failed",
 			slog.String("stage_id", stage.ID.String()),
 			slog.String("error", err.Error()))
+		if silent {
+			return nil
+		}
 		s.replyApproval(ctx, p, "Could not record the approval. Try the dashboard.")
 		return nil
 	}
 	if !res.Inserted {
 		// A previous submission from the same approver already
-		// settled the gate. Surface that fact rather than
-		// re-running the transition.
+		// settled the gate. Reply-comment approvals (E17.4 / #339)
+		// rely on the existing dedup as an idempotency guarantee:
+		// a duplicate "+1" from the same reviewer is a no-op.
+		// Slash commands surface the prior decision so the
+		// reviewer who deliberately typed the command knows what
+		// happened.
+		if silent {
+			return nil
+		}
 		s.replyApproval(ctx, p, fmt.Sprintf("@%s already submitted a `%s` decision on this stage; the prior decision wins.", subject, res.Approval.Decision))
 		return nil
 	}
@@ -145,6 +168,9 @@ func (s *Server) HandleApprovalCommand(ctx context.Context, p webhook.ApprovalCo
 			"slash-command approval: advance stage failed",
 			slog.String("stage_id", stage.ID.String()),
 			slog.String("error", err.Error()))
+		if silent {
+			return nil
+		}
 		s.replyApproval(ctx, p, "Approval recorded but the run could not advance. Check the dashboard.")
 		return nil
 	}
@@ -177,7 +203,14 @@ func (s *Server) HandleApprovalCommand(ctx context.Context, p webhook.ApprovalCo
 				slog.String("stage_id", advanced.ID.String()),
 				slog.String("error", err.Error()))
 		}
-	} else {
+	} else if !silent {
+		// Reply-comment approvals (E17.4 / #339) skip the per-call
+		// success reply: the NotifyPlanApproved broadcast (#274)
+		// covers plan-approve, and other cases (plan-reject or
+		// review-stage rejection that reaches here) wouldn't
+		// happen on the reply path — the matcher only emits
+		// MatchActionApprove. Silence keeps a "+1" reply from
+		// echoing back a confirmation.
 		s.replyApproval(ctx, p, formatSuccessReply(decision, subject, runRow.ID, advanced))
 	}
 
@@ -329,6 +362,21 @@ func (s *Server) replyApproval(ctx context.Context, p webhook.ApprovalCommandPar
 			slog.Int("issue", p.IssueNumber),
 			slog.String("error", err.Error()))
 	}
+}
+
+// approvalSurfaceForSource maps the dispatcher's ApprovalSource onto
+// the approval.Surface stamped on the persisted row. The two paths
+// stay distinguishable in the audit log so a post-hoc reviewer can
+// tell a deliberate slash command from a reply-pattern "+1".
+//
+// Empty / unknown sources default to SurfaceGitHubComment to match
+// pre-E17.4 behavior — defensive against any future caller that
+// fails to set Source.
+func approvalSurfaceForSource(src webhook.ApprovalSource) approval.Surface {
+	if src == webhook.ApprovalSourceReplyComment {
+		return approval.SurfaceGitHubReplyComment
+	}
+	return approval.SurfaceGitHubComment
 }
 
 // decodeMatchAction translates the dispatcher's tagged action into

--- a/backend/internal/server/issue_approval_test.go
+++ b/backend/internal/server/issue_approval_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kuhlman-labs/fishhawk/backend/internal/githubclient"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/issuecomment"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/orchestrator"
+	"github.com/kuhlman-labs/fishhawk/backend/internal/role"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/run"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/stagecheck"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/webhook"
@@ -668,6 +669,228 @@ func TestHandleApprovalCommand_SlashCommand_NoAwaitingStage_StillReplies(t *test
 	}
 	if !strings.Contains(got[0].body, "No stage on this issue's run is awaiting approval") {
 		t.Errorf("reply should explain no-awaiting-stage: %q", got[0].body)
+	}
+}
+
+// TestHandleApprovalCommand_ReplyComment_HappyPath covers the
+// E17.4 / #339 happy path end-to-end: an authorized reviewer types
+// "+1" → the matcher (E17.3) routes Source=reply_comment →
+// HandleApprovalCommand writes the approval with
+// SurfaceGitHubReplyComment, advances the stage, fires the
+// NotifyPlanApproved broadcast, and posts NO inline reply.
+func TestHandleApprovalCommand_ReplyComment_HappyPath(t *testing.T) {
+	rr := newOrchestratorRepo()
+	r := rr.seedRun()
+	r.TriggerSource = run.TriggerGitHubIssue
+	triggerRef := "issue:42"
+	r.TriggerRef = &triggerRef
+	r.InstallationID = ptrInt64(99)
+	r.Repo = "x/y"
+
+	stage := rr.seedStage(r.ID, 0, run.StageStateAwaitingApproval)
+	stage.Type = run.StageTypePlan
+
+	ar := newFakeApprovalRepo()
+	au := newAuditCompleteAuditFake()
+	gh := newSlashGitHubRecorder()
+	o := &orchestrator.Orchestrator{Runs: rr}
+
+	s := New(Config{
+		Addr:         "127.0.0.1:0",
+		RunRepo:      rr,
+		ApprovalRepo: ar,
+		AuditRepo:    au,
+		Orchestrator: o,
+		ExternalURL:  "https://app.fishhawk.example.com",
+	})
+	s.issueNotifier = issuecomment.New(issuecomment.Deps{
+		GitHub: gh, Runs: rr, Audit: au,
+		ExternalURL: "https://app.fishhawk.example.com",
+	})
+
+	if err := s.HandleApprovalCommand(context.Background(), webhook.ApprovalCommandParams{
+		Repo: "x/y", IssueNumber: 42, InstallationID: 99, SenderLogin: "alice",
+		Decision: webhook.MatchActionApprove,
+		Source:   webhook.ApprovalSourceReplyComment,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Stage transitioned.
+	if stage.State != run.StageStateSucceeded {
+		t.Errorf("stage state = %q, want succeeded", stage.State)
+	}
+
+	// Approval row carries the new Surface value.
+	if len(ar.all) != 1 {
+		t.Fatalf("expected 1 approval row; got %d", len(ar.all))
+	}
+	got := ar.all[0]
+	if got.Surface != approval.SurfaceGitHubReplyComment {
+		t.Errorf("Surface = %q, want %q", got.Surface, approval.SurfaceGitHubReplyComment)
+	}
+	if got.ApproverSubject != "alice" {
+		t.Errorf("approver = %q, want alice", got.ApproverSubject)
+	}
+	if got.Decision != approval.DecisionApprove {
+		t.Errorf("decision = %q", got.Decision)
+	}
+
+	// Exactly one comment expected: the NotifyPlanApproved
+	// broadcast. The per-call success reply is suppressed for the
+	// reply path (would echo "Approved" back at a "+1", which is
+	// noise), AND the sticky-status seed comment fires too. So
+	// two GitHub calls total — broadcast + status seed.
+	calls := gh.calls()
+	broadcast, status := splitBroadcastAndStatus(calls)
+	if broadcast == "" {
+		t.Errorf("expected plan-approved broadcast; got bodies %v", commentBodies(calls))
+	}
+	if status == "" {
+		t.Errorf("expected sticky-status comment; got bodies %v", commentBodies(calls))
+	}
+	for _, c := range calls {
+		if strings.HasPrefix(c.body, "Approved by ") {
+			t.Errorf("reply-comment path should not echo a per-call success reply: %q", c.body)
+		}
+	}
+}
+
+// TestHandleApprovalCommand_ReplyComment_NonApprover_SkipsSilently
+// finishes the silent-skip contract from E17.3: a "+1" from a user
+// not in the gate's approver list is dropped without a reply.
+func TestHandleApprovalCommand_ReplyComment_NonApprover_SkipsSilently(t *testing.T) {
+	rr := newOrchestratorRepo()
+	r := rr.seedRun()
+	r.TriggerSource = run.TriggerGitHubIssue
+	triggerRef := "issue:42"
+	r.TriggerRef = &triggerRef
+	r.InstallationID = ptrInt64(99)
+	r.Repo = "x/y"
+	r.WorkflowID = "feature_change"
+	// Workflow spec restricts plan-stage approvers to the tech_lead
+	// role; the stub team lister returns no members for that team,
+	// so any subject (including "passerby") fails the role check.
+	r.WorkflowSpec = []byte(`version: "0.3"
+roles:
+  tech_lead:
+    members: ["@org/tech-leads"]
+workflows:
+  feature_change:
+    stages:
+      - id: plan
+        type: plan
+        executor:
+          agent: claude-code
+        inputs:
+          - source: github_issue
+            required: true
+        gates:
+          - type: approval
+            approvers:
+              any_of: [tech_lead]
+      - id: implement
+        type: implement
+        executor:
+          agent: claude-code
+`)
+
+	stage := rr.seedStage(r.ID, 0, run.StageStateAwaitingApproval)
+	stage.Type = run.StageTypePlan
+
+	ar := newFakeApprovalRepo()
+	au := newAuditCompleteAuditFake()
+	gh := newSlashGitHubRecorder()
+	resolver := role.NewResolver(&stubTeamLister{teamMembers: nil})
+
+	s := New(Config{
+		Addr: "127.0.0.1:0", RunRepo: rr, ApprovalRepo: ar, AuditRepo: au,
+		RoleResolver: resolver,
+		ExternalURL:  "https://app.fishhawk.example.com",
+	})
+	s.issueNotifier = issuecomment.New(issuecomment.Deps{
+		GitHub: gh, Runs: rr, Audit: au,
+		ExternalURL: "https://app.fishhawk.example.com",
+	})
+
+	if err := s.HandleApprovalCommand(context.Background(), webhook.ApprovalCommandParams{
+		Repo: "x/y", IssueNumber: 42, InstallationID: 99,
+		SenderLogin: "passerby", // not in any role
+		Decision:    webhook.MatchActionApprove,
+		Source:      webhook.ApprovalSourceReplyComment,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(ar.all) != 0 {
+		t.Errorf("no approval row should be written for non-approver; got %+v", ar.all)
+	}
+	if stage.State != run.StageStateAwaitingApproval {
+		t.Errorf("stage state advanced unexpectedly: %q", stage.State)
+	}
+	if calls := gh.calls(); len(calls) != 0 {
+		t.Errorf("non-approver reply should not produce any GitHub comment; got %d: %v",
+			len(calls), commentBodies(calls))
+	}
+}
+
+// TestHandleApprovalCommand_ReplyComment_DuplicateIdempotent locks in
+// the idempotency guarantee. A second "+1" from the same reviewer
+// finds the existing approval row (dedup on (stage_id, subject)) and
+// silently no-ops on the reply path.
+func TestHandleApprovalCommand_ReplyComment_DuplicateIdempotent(t *testing.T) {
+	rr := newOrchestratorRepo()
+	r := rr.seedRun()
+	r.TriggerSource = run.TriggerGitHubIssue
+	triggerRef := "issue:42"
+	r.TriggerRef = &triggerRef
+	r.InstallationID = ptrInt64(99)
+	r.Repo = "x/y"
+
+	rr.seedStage(r.ID, 0, run.StageStateAwaitingApproval)
+
+	ar := newFakeApprovalRepo()
+	au := newAuditCompleteAuditFake()
+	gh := newSlashGitHubRecorder()
+	o := &orchestrator.Orchestrator{Runs: rr}
+
+	s := New(Config{
+		Addr: "127.0.0.1:0", RunRepo: rr, ApprovalRepo: ar, AuditRepo: au,
+		Orchestrator: o, ExternalURL: "https://app.fishhawk.example.com",
+	})
+	s.issueNotifier = issuecomment.New(issuecomment.Deps{
+		GitHub: gh, Runs: rr, Audit: au,
+		ExternalURL: "https://app.fishhawk.example.com",
+	})
+
+	params := webhook.ApprovalCommandParams{
+		Repo: "x/y", IssueNumber: 42, InstallationID: 99, SenderLogin: "alice",
+		Decision: webhook.MatchActionApprove,
+		Source:   webhook.ApprovalSourceReplyComment,
+	}
+	// Two "+1" replies from alice — the second is a re-fire after
+	// the first stage transition has already settled.
+	if err := s.HandleApprovalCommand(context.Background(), params); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.HandleApprovalCommand(context.Background(), params); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(ar.all) != 1 {
+		t.Errorf("approval row should be deduped to 1; got %d", len(ar.all))
+	}
+	// Body scan: only the first attempt's broadcast + sticky status
+	// fire. The second attempt finds no awaiting stage (it
+	// transitioned on the first call) and silent-skips.
+	calls := gh.calls()
+	for _, c := range calls {
+		if strings.HasPrefix(c.body, "Approved by ") {
+			t.Errorf("reply-comment duplicate must not echo a success reply: %q", c.body)
+		}
+		if strings.Contains(c.body, "already submitted") {
+			t.Errorf("reply-comment duplicate must not surface the 'prior decision' reply: %q", c.body)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

E17.3 / #338 added the reply-pattern matcher and routed `Source = ApprovalSourceReplyComment` to `HandleApprovalCommand`, but parked the actual approval-write on the existing slash code path (`SurfaceGitHubComment`). This PR closes that loop.

- **New Surface value**: `SurfaceGitHubReplyComment` on `approval.Surface`, backed by migration 0022 that extends `approvals.surface_check`. Filed as a distinct value (not reusing `github_comment`) so the audit log can attribute a decision to the right UX affordance — slash commands carry a typed rationale and produce explicit help replies on misuse; reply-pattern approvals have no rationale and silently skip on misuse.
- **Source-aware Surface mapping**: new `approvalSurfaceForSource` helper. Slash → `github_comment`; reply → `github_reply_comment`.
- **Silent-skip extended to every post-context branch** on the reply path: authorization failure, submit failure, existing-dedup hit, advance failure, and the post-advance success reply. The `NotifyPlanApproved` broadcast (#274) still fires for plan-approve — that's the canonical confirmation on the issue thread; only the per-call success reply is silenced. Slash commands keep all their explicit replies.
- **Idempotency**: a duplicate "+1" from the same reviewer hits the existing `approval.Repository.Submit` dedup on `(stage_id, approver_subject)` and silently no-ops on the reply path.

## Test plan

- [x] `go test -race ./backend/...`
- [x] `golangci-lint run backend/...`
- [x] Coverage gate: 82.4% aggregate (≥ 80% threshold)
- [x] **Happy path** — reply approval writes `SurfaceGitHubReplyComment`, stage advances, `NotifyPlanApproved` broadcast + sticky-status seed fire, no per-call success reply echoes back the "+1"
- [x] **Non-approver silent skip** — unauthorized reply (passerby not in tech_lead) produces no approval row, no stage advance, no GitHub call. Uses a stub team lister with no members so the role check fails deterministically
- [x] **Duplicate idempotent** — two "+1" replies from the same reviewer produce exactly one approval row; no "Approved by" or "already submitted" reply echoes
- [x] **Migration test** — `TestMigrateDown_RemovesTables` updated for the new latest migration; verifies `approvals_surface_check` no longer references `github_reply_comment` after MigrateDown and 0021's column stays intact

## Notes

- Migration **0022** adds the new CHECK constraint value. The down migration restores the pre-E17.4 set; operator should clear any `github_reply_comment` rows before downgrading.
- The audit row's category stays `approval_submitted` for both slash and reply paths — the Surface field on the approval row is the discriminator. Adopting a new category (e.g. `plan_approved_via_reply_comment`) would have forked the audit vocabulary without a load-bearing reason.
- E17.3b / #360 (adaptive reaction polling) is the follow-up that catches the click-only-thumbs-up case. It will introduce `SurfaceGitHubReaction` alongside its worker.

Closes #339