### PR TITLE
mcp: fishhawk_get_run_status tool (E19.5 / #345)

### DIFF
--- a/backend/cmd/fishhawk-mcp/client.go
+++ b/backend/cmd/fishhawk-mcp/client.go
@@ -102,15 +102,33 @@ func (c *apiClient) GetRun(ctx context.Context, id uuid.UUID) (*Run, error) {
 	return &r, nil
 }
 
-// Stage mirrors the wire shape, scoped to the fields the MCP tools
-// need: id, run_id, type, state. Other fields (executor, sequence,
-// failure_*) are surfaced in E19.5's get_run_status output but the
-// get_plan tool only needs to find the plan stage on a run.
+// Stage mirrors the wire shape. The fields cover both get_plan's
+// "find the plan stage" use case and get_run_status's "tell me
+// what's happening" view: type/state for the lifecycle, sequence
+// for ordering, executor + timestamps + failure fields for the
+// agent's context.
 type Stage struct {
-	ID    uuid.UUID `json:"id"`
-	RunID uuid.UUID `json:"run_id"`
-	Type  string    `json:"type"`
-	State string    `json:"state"`
+	ID              uuid.UUID     `json:"id"`
+	RunID           uuid.UUID     `json:"run_id"`
+	Sequence        int           `json:"sequence"`
+	Type            string        `json:"type"`
+	Executor        StageExecutor `json:"executor"`
+	State           string        `json:"state"`
+	StartedAt       *time.Time    `json:"started_at,omitempty"`
+	EndedAt         *time.Time    `json:"ended_at,omitempty"`
+	FailureCategory *string       `json:"failure_category,omitempty"`
+	FailureReason   *string       `json:"failure_reason,omitempty"`
+	CreatedAt       time.Time     `json:"created_at"`
+	UpdatedAt       time.Time     `json:"updated_at"`
+}
+
+// StageExecutor mirrors the OpenAPI sub-schema. The closed-set
+// kind field (`agent` | `human`) is what an agent reads to know
+// whether a downstream stage will be self-driven or wait for a
+// human.
+type StageExecutor struct {
+	Kind string `json:"kind"`
+	Ref  string `json:"ref"`
 }
 
 type listStagesResult struct {
@@ -153,6 +171,53 @@ type listArtifactsResult struct {
 func (c *apiClient) ListStageArtifacts(ctx context.Context, stageID uuid.UUID) ([]Artifact, error) {
 	var res listArtifactsResult
 	if err := c.do(ctx, http.MethodGet, "/v0/stages/"+stageID.String()+"/artifacts", nil, &res); err != nil {
+		return nil, err
+	}
+	return res.Items, nil
+}
+
+// AuditEntry mirrors the OpenAPI AuditEntry schema. Payload is
+// left as json.RawMessage so the MCP tool can pass the typed shape
+// directly through to the client without re-encoding category-
+// specific payloads — the agent introspects them as JSON.
+type AuditEntry struct {
+	ID           uuid.UUID       `json:"id"`
+	Sequence     int64           `json:"sequence"`
+	RunID        uuid.UUID       `json:"run_id"`
+	StageID      *uuid.UUID      `json:"stage_id,omitempty"`
+	Timestamp    time.Time       `json:"ts"`
+	Category     string          `json:"category"`
+	ActorKind    *string         `json:"actor_kind,omitempty"`
+	ActorSubject *string         `json:"actor_subject,omitempty"`
+	Payload      json.RawMessage `json:"payload,omitempty"`
+	PrevHash     *string         `json:"prev_hash,omitempty"`
+	EntryHash    string          `json:"entry_hash"`
+}
+
+type listAuditResult struct {
+	Items      []AuditEntry `json:"items"`
+	NextCursor string       `json:"next_cursor,omitempty"`
+}
+
+// ListRecentRunAudit calls GET /v0/audit?run_id=<id>&limit=<N>.
+// Returns rows time-descending — exactly the order an agent wants
+// when surfacing "what's happened recently" in the get_run_status
+// view. The cross-chain endpoint is the only way to get
+// descending order without a paginate-to-end walk; per-run rows
+// for the queried run are the only thing returned because global
+// rows have run_id IS NULL and don't match the filter.
+//
+// The MCP tool layer is responsible for clamping limit to the
+// server's range before calling this; the client passes it
+// through verbatim.
+func (c *apiClient) ListRecentRunAudit(ctx context.Context, runID uuid.UUID, limit int) ([]AuditEntry, error) {
+	q := url.Values{}
+	q.Set("run_id", runID.String())
+	if limit > 0 {
+		q.Set("limit", strconv.Itoa(limit))
+	}
+	var res listAuditResult
+	if err := c.do(ctx, http.MethodGet, "/v0/audit?"+q.Encode(), nil, &res); err != nil {
 		return nil, err
 	}
 	return res.Items, nil

--- a/backend/cmd/fishhawk-mcp/tools.go
+++ b/backend/cmd/fishhawk-mcp/tools.go
@@ -30,8 +30,8 @@ type runResolver struct {
 func registerTools(srv *mcp.Server, resolver *runResolver) {
 	registerGetActiveRun(srv, resolver)
 	registerGetPlan(srv, resolver)
+	registerGetRunStatus(srv, resolver)
 	// Subsequent tools register here:
-	//   E19.5 / #345 — fishhawk_get_run_status
 	//   E19.6 / #346 — fishhawk_list_audit
 }
 
@@ -351,6 +351,109 @@ func (r *runResolver) tryGetPlanForRun(ctx context.Context, runID uuid.UUID) (*P
 		return nil, false, fmt.Errorf("decode plan artifact: %w", err)
 	}
 	return &p, true, nil
+}
+
+// auditLimitDefault is the default value for the get_run_status
+// tool's audit_limit input. Five is enough for "what's happening
+// right now" without overwhelming the agent's reasoning window.
+const auditLimitDefault = 5
+
+// auditLimitMax caps the audit_limit input. The backend's /v0/audit
+// endpoint accepts up to 500; we cap lower because the get_run_
+// status tool's job is to surface recent activity, not to paginate
+// the full chain. Agents wanting more rows can use the dedicated
+// fishhawk_list_audit tool (E19.6 / #346).
+const auditLimitMax = 50
+
+// GetRunStatusInput is the tool's input schema.
+type GetRunStatusInput struct {
+	RunID      string `json:"run_id" jsonschema:"the Fishhawk run UUID"`
+	AuditLimit int    `json:"audit_limit,omitempty" jsonschema:"how many recent audit entries to include (default 5, capped at 50)"`
+}
+
+// GetRunStatusOutput bundles the three /v0 reads into one
+// agent-friendly response. Stages come back sequence-ascending so
+// the agent reads them in the order the pipeline executes; audit
+// rows come back time-descending so "most recent" is item 0.
+type GetRunStatusOutput struct {
+	Run         Run          `json:"run"`
+	Stages      []Stage      `json:"stages" jsonschema:"ordered by sequence ascending"`
+	RecentAudit []AuditEntry `json:"recent_audit" jsonschema:"time-descending; item 0 is the most recent"`
+}
+
+// registerGetRunStatus wires the fishhawk_get_run_status tool. The
+// handler aggregates three backend calls (GetRun + ListRunStages +
+// ListRecentRunAudit) into one MCP tool call so the agent saves
+// the round-trip-back latency that a sequential chain of
+// individual tool calls would impose. Read-only per ADR-021.
+func registerGetRunStatus(srv *mcp.Server, resolver *runResolver) {
+	mcp.AddTool(srv, &mcp.Tool{
+		Name: "fishhawk_get_run_status",
+		Description: strings.TrimSpace(`
+Snapshot a Fishhawk run's current state in one call.
+
+Returns the Run row (state, workflow, trigger, PR URL when stamped),
+the full ordered stage list (each stage's id / type / state /
+executor / timing / failure category if any), and the N most-recent
+audit entries time-descending (default 5; capped at 50).
+
+Use this as the agent's "where are we" query — replaces a sequential
+chain of GetRun / ListStages / ListAudit calls with a single
+round-trip. For deeper audit pagination, use fishhawk_list_audit.
+`),
+	}, resolver.getRunStatus)
+}
+
+// getRunStatus is the tool handler.
+func (r *runResolver) getRunStatus(ctx context.Context, _ *mcp.CallToolRequest, in GetRunStatusInput) (*mcp.CallToolResult, GetRunStatusOutput, error) {
+	runID, err := uuid.Parse(in.RunID)
+	if err != nil {
+		return nil, GetRunStatusOutput{}, fmt.Errorf("run_id %q is not a valid UUID: %w", in.RunID, err)
+	}
+
+	limit := clampAuditLimit(in.AuditLimit)
+
+	runRow, err := r.api.GetRun(ctx, runID)
+	if err != nil {
+		return nil, GetRunStatusOutput{}, fmt.Errorf("get run: %w", err)
+	}
+
+	stages, err := r.api.ListRunStages(ctx, runID)
+	if err != nil {
+		return nil, GetRunStatusOutput{}, fmt.Errorf("list stages: %w", err)
+	}
+	// Defensive sort. The backend returns sequence-ascending, but
+	// re-sorting locally insulates the agent from any future
+	// ordering change and costs nothing on a list of < 10 stages.
+	sort.SliceStable(stages, func(i, j int) bool {
+		return stages[i].Sequence < stages[j].Sequence
+	})
+
+	recent, err := r.api.ListRecentRunAudit(ctx, runID, limit)
+	if err != nil {
+		return nil, GetRunStatusOutput{}, fmt.Errorf("list recent audit: %w", err)
+	}
+
+	return nil, GetRunStatusOutput{
+		Run:         *runRow,
+		Stages:      stages,
+		RecentAudit: recent,
+	}, nil
+}
+
+// clampAuditLimit applies the default + cap. Negative or zero
+// falls back to auditLimitDefault; values over auditLimitMax clamp
+// to the cap. The backend would reject too-large values with a
+// 400; we clamp client-side so the agent's bad input doesn't
+// surface as a confusing API error.
+func clampAuditLimit(n int) int {
+	if n <= 0 {
+		return auditLimitDefault
+	}
+	if n > auditLimitMax {
+		return auditLimitMax
+	}
+	return n
 }
 
 // findMostRecent returns the most-recent run from a filter-scoped

--- a/backend/cmd/fishhawk-mcp/tools_test.go
+++ b/backend/cmd/fishhawk-mcp/tools_test.go
@@ -45,6 +45,13 @@ type fakeBackend struct {
 	artifactsStatus   int
 	stagesCalledByID  map[uuid.UUID]int
 	artifactsCalledID map[uuid.UUID]int
+
+	// E19.5 fixtures: per-run audit responses. Captured limit lets
+	// tests verify clamping behavior end-to-end.
+	auditByRun      map[uuid.UUID][]AuditEntry
+	auditStatus     int
+	lastAuditLimit  string
+	auditCalledByID map[uuid.UUID]int
 }
 
 func newFakeBackend(t *testing.T) (*fakeBackend, *httptest.Server) {
@@ -54,12 +61,15 @@ func newFakeBackend(t *testing.T) (*fakeBackend, *httptest.Server) {
 		getStatus:         http.StatusOK,
 		stagesStatus:      http.StatusOK,
 		artifactsStatus:   http.StatusOK,
+		auditStatus:       http.StatusOK,
 		listByQuery:       map[string]listRunsResult{},
 		getRunByID:        map[uuid.UUID]Run{},
 		stagesByRun:       map[uuid.UUID][]Stage{},
 		artifactsByStage:  map[uuid.UUID][]Artifact{},
 		stagesCalledByID:  map[uuid.UUID]int{},
 		artifactsCalledID: map[uuid.UUID]int{},
+		auditByRun:        map[uuid.UUID][]AuditEntry{},
+		auditCalledByID:   map[uuid.UUID]int{},
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /v0/runs", func(w http.ResponseWriter, r *http.Request) {
@@ -105,6 +115,25 @@ func newFakeBackend(t *testing.T) (*fakeBackend, *httptest.Server) {
 		fb.mu.Unlock()
 		w.WriteHeader(fb.stagesStatus)
 		_ = json.NewEncoder(w).Encode(listStagesResult{Items: items})
+	})
+	mux.HandleFunc("GET /v0/audit", func(w http.ResponseWriter, r *http.Request) {
+		runIDQ := r.URL.Query().Get("run_id")
+		w.Header().Set("Content-Type", "application/json")
+		id, perr := uuid.Parse(runIDQ)
+		if perr != nil {
+			// /v0/audit allows missing run_id (global feed); the
+			// MCP tool always sets it, so a missing one in tests
+			// is a programming error.
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		fb.mu.Lock()
+		fb.lastAuditLimit = r.URL.Query().Get("limit")
+		fb.auditCalledByID[id]++
+		items := fb.auditByRun[id]
+		fb.mu.Unlock()
+		w.WriteHeader(fb.auditStatus)
+		_ = json.NewEncoder(w).Encode(listAuditResult{Items: items})
 	})
 	mux.HandleFunc("GET /v0/stages/{stage_id}/artifacts", func(w http.ResponseWriter, r *http.Request) {
 		id, perr := uuid.Parse(r.PathValue("stage_id"))
@@ -669,6 +698,228 @@ func TestGetPlan_BackendError_StagesList_Surfaced(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "list stages") {
 		t.Errorf("error wording: %v", err)
+	}
+}
+
+// --- get_run_status (E19.5 / #345) ---
+
+func auditFixture(seq int64, runID uuid.UUID, category, actor string, offset time.Duration) AuditEntry {
+	body, _ := json.Marshal(map[string]any{"actor": actor})
+	return AuditEntry{
+		ID:           uuid.New(),
+		Sequence:     seq,
+		RunID:        runID,
+		Timestamp:    time.Now().UTC().Add(-offset),
+		Category:     category,
+		ActorSubject: &actor,
+		Payload:      body,
+		EntryHash:    "h",
+	}
+}
+
+func TestGetRunStatus_HappyPath_BundlesThreeReads(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	runID := uuid.New()
+	fb.getRunByID[runID] = Run{
+		ID: runID, Repo: "x/y", WorkflowID: "feature_change",
+		State: "running",
+	}
+	planStageID := uuid.New()
+	implStageID := uuid.New()
+	fb.stagesByRun[runID] = []Stage{
+		{ID: planStageID, RunID: runID, Sequence: 1, Type: "plan", State: "succeeded",
+			Executor: StageExecutor{Kind: "agent", Ref: "claude-code"}},
+		{ID: implStageID, RunID: runID, Sequence: 2, Type: "implement", State: "running",
+			Executor: StageExecutor{Kind: "agent", Ref: "claude-code"}},
+	}
+	fb.auditByRun[runID] = []AuditEntry{
+		// Returned time-descending — the fake serves what's there
+		// without re-sorting; the production /v0/audit endpoint
+		// orders so. Tests load these in the expected order.
+		auditFixture(3, runID, "approval_submitted", "alice", 1*time.Minute),
+		auditFixture(2, runID, "plan_generated", "system", 10*time.Minute),
+		auditFixture(1, runID, "run_dispatched", "github-webhook", 15*time.Minute),
+	}
+
+	r := newResolver(srv, nil)
+	_, out, err := r.getRunStatus(context.Background(), nil, GetRunStatusInput{RunID: runID.String()})
+	if err != nil {
+		t.Fatalf("getRunStatus: %v", err)
+	}
+
+	if out.Run.ID != runID {
+		t.Errorf("Run.ID = %s, want %s", out.Run.ID, runID)
+	}
+	if len(out.Stages) != 2 {
+		t.Fatalf("expected 2 stages; got %d", len(out.Stages))
+	}
+	if out.Stages[0].Type != "plan" || out.Stages[1].Type != "implement" {
+		t.Errorf("stages not in sequence order: %+v", out.Stages)
+	}
+	if len(out.RecentAudit) != 3 {
+		t.Fatalf("expected 3 audit rows; got %d", len(out.RecentAudit))
+	}
+	if out.RecentAudit[0].Category != "approval_submitted" {
+		t.Errorf("first audit row should be newest (approval_submitted); got %q", out.RecentAudit[0].Category)
+	}
+}
+
+func TestGetRunStatus_StagesReSortedBySequence(t *testing.T) {
+	// Defensive sort: even if the backend ever stops ordering by
+	// sequence, the agent still sees the pipeline in order.
+	fb, srv := newFakeBackend(t)
+	runID := uuid.New()
+	fb.getRunByID[runID] = Run{ID: runID}
+	fb.stagesByRun[runID] = []Stage{
+		{ID: uuid.New(), Sequence: 3, Type: "review", State: "pending"},
+		{ID: uuid.New(), Sequence: 1, Type: "plan", State: "succeeded"},
+		{ID: uuid.New(), Sequence: 2, Type: "implement", State: "running"},
+	}
+
+	r := newResolver(srv, nil)
+	_, out, err := r.getRunStatus(context.Background(), nil, GetRunStatusInput{RunID: runID.String()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := []int{out.Stages[0].Sequence, out.Stages[1].Sequence, out.Stages[2].Sequence}
+	if got[0] != 1 || got[1] != 2 || got[2] != 3 {
+		t.Errorf("stage sequences = %v, want [1,2,3]", got)
+	}
+}
+
+func TestGetRunStatus_AuditLimit_DefaultsToFive(t *testing.T) {
+	// audit_limit unset → request goes out with limit=5.
+	fb, srv := newFakeBackend(t)
+	runID := uuid.New()
+	fb.getRunByID[runID] = Run{ID: runID}
+
+	r := newResolver(srv, nil)
+	_, _, err := r.getRunStatus(context.Background(), nil, GetRunStatusInput{RunID: runID.String()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fb.lastAuditLimit != "5" {
+		t.Errorf("audit request limit = %q, want 5", fb.lastAuditLimit)
+	}
+}
+
+func TestGetRunStatus_AuditLimit_ClampedToFifty(t *testing.T) {
+	// audit_limit > 50 → request goes out with limit=50.
+	fb, srv := newFakeBackend(t)
+	runID := uuid.New()
+	fb.getRunByID[runID] = Run{ID: runID}
+
+	r := newResolver(srv, nil)
+	_, _, err := r.getRunStatus(context.Background(), nil, GetRunStatusInput{
+		RunID:      runID.String(),
+		AuditLimit: 1000,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fb.lastAuditLimit != "50" {
+		t.Errorf("audit request limit = %q, want 50 (clamped)", fb.lastAuditLimit)
+	}
+}
+
+func TestGetRunStatus_AuditLimit_ExplicitValueForwarded(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	runID := uuid.New()
+	fb.getRunByID[runID] = Run{ID: runID}
+
+	r := newResolver(srv, nil)
+	_, _, err := r.getRunStatus(context.Background(), nil, GetRunStatusInput{
+		RunID:      runID.String(),
+		AuditLimit: 20,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fb.lastAuditLimit != "20" {
+		t.Errorf("audit request limit = %q, want 20", fb.lastAuditLimit)
+	}
+}
+
+func TestGetRunStatus_RejectsInvalidUUID(t *testing.T) {
+	_, srv := newFakeBackend(t)
+	r := newResolver(srv, nil)
+
+	_, _, err := r.getRunStatus(context.Background(), nil, GetRunStatusInput{RunID: "not-a-uuid"})
+	if err == nil {
+		t.Fatal("expected error on malformed run_id")
+	}
+	if !strings.Contains(err.Error(), "not a valid UUID") {
+		t.Errorf("error wording: %v", err)
+	}
+}
+
+func TestGetRunStatus_MissingRun_404Surfaced(t *testing.T) {
+	// GetRun returns 404 → the wrapped error reaches the caller.
+	fb, srv := newFakeBackend(t)
+	fb.getStatus = http.StatusNotFound
+
+	r := newResolver(srv, nil)
+	_, _, err := r.getRunStatus(context.Background(), nil, GetRunStatusInput{RunID: uuid.New().String()})
+	if err == nil {
+		t.Fatal("expected 404 to surface")
+	}
+	if !strings.Contains(err.Error(), "get run") {
+		t.Errorf("error wording: %v", err)
+	}
+}
+
+func TestGetRunStatus_StagesEndpointError_Surfaced(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	runID := uuid.New()
+	fb.getRunByID[runID] = Run{ID: runID}
+	fb.stagesStatus = http.StatusInternalServerError
+
+	r := newResolver(srv, nil)
+	_, _, err := r.getRunStatus(context.Background(), nil, GetRunStatusInput{RunID: runID.String()})
+	if err == nil {
+		t.Fatal("expected stages 500 to surface")
+	}
+	if !strings.Contains(err.Error(), "list stages") {
+		t.Errorf("error wording: %v", err)
+	}
+}
+
+func TestGetRunStatus_AuditEndpointError_Surfaced(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	runID := uuid.New()
+	fb.getRunByID[runID] = Run{ID: runID}
+	fb.auditStatus = http.StatusInternalServerError
+
+	r := newResolver(srv, nil)
+	_, _, err := r.getRunStatus(context.Background(), nil, GetRunStatusInput{RunID: runID.String()})
+	if err == nil {
+		t.Fatal("expected audit 500 to surface")
+	}
+	if !strings.Contains(err.Error(), "list recent audit") {
+		t.Errorf("error wording: %v", err)
+	}
+}
+
+func TestGetRunStatus_EmptyStagesAndAudit_OK(t *testing.T) {
+	// Brand-new run before any stages or audit rows landed —
+	// still returns Status=ok with empty arrays rather than erroring.
+	fb, srv := newFakeBackend(t)
+	runID := uuid.New()
+	fb.getRunByID[runID] = Run{ID: runID, State: "pending"}
+
+	r := newResolver(srv, nil)
+	_, out, err := r.getRunStatus(context.Background(), nil, GetRunStatusInput{RunID: runID.String()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Run.ID != runID {
+		t.Errorf("Run.ID = %s", out.Run.ID)
+	}
+	if got := len(out.Stages); got != 0 {
+		t.Errorf("Stages length = %d, want 0", got)
+	}
+	if got := len(out.RecentAudit); got != 0 {
+		t.Errorf("RecentAudit length = %d, want 0", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Third MCP tool. The agent's "where are we" query — bundles three backend reads (Run row, ordered stage list, recent audit) into one MCP tool call so an LLM saves the round-trip-back latency a sequential chain would impose.

- **Inputs**: `run_id` (required UUID) + `audit_limit` (optional, default 5, max 50, client-side clamped so bad agent input doesn't surface as a confusing backend 400).
- **Output**: `Run` (state, workflow, trigger, PR URL), `Stages` (sequence-ascending, with executor + timestamps + failure category), `RecentAudit` (time-descending; item 0 is the most recent).
- **Recent audit shape**: uses the cross-chain `/v0/audit?run_id=<id>&limit=<N>` endpoint because per-run `/v0/runs/{id}/audit` is sequence-ascending — fetching `limit=5` there would return the **oldest** 5 entries, not the newest. The `run_id` filter scopes the cross-chain feed to the run's rows.
- **Defensive stage sort**: client-side sort by Sequence so the agent sees pipeline order even if the backend ever stops ordering.

## Client extensions

- `Stage` gains `Sequence`, `Executor` (Kind/Ref), `StartedAt`, `EndedAt`, `FailureCategory`, `FailureReason`, `CreatedAt`, `UpdatedAt`. Additive — E19.4's get_plan path only reads `Type` / `State`.
- New `AuditEntry` type mirroring the OpenAPI schema. Payload stays `json.RawMessage`.
- New `ListRecentRunAudit(ctx, runID, limit)` wrapping the cross-chain endpoint.

## Test plan

- [x] `go test -race ./backend/cmd/fishhawk-mcp/...`
- [x] `go test -race ./backend/...`
- [x] `golangci-lint run backend/...`
- [x] Coverage gate: 82.5% aggregate (≥ 80% threshold)
- [x] **Ten cases**: happy path bundles three reads (stages ordered, audit newest-first); defensive sort with out-of-order stages; `audit_limit` default 5; `audit_limit > 50` clamps to 50 (verified via lastAuditLimit capture); explicit value 20 forwarded verbatim; invalid UUID rejected before any API call; missing run (GetRun 404) surfaces wrapped error; stages 500 surfaces "list stages" error; audit 500 surfaces "list recent audit" error; empty stages + empty audit → OK with empty arrays

## Notes

- Read-only per ADR-021.
- Agents wanting more rows than 50 use the dedicated `fishhawk_list_audit` tool (E19.6 / #346, the next ticket).
- `fakeBackend` test harness extended with `auditByRun` + `lastAuditLimit` so the three MCP tool tests share scaffolding.

Closes #345