### PR TITLE
scripts: add test wrapper for the multi-module go gates (#380)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,26 +24,24 @@ Pre-alpha. Most code referenced in `docs/MVP_SPEC.md` doesn't exist yet — it's
 
 ## Build, test, lint
 
-Multi-module Go workspace; **no root `go.mod`**, so `go build ./...` from root fails. Use:
+Multi-module Go workspace; **no root `go.mod`**, so `go build ./...` from root fails. The common gates are wrapped by `scripts/test`:
+
+```sh
+scripts/test               # `go test -race ./...` in every registered module
+scripts/test coverage      # the same, plus the aggregate coverage gate
+scripts/test single -run TestName ./backend/internal/version/   # passthrough
+```
+
+Per-module without the wrapper (still useful for `go build` and `golangci-lint`):
 
 ```sh
 go build ./backend/...
-go test -race ./backend/...
 golangci-lint run ./backend/...
-go test -race -run TestName ./backend/internal/version/   # single test
-```
-
-CI loops over registered modules — adding `use ./<dir>` to `go.work` auto-includes it:
-
-```sh
-for m in $(go work edit -json | jq -r '.Use[].DiskPath'); do
-  (cd "$m" && go build ./... && go test -race ./...)
-done
 ```
 
 `.golangci.yml` is **v2 format** (`version: "2"` at top). Local install must be golangci-lint v2.x; v1 binaries reject this config.
 
-**Coverage gate**: aggregate ≥ 80% across **all** registered modules, excluding sqlc-generated `*/db/` packages (CI uses `--exclude '/db/'` so new sqlc packages auto-skip). Tiered targets in `docs/ARCHITECTURE.md` §9. CI fails `CI Pass` if the threshold drops. Reproduce locally:
+**Coverage gate**: aggregate ≥ 80% across **all** registered modules, excluding sqlc-generated `*/db/` packages (CI uses `--exclude '/db/'` so new sqlc packages auto-skip). Tiered targets in `docs/ARCHITECTURE.md` §9. CI fails `CI Pass` if the threshold drops. `scripts/test coverage` runs the same check. The underlying loop (CI uses the same shape):
 
 ```sh
 profiles=()

--- a/scripts/test
+++ b/scripts/test
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# scripts/test — wraps the multi-module Go test + coverage gates.
+#
+# Mirrors the loop CI uses for the Go lane: reads registered modules
+# from go.work, runs each module's tests in its own directory.
+# Fail-fast on the first module whose tests fail.
+#
+# Usage:
+#   scripts/test              run `go test -race ./...` in every module
+#   scripts/test coverage     the gate above + scripts/check-coverage.py
+#   scripts/test single ARGS  pass-through to `go test -race ARGS`
+#                             example:
+#                             scripts/test single -run TestX ./backend/internal/version/...
+#
+# Frontend gates (pnpm format:check / typecheck / test) are NOT
+# covered here — they have their own conventions per docs/.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+modules() {
+  go work edit -json | jq -r '.Use[].DiskPath'
+}
+
+cmd_test() {
+  while IFS= read -r m; do
+    printf '>>> %s\n' "$m"
+    (cd "$m" && go test -race ./...)
+  done < <(modules)
+}
+
+cmd_coverage() {
+  local profiles=()
+  while IFS= read -r m; do
+    printf '>>> %s\n' "$m"
+    (cd "$m" && go test -race -coverprofile=coverage.out -covermode=atomic ./...)
+    profiles+=("$m/coverage.out")
+  done < <(modules)
+  python3 "$ROOT/scripts/check-coverage.py" --threshold 80 --exclude '/db/' "${profiles[@]}"
+}
+
+cmd_single() {
+  if [ "$#" -eq 0 ]; then
+    cat >&2 <<'EOF'
+usage: scripts/test single <args>
+example: scripts/test single -run TestNotifyPlanReady ./backend/internal/issuecomment/...
+EOF
+    exit 1
+  fi
+  go test -race "$@"
+}
+
+usage() {
+  cat <<'EOF'
+usage: scripts/test [SUBCOMMAND] [ARGS]
+
+  test                 (default) run `go test -race ./...` in every module
+  coverage             run tests + aggregate coverage gate
+  single ARGS          pass-through to `go test -race ARGS`
+  -h | --help | help   show this message
+EOF
+}
+
+case "${1:-test}" in
+  test|"")          cmd_test ;;
+  coverage|cover)   cmd_coverage ;;
+  single)           shift; cmd_single "$@" ;;
+  -h|--help|help)   usage ;;
+  *)
+    echo "scripts/test: unknown subcommand: $1" >&2
+    usage >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary

- New `scripts/test` wraps the multi-module Go test + coverage gates so collaborators don't retype the 7-line for-loop every gate-run.
- Three subcommands: `scripts/test` (test only), `scripts/test coverage` (test + aggregate coverage gate), `scripts/test single ARGS` (passthrough to `go test -race`).
- Reads registered modules from `go work edit -json | jq -r '.Use[].DiskPath'` so new modules added to `go.work` auto-include without script edits.
- Fail-fast on the first module whose tests fail — matches CI's behavior.
- `CLAUDE.md`'s "Build, test, lint" section now points at the wrapper as the first-class path. The underlying for-loop stays in CLAUDE.md as a reference so the operator can still reproduce CI directly.

## Test plan

- [x] `scripts/test --help` prints usage.
- [x] `scripts/test` runs in every module, fails fast on the first failure (verified locally — pass).
- [x] `scripts/test coverage` runs the gate and emits the same per-package table + aggregate that the manual incantation produces (verified locally — 82.5% PASS).
- [x] `scripts/test single -run TestNotifyPlanReady_FullPlanSpec_ApprovalFooter ./backend/internal/issuecomment/...` runs that test only.
- [x] Bash 3.2 compatible (no associative arrays per the macOS bash trap in CLAUDE.md).

## Notes

CI workflows are NOT switched to the wrapper in this PR — the inline commands stay on the critical path on day one. A follow-up can migrate CI once the wrapper has run locally without surprises for a couple of weeks.

Closes #380.

🤖 Generated with [Claude Code](https://claude.com/claude-code)