### PR TITLE
mcp: fishhawk_get_plan tool (E19.4 / #344)

### DIFF
--- a/backend/cmd/fishhawk-mcp/client.go
+++ b/backend/cmd/fishhawk-mcp/client.go
@@ -102,6 +102,62 @@ func (c *apiClient) GetRun(ctx context.Context, id uuid.UUID) (*Run, error) {
 	return &r, nil
 }
 
+// Stage mirrors the wire shape, scoped to the fields the MCP tools
+// need: id, run_id, type, state. Other fields (executor, sequence,
+// failure_*) are surfaced in E19.5's get_run_status output but the
+// get_plan tool only needs to find the plan stage on a run.
+type Stage struct {
+	ID    uuid.UUID `json:"id"`
+	RunID uuid.UUID `json:"run_id"`
+	Type  string    `json:"type"`
+	State string    `json:"state"`
+}
+
+type listStagesResult struct {
+	Items []Stage `json:"items"`
+}
+
+// ListRunStages calls GET /v0/runs/{run_id}/stages. Stages come back
+// ordered by sequence ascending; the tool layer picks the plan
+// stage from the list.
+func (c *apiClient) ListRunStages(ctx context.Context, runID uuid.UUID) ([]Stage, error) {
+	var res listStagesResult
+	if err := c.do(ctx, http.MethodGet, "/v0/runs/"+runID.String()+"/stages", nil, &res); err != nil {
+		return nil, err
+	}
+	return res.Items, nil
+}
+
+// Artifact is the wire shape with content inline. The backend
+// returns content directly on the listStageArtifacts endpoint (per
+// the OpenAPI Artifact schema), so the MCP tool doesn't need a
+// separate /v0/artifacts/{id} fetch.
+type Artifact struct {
+	ID            uuid.UUID       `json:"id"`
+	StageID       uuid.UUID       `json:"stage_id"`
+	Kind          string          `json:"kind"`
+	SchemaVersion *string         `json:"schema_version,omitempty"`
+	ContentHash   string          `json:"content_hash"`
+	Content       json.RawMessage `json:"content,omitempty"`
+	CreatedAt     time.Time       `json:"created_at"`
+}
+
+type listArtifactsResult struct {
+	Items []Artifact `json:"items"`
+}
+
+// ListStageArtifacts calls GET /v0/stages/{stage_id}/artifacts.
+// Artifacts come back ordered by created_at ascending; callers
+// pick the most-recent (the SPA pre-trace does the same — see
+// `frontend/src/routes/stage-detail.tsx`).
+func (c *apiClient) ListStageArtifacts(ctx context.Context, stageID uuid.UUID) ([]Artifact, error) {
+	var res listArtifactsResult
+	if err := c.do(ctx, http.MethodGet, "/v0/stages/"+stageID.String()+"/artifacts", nil, &res); err != nil {
+		return nil, err
+	}
+	return res.Items, nil
+}
+
 func (c *apiClient) ListRuns(ctx context.Context, f listRunsFilter) (*listRunsResult, error) {
 	q := url.Values{}
 	if f.Repo != "" {

--- a/backend/cmd/fishhawk-mcp/tools.go
+++ b/backend/cmd/fishhawk-mcp/tools.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -27,8 +29,8 @@ type runResolver struct {
 // ordering for clients that index on position.
 func registerTools(srv *mcp.Server, resolver *runResolver) {
 	registerGetActiveRun(srv, resolver)
+	registerGetPlan(srv, resolver)
 	// Subsequent tools register here:
-	//   E19.4 / #344 — fishhawk_get_plan
 	//   E19.5 / #345 — fishhawk_get_run_status
 	//   E19.6 / #346 — fishhawk_list_audit
 }
@@ -144,6 +146,211 @@ func (r *runResolver) getActiveRun(ctx context.Context, _ *mcp.CallToolRequest, 
 	// Path 4: nothing to resolve from. Tell the caller exactly
 	// what they could pass.
 	return nil, GetActiveRunOutput{}, errors.New("no active run resolvable from context; pass pr_number or trigger_ref, or set FISHHAWK_RUN_ID in the environment")
+}
+
+// retryPlanChainDepth caps the parent-walk so a corrupt
+// parent_run_id cycle can't loop forever. Mirrors the constant of
+// the same name in `backend/internal/server/prompt.go` — keep them
+// aligned so the MCP tool returns the same plan the backend's
+// prompt builder would resolve for the same run.
+const retryPlanChainDepth = 8
+
+// GetPlanInput is the get_plan tool's input schema. run_id is the
+// only field — the resolver walks the parent chain itself; agents
+// don't need to know about the retry-chain mechanism.
+type GetPlanInput struct {
+	RunID string `json:"run_id" jsonschema:"the Fishhawk run UUID; the tool walks parent_run_id internally for CI-retry chains"`
+}
+
+// PlanContent mirrors the standard_v1 plan shape. Fields the agent
+// reads to reason about scope, approach, and verification expectations.
+// Kept flat for jsonschema friendliness; the SDK turns the struct
+// into an output schema the MCP client can introspect.
+type PlanContent struct {
+	PlanVersion         string             `json:"plan_version"`
+	TicketReference     PlanTicketRef      `json:"ticket_reference"`
+	GeneratedBy         PlanGeneratedBy    `json:"generated_by"`
+	Summary             string             `json:"summary"`
+	Scope               PlanScope          `json:"scope"`
+	Approach            []PlanApproachStep `json:"approach"`
+	Verification        PlanVerification   `json:"verification"`
+	RisksAndAssumptions []string           `json:"risks_and_assumptions,omitempty"`
+}
+
+// PlanTicketRef identifies the ticket that originated the run.
+type PlanTicketRef struct {
+	Type string `json:"type"`
+	URL  string `json:"url"`
+	ID   string `json:"id"`
+}
+
+// PlanGeneratedBy identifies the agent + model + timestamp that
+// produced the plan artifact.
+type PlanGeneratedBy struct {
+	Agent     string    `json:"agent"`
+	Model     string    `json:"model"`
+	Version   string    `json:"version,omitempty"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// PlanScope lists the files the agent intends to touch + estimate.
+type PlanScope struct {
+	Files                 []PlanScopeFile `json:"files"`
+	EstimatedLinesChanged int             `json:"estimated_lines_changed,omitempty"`
+}
+
+// PlanScopeFile is one path the plan covers.
+type PlanScopeFile struct {
+	Path      string `json:"path"`
+	Operation string `json:"operation"`
+}
+
+// PlanApproachStep is one numbered step in the approach list.
+type PlanApproachStep struct {
+	Step        int    `json:"step"`
+	Description string `json:"description"`
+}
+
+// PlanVerification carries the test_strategy and rollback_plan.
+type PlanVerification struct {
+	TestStrategy string `json:"test_strategy"`
+	RollbackPlan string `json:"rollback_plan"`
+}
+
+// GetPlanOutput is the response shape. Status is `available` or
+// `no_plan_yet`; on `no_plan_yet` Plan is nil and Message explains
+// why so an agent reading the response can branch on the state
+// without parsing prose.
+type GetPlanOutput struct {
+	Status      string       `json:"status" jsonschema:"either 'available' or 'no_plan_yet'"`
+	Message     string       `json:"message,omitempty" jsonschema:"human-readable explanation when status=no_plan_yet"`
+	Plan        *PlanContent `json:"plan,omitempty"`
+	ResolvedVia string       `json:"resolved_via,omitempty" jsonschema:"'self' when the plan came from the requested run; 'parent:<run_id>' when the parent-walk resolved it for a CI-retry chain"`
+}
+
+// registerGetPlan wires the fishhawk_get_plan tool. The handler
+// mirrors `backend/internal/server/prompt.go::loadApprovedPlanForRun`
+// — find the plan stage on the run, fall back to parent_run_id when
+// no plan stage exists (the CI-retry case per #279 / E16). Read-only
+// per ADR-021; never modifies state.
+func registerGetPlan(srv *mcp.Server, resolver *runResolver) {
+	mcp.AddTool(srv, &mcp.Tool{
+		Name: "fishhawk_get_plan",
+		Description: strings.TrimSpace(`
+Fetch the approved plan for a Fishhawk run.
+
+Walks parent_run_id up to 8 levels so CI-retry runs (which skip the
+plan stage and re-execute against the parent's plan) resolve to the
+canonical plan. Returns the parsed standard_v1 plan shape: summary,
+scope.files, approach steps, verification (test_strategy +
+rollback_plan), and risks_and_assumptions when present.
+
+Response status:
+  - "available"     — Plan is populated; ResolvedVia tells you whether
+                      it came from the requested run ("self") or a
+                      parent in the retry chain ("parent:<run_id>").
+  - "no_plan_yet"   — The run (and its parents) have no terminal plan
+                      artifact yet. Message names the chain depth
+                      searched.
+`),
+	}, resolver.getPlan)
+}
+
+// getPlan is the tool handler.
+func (r *runResolver) getPlan(ctx context.Context, _ *mcp.CallToolRequest, in GetPlanInput) (*mcp.CallToolResult, GetPlanOutput, error) {
+	runID, err := uuid.Parse(in.RunID)
+	if err != nil {
+		return nil, GetPlanOutput{}, fmt.Errorf("run_id %q is not a valid UUID: %w", in.RunID, err)
+	}
+
+	// Walk the chain. Cap at retryPlanChainDepth so a corrupt
+	// parent cycle can't loop the agent.
+	current := runID
+	for depth := 0; depth < retryPlanChainDepth; depth++ {
+		p, found, err := r.tryGetPlanForRun(ctx, current)
+		if err != nil {
+			return nil, GetPlanOutput{}, err
+		}
+		if found {
+			resolvedVia := "self"
+			if current != runID {
+				resolvedVia = "parent:" + current.String()
+			}
+			return nil, GetPlanOutput{
+				Status:      "available",
+				Plan:        p,
+				ResolvedVia: resolvedVia,
+			}, nil
+		}
+		runRow, err := r.api.GetRun(ctx, current)
+		if err != nil {
+			return nil, GetPlanOutput{}, fmt.Errorf("get run for parent walk: %w", err)
+		}
+		if runRow.ParentRunID == nil {
+			return nil, GetPlanOutput{
+				Status:  "no_plan_yet",
+				Message: fmt.Sprintf("no terminal plan artifact on run %s (chain root reached at depth %d)", runID, depth),
+			}, nil
+		}
+		current = *runRow.ParentRunID
+	}
+	return nil, GetPlanOutput{
+		Status:  "no_plan_yet",
+		Message: fmt.Sprintf("no terminal plan artifact on run %s after walking %d parent levels (chain depth cap)", runID, retryPlanChainDepth),
+	}, nil
+}
+
+// tryGetPlanForRun mirrors prompt.go's tryLoadPlanForRun. Returns
+// (plan, true, nil) on a hit; (nil, false, nil) when the run has no
+// plan stage or no usable plan artifact (caller walks to parent);
+// (nil, false, err) on transport / decode failure.
+func (r *runResolver) tryGetPlanForRun(ctx context.Context, runID uuid.UUID) (*PlanContent, bool, error) {
+	stages, err := r.api.ListRunStages(ctx, runID)
+	if err != nil {
+		return nil, false, fmt.Errorf("list stages: %w", err)
+	}
+	var planStageID uuid.UUID
+	for _, st := range stages {
+		if st.Type == "plan" {
+			planStageID = st.ID
+			break
+		}
+	}
+	if planStageID == uuid.Nil {
+		return nil, false, nil
+	}
+	arts, err := r.api.ListStageArtifacts(ctx, planStageID)
+	if err != nil {
+		return nil, false, fmt.Errorf("list plan stage artifacts: %w", err)
+	}
+	var picked *Artifact
+	for i := range arts {
+		a := &arts[i]
+		if a.Kind != "plan" {
+			continue
+		}
+		if a.SchemaVersion == nil || *a.SchemaVersion != "standard_v1" {
+			continue
+		}
+		if picked == nil || a.CreatedAt.After(picked.CreatedAt) {
+			picked = a
+		}
+	}
+	if picked == nil {
+		return nil, false, nil
+	}
+	if len(picked.Content) == 0 {
+		// Backend invariant: ListStageArtifacts returns content
+		// inline. An empty content suggests a partial response we
+		// shouldn't try to parse — surface as not-yet rather than
+		// a confusing JSON parse error.
+		return nil, false, nil
+	}
+	var p PlanContent
+	if err := json.Unmarshal(picked.Content, &p); err != nil {
+		return nil, false, fmt.Errorf("decode plan artifact: %w", err)
+	}
+	return &p, true, nil
 }
 
 // findMostRecent returns the most-recent run from a filter-scoped

--- a/backend/cmd/fishhawk-mcp/tools_test.go
+++ b/backend/cmd/fishhawk-mcp/tools_test.go
@@ -16,7 +16,9 @@ import (
 // fakeBackend is a thin httptest server that records the last
 // /v0/runs query (so tests can assert filter forwarding) and a
 // /v0/runs/{id} fetch path (so the FISHHAWK_RUN_ID branch has
-// somewhere to land).
+// somewhere to land). E19.4 / #344 added the per-run stage list
+// and per-stage artifact list endpoints so the get_plan tests can
+// drive the parent-walk loop without a full backend.
 type fakeBackend struct {
 	mu sync.Mutex
 
@@ -24,20 +26,40 @@ type fakeBackend struct {
 	listResp      listRunsResult
 	listStatus    int
 
-	getResp   Run
-	getStatus int
+	// /v0/runs/{run_id} fetches consult getRunByID first; the
+	// fallback getResp is the default when the id isn't keyed.
+	getRunByID map[uuid.UUID]Run
+	getResp    Run
+	getStatus  int
 
 	// Per-call response overrides keyed by query string for tests
 	// that exercise multiple resolution paths in one server.
 	listByQuery map[string]listRunsResult
+
+	// E19.4 fixtures: stages keyed by run id, artifacts keyed by
+	// stage id. Empty map → 200 with empty items list (mirrors the
+	// backend's behavior for runs that haven't created stages yet).
+	stagesByRun       map[uuid.UUID][]Stage
+	artifactsByStage  map[uuid.UUID][]Artifact
+	stagesStatus      int
+	artifactsStatus   int
+	stagesCalledByID  map[uuid.UUID]int
+	artifactsCalledID map[uuid.UUID]int
 }
 
 func newFakeBackend(t *testing.T) (*fakeBackend, *httptest.Server) {
 	t.Helper()
 	fb := &fakeBackend{
-		listStatus:  http.StatusOK,
-		getStatus:   http.StatusOK,
-		listByQuery: map[string]listRunsResult{},
+		listStatus:        http.StatusOK,
+		getStatus:         http.StatusOK,
+		stagesStatus:      http.StatusOK,
+		artifactsStatus:   http.StatusOK,
+		listByQuery:       map[string]listRunsResult{},
+		getRunByID:        map[uuid.UUID]Run{},
+		stagesByRun:       map[uuid.UUID][]Stage{},
+		artifactsByStage:  map[uuid.UUID][]Artifact{},
+		stagesCalledByID:  map[uuid.UUID]int{},
+		artifactsCalledID: map[uuid.UUID]int{},
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /v0/runs", func(w http.ResponseWriter, r *http.Request) {
@@ -55,8 +77,48 @@ func newFakeBackend(t *testing.T) (*fakeBackend, *httptest.Server) {
 	})
 	mux.HandleFunc("GET /v0/runs/{run_id}", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		id, perr := uuid.Parse(r.PathValue("run_id"))
+		if perr != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		fb.mu.Lock()
+		row, ok := fb.getRunByID[id]
+		fb.mu.Unlock()
 		w.WriteHeader(fb.getStatus)
+		if ok {
+			_ = json.NewEncoder(w).Encode(row)
+			return
+		}
 		_ = json.NewEncoder(w).Encode(fb.getResp)
+	})
+	mux.HandleFunc("GET /v0/runs/{run_id}/stages", func(w http.ResponseWriter, r *http.Request) {
+		id, perr := uuid.Parse(r.PathValue("run_id"))
+		w.Header().Set("Content-Type", "application/json")
+		if perr != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		fb.mu.Lock()
+		fb.stagesCalledByID[id]++
+		items := fb.stagesByRun[id]
+		fb.mu.Unlock()
+		w.WriteHeader(fb.stagesStatus)
+		_ = json.NewEncoder(w).Encode(listStagesResult{Items: items})
+	})
+	mux.HandleFunc("GET /v0/stages/{stage_id}/artifacts", func(w http.ResponseWriter, r *http.Request) {
+		id, perr := uuid.Parse(r.PathValue("stage_id"))
+		w.Header().Set("Content-Type", "application/json")
+		if perr != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		fb.mu.Lock()
+		fb.artifactsCalledID[id]++
+		items := fb.artifactsByStage[id]
+		fb.mu.Unlock()
+		w.WriteHeader(fb.artifactsStatus)
+		_ = json.NewEncoder(w).Encode(listArtifactsResult{Items: items})
 	})
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
@@ -331,4 +393,308 @@ func TestRegisterTools_RegistersGetActiveRun(t *testing.T) {
 		getenv: envFuncFromMap(nil),
 	}
 	registerTools(srv, resolver)
+}
+
+// --- get_plan (E19.4 / #344) ---
+
+// samplePlanContent returns a small but complete standard_v1
+// fixture. Used as the inline content on the plan artifact rows
+// the fake backend serves.
+func samplePlanContent() PlanContent {
+	return PlanContent{
+		PlanVersion: "standard_v1",
+		TicketReference: PlanTicketRef{
+			Type: "github_issue",
+			URL:  "https://github.com/x/y/issues/42",
+			ID:   "x/y#42",
+		},
+		GeneratedBy: PlanGeneratedBy{
+			Agent:     "claude-code",
+			Model:     "claude-opus-4-7",
+			Timestamp: time.Date(2026, 5, 15, 10, 0, 0, 0, time.UTC),
+		},
+		Summary: "Add a dryRun flag to the dispatcher.",
+		Scope: PlanScope{
+			Files: []PlanScopeFile{
+				{Path: "backend/internal/webhook/dispatcher.go", Operation: "modify"},
+			},
+			EstimatedLinesChanged: 40,
+		},
+		Approach: []PlanApproachStep{
+			{Step: 1, Description: "Plumb dryRun through Handle."},
+			{Step: 2, Description: "Add a unit test."},
+		},
+		Verification: PlanVerification{
+			TestStrategy: "Run the dispatcher tests.",
+			RollbackPlan: "Revert the PR.",
+		},
+		RisksAndAssumptions: []string{
+			"Operators set dryRun via a feature flag.",
+		},
+	}
+}
+
+// seedPlanArtifact attaches a plan artifact to a stage in the fake
+// backend. createdAge sets the artifact's CreatedAt so tests can
+// distinguish older vs newer when the most-recent-wins rule fires.
+func seedPlanArtifact(fb *fakeBackend, stageID uuid.UUID, content PlanContent, createdAge time.Duration) Artifact {
+	v := "standard_v1"
+	body, _ := json.Marshal(content)
+	art := Artifact{
+		ID:            uuid.New(),
+		StageID:       stageID,
+		Kind:          "plan",
+		SchemaVersion: &v,
+		ContentHash:   "h",
+		Content:       body,
+		CreatedAt:     time.Now().UTC().Add(-createdAge),
+	}
+	fb.mu.Lock()
+	fb.artifactsByStage[stageID] = append(fb.artifactsByStage[stageID], art)
+	fb.mu.Unlock()
+	return art
+}
+
+func TestGetPlan_RejectsInvalidUUID(t *testing.T) {
+	_, srv := newFakeBackend(t)
+	r := newResolver(srv, nil)
+
+	_, _, err := r.getPlan(context.Background(), nil, GetPlanInput{RunID: "not-a-uuid"})
+	if err == nil {
+		t.Fatal("expected error on malformed run_id")
+	}
+	if !strings.Contains(err.Error(), "not a valid UUID") {
+		t.Errorf("error wording: %v", err)
+	}
+}
+
+func TestGetPlan_FromCurrentRun_StatusAvailableResolvedViaSelf(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	runID := uuid.New()
+	planStageID := uuid.New()
+	fb.stagesByRun[runID] = []Stage{
+		{ID: planStageID, RunID: runID, Type: "plan", State: "succeeded"},
+		{ID: uuid.New(), RunID: runID, Type: "implement", State: "pending"},
+	}
+	expectedSummary := "Add a dryRun flag to the dispatcher."
+	seedPlanArtifact(fb, planStageID, samplePlanContent(), time.Hour)
+
+	r := newResolver(srv, nil)
+	_, out, err := r.getPlan(context.Background(), nil, GetPlanInput{RunID: runID.String()})
+	if err != nil {
+		t.Fatalf("getPlan: %v", err)
+	}
+	if out.Status != "available" {
+		t.Errorf("Status = %q, want available", out.Status)
+	}
+	if out.ResolvedVia != "self" {
+		t.Errorf("ResolvedVia = %q, want self", out.ResolvedVia)
+	}
+	if out.Plan == nil {
+		t.Fatal("Plan should be non-nil when Status=available")
+	}
+	if out.Plan.Summary != expectedSummary {
+		t.Errorf("summary = %q", out.Plan.Summary)
+	}
+	if got := len(out.Plan.Scope.Files); got != 1 {
+		t.Errorf("scope.files count = %d", got)
+	}
+}
+
+func TestGetPlan_PicksMostRecentArtifactWhenMultipleExist(t *testing.T) {
+	// Same plan stage carries two standard_v1 artifacts (a re-upload
+	// after a plan edit). The resolver must pick the newer one.
+	fb, srv := newFakeBackend(t)
+	runID := uuid.New()
+	planStageID := uuid.New()
+	fb.stagesByRun[runID] = []Stage{{ID: planStageID, RunID: runID, Type: "plan", State: "succeeded"}}
+
+	older := samplePlanContent()
+	older.Summary = "stale plan"
+	seedPlanArtifact(fb, planStageID, older, 24*time.Hour)
+
+	newer := samplePlanContent()
+	newer.Summary = "fresh plan"
+	seedPlanArtifact(fb, planStageID, newer, time.Hour)
+
+	r := newResolver(srv, nil)
+	_, out, err := r.getPlan(context.Background(), nil, GetPlanInput{RunID: runID.String()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Plan == nil || out.Plan.Summary != "fresh plan" {
+		t.Errorf("Plan.Summary = %v, want 'fresh plan'", out.Plan)
+	}
+}
+
+func TestGetPlan_RetryChain_WalksParentRunID(t *testing.T) {
+	// Child run has no plan stage (CI-retry shape per #279 / E16);
+	// parent run has the plan. The walk should resolve the parent's
+	// plan and stamp ResolvedVia=parent:<id>.
+	fb, srv := newFakeBackend(t)
+	parentID := uuid.New()
+	childID := uuid.New()
+	parentPlanStage := uuid.New()
+
+	fb.getRunByID[childID] = Run{
+		ID:          childID,
+		ParentRunID: &parentID,
+		State:       "running",
+		Repo:        "x/y",
+	}
+	fb.getRunByID[parentID] = Run{ID: parentID, State: "running", Repo: "x/y"}
+	// Child has only an implement stage (the retry's shape).
+	fb.stagesByRun[childID] = []Stage{
+		{ID: uuid.New(), RunID: childID, Type: "implement", State: "running"},
+	}
+	// Parent has the plan stage carrying the artifact.
+	fb.stagesByRun[parentID] = []Stage{
+		{ID: parentPlanStage, RunID: parentID, Type: "plan", State: "succeeded"},
+	}
+	seedPlanArtifact(fb, parentPlanStage, samplePlanContent(), time.Hour)
+
+	r := newResolver(srv, nil)
+	_, out, err := r.getPlan(context.Background(), nil, GetPlanInput{RunID: childID.String()})
+	if err != nil {
+		t.Fatalf("getPlan: %v", err)
+	}
+	if out.Status != "available" {
+		t.Errorf("Status = %q, want available", out.Status)
+	}
+	if out.ResolvedVia != "parent:"+parentID.String() {
+		t.Errorf("ResolvedVia = %q, want parent:%s", out.ResolvedVia, parentID)
+	}
+	if out.Plan == nil {
+		t.Fatal("Plan should be non-nil")
+	}
+}
+
+func TestGetPlan_NoPlanYet_ChainRootReached(t *testing.T) {
+	// Run has no plan stage AND no parent. The structured
+	// no_plan_yet response names the chain depth searched (0,
+	// since the root is the requested run itself).
+	fb, srv := newFakeBackend(t)
+	runID := uuid.New()
+	fb.getRunByID[runID] = Run{ID: runID, State: "running", Repo: "x/y"}
+	fb.stagesByRun[runID] = nil // no stages — plan stage absent
+
+	r := newResolver(srv, nil)
+	_, out, err := r.getPlan(context.Background(), nil, GetPlanInput{RunID: runID.String()})
+	if err != nil {
+		t.Fatalf("getPlan: %v", err)
+	}
+	if out.Status != "no_plan_yet" {
+		t.Errorf("Status = %q, want no_plan_yet", out.Status)
+	}
+	if out.Plan != nil {
+		t.Errorf("Plan should be nil on no_plan_yet; got %+v", out.Plan)
+	}
+	if !strings.Contains(out.Message, "chain root reached") {
+		t.Errorf("Message should explain the chain shape: %q", out.Message)
+	}
+}
+
+func TestGetPlan_NoPlanYet_PlanStagePending(t *testing.T) {
+	// Plan stage exists but has no terminal plan artifact yet
+	// (mid-upload race). Same no_plan_yet response shape so the
+	// agent can branch without parsing prose.
+	fb, srv := newFakeBackend(t)
+	runID := uuid.New()
+	planStageID := uuid.New()
+	fb.getRunByID[runID] = Run{ID: runID, State: "running"}
+	fb.stagesByRun[runID] = []Stage{
+		{ID: planStageID, RunID: runID, Type: "plan", State: "running"},
+	}
+	// Artifacts map: empty — no plan uploaded yet.
+
+	r := newResolver(srv, nil)
+	_, out, err := r.getPlan(context.Background(), nil, GetPlanInput{RunID: runID.String()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Status != "no_plan_yet" {
+		t.Errorf("Status = %q, want no_plan_yet", out.Status)
+	}
+}
+
+func TestGetPlan_RetryChain_DepthCap_NoPlanYet(t *testing.T) {
+	// Build a chain of 10 runs, no plan stage on any of them. The
+	// walk stops at retryPlanChainDepth (8) and returns
+	// no_plan_yet with a "depth cap" message rather than looping
+	// forever.
+	fb, srv := newFakeBackend(t)
+	const chainLen = 10
+	ids := make([]uuid.UUID, chainLen)
+	for i := range ids {
+		ids[i] = uuid.New()
+	}
+	for i := 0; i < chainLen; i++ {
+		row := Run{ID: ids[i], Repo: "x/y", State: "running"}
+		if i+1 < chainLen {
+			row.ParentRunID = &ids[i+1]
+		}
+		fb.getRunByID[ids[i]] = row
+		fb.stagesByRun[ids[i]] = nil
+	}
+
+	r := newResolver(srv, nil)
+	_, out, err := r.getPlan(context.Background(), nil, GetPlanInput{RunID: ids[0].String()})
+	if err != nil {
+		t.Fatalf("getPlan: %v", err)
+	}
+	if out.Status != "no_plan_yet" {
+		t.Errorf("Status = %q, want no_plan_yet", out.Status)
+	}
+	if !strings.Contains(out.Message, "chain depth cap") {
+		t.Errorf("Message should mention chain depth cap: %q", out.Message)
+	}
+	// Defensive: the walk visited at most retryPlanChainDepth
+	// stages-fetches, never the 9th id in the chain.
+	if got := fb.stagesCalledByID[ids[retryPlanChainDepth]]; got != 0 {
+		t.Errorf("walk visited id[%d] %d times; expected 0 (past the cap)",
+			retryPlanChainDepth, got)
+	}
+}
+
+func TestGetPlan_BackendError_StagesList_Surfaced(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	runID := uuid.New()
+	fb.getRunByID[runID] = Run{ID: runID}
+	fb.stagesStatus = http.StatusInternalServerError
+
+	r := newResolver(srv, nil)
+	_, _, err := r.getPlan(context.Background(), nil, GetPlanInput{RunID: runID.String()})
+	if err == nil {
+		t.Fatal("expected error on stages 500")
+	}
+	if !strings.Contains(err.Error(), "list stages") {
+		t.Errorf("error wording: %v", err)
+	}
+}
+
+func TestGetPlan_IgnoresNonStandardV1PlanArtifacts(t *testing.T) {
+	// A plan stage might carry future-schema artifacts. The
+	// resolver only returns standard_v1 — anything else is invisible
+	// to v0's MCP tools.
+	fb, srv := newFakeBackend(t)
+	runID := uuid.New()
+	planStageID := uuid.New()
+	fb.stagesByRun[runID] = []Stage{{ID: planStageID, RunID: runID, Type: "plan", State: "succeeded"}}
+
+	v := "future_v2"
+	body, _ := json.Marshal(map[string]any{"plan_version": "future_v2"})
+	fb.artifactsByStage[planStageID] = []Artifact{{
+		ID: uuid.New(), StageID: planStageID, Kind: "plan",
+		SchemaVersion: &v, Content: body,
+		CreatedAt: time.Now().UTC(),
+	}}
+
+	r := newResolver(srv, nil)
+	_, out, err := r.getPlan(context.Background(), nil, GetPlanInput{RunID: runID.String()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Status != "no_plan_yet" {
+		t.Errorf("Status = %q, want no_plan_yet (future schema is invisible)", out.Status)
+	}
 }


### PR DESCRIPTION
## Summary

Second MCP tool. Surfaces the approved plan for a run so the agent (in-runner or interactive) can reason about scope, approach, and verification without an out-of-band CLI alt-tab.

Resolution mirrors `backend/internal/server/prompt.go::loadApprovedPlanForRun`:

1. **Look on the requested run.** If the plan stage exists and carries a `standard_v1` plan artifact, return it — `ResolvedVia=self`.
2. **Otherwise walk `parent_run_id`.** CI-retry runs (#279 / E16) skip the plan stage and re-execute against the parent's plan. The walk caps at `retryPlanChainDepth` (8, matches the backend's constant) so a corrupt parent cycle can't loop the agent. `ResolvedVia=parent:<id>` identifies the ancestor that carried the plan.
3. **Otherwise return a structured "no_plan_yet" response** naming the chain shape (root reached / depth cap). Agents branch on `status` without parsing prose.

## Implementation

- **`client.go`** gains `Stage` / `Artifact` types + `ListRunStages` / `ListStageArtifacts` wrappers. Both endpoints return content inline (artifacts include `content` per the OpenAPI schema), so no separate `/v0/artifacts/{id}` fetch.
- **`tools.go`** registers `fishhawk_get_plan` alongside `fishhawk_get_active_run`. `PlanContent` + sub-types mirror the standard_v1 wire shape — the SDK turns the struct into the output schema; agents introspect it without parsing.
- `retryPlanChainDepth=8` matches `backend/internal/server/prompt.go`'s constant. Keep aligned so MCP and the prompt builder resolve the same plan for the same run.
- Non-standard_v1 plan artifacts are invisible; future schema versions can land alongside without changing tool behavior.

## Test plan

- [x] `go test -race ./backend/cmd/fishhawk-mcp/...`
- [x] `go test -race ./backend/...`
- [x] `golangci-lint run backend/...`
- [x] Coverage gate: 82.4% aggregate (≥ 80% threshold)
- [x] **Nine cases**: rejects invalid UUID before API call; `Status=available, ResolvedVia=self`; most-recent artifact wins on multi-upload stage; retry chain walks `parent_run_id` → `Status=available, ResolvedVia=parent:<id>`; no_plan_yet at chain root; no_plan_yet when plan stage exists but artifact absent; 10-deep chain hits depth cap → no_plan_yet with depth-cap message (defensive: walk visited at most 8 runs); backend 500 surfaces wrapped error; non-standard_v1 artifact ignored

## Notes

- Read-only per ADR-021. The tool gives agents context; humans approve / retry via CLI / SPA / GitHub.
- The `fakeBackend` test harness gains `stagesByRun` + `artifactsByStage` maps so get_plan tests share scaffolding with get_active_run.

Closes #344