### PR TITLE
mcp: fishhawk_get_active_run tool + thin HTTP client (E19.3 / #343)

### DIFF
--- a/backend/cmd/fishhawk-mcp/client.go
+++ b/backend/cmd/fishhawk-mcp/client.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// apiClient is the MCP server's typed wrapper around the Fishhawk
+// backend HTTP API. Intentionally a thin local copy rather than an
+// import of `cli/internal/httpclient` so the dependency direction
+// stays clean (backend → cli would invert the module hierarchy and
+// force a published cli version on every backend release).
+//
+// Only the slice of endpoints the MCP tools actually need lives
+// here. Subsequent tool tickets (E19.4 / #344, E19.5 / #345,
+// E19.6 / #346) extend this surface as they land.
+type apiClient struct {
+	baseURL string
+	token   string
+	http    *http.Client
+}
+
+func newAPIClient(cfg config) *apiClient {
+	return &apiClient{
+		baseURL: cfg.backendURL,
+		token:   cfg.apiToken,
+		http:    &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// apiError is the typed form of the OpenAPI error envelope. Mirrors
+// the CLI's *APIError so the wire shape stays consistent across
+// surfaces; callers errors.As into this to switch on Code.
+type apiError struct {
+	StatusCode int
+	Code       string
+	Message    string
+	Details    map[string]any
+}
+
+func (e *apiError) Error() string {
+	if e.Code == "" {
+		return fmt.Sprintf("fishhawk: HTTP %d", e.StatusCode)
+	}
+	return fmt.Sprintf("fishhawk: HTTP %d (%s): %s", e.StatusCode, e.Code, e.Message)
+}
+
+// Run mirrors the OpenAPI Run schema's wire shape. Subset: the MCP
+// tools surface every operator-relevant field, but skip internal
+// bookkeeping (workflow_sha etc.) the agent has no use for. JSON
+// tags match the backend exactly so the renderer in tools.go can
+// pass the decoded struct straight back to the MCP client without
+// re-mapping.
+type Run struct {
+	ID                 uuid.UUID  `json:"id"`
+	Repo               string     `json:"repo"`
+	WorkflowID         string     `json:"workflow_id"`
+	WorkflowSHA        string     `json:"workflow_sha"`
+	TriggerSource      string     `json:"trigger_source"`
+	TriggerRef         *string    `json:"trigger_ref"`
+	State              string     `json:"state"`
+	ParentRunID        *uuid.UUID `json:"parent_run_id"`
+	PullRequestURL     *string    `json:"pull_request_url"`
+	RetryAttempt       int        `json:"retry_attempt"`
+	MaxRetriesSnapshot int        `json:"max_retries_snapshot"`
+	CreatedAt          time.Time  `json:"created_at"`
+	UpdatedAt          time.Time  `json:"updated_at"`
+}
+
+type listRunsResult struct {
+	Items      []Run  `json:"items"`
+	NextCursor string `json:"next_cursor"`
+}
+
+// listRunsFilter scopes a runs query. Empty values drop from the
+// query string. The MCP server only uses three of the backend's
+// supported filters (repo, pull_request_url, trigger_ref) — the
+// resolution logic in tools.go picks the right one per input
+// shape.
+type listRunsFilter struct {
+	Repo           string
+	PullRequestURL string
+	TriggerRef     string
+	Limit          int
+}
+
+func (c *apiClient) GetRun(ctx context.Context, id uuid.UUID) (*Run, error) {
+	var r Run
+	if err := c.do(ctx, http.MethodGet, "/v0/runs/"+id.String(), nil, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+func (c *apiClient) ListRuns(ctx context.Context, f listRunsFilter) (*listRunsResult, error) {
+	q := url.Values{}
+	if f.Repo != "" {
+		q.Set("repo", f.Repo)
+	}
+	if f.PullRequestURL != "" {
+		q.Set("pull_request_url", f.PullRequestURL)
+	}
+	if f.TriggerRef != "" {
+		q.Set("trigger_ref", f.TriggerRef)
+	}
+	if f.Limit > 0 {
+		q.Set("limit", strconv.Itoa(f.Limit))
+	}
+	path := "/v0/runs"
+	if encoded := q.Encode(); encoded != "" {
+		path = path + "?" + encoded
+	}
+	var res listRunsResult
+	if err := c.do(ctx, http.MethodGet, path, nil, &res); err != nil {
+		return nil, err
+	}
+	return &res, nil
+}
+
+// do performs the request and decodes the JSON body into out. On
+// non-2xx the body is parsed as the OpenAPI error envelope and
+// returned as *apiError. Same posture as the CLI's httpclient.do.
+func (c *apiClient) do(ctx context.Context, method, path string, body []byte, out any) error {
+	if c.baseURL == "" {
+		return errors.New("apiClient: baseURL not set")
+	}
+	var rdr io.Reader
+	if body != nil {
+		rdr = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, rdr)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Accept", "application/json")
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("http: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read body: %w", err)
+	}
+	if resp.StatusCode >= 400 {
+		ae := &apiError{StatusCode: resp.StatusCode}
+		var env struct {
+			Error struct {
+				Code    string         `json:"code"`
+				Message string         `json:"message"`
+				Details map[string]any `json:"details"`
+			} `json:"error"`
+		}
+		if json.Unmarshal(raw, &env) == nil {
+			ae.Code = env.Error.Code
+			ae.Message = env.Error.Message
+			ae.Details = env.Error.Details
+		}
+		return ae
+	}
+	if out == nil {
+		return nil
+	}
+	if err := json.Unmarshal(raw, out); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+	return nil
+}

--- a/backend/cmd/fishhawk-mcp/main.go
+++ b/backend/cmd/fishhawk-mcp/main.go
@@ -74,6 +74,10 @@ func run(ctx context.Context, stderr io.Writer) int {
 		return exitFailure
 	}
 	srv := buildServer(cfg)
+	registerTools(srv, &runResolver{
+		api:    newAPIClient(cfg),
+		getenv: os.Getenv,
+	})
 	if err := srv.Run(ctx, &mcp.StdioTransport{}); err != nil {
 		_, _ = fmt.Fprintf(stderr, "fishhawk-mcp: transport error: %v\n", err)
 		return exitFailure
@@ -114,21 +118,14 @@ func loadConfig(getenv func(string) string) (config, error) {
 	return c, nil
 }
 
-// buildServer constructs the MCP server with the tool registry. In
-// E19.2 the registry is empty by design; subsequent E19.x tickets
-// register tools here. Splitting the constructor out of run keeps
-// the test surface small — the test exercises loadConfig + this
-// builder without driving stdio.
-func buildServer(cfg config) *mcp.Server {
-	srv := mcp.NewServer(&mcp.Implementation{
+// buildServer constructs the MCP server shell without any tools.
+// Splitting the constructor out of run + registerTools keeps the
+// test surface small — buildServer is the empty server every test
+// can start from, registerTools is the part each tool's test
+// exercises.
+func buildServer(_ config) *mcp.Server {
+	return mcp.NewServer(&mcp.Implementation{
 		Name:    serverName,
 		Version: serverVersion,
 	}, nil)
-	// Tools register here as they land:
-	//   E19.3 / #343 — fishhawk_get_active_run
-	//   E19.4 / #344 — fishhawk_get_plan
-	//   E19.5 / #345 — fishhawk_get_run_status
-	//   E19.6 / #346 — fishhawk_list_audit
-	_ = cfg // cfg threads through to the tool registrars
-	return srv
 }

--- a/backend/cmd/fishhawk-mcp/tools.go
+++ b/backend/cmd/fishhawk-mcp/tools.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// runResolver bundles the API client + an env getter so the tool
+// handlers can read FISHHAWK_RUN_ID / GITHUB_REPOSITORY without
+// reaching into os.Getenv directly. Tests substitute an envFunc
+// backed by a literal map; production passes os.Getenv.
+type runResolver struct {
+	api    *apiClient
+	getenv func(string) string
+}
+
+// registerTools wires every MCP tool onto srv. Called once at
+// server startup; the SDK keeps the handlers alive for the
+// lifetime of the stdio session. Tools register in alphabetical
+// order so the protocol's tool-listing endpoint returns a stable
+// ordering for clients that index on position.
+func registerTools(srv *mcp.Server, resolver *runResolver) {
+	registerGetActiveRun(srv, resolver)
+	// Subsequent tools register here:
+	//   E19.4 / #344 — fishhawk_get_plan
+	//   E19.5 / #345 — fishhawk_get_run_status
+	//   E19.6 / #346 — fishhawk_list_audit
+}
+
+// GetActiveRunInput is the tool's input schema (E19.3 / #343). All
+// fields optional — every field is a hint the resolver may use to
+// pick the right run.
+type GetActiveRunInput struct {
+	Repo       string `json:"repo,omitempty" jsonschema:"GitHub repo as owner/name; falls back to GITHUB_REPOSITORY env when omitted"`
+	PRNumber   int    `json:"pr_number,omitempty" jsonschema:"GitHub pull request number; resolves to the most-recent run whose pull_request_url matches"`
+	TriggerRef string `json:"trigger_ref,omitempty" jsonschema:"explicit trigger reference (e.g. 'issue:42'); resolves to the most-recent run on that ref"`
+}
+
+// GetActiveRunOutput mirrors the OpenAPI Run schema. Keeping the
+// fields flat (not nested under a `run` key) lets the MCP client's
+// natural-language reasoning index directly on field names without
+// schema-walking.
+type GetActiveRunOutput struct {
+	Run Run `json:"run"`
+}
+
+// registerGetActiveRun wires the fishhawk_get_active_run tool. The
+// resolver order matches the issue spec: pr_number > trigger_ref >
+// env-based detection. Each path queries the backend with a
+// different filter; the runRow-most-recent winner returns to the
+// caller. When no resolution path produces a hit, the handler
+// returns a structured error explaining what input the caller
+// could provide — agents reading the response have enough context
+// to ask the human for the missing piece.
+func registerGetActiveRun(srv *mcp.Server, resolver *runResolver) {
+	mcp.AddTool(srv, &mcp.Tool{
+		Name: "fishhawk_get_active_run",
+		Description: strings.TrimSpace(`
+Resolve the Fishhawk run for the current context.
+
+Resolution order:
+  1. If pr_number is set, returns the most-recent run on that PR.
+  2. Else if trigger_ref is set (e.g. "issue:42"), returns the
+     most-recent run on that ref.
+  3. Else if FISHHAWK_RUN_ID is set in the env (the runner case),
+     fetches that run directly.
+  4. Otherwise returns an error asking for pr_number or trigger_ref.
+
+repo defaults to GITHUB_REPOSITORY env when omitted. Returns the
+full Run shape with id, state, workflow_id, trigger info, and
+pull-request URL.
+`),
+	}, resolver.getActiveRun)
+}
+
+// getActiveRun is the tool handler. Pure-ish on its inputs; only
+// side effects are the HTTP call and reading env.
+func (r *runResolver) getActiveRun(ctx context.Context, _ *mcp.CallToolRequest, in GetActiveRunInput) (*mcp.CallToolResult, GetActiveRunOutput, error) {
+	repo := in.Repo
+	if repo == "" {
+		repo = r.getenv("GITHUB_REPOSITORY")
+	}
+
+	// Path 1: pr_number → query by pull_request_url. Requires
+	// repo to construct the canonical URL the backend stores.
+	if in.PRNumber > 0 {
+		if repo == "" {
+			return nil, GetActiveRunOutput{}, fmt.Errorf("repo required when pr_number is set; pass repo or set GITHUB_REPOSITORY")
+		}
+		prURL := fmt.Sprintf("https://github.com/%s/pull/%d", repo, in.PRNumber)
+		runRow, err := r.findMostRecent(ctx, listRunsFilter{
+			Repo:           repo,
+			PullRequestURL: prURL,
+			Limit:          5,
+		})
+		if err != nil {
+			return nil, GetActiveRunOutput{}, fmt.Errorf("list runs by pr_number: %w", err)
+		}
+		if runRow == nil {
+			return nil, GetActiveRunOutput{}, fmt.Errorf("no Fishhawk run found for %s pull/%d", repo, in.PRNumber)
+		}
+		return nil, GetActiveRunOutput{Run: *runRow}, nil
+	}
+
+	// Path 2: trigger_ref → query by trigger_ref. Repo is
+	// optional but recommended (scopes the search across
+	// installations that share an issue-number namespace).
+	if in.TriggerRef != "" {
+		runRow, err := r.findMostRecent(ctx, listRunsFilter{
+			Repo:       repo,
+			TriggerRef: in.TriggerRef,
+			Limit:      5,
+		})
+		if err != nil {
+			return nil, GetActiveRunOutput{}, fmt.Errorf("list runs by trigger_ref: %w", err)
+		}
+		if runRow == nil {
+			return nil, GetActiveRunOutput{}, fmt.Errorf("no Fishhawk run found for trigger_ref=%q", in.TriggerRef)
+		}
+		return nil, GetActiveRunOutput{Run: *runRow}, nil
+	}
+
+	// Path 3: FISHHAWK_RUN_ID in env. The in-runner agent (E19.8
+	// / future) gets this stamped at stage-start; the operator
+	// can also export it manually.
+	if runID := r.getenv("FISHHAWK_RUN_ID"); runID != "" {
+		id, parseErr := uuid.Parse(runID)
+		if parseErr != nil {
+			return nil, GetActiveRunOutput{}, fmt.Errorf("FISHHAWK_RUN_ID=%q is not a valid UUID: %w", runID, parseErr)
+		}
+		runRow, err := r.api.GetRun(ctx, id)
+		if err != nil {
+			return nil, GetActiveRunOutput{}, fmt.Errorf("get run by FISHHAWK_RUN_ID: %w", err)
+		}
+		return nil, GetActiveRunOutput{Run: *runRow}, nil
+	}
+
+	// Path 4: nothing to resolve from. Tell the caller exactly
+	// what they could pass.
+	return nil, GetActiveRunOutput{}, errors.New("no active run resolvable from context; pass pr_number or trigger_ref, or set FISHHAWK_RUN_ID in the environment")
+}
+
+// findMostRecent returns the most-recent run from a filter-scoped
+// list query, or nil when the page is empty. The backend's
+// /v0/runs list orders descending by created_at (per #213); we
+// re-sort defensively in case the ordering ever changes.
+func (r *runResolver) findMostRecent(ctx context.Context, f listRunsFilter) (*Run, error) {
+	page, err := r.api.ListRuns(ctx, f)
+	if err != nil {
+		return nil, err
+	}
+	if len(page.Items) == 0 {
+		return nil, nil
+	}
+	items := page.Items
+	sort.SliceStable(items, func(i, j int) bool {
+		return items[i].CreatedAt.After(items[j].CreatedAt)
+	})
+	return &items[0], nil
+}

--- a/backend/cmd/fishhawk-mcp/tools_test.go
+++ b/backend/cmd/fishhawk-mcp/tools_test.go
@@ -1,0 +1,334 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// fakeBackend is a thin httptest server that records the last
+// /v0/runs query (so tests can assert filter forwarding) and a
+// /v0/runs/{id} fetch path (so the FISHHAWK_RUN_ID branch has
+// somewhere to land).
+type fakeBackend struct {
+	mu sync.Mutex
+
+	lastListQuery string
+	listResp      listRunsResult
+	listStatus    int
+
+	getResp   Run
+	getStatus int
+
+	// Per-call response overrides keyed by query string for tests
+	// that exercise multiple resolution paths in one server.
+	listByQuery map[string]listRunsResult
+}
+
+func newFakeBackend(t *testing.T) (*fakeBackend, *httptest.Server) {
+	t.Helper()
+	fb := &fakeBackend{
+		listStatus:  http.StatusOK,
+		getStatus:   http.StatusOK,
+		listByQuery: map[string]listRunsResult{},
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /v0/runs", func(w http.ResponseWriter, r *http.Request) {
+		fb.mu.Lock()
+		fb.lastListQuery = r.URL.RawQuery
+		resp, override := fb.listByQuery[r.URL.RawQuery]
+		fb.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(fb.listStatus)
+		if override {
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(fb.listResp)
+	})
+	mux.HandleFunc("GET /v0/runs/{run_id}", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(fb.getStatus)
+		_ = json.NewEncoder(w).Encode(fb.getResp)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return fb, srv
+}
+
+func newResolver(srv *httptest.Server, env map[string]string) *runResolver {
+	return &runResolver{
+		api: newAPIClient(config{
+			backendURL: srv.URL,
+			apiToken:   "tok-test",
+		}),
+		getenv: envFuncFromMap(env),
+	}
+}
+
+func envFuncFromMap(env map[string]string) func(string) string {
+	return func(k string) string { return env[k] }
+}
+
+func sampleRun(id uuid.UUID, repo string, age time.Duration) Run {
+	pr := "https://github.com/" + repo + "/pull/42"
+	tr := "issue:42"
+	return Run{
+		ID: id, Repo: repo, WorkflowID: "feature_change",
+		TriggerSource:  "github_issue",
+		TriggerRef:     &tr,
+		State:          "running",
+		PullRequestURL: &pr,
+		CreatedAt:      time.Now().UTC().Add(-age),
+		UpdatedAt:      time.Now().UTC().Add(-age),
+	}
+}
+
+func TestGetActiveRun_ByPRNumber_QueriesPullRequestURL(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	id := uuid.New()
+	fb.listResp = listRunsResult{Items: []Run{sampleRun(id, "x/y", time.Hour)}}
+	r := newResolver(srv, nil)
+
+	_, out, err := r.getActiveRun(context.Background(), nil, GetActiveRunInput{
+		Repo:     "x/y",
+		PRNumber: 42,
+	})
+	if err != nil {
+		t.Fatalf("getActiveRun: %v", err)
+	}
+	if out.Run.ID != id {
+		t.Errorf("Run.ID = %s, want %s", out.Run.ID, id)
+	}
+	// Verify the filter actually hit the backend.
+	for _, want := range []string{
+		"repo=x%2Fy",
+		"pull_request_url=https%3A%2F%2Fgithub.com%2Fx%2Fy%2Fpull%2F42",
+	} {
+		if !strings.Contains(fb.lastListQuery, want) {
+			t.Errorf("query missing %q: %s", want, fb.lastListQuery)
+		}
+	}
+}
+
+func TestGetActiveRun_ByPRNumber_RequiresRepo(t *testing.T) {
+	// pr_number set, repo missing, GITHUB_REPOSITORY unset → the
+	// tool can't build the canonical pull_request_url. Surface a
+	// clean error rather than silently scoping the search to all
+	// installations.
+	_, srv := newFakeBackend(t)
+	r := newResolver(srv, nil)
+
+	_, _, err := r.getActiveRun(context.Background(), nil, GetActiveRunInput{
+		PRNumber: 42,
+	})
+	if err == nil {
+		t.Fatal("expected error when repo and GITHUB_REPOSITORY are both unset")
+	}
+	if !strings.Contains(err.Error(), "repo required") {
+		t.Errorf("error wording: %v", err)
+	}
+}
+
+func TestGetActiveRun_ByPRNumber_FallsBackToGitHubRepositoryEnv(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	id := uuid.New()
+	fb.listResp = listRunsResult{Items: []Run{sampleRun(id, "x/y", time.Hour)}}
+	r := newResolver(srv, map[string]string{"GITHUB_REPOSITORY": "x/y"})
+
+	_, out, err := r.getActiveRun(context.Background(), nil, GetActiveRunInput{
+		PRNumber: 42,
+	})
+	if err != nil {
+		t.Fatalf("getActiveRun: %v", err)
+	}
+	if out.Run.ID != id {
+		t.Errorf("Run.ID = %s, want %s", out.Run.ID, id)
+	}
+}
+
+func TestGetActiveRun_ByTriggerRef_QueriesTriggerRefFilter(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	id := uuid.New()
+	fb.listResp = listRunsResult{Items: []Run{sampleRun(id, "x/y", time.Hour)}}
+	r := newResolver(srv, map[string]string{"GITHUB_REPOSITORY": "x/y"})
+
+	_, out, err := r.getActiveRun(context.Background(), nil, GetActiveRunInput{
+		TriggerRef: "issue:42",
+	})
+	if err != nil {
+		t.Fatalf("getActiveRun: %v", err)
+	}
+	if out.Run.ID != id {
+		t.Errorf("Run.ID = %s, want %s", out.Run.ID, id)
+	}
+	for _, want := range []string{"repo=x%2Fy", "trigger_ref=issue%3A42"} {
+		if !strings.Contains(fb.lastListQuery, want) {
+			t.Errorf("query missing %q: %s", want, fb.lastListQuery)
+		}
+	}
+}
+
+func TestGetActiveRun_ByEnvRunID_DirectFetch(t *testing.T) {
+	// The runner case: FISHHAWK_RUN_ID stamped on the env →
+	// fetch the run directly without a list scan.
+	fb, srv := newFakeBackend(t)
+	id := uuid.MustParse("11111111-2222-3333-4444-555555555555")
+	fb.getResp = sampleRun(id, "x/y", time.Hour)
+	r := newResolver(srv, map[string]string{"FISHHAWK_RUN_ID": id.String()})
+
+	_, out, err := r.getActiveRun(context.Background(), nil, GetActiveRunInput{})
+	if err != nil {
+		t.Fatalf("getActiveRun: %v", err)
+	}
+	if out.Run.ID != id {
+		t.Errorf("Run.ID = %s, want %s", out.Run.ID, id)
+	}
+}
+
+func TestGetActiveRun_ByEnvRunID_RejectsInvalidUUID(t *testing.T) {
+	// Defensive: if the runner stamps a malformed env, surface a
+	// clear error rather than a generic 4xx from the GET path.
+	_, srv := newFakeBackend(t)
+	r := newResolver(srv, map[string]string{"FISHHAWK_RUN_ID": "not-a-uuid"})
+
+	_, _, err := r.getActiveRun(context.Background(), nil, GetActiveRunInput{})
+	if err == nil {
+		t.Fatal("expected error on malformed FISHHAWK_RUN_ID")
+	}
+	if !strings.Contains(err.Error(), "not a valid UUID") {
+		t.Errorf("error wording: %v", err)
+	}
+}
+
+func TestGetActiveRun_NoResolutionPath_ReturnsStructuredError(t *testing.T) {
+	// No pr_number, no trigger_ref, no FISHHAWK_RUN_ID. The error
+	// message must list every input the caller could supply so an
+	// agent reading it can ask the human for the missing piece.
+	_, srv := newFakeBackend(t)
+	r := newResolver(srv, nil)
+
+	_, _, err := r.getActiveRun(context.Background(), nil, GetActiveRunInput{})
+	if err == nil {
+		t.Fatal("expected error when no resolution path is available")
+	}
+	for _, want := range []string{"pr_number", "trigger_ref", "FISHHAWK_RUN_ID"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error should name %q as an option: %v", want, err)
+		}
+	}
+}
+
+func TestGetActiveRun_PRNumber_NoMatchingRun(t *testing.T) {
+	// Empty list response → friendly error naming the repo + PR
+	// number so the caller knows the lookup itself worked but
+	// nothing matched.
+	fb, srv := newFakeBackend(t)
+	fb.listResp = listRunsResult{Items: nil}
+	r := newResolver(srv, nil)
+
+	_, _, err := r.getActiveRun(context.Background(), nil, GetActiveRunInput{
+		Repo:     "x/y",
+		PRNumber: 42,
+	})
+	if err == nil {
+		t.Fatal("expected not-found error")
+	}
+	if !strings.Contains(err.Error(), "x/y") || !strings.Contains(err.Error(), "pull/42") {
+		t.Errorf("error should name the repo + PR: %v", err)
+	}
+}
+
+func TestGetActiveRun_PicksMostRecentByCreatedAt(t *testing.T) {
+	// Two runs on the same PR (e.g., a retry chain). The resolver
+	// returns the newer one. Defensive sort — even if the
+	// backend ever stops ordering, we still pick correctly.
+	fb, srv := newFakeBackend(t)
+	older := uuid.New()
+	newer := uuid.New()
+	fb.listResp = listRunsResult{Items: []Run{
+		sampleRun(older, "x/y", 24*time.Hour),
+		sampleRun(newer, "x/y", time.Hour),
+	}}
+	r := newResolver(srv, nil)
+
+	_, out, err := r.getActiveRun(context.Background(), nil, GetActiveRunInput{
+		Repo:     "x/y",
+		PRNumber: 42,
+	})
+	if err != nil {
+		t.Fatalf("getActiveRun: %v", err)
+	}
+	if out.Run.ID != newer {
+		t.Errorf("Run.ID = %s, want newer %s", out.Run.ID, newer)
+	}
+}
+
+func TestGetActiveRun_BackendError_Surfaced(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	fb.listStatus = http.StatusInternalServerError
+	r := newResolver(srv, nil)
+
+	_, _, err := r.getActiveRun(context.Background(), nil, GetActiveRunInput{
+		Repo:     "x/y",
+		PRNumber: 42,
+	})
+	if err == nil {
+		t.Fatal("expected backend error")
+	}
+	// Both wrapped error and the underlying *apiError reach the
+	// caller; just verify the surface message is helpful.
+	if !strings.Contains(err.Error(), "list runs") {
+		t.Errorf("error wording: %v", err)
+	}
+}
+
+func TestGetActiveRun_ResolutionOrder_PRNumberBeatsTriggerRef(t *testing.T) {
+	// Both pr_number and trigger_ref provided — the spec's
+	// resolution order says pr_number wins. Verify the trigger_ref
+	// branch isn't even consulted (it would otherwise hit the
+	// backend with a different query).
+	fb, srv := newFakeBackend(t)
+	id := uuid.New()
+	fb.listResp = listRunsResult{Items: []Run{sampleRun(id, "x/y", time.Hour)}}
+	r := newResolver(srv, nil)
+
+	_, out, err := r.getActiveRun(context.Background(), nil, GetActiveRunInput{
+		Repo:       "x/y",
+		PRNumber:   42,
+		TriggerRef: "issue:42",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Run.ID != id {
+		t.Errorf("Run.ID = %s, want %s", out.Run.ID, id)
+	}
+	if !strings.Contains(fb.lastListQuery, "pull_request_url=") {
+		t.Errorf("expected pull_request_url filter (pr_number wins); got %s", fb.lastListQuery)
+	}
+	if strings.Contains(fb.lastListQuery, "trigger_ref=") {
+		t.Errorf("trigger_ref filter should not have been used: %s", fb.lastListQuery)
+	}
+}
+
+func TestRegisterTools_RegistersGetActiveRun(t *testing.T) {
+	// Smoke test: registerTools doesn't panic and the SDK accepts
+	// the tool definition. Full handshake verification lives in
+	// the SDK; we just assert the registration call sequence
+	// completes for v0's tool set.
+	cfg := config{backendURL: "http://localhost:8080", apiToken: "tok"}
+	srv := buildServer(cfg)
+	resolver := &runResolver{
+		api:    newAPIClient(cfg),
+		getenv: envFuncFromMap(nil),
+	}
+	registerTools(srv, resolver)
+}


### PR DESCRIPTION
## Summary

First MCP tool. Resolves "the run for the current context" so the agent / operator doesn't need to type a UUID.

Resolution order (per the issue spec):

1. `pr_number` set → `/v0/runs?repo=…&pull_request_url=…`, return most-recent. Requires `repo` (or `GITHUB_REPOSITORY` env).
2. `trigger_ref` set (e.g. `issue:42`) → `/v0/runs?…&trigger_ref=…`, return most-recent.
3. `FISHHAWK_RUN_ID` env → `GET /v0/runs/{id}` directly. This is the in-runner agent path E19.8 will provision at stage-start.
4. Otherwise → structured error naming every input the caller could supply (so an agent reading the message can ask the human for the missing piece).

## Implementation

- **`client.go`** — thin `apiClient` (BaseURL, Token, GetRun, ListRuns). Intentionally local rather than importing `cli/internal/httpclient`: backend → cli would invert the module dependency direction and force a published cli version on every backend release. Future tools (E19.4–E19.6) extend this client.
- **`tools.go`** — `runResolver` bundles the client + an env-getter so tests can substitute a literal map. `registerTools` is the entry point E19.2 scaffolded; this PR adds the first registration. Function is a list of registrar calls in alphabetical order so subsequent tools plug in cleanly.
- **`main.go`** wires the resolver into the production server via `os.Getenv`; tests construct it directly with the fake backend.
- Most-recent-wins by `created_at` within the returned page. Backend's `/v0/runs` already orders desc; resolver re-sorts defensively so a future ordering change doesn't silently break this path.

## Test plan

- [x] `go test -race ./backend/cmd/fishhawk-mcp/...`
- [x] `go test -race ./backend/...`
- [x] `golangci-lint run backend/...`
- [x] Coverage gate: 82.3% aggregate (≥ 80% threshold)
- [x] Twelve cases: pr_number happy path, pr_number requires repo (clean error), pr_number falls back to `GITHUB_REPOSITORY`, trigger_ref happy path, `FISHHAWK_RUN_ID` direct GET, `FISHHAWK_RUN_ID` malformed UUID → clean error, no-resolution-path error names all three options, backend 500 surfaces wrapped error, no-match returns friendly error naming the repo + PR, most-recent-wins on multi-run pages (retry chain case), resolution order pr_number > trigger_ref, `registerTools` smoke

## Notes

- v0 stays read-only per ADR-021. The agent can articulate proposed actions; humans take them via CLI / SPA / GitHub.
- `FISHHAWK_RUN_ID` is the cleanest in-runner path; the issue mentioned shelling out to `git` + GitHub API for branch→PR detection. Deferred — `FISHHAWK_RUN_ID` plus the explicit-input paths cover the v0 cases without the invasive scope.

Closes #343