### PR TITLE
spec: document the issue-comment plan-review flow (E17.6 / #341)

### DIFF
--- a/docs/spec/workflow-v0.md
+++ b/docs/spec/workflow-v0.md
@@ -7,15 +7,15 @@ Reference for `.fishhawk/workflows.yaml`. The canonical schema is [`workflow-v0.
 ## Top-level shape
 
 ```yaml
-version: "0.3"          # required, exactly "0.3" in v0
-roles:                  # optional; named groups referenced by gates
+version: "0.3" # required, exactly "0.3" in v0
+roles: # optional; named groups referenced by gates
   <role_id>:
     members: ["@org/team", "@user"]
-workflows:              # required; at least one workflow
+workflows: # required; at least one workflow
   <workflow_id>:
     description: "..."
-    on_ci_failure:      # optional; auto-retry policy (#276)
-      max_retries: 1    # default when the block is absent
+    on_ci_failure: # optional; auto-retry policy (#276)
+      max_retries: 1 # default when the block is absent
     stages: [...]
 ```
 
@@ -25,16 +25,16 @@ Identifiers (`<role_id>`, `<workflow_id>`, stage `id`s) are `snake_case` — `^[
 
 ```yaml
 - id: plan
-  type: plan | implement | review     # closed set; no custom types
-  executor:                           # exactly one of agent or human
-    agent: claude-code                # any string; v0 ships claude-code
+  type: plan | implement | review # closed set; no custom types
+  executor: # exactly one of agent or human
+    agent: claude-code # any string; v0 ships claude-code
     # OR
     human: true
-  inputs:      [<input>...]           # optional
-  produces:    [<artifact>...]        # optional
-  constraints: [<constraint>...]      # optional, only meaningful for implement
-  budget:      <budget>               # optional
-  gates:       [<gate>...]            # optional
+  inputs: [<input>...] # optional
+  produces: [<artifact>...] # optional
+  constraints: [<constraint>...] # optional, only meaningful for implement
+  budget: <budget> # optional
+  gates: [<gate>...] # optional
 ```
 
 Stage `id` is unique within the workflow. The `from_stage` field on inputs cross-references it; the validator (E1.3 / #18) enforces this beyond the schema.
@@ -57,14 +57,24 @@ Two shapes:
 
 ```yaml
 - artifact: plan | pull_request
-  schema: standard_v1                 # plan only; identifies the artifact schema version
+  schema: standard_v1 # plan only; identifies the artifact schema version
   persistence:
     - target: originating_issue | fishhawk_audit_log
       mode: rendered_comment | canonical
-      update_on_change: true          # republish if the artifact is regenerated
+      update_on_change: true # republish if the artifact is regenerated
 ```
 
 `canonical` is the authoritative copy (stored in the audit log). `rendered_comment` is the human-readable echo on the originating tracker (the GitHub issue), kept in sync.
+
+### `originating_issue` + `rendered_comment` — plan-review surface (ADR-020 / #321)
+
+When a plan stage's `produces` declares `target: originating_issue, mode: rendered_comment`, the backend posts the full standard_v1 plan as a markdown document on the triggering issue (E17.2 / #337). This is the **canonical plan-review surface**: reviewers read and approve from the issue thread, not the SPA. The SPA's plan-document page is a read-only mirror with a `View on GitHub` affordance (E17.5 / #340).
+
+`update_on_change: true` wires re-uploads to edit the existing comment in place via `PATCH /repos/{owner}/{repo}/issues/comments/{id}` (E20.1 / #327 surface). The plan's `github_comment_id` lives in the audit log (`KindPlanFull` / `KindPlanUpdated` rows) so a re-upload after the comment was operator-deleted falls back to a fresh `CreateIssueComment`.
+
+When the flag is omitted, the post is one-shot — the comment lands on the first plan upload and re-uploads are silently skipped (the existing post stays as the record).
+
+When the spec doesn't declare `target: originating_issue` at all, the backend falls back to the legacy summary-post path (`#234`): a short summary comment with a link to the SPA's plan-document page.
 
 ## Constraints (implement stages)
 
@@ -76,7 +86,7 @@ constraints:
   - forbidden_paths:
       - "infra/**"
       - ".github/workflows/**"
-  - allowed_paths:                    # mutually informative with forbidden
+  - allowed_paths: # mutually informative with forbidden
       - "docs/**"
       - "**/*.md"
   - required_outcomes:
@@ -105,8 +115,8 @@ Two types:
 # Approval gate — blocks until an approver acts.
 - type: approval
   approvers:
-    any_of: [tech_lead, senior_engineer]   # or all_of
-  sla: 4_business_hours                    # optional; D-category timeout
+    any_of: [tech_lead, senior_engineer] # or all_of
+  sla: 4_business_hours # optional; D-category timeout
 
 # Check gate — placeholder for workflows that delegate to GitHub branch
 # protection. Carries no spec-level fields in 0.2 (#254 / ADR-017).
@@ -121,8 +131,18 @@ Two types:
 
 **Where `approval` gates enforce** (ADR-018 / #311):
 
-- **Plan stages**: enforced by Fishhawk. The in-Fishhawk approval surface (HTTP `POST /v0/stages/{id}/approvals`, slash commands `/fishhawk approve` / `/fishhawk reject`) reads `approvers` and `sla` and gates the transition. This is the meaningful Fishhawk vote — it approves intent before any code is written; GitHub has no equivalent.
+- **Plan stages**: enforced by Fishhawk. The gate reads `approvers` and `sla` and accepts a decision from any of the convergent surfaces below (ADR-020 / #321). The vote approves intent before any code is written; GitHub has no equivalent.
 - **Review stages**: `approvers` is **informational** in v0. Branch protection's required-reviewers is the actual gate; Fishhawk records reviewer activity from `pull_request_review.submitted` events and transitions the review stage to `succeeded` on `pull_request.closed` with `merged=true` (#312). The in-Fishhawk approval API refuses review-stage submissions with `409 review_stage_managed_by_github` and points the caller at the PR. Teams that want strict approver enforcement configure branch protection's required-reviewers.
+
+**Plan-stage approval surfaces** (ADR-020 / #321 — every action reachable from where developers already work):
+
+| Surface              | How                                                                                                                                     | Surface value          |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- |
+| GitHub reply comment | Type `+1` / `👍` / `:+1:` / `lgtm` as a fresh comment on the issue thread (E17.3 / #338 + E17.4 / #339)                                 | `github_reply_comment` |
+| GitHub slash command | Type `/fishhawk approve [reason]` or `/fishhawk reject [reason]` on the issue thread                                                    | `github_comment`       |
+| HTTP / SPA / CLI     | `POST /v0/stages/{id}/approvals` (used by the SPA's approval surface and `fishhawk plan approve / reject` — E18.1 / #332, E18.2 / #333) | `api` / `ui` / `cli`   |
+
+All surfaces converge on the same `approvals` table row + an `approval_submitted` audit chain entry. The surface-of-origin is recorded in `approval.surface` (closed enum: `api`, `ui`, `cli`, `github_comment`, `github_reply_comment`) so a post-hoc reviewer can attribute the decision to the right UX affordance. The reply-comment surface skips silently on non-approver reactors and unmatched contexts (a generic "+1" reply on an unrelated issue thread isn't an error); the slash and HTTP/CLI paths reply / surface errors loudly. A future polling worker (E17.3b / #360) will add a `github_reaction` surface for click-only thumbs-up reactions GitHub doesn't deliver via webhook.
 
 `blocking_checks` was removed in v0.2 (ADR-017 / #249). Required CI checks are now derived from GitHub branch protection / rulesets at run-create time and snapshotted onto the run row (#251). The `fishhawk_audit_complete` signal is still computed by Fishhawk (#229) and published as a Check Run on the PR (#231) so branch protection can enforce it.
 
@@ -132,8 +152,8 @@ Two types:
 workflows:
   feature_change:
     on_ci_failure:
-      max_retries: 1    # 0 disables; 1 (default) = retry once; max 5
-    stages: [ … ]
+      max_retries: 1 # 0 disables; 1 (default) = retry once; max 5
+    stages: […]
 ```
 
 Per-workflow auto-retry policy (#276 / E16). When a required CI check fails on the implement stage's PR, the dispatcher fires a fresh implement workflow_dispatch up to `max_retries` times, threading each retry via `parent_run_id` (#216).
@@ -145,22 +165,22 @@ Per-workflow auto-retry policy (#276 / E16). When a required CI check fails on t
 
 ## Identifier namespaces
 
-| Field | Pattern / values | Notes |
-|---|---|---|
-| `version` | `"0.3"` | current value; 0.2 added v0.2's `blocking_checks` drop, 0.3 adds `on_ci_failure.max_retries` (#277) |
-| Role / workflow / stage IDs | `^[a-z][a-z0-9_]*$` | snake_case |
-| Member refs | `^@[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)?$` | GitHub user or team |
-| Stage `type` | `plan` \| `implement` \| `review` | closed set |
-| Executor | `agent: <string>` xor `human: true` | mutually exclusive |
-| Input `source` | `github_issue` \| `pull_request` | v0; v0.x adds Linear/Jira |
-| Artifact | `plan` \| `pull_request` | closed set |
-| Persistence target | `originating_issue` \| `fishhawk_audit_log` | closed set |
-| Persistence mode | `rendered_comment` \| `canonical` | closed set |
-| Constraint kind | `max_files_changed`, `forbidden_paths`, `allowed_paths`, `required_outcomes` | exactly one per constraint |
-| `required_outcomes` items | `tests_added_or_updated`, `ci_green` | closed set |
-| Budget enforcement | `advisory` \| `blocking` | v0 ships advisory only |
-| Gate `type` | `approval` \| `check` | closed set |
-| Approvers shape | `any_of: [<role_id>...]` xor `all_of: [<role_id>...]` | one shape per gate |
+| Field                       | Pattern / values                                                             | Notes                                                                                               |
+| --------------------------- | ---------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `version`                   | `"0.3"`                                                                      | current value; 0.2 added v0.2's `blocking_checks` drop, 0.3 adds `on_ci_failure.max_retries` (#277) |
+| Role / workflow / stage IDs | `^[a-z][a-z0-9_]*$`                                                          | snake_case                                                                                          |
+| Member refs                 | `^@[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)?$`                                    | GitHub user or team                                                                                 |
+| Stage `type`                | `plan` \| `implement` \| `review`                                            | closed set                                                                                          |
+| Executor                    | `agent: <string>` xor `human: true`                                          | mutually exclusive                                                                                  |
+| Input `source`              | `github_issue` \| `pull_request`                                             | v0; v0.x adds Linear/Jira                                                                           |
+| Artifact                    | `plan` \| `pull_request`                                                     | closed set                                                                                          |
+| Persistence target          | `originating_issue` \| `fishhawk_audit_log`                                  | closed set                                                                                          |
+| Persistence mode            | `rendered_comment` \| `canonical`                                            | closed set                                                                                          |
+| Constraint kind             | `max_files_changed`, `forbidden_paths`, `allowed_paths`, `required_outcomes` | exactly one per constraint                                                                          |
+| `required_outcomes` items   | `tests_added_or_updated`, `ci_green`                                         | closed set                                                                                          |
+| Budget enforcement          | `advisory` \| `blocking`                                                     | v0 ships advisory only                                                                              |
+| Gate `type`                 | `approval` \| `check`                                                        | closed set                                                                                          |
+| Approvers shape             | `any_of: [<role_id>...]` xor `all_of: [<role_id>...]`                        | one shape per gate                                                                                  |
 
 ## Validation rules beyond the schema
 


### PR DESCRIPTION
## Summary

Closes out E17 / #323. Captures the post-ADR-020 plan-review model and the three convergent approval surfaces in the workflow spec doc.

- **New "`originating_issue` + `rendered_comment` — plan-review surface" sub-section** under Produces. Explains that the full standard_v1 plan posts as markdown on the triggering issue, the SPA is read-only mirror with a `View on GitHub` affordance, and `update_on_change: true` wires re-uploads to edit the existing comment in place. Falls back to a fresh create if the operator deletes the comment. Omitting the flag makes the post one-shot; omitting `target: originating_issue` entirely keeps the legacy summary-post path.

- **New "Plan-stage approval surfaces" table** after the Gates section. Lists the three convergent surfaces and the `approval.surface` value each writes:

  | Surface | How | Surface value |
  |---|---|---|
  | GitHub reply comment | `+1` / `👍` / `:+1:` / `lgtm` body (E17.3 / #338 + E17.4 / #339) | `github_reply_comment` |
  | GitHub slash command | `/fishhawk approve` / `/fishhawk reject` | `github_comment` |
  | HTTP / SPA / CLI | `POST /v0/stages/{id}/approvals` (E18.1 / #332, E18.2 / #333) | `api` / `ui` / `cli` |

  Surrounding paragraph captures the convergence (one approvals row + one `approval_submitted` audit entry across all surfaces), the reply-path's silent-skip semantics, and the future `github_reaction` surface coming with E17.3b / #360.

## Test plan

- [x] Schema validation clean: `check-jsonschema --schemafile docs/spec/workflow-v0.schema.json docs/spec/examples/workflow-v0-feature-change.yaml docs/spec/examples/workflow-v0-routine-change.yaml`
- [x] Prettier clean (per the frontend's prettier config; reformatted column alignment in the new table)
- [x] Example workflows already in compliance — `feature-change.yaml`'s plan stage uses `target: originating_issue, mode: rendered_comment, update_on_change: true`; `routine-change.yaml` has no plan stage

## Notes

- No JSON Schema change (per the issue's "out of scope" — the fields are already in the schema, this is pure prose).
- Pre-alpha state: no migration messaging for existing spec files. Teams update their spec at their own pace.

Closes #341