### PR TITLE
mcp: fishhawk_list_audit tool — completes the v0 MCP tool set (E19.6 / #346)

### DIFF
--- a/backend/cmd/fishhawk-mcp/README.md
+++ b/backend/cmd/fishhawk-mcp/README.md
@@ -11,12 +11,14 @@ All v0 tools are read-only. Action verbs (approve, retry, cancel) stay in the CL
 
 ## Status
 
-E19.2 / #342 ships scaffolding + handshake only. Tools land in:
+E19.2 / #342 shipped scaffolding + handshake. E19.3–E19.6 landed the v0 tool surface (all read-only per ADR-021):
 
-- E19.3 / #343 — `fishhawk_get_active_run`
-- E19.4 / #344 — `fishhawk_get_plan`
-- E19.5 / #345 — `fishhawk_get_run_status`
-- E19.6 / #346 — `fishhawk_list_audit`
+- `fishhawk_get_active_run` (E19.3 / #343) — resolves "the run for the current context" from `pr_number`, `trigger_ref`, or `FISHHAWK_RUN_ID` env.
+- `fishhawk_get_plan` (E19.4 / #344) — returns the approved standard_v1 plan; walks `parent_run_id` up to 8 levels for CI-retry chains.
+- `fishhawk_get_run_status` (E19.5 / #345) — bundles Run + ordered stages + recent audit (time-descending) into one call. The agent's "where are we" query.
+- `fishhawk_list_audit` (E19.6 / #346) — filtered audit access (category, stage_id) with cursor pagination. Mirrors the CLI's `fishhawk audit list`.
+
+E19.7 / #347 wires the binary into the release pipeline next.
 
 ## Build
 

--- a/backend/cmd/fishhawk-mcp/client.go
+++ b/backend/cmd/fishhawk-mcp/client.go
@@ -199,6 +199,48 @@ type listAuditResult struct {
 	NextCursor string       `json:"next_cursor,omitempty"`
 }
 
+// ListRunAuditFilter scopes a per-run audit query. Empty values
+// drop from the query string; zero Limit lets the server pick its
+// default (100, per the OpenAPI; 500 max). The MCP tool layer
+// clamps to a lower cap before calling.
+type ListRunAuditFilter struct {
+	Category string
+	StageID  string
+	Limit    int
+	Cursor   string
+}
+
+// ListRunAudit calls GET /v0/runs/{run_id}/audit with optional
+// category / stage_id / limit / cursor filters. Returns entries
+// sequence-ascending (matches the API surface: per-run scope for
+// the run-detail UI + verifier path). For "most-recent-first"
+// queries use ListRecentRunAudit which hits the cross-chain
+// endpoint with time-descending order.
+func (c *apiClient) ListRunAudit(ctx context.Context, runID uuid.UUID, f ListRunAuditFilter) ([]AuditEntry, string, error) {
+	q := url.Values{}
+	if f.Category != "" {
+		q.Set("category", f.Category)
+	}
+	if f.StageID != "" {
+		q.Set("stage_id", f.StageID)
+	}
+	if f.Limit > 0 {
+		q.Set("limit", strconv.Itoa(f.Limit))
+	}
+	if f.Cursor != "" {
+		q.Set("cursor", f.Cursor)
+	}
+	path := "/v0/runs/" + runID.String() + "/audit"
+	if encoded := q.Encode(); encoded != "" {
+		path = path + "?" + encoded
+	}
+	var res listAuditResult
+	if err := c.do(ctx, http.MethodGet, path, nil, &res); err != nil {
+		return nil, "", err
+	}
+	return res.Items, res.NextCursor, nil
+}
+
 // ListRecentRunAudit calls GET /v0/audit?run_id=<id>&limit=<N>.
 // Returns rows time-descending — exactly the order an agent wants
 // when surfacing "what's happened recently" in the get_run_status

--- a/backend/cmd/fishhawk-mcp/tools.go
+++ b/backend/cmd/fishhawk-mcp/tools.go
@@ -31,8 +31,7 @@ func registerTools(srv *mcp.Server, resolver *runResolver) {
 	registerGetActiveRun(srv, resolver)
 	registerGetPlan(srv, resolver)
 	registerGetRunStatus(srv, resolver)
-	// Subsequent tools register here:
-	//   E19.6 / #346 — fishhawk_list_audit
+	registerListAudit(srv, resolver)
 }
 
 // GetActiveRunInput is the tool's input schema (E19.3 / #343). All
@@ -452,6 +451,106 @@ func clampAuditLimit(n int) int {
 	}
 	if n > auditLimitMax {
 		return auditLimitMax
+	}
+	return n
+}
+
+// listAuditLimitDefault / listAuditLimitMax cap the
+// fishhawk_list_audit tool's limit input. The backend's
+// /v0/runs/{id}/audit endpoint accepts up to 500; the MCP tool
+// caps lower (200) because the agent's reasoning window has a
+// practical limit on how many entries it can process per call.
+// Pagination via cursor covers the > 200 case.
+const (
+	listAuditLimitDefault = 50
+	listAuditLimitMax     = 200
+)
+
+// ListAuditInput is the tool's input schema. category / stage_id
+// are optional filters; limit / cursor drive pagination through
+// the per-run audit endpoint.
+type ListAuditInput struct {
+	RunID    string `json:"run_id" jsonschema:"the Fishhawk run UUID"`
+	Category string `json:"category,omitempty" jsonschema:"single category filter (e.g. 'approval_submitted', 'plan_generated', 'ci_failure_retry_dispatched')"`
+	StageID  string `json:"stage_id,omitempty" jsonschema:"scope entries to a specific stage UUID"`
+	Limit    int    `json:"limit,omitempty" jsonschema:"max items per page (default 50, capped at 200)"`
+	Cursor   string `json:"cursor,omitempty" jsonschema:"pagination cursor returned by a prior list call as next_cursor"`
+}
+
+// ListAuditOutput mirrors the OpenAPI paginated list envelope.
+// NextCursor is the opaque token the agent feeds back into the
+// next call to walk past the current page; empty when the page
+// reached the end of the chain.
+type ListAuditOutput struct {
+	Items      []AuditEntry `json:"items"`
+	NextCursor string       `json:"next_cursor,omitempty" jsonschema:"opaque pagination cursor; empty when no more pages remain"`
+}
+
+// registerListAudit wires the fishhawk_list_audit tool. Forwards
+// filters verbatim to GET /v0/runs/{id}/audit — the same endpoint
+// the CLI's `fishhawk audit list` uses (E18.4 / #335). Read-only
+// per ADR-021.
+func registerListAudit(srv *mcp.Server, resolver *runResolver) {
+	mcp.AddTool(srv, &mcp.Tool{
+		Name: "fishhawk_list_audit",
+		Description: strings.TrimSpace(`
+List audit entries for a Fishhawk run with optional filters.
+
+Returns rows sequence-ascending (matches the per-run scope the
+backend exposes for the run-detail UI + verifier path). For "most-
+recent N" queries, use fishhawk_get_run_status which uses the
+cross-chain endpoint for time-descending order.
+
+Inputs:
+  - run_id    (required) — Fishhawk run UUID.
+  - category  — single category filter (e.g. 'approval_submitted').
+  - stage_id  — scope to a stage's entries.
+  - limit     — default 50, capped at 200. For deeper paging use
+                the returned next_cursor.
+  - cursor    — opaque pagination token from a prior call.
+
+Response: items[] (AuditEntry shape) + next_cursor (empty when the
+chain is exhausted).
+`),
+	}, resolver.listAudit)
+}
+
+// listAudit is the tool handler.
+func (r *runResolver) listAudit(ctx context.Context, _ *mcp.CallToolRequest, in ListAuditInput) (*mcp.CallToolResult, ListAuditOutput, error) {
+	runID, err := uuid.Parse(in.RunID)
+	if err != nil {
+		return nil, ListAuditOutput{}, fmt.Errorf("run_id %q is not a valid UUID: %w", in.RunID, err)
+	}
+	// Validate stage_id locally before the API round-trip so a
+	// malformed input surfaces as a clean tool error rather than
+	// a generic backend 400. Mirrors the CLI's E18.4 posture.
+	if in.StageID != "" {
+		if _, err := uuid.Parse(in.StageID); err != nil {
+			return nil, ListAuditOutput{}, fmt.Errorf("stage_id %q is not a valid UUID: %w", in.StageID, err)
+		}
+	}
+	limit := clampListAuditLimit(in.Limit)
+	items, nextCursor, err := r.api.ListRunAudit(ctx, runID, ListRunAuditFilter{
+		Category: in.Category,
+		StageID:  in.StageID,
+		Limit:    limit,
+		Cursor:   in.Cursor,
+	})
+	if err != nil {
+		return nil, ListAuditOutput{}, fmt.Errorf("list audit: %w", err)
+	}
+	return nil, ListAuditOutput{Items: items, NextCursor: nextCursor}, nil
+}
+
+// clampListAuditLimit applies the default + cap. Centralized so
+// the test surface can exercise the clamp directly without driving
+// the full tool flow.
+func clampListAuditLimit(n int) int {
+	if n <= 0 {
+		return listAuditLimitDefault
+	}
+	if n > listAuditLimitMax {
+		return listAuditLimitMax
 	}
 	return n
 }

--- a/backend/cmd/fishhawk-mcp/tools_test.go
+++ b/backend/cmd/fishhawk-mcp/tools_test.go
@@ -52,24 +52,38 @@ type fakeBackend struct {
 	auditStatus     int
 	lastAuditLimit  string
 	auditCalledByID map[uuid.UUID]int
+
+	// E19.6 fixtures: per-run audit responses + recorded query
+	// state for the /v0/runs/{id}/audit endpoint. Distinct from
+	// the cross-chain capture above so tests can verify which
+	// surface a tool routed to (and let the same backend serve
+	// both shapes for the test suite that mixes them).
+	perRunAuditByRun         map[uuid.UUID][]AuditEntry
+	perRunAuditNextByRun     map[uuid.UUID]string
+	perRunAuditStatus        int
+	perRunAuditLastQueryByID map[uuid.UUID]string
 }
 
 func newFakeBackend(t *testing.T) (*fakeBackend, *httptest.Server) {
 	t.Helper()
 	fb := &fakeBackend{
-		listStatus:        http.StatusOK,
-		getStatus:         http.StatusOK,
-		stagesStatus:      http.StatusOK,
-		artifactsStatus:   http.StatusOK,
-		auditStatus:       http.StatusOK,
-		listByQuery:       map[string]listRunsResult{},
-		getRunByID:        map[uuid.UUID]Run{},
-		stagesByRun:       map[uuid.UUID][]Stage{},
-		artifactsByStage:  map[uuid.UUID][]Artifact{},
-		stagesCalledByID:  map[uuid.UUID]int{},
-		artifactsCalledID: map[uuid.UUID]int{},
-		auditByRun:        map[uuid.UUID][]AuditEntry{},
-		auditCalledByID:   map[uuid.UUID]int{},
+		listStatus:               http.StatusOK,
+		getStatus:                http.StatusOK,
+		stagesStatus:             http.StatusOK,
+		artifactsStatus:          http.StatusOK,
+		auditStatus:              http.StatusOK,
+		perRunAuditStatus:        http.StatusOK,
+		listByQuery:              map[string]listRunsResult{},
+		getRunByID:               map[uuid.UUID]Run{},
+		stagesByRun:              map[uuid.UUID][]Stage{},
+		artifactsByStage:         map[uuid.UUID][]Artifact{},
+		stagesCalledByID:         map[uuid.UUID]int{},
+		artifactsCalledID:        map[uuid.UUID]int{},
+		auditByRun:               map[uuid.UUID][]AuditEntry{},
+		auditCalledByID:          map[uuid.UUID]int{},
+		perRunAuditByRun:         map[uuid.UUID][]AuditEntry{},
+		perRunAuditNextByRun:     map[uuid.UUID]string{},
+		perRunAuditLastQueryByID: map[uuid.UUID]string{},
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /v0/runs", func(w http.ResponseWriter, r *http.Request) {
@@ -115,6 +129,21 @@ func newFakeBackend(t *testing.T) (*fakeBackend, *httptest.Server) {
 		fb.mu.Unlock()
 		w.WriteHeader(fb.stagesStatus)
 		_ = json.NewEncoder(w).Encode(listStagesResult{Items: items})
+	})
+	mux.HandleFunc("GET /v0/runs/{run_id}/audit", func(w http.ResponseWriter, r *http.Request) {
+		id, perr := uuid.Parse(r.PathValue("run_id"))
+		w.Header().Set("Content-Type", "application/json")
+		if perr != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		fb.mu.Lock()
+		fb.perRunAuditLastQueryByID[id] = r.URL.RawQuery
+		items := fb.perRunAuditByRun[id]
+		next := fb.perRunAuditNextByRun[id]
+		fb.mu.Unlock()
+		w.WriteHeader(fb.perRunAuditStatus)
+		_ = json.NewEncoder(w).Encode(listAuditResult{Items: items, NextCursor: next})
 	})
 	mux.HandleFunc("GET /v0/audit", func(w http.ResponseWriter, r *http.Request) {
 		runIDQ := r.URL.Query().Get("run_id")
@@ -947,5 +976,219 @@ func TestGetPlan_IgnoresNonStandardV1PlanArtifacts(t *testing.T) {
 	}
 	if out.Status != "no_plan_yet" {
 		t.Errorf("Status = %q, want no_plan_yet (future schema is invisible)", out.Status)
+	}
+}
+
+// --- list_audit (E19.6 / #346) ---
+
+func TestListAudit_HappyPath_DefaultsLimit(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	runID := uuid.New()
+	fb.perRunAuditByRun[runID] = []AuditEntry{
+		auditFixture(1, runID, "run_dispatched", "github-webhook", 30*time.Minute),
+		auditFixture(2, runID, "plan_generated", "system", 15*time.Minute),
+		auditFixture(3, runID, "approval_submitted", "alice", 5*time.Minute),
+	}
+
+	r := newResolver(srv, nil)
+	_, out, err := r.listAudit(context.Background(), nil, ListAuditInput{RunID: runID.String()})
+	if err != nil {
+		t.Fatalf("listAudit: %v", err)
+	}
+	if got := len(out.Items); got != 3 {
+		t.Errorf("Items length = %d, want 3", got)
+	}
+	q := fb.perRunAuditLastQueryByID[runID]
+	if !strings.Contains(q, "limit=50") {
+		t.Errorf("expected default limit=50; got %q", q)
+	}
+	// No filters → no category / stage_id / cursor in the query.
+	for _, unwanted := range []string{"category=", "stage_id=", "cursor="} {
+		if strings.Contains(q, unwanted) {
+			t.Errorf("unfiltered call should not carry %q; got %q", unwanted, q)
+		}
+	}
+}
+
+func TestListAudit_FiltersForwarded(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	runID := uuid.New()
+	stageID := uuid.New()
+
+	r := newResolver(srv, nil)
+	_, _, err := r.listAudit(context.Background(), nil, ListAuditInput{
+		RunID:    runID.String(),
+		Category: "approval_submitted",
+		StageID:  stageID.String(),
+		Limit:    25,
+		Cursor:   "tok-abc",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	q := fb.perRunAuditLastQueryByID[runID]
+	for _, want := range []string{
+		"category=approval_submitted",
+		"stage_id=" + stageID.String(),
+		"limit=25",
+		"cursor=tok-abc",
+	} {
+		if !strings.Contains(q, want) {
+			t.Errorf("query missing %q: %s", want, q)
+		}
+	}
+}
+
+func TestListAudit_Limit_ClampedTo200(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	runID := uuid.New()
+
+	r := newResolver(srv, nil)
+	_, _, err := r.listAudit(context.Background(), nil, ListAuditInput{
+		RunID: runID.String(),
+		Limit: 5000,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	q := fb.perRunAuditLastQueryByID[runID]
+	if !strings.Contains(q, "limit=200") {
+		t.Errorf("limit should clamp to 200; got %q", q)
+	}
+}
+
+func TestListAudit_NextCursorPropagated(t *testing.T) {
+	// Page 1 returns a next_cursor; the tool surfaces it so the
+	// agent can call again with cursor=<token>. Verify both the
+	// outbound forwarding and the inbound round-trip.
+	fb, srv := newFakeBackend(t)
+	runID := uuid.New()
+	fb.perRunAuditByRun[runID] = []AuditEntry{
+		auditFixture(1, runID, "run_dispatched", "github-webhook", time.Hour),
+	}
+	fb.perRunAuditNextByRun[runID] = "tok-page2"
+
+	r := newResolver(srv, nil)
+	_, out, err := r.listAudit(context.Background(), nil, ListAuditInput{RunID: runID.String()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.NextCursor != "tok-page2" {
+		t.Errorf("NextCursor = %q, want tok-page2", out.NextCursor)
+	}
+
+	// Round-trip: feed the cursor back in.
+	_, _, err = r.listAudit(context.Background(), nil, ListAuditInput{
+		RunID:  runID.String(),
+		Cursor: "tok-page2",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	q := fb.perRunAuditLastQueryByID[runID]
+	if !strings.Contains(q, "cursor=tok-page2") {
+		t.Errorf("page-2 call should forward cursor; got %q", q)
+	}
+}
+
+func TestListAudit_BadRunUUID(t *testing.T) {
+	_, srv := newFakeBackend(t)
+	r := newResolver(srv, nil)
+
+	_, _, err := r.listAudit(context.Background(), nil, ListAuditInput{RunID: "not-a-uuid"})
+	if err == nil {
+		t.Fatal("expected error on malformed run_id")
+	}
+	if !strings.Contains(err.Error(), "run_id") || !strings.Contains(err.Error(), "not a valid UUID") {
+		t.Errorf("error wording: %v", err)
+	}
+}
+
+func TestListAudit_BadStageUUID_RejectedBeforeAPICall(t *testing.T) {
+	// stage_id parses locally so a malformed input surfaces as a
+	// clean tool error rather than a confusing backend 400.
+	fb, srv := newFakeBackend(t)
+	r := newResolver(srv, nil)
+
+	_, _, err := r.listAudit(context.Background(), nil, ListAuditInput{
+		RunID:   uuid.New().String(),
+		StageID: "nope",
+	})
+	if err == nil {
+		t.Fatal("expected error on malformed stage_id")
+	}
+	if !strings.Contains(err.Error(), "stage_id") {
+		t.Errorf("error should name the stage_id field: %v", err)
+	}
+	// Defensive: the backend must NOT have been hit when local
+	// validation failed.
+	if len(fb.perRunAuditLastQueryByID) != 0 {
+		t.Errorf("backend hit despite local validation failure: %v", fb.perRunAuditLastQueryByID)
+	}
+}
+
+func TestListAudit_BackendError_Surfaced(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	runID := uuid.New()
+	fb.perRunAuditStatus = http.StatusInternalServerError
+
+	r := newResolver(srv, nil)
+	_, _, err := r.listAudit(context.Background(), nil, ListAuditInput{RunID: runID.String()})
+	if err == nil {
+		t.Fatal("expected 500 to surface")
+	}
+	if !strings.Contains(err.Error(), "list audit") {
+		t.Errorf("error wording: %v", err)
+	}
+}
+
+func TestListAudit_MissingRun_404Surfaced(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	fb.perRunAuditStatus = http.StatusNotFound
+
+	r := newResolver(srv, nil)
+	_, _, err := r.listAudit(context.Background(), nil, ListAuditInput{RunID: uuid.New().String()})
+	if err == nil {
+		t.Fatal("expected 404 to surface")
+	}
+}
+
+func TestListAudit_EmptyPage_OK(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	runID := uuid.New()
+	// perRunAuditByRun left empty for this id.
+	_ = fb
+
+	r := newResolver(srv, nil)
+	_, out, err := r.listAudit(context.Background(), nil, ListAuditInput{RunID: runID.String()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := len(out.Items); got != 0 {
+		t.Errorf("expected empty items; got %d", got)
+	}
+	if out.NextCursor != "" {
+		t.Errorf("empty page should have empty cursor; got %q", out.NextCursor)
+	}
+}
+
+func TestClampListAuditLimit(t *testing.T) {
+	// Centralized clamp logic — test directly without the full
+	// tool flow so future tweaks have a fast feedback loop.
+	cases := []struct {
+		in, want int
+	}{
+		{0, listAuditLimitDefault},
+		{-1, listAuditLimitDefault},
+		{1, 1},
+		{50, 50},
+		{200, 200},
+		{201, listAuditLimitMax},
+		{99999, listAuditLimitMax},
+	}
+	for _, tc := range cases {
+		if got := clampListAuditLimit(tc.in); got != tc.want {
+			t.Errorf("clampListAuditLimit(%d) = %d, want %d", tc.in, got, tc.want)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Fourth and final MCP tool. Filtered audit access for the agent / operator. Mirrors the CLI's `fishhawk audit list` (E18.4 / #335) via the same backend endpoint.

**Inputs**: `run_id` (required UUID), `category` (optional), `stage_id` (optional, validated as UUID locally before the API call), `limit` (default 50, max 200), `cursor` (pagination token from a prior `next_cursor`).

**Output**: `Items[]` (AuditEntry shape) + `NextCursor` (opaque; empty when exhausted).

Routes to `GET /v0/runs/{id}/audit` (sequence-ascending). For "most-recent N" queries, agents use `fishhawk_get_run_status`'s `RecentAudit` field, which hits the cross-chain `/v0/audit` endpoint for time-descending order. The two coexist because the endpoints have different ordering contracts.

## Implementation

- `client.go` gains `ListRunAudit(ctx, runID, filter)`. Distinct from `ListRecentRunAudit` (E19.5's helper). The cap is **client-side** (200) — the backend allows 500, but a v0 agent's reasoning window has a practical lower limit; pagination via cursor covers > 200.
- `tools.go` adds `registerListAudit` to the `registerTools` chain. `clampListAuditLimit` is factored out so the boundary logic has direct test coverage.

## Test plan

- [x] `go test -race ./backend/cmd/fishhawk-mcp/...`
- [x] `go test -race ./backend/...`
- [x] `golangci-lint run backend/...`
- [x] Coverage gate: 82.6% aggregate (≥ 80% threshold)
- [x] **Ten cases**: happy path (default limit=50, no unwanted filters); all filters forwarded; limit clamps to 200; `next_cursor` round-trip (page-1 returns token → page-2 query forwards it as `cursor=<token>`); bad `run_id` rejected; bad `stage_id` rejected before API call (defensive: backend not hit); 500 surfaces wrapped error; 404 surfaces; empty page → OK with empty Items + empty NextCursor; `clampListAuditLimit` unit table covers 7 boundary values

## Notes

- Read-only per ADR-021. Completes the v0 MCP tool surface:
  - `fishhawk_get_active_run` (E19.3 / #343)
  - `fishhawk_get_plan` (E19.4 / #344)
  - `fishhawk_get_run_status` (E19.5 / #345)
  - `fishhawk_list_audit` (this PR / E19.6 / #346)
- README updated to reflect the complete set. E19.7 / #347 (release pipeline) is next.

Closes #346