### PR TITLE
mcp: phase A close-out — docs sweep + write-tool E2E (#395 / E22.6)

### DIFF
--- a/backend/internal/integration/mcp/e2e_test.go
+++ b/backend/internal/integration/mcp/e2e_test.go
@@ -39,6 +39,7 @@ import (
 	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
 	"github.com/testcontainers/testcontainers-go/wait"
 
+	"github.com/kuhlman-labs/fishhawk/backend/internal/apitoken"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/audit"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/mcptoken"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/postgres"
@@ -56,6 +57,9 @@ type e2eFixture struct {
 	runID        uuid.UUID
 	signingPriv  ed25519.PrivateKey
 	mcpTokenRepo mcptoken.Repository
+	runRepo      runpkg.Repository
+	apitokenRepo apitoken.Repository
+	operatorTok  string // fhk_* apitoken with the full operator write scopes
 	mcpBinary    string // path to the built fishhawk-mcp binary
 }
 
@@ -104,17 +108,21 @@ func newFixture(t *testing.T) *e2eFixture {
 
 	// 3. Build the real repos + the backend server. SigningRepo,
 	// RunRepo, MCPTokenRepo, AuditRepo are the four the
-	// mcp-token + bearerAuth + tool paths consult.
+	// mcp-token + bearerAuth + tool paths consult. APITokenRepo
+	// is wired so the operator-side write tools (E22 / #389) have
+	// a real authenticator to resolve against.
 	runRepo := runpkg.NewPostgresRepository(pool)
 	signingRepo := signing.NewPostgresRepository(pool)
 	auditRepo := audit.NewPostgresRepository(pool)
 	mcpRepo := mcptoken.NewPostgresRepository(pool)
+	apiRepo := apitoken.NewPostgresRepository(pool)
 	s := server.New(server.Config{
 		Addr:         "127.0.0.1:0",
 		RunRepo:      runRepo,
 		SigningRepo:  signingRepo,
 		AuditRepo:    auditRepo,
 		MCPTokenRepo: mcpRepo,
+		APITokenRepo: apiRepo,
 	})
 	httpSrv := httptest.NewServer(s.Handler())
 	t.Cleanup(httpSrv.Close)
@@ -135,6 +143,17 @@ func newFixture(t *testing.T) *e2eFixture {
 	issued, err := signingRepo.Issue(ctx, r.ID, time.Hour)
 	if err != nil {
 		t.Fatalf("Issue signing key: %v", err)
+	}
+
+	// Issue an operator-side apitoken with the full write scopes
+	// E22's Phase A tools require. Same shape `fishhawkd token
+	// issue` produces in dev.
+	operatorTok, err := apiRepo.Issue(ctx, "brett@e2e-test", []string{
+		"read:runs", "read:audit",
+		"write:runs", "write:approvals", "write:stages",
+	})
+	if err != nil {
+		t.Fatalf("Issue operator apitoken: %v", err)
 	}
 
 	// 5. Build the fishhawk-mcp binary into a temp dir. We use a
@@ -161,6 +180,9 @@ func newFixture(t *testing.T) *e2eFixture {
 		runID:        r.ID,
 		signingPriv:  issued.PrivateKey,
 		mcpTokenRepo: mcpRepo,
+		runRepo:      runRepo,
+		apitokenRepo: apiRepo,
+		operatorTok:  operatorTok.PlainText,
 		mcpBinary:    binary,
 	}
 }
@@ -394,4 +416,91 @@ func isDockerUnavailable(err error) bool {
 		}
 	}
 	return errors.Is(err, exec.ErrNotFound)
+}
+
+// TestE2E_MCPLoop_OperatorWritePath_StartRun covers E22.6's "exercise
+// one write tool end-to-end" acceptance criterion. The flow:
+//
+//  1. Operator-side fhk_* apitoken (with write:runs scope) registers
+//     with the spawned fishhawk-mcp binary via FISHHAWK_API_TOKEN.
+//  2. Calls fishhawk_start_run with valid params.
+//  3. Asserts the backend response carries a fresh run id.
+//  4. Verifies the run row exists in Postgres directly — proves the
+//     MCP → backend → DB write path is intact end-to-end.
+//
+// Distinct from the existing read-only tests (#371) because this is
+// the first time we exercise a write tool through the real MCP
+// binary + real backend + real DB stack.
+func TestE2E_MCPLoop_OperatorWritePath_StartRun(t *testing.T) {
+	fx := newFixture(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	session := connectMCPClient(t, ctx, fx.mcpBinary, fx.operatorTok, fx.url)
+
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name: "fishhawk_start_run",
+		Arguments: map[string]any{
+			"repo":           "kuhlman-labs/fishhawk",
+			"workflow_id":    "feature_change",
+			"workflow_sha":   "deadbeef-mcp-e2e",
+			"trigger_source": "cli",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CallTool fishhawk_start_run: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("tool returned error: %+v", result.Content)
+	}
+
+	// Extract the created run id from the structured output. The
+	// tool surfaces {run: {id, ...}, idempotent} per StartRunOutput.
+	if result.StructuredContent == nil {
+		t.Fatal("tool returned no StructuredContent")
+	}
+	raw, err := json.Marshal(result.StructuredContent)
+	if err != nil {
+		t.Fatalf("marshal structured content: %v", err)
+	}
+	var out struct {
+		Run struct {
+			ID    string `json:"id"`
+			Repo  string `json:"repo"`
+			State string `json:"state"`
+		} `json:"run"`
+		Idempotent bool `json:"idempotent"`
+	}
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("decode structured output: %v", err)
+	}
+	if out.Run.ID == "" {
+		t.Fatalf("created run has no id; structured output: %s", raw)
+	}
+	if out.Idempotent {
+		t.Errorf("fresh start_run returned Idempotent=true; expected false")
+	}
+	if out.Run.Repo != "kuhlman-labs/fishhawk" {
+		t.Errorf("run.Repo = %q, want kuhlman-labs/fishhawk", out.Run.Repo)
+	}
+	if out.Run.State != "pending" {
+		t.Errorf("run.State = %q, want pending", out.Run.State)
+	}
+
+	// Verify the run actually landed in the DB. Closes the "MCP →
+	// backend → DB" loop end-to-end.
+	createdID, err := uuid.Parse(out.Run.ID)
+	if err != nil {
+		t.Fatalf("created run id %q is not a UUID: %v", out.Run.ID, err)
+	}
+	got, err := fx.runRepo.GetRun(ctx, createdID)
+	if err != nil {
+		t.Fatalf("GetRun for created id: %v", err)
+	}
+	if got.WorkflowID != "feature_change" {
+		t.Errorf("DB row WorkflowID = %q, want feature_change", got.WorkflowID)
+	}
+	if got.WorkflowSHA != "deadbeef-mcp-e2e" {
+		t.Errorf("DB row WorkflowSHA = %q, want deadbeef-mcp-e2e", got.WorkflowSHA)
+	}
 }

--- a/docs/mcp/install.md
+++ b/docs/mcp/install.md
@@ -1,14 +1,14 @@
 # fishhawk-mcp install
 
-Operator-facing install path for the Fishhawk MCP server. Covers manual binary install + `claude mcp add` registration. The model decision lives in [ADR-021](https://github.com/kuhlman-labs/fishhawk/issues/322); the module source lives at `backend/cmd/fishhawk-mcp/`.
+Operator-facing install path for the Fishhawk MCP server. Covers manual binary install + `claude mcp add` registration. The model decision lives in [ADR-021](https://github.com/kuhlman-labs/fishhawk/issues/322); the lifecycle-write tools landed under [E22 / #389](https://github.com/kuhlman-labs/fishhawk/issues/389); the module source lives at `backend/cmd/fishhawk-mcp/`.
 
 ## Status
 
-E19.7 / #347. Direct binary download is the v0 install path; Homebrew / other package-manager distribution is out of scope.
+E19.7 / #347 shipped the release pipeline + v0 read-only tools. E22 added the lifecycle-write surface (start_run, cancel_run, retry_stage, approve_plan, reject_plan, list_runs). Direct binary download is the v0 install path; Homebrew / other package-manager distribution is out of scope.
 
 ## Prerequisites
 
-- A Fishhawk API token. The backend's API-token surface (E13 / forthcoming) issues these against a GitHub-authenticated identity. Until the surface lands, dev backends with stubbed auth accept any non-empty value — operators set `FISHHAWK_API_TOKEN=dev` to start.
+- A Fishhawk API token (`fhk_*`). Issued by the backend's apitoken surface; for local dev, `fishhawkd token issue --subject <login> --scopes read:runs,read:audit,write:runs,write:approvals,write:stages` mints a token with the full operator surface.
 - A reachable Fishhawk backend. `https://app.fishhawk.[tld]` for production installs; `http://localhost:8080` for local dev.
 - Claude Code installed (any version supporting `claude mcp add`).
 
@@ -66,12 +66,12 @@ export FISHHAWK_BACKEND_URL="https://app.fishhawk.example.com"
 
 ```sh
 claude mcp add fishhawk \
-  --command /usr/local/bin/fishhawk-mcp \
   --env FISHHAWK_API_TOKEN=$FISHHAWK_API_TOKEN \
-  --env FISHHAWK_BACKEND_URL=$FISHHAWK_BACKEND_URL
+  --env FISHHAWK_BACKEND_URL=$FISHHAWK_BACKEND_URL \
+  -- /usr/local/bin/fishhawk-mcp
 ```
 
-The exact flag shape varies by Claude Code version — `claude mcp add --help` is authoritative. Some clients prefer a config file path; some take env vars inline.
+`--` separates Claude Code's flags from the binary path. The exact flag shape varies by Claude Code version — `claude mcp add --help` is authoritative. Some clients prefer a config file path; some take env vars inline.
 
 ### 5. Smoke-test the registration
 
@@ -83,7 +83,12 @@ The agent should call `fishhawk_get_run_status` and return the Run row + ordered
 
 ## Tool surface
 
-All read-only per ADR-021. Action verbs (approve, retry, cancel) stay in the CLI / SPA / GitHub — agents articulate proposed actions; humans take them.
+Two audiences with different scopes:
+
+- **Operator-side** (your terminal Claude Code with an `fhk_*` apitoken): full lifecycle. Read tools work with `read:runs,read:audit`; the write tools need `write:runs,write:approvals,write:stages` per the table below.
+- **Runner-side** (the agent inside a Fishhawk runner with an `fhm_*` mcptoken, scope `mcp:read`): read-only. Per ADR-021 / [ADR-022's addendum](https://github.com/kuhlman-labs/fishhawk/issues/388) — runner identity is read-only across all runner backends. The agent never approves its own work.
+
+### Read tools
 
 | Tool | What |
 |---|---|
@@ -92,18 +97,36 @@ All read-only per ADR-021. Action verbs (approve, retry, cancel) stay in the CLI
 | `fishhawk_get_run_status` | Bundles Run + ordered stages + recent audit (time-descending) into one tool call. |
 | `fishhawk_list_audit` | Filtered audit access (`category`, `stage_id`) with cursor pagination. |
 
+### Write tools (operator-side only)
+
+| Tool | What | Required scope |
+|---|---|---|
+| `fishhawk_start_run` | Create a new run; mirrors `fishhawk run start`. Optional `idempotency_key` for safe re-submit. | `write:runs` |
+| `fishhawk_cancel_run` | Cancel a running run; mirrors `fishhawk run cancel`. Idempotent on re-cancel. | `write:runs` |
+| `fishhawk_retry_stage` | Re-fire a failed stage per its category; mirrors `fishhawk run retry`. Categories A/C re-dispatch; B / gate-rejected D surface as `retry_not_applicable`. | `write:stages` |
+| `fishhawk_approve_plan` | Approve the plan stage of a run (resolves stage from run id); mirrors `fishhawk plan approve`. | `write:approvals` |
+| `fishhawk_reject_plan` | Reject the plan stage with optional rationale; mirrors `fishhawk plan reject`. | `write:approvals` |
+| `fishhawk_list_runs` | Enumerate runs with filters (`repo`, `workflow_id`, `state`) + cursor pagination. | `read:runs` |
+
+**Auth posture** (today, v0):
+
+- `fhm_*` mcptokens calling `fishhawk_approve_plan` / `fishhawk_reject_plan` are rejected by the backend's role check (`checkApproverAuthorization`) when `RoleResolver` is wired — the runner's `mcp:run:<id>` subject won't match any team in the gate's approver list.
+- `fhm_*` mcptokens calling the other write tools (`start_run`, `cancel_run`, `retry_stage`) are **not yet** gated on scope at the handler — that enforcement is tracked at [#402](https://github.com/kuhlman-labs/fishhawk/issues/402). Until that lands, the read-only-runner property holds by convention (no production code path in the runner calls write tools) rather than wire enforcement.
+
 ## Runner integration
 
-E19.8 wires `fishhawk-mcp` into the runner's container image so the in-runner Claude Code agent has Fishhawk awareness mid-execution. Until that ticket lands, operators only see the MCP server in interactive Claude Code sessions on their dev machines.
+[E19.8 / #348](https://github.com/kuhlman-labs/fishhawk/issues/348) wires `fishhawk-mcp` into the runner so the in-runner Claude Code agent has Fishhawk awareness mid-execution. The runner fetches an `fhm_*` mcptoken via the signed `POST /v0/runs/{id}/mcp-token` endpoint at stage start, stamps it onto the agent's env (`FISHHAWK_API_TOKEN`), and the agent can call the read tools to introspect its own context. Write tools are not on the runner's surface (per ADR-022's addendum).
 
 ## Troubleshooting
 
 | Symptom | Likely cause |
 |---|---|
 | `FISHHAWK_API_TOKEN is required` on startup | The env var is unset or empty. Set it (see step 3). |
-| Claude Code says the tool isn't available | The MCP add step didn't take. Re-run `claude mcp add fishhawk` and verify with `claude mcp list`. |
+| Claude Code says the tool isn't available | The MCP add step didn't take. Re-run `claude mcp add fishhawk` and verify with `claude mcp list`. After rebuilding the binary, restart Claude Code so it re-spawns the MCP subprocess. |
 | `fishhawk: HTTP 401 (...)` from any tool | Token expired or invalid. Reissue via the backend's API-token surface. |
+| `fishhawk: HTTP 403 (insufficient_scope)` from a write tool | The token doesn't carry the required write scope (see the Write tools table). Reissue with `--scopes` including the right write scopes. |
 | `fishhawk: HTTP 404` from `fishhawk_get_plan` | Run id valid but the plan stage hasn't terminated — the tool returns a structured `no_plan_yet` response, not an error. Other 404s usually mean the run id is wrong. |
+| `no plan stage on run …` from `fishhawk_approve_plan` | The run's workflow doesn't have a plan stage (e.g. `routine_change`). Approve at the stage level directly via the CLI / SPA. |
 
 ## See also
 


### PR DESCRIPTION
## Summary

Closes Phase A of E22 / #389. Two pieces:

### `docs/mcp/install.md` sweep

Updated for the full 10-tool Phase A surface:

- Token prerequisite split between operator-side `fhk_*` apitokens (with write scopes) and runner-side `fhm_*` mcptokens (`mcp:read` only). Bootstrap command shows the full operator scope list.
- Tool surface reorganized: separate **Read** / **Write** tables with required scope per write tool.
- **Auth posture is honest about today's state**: approvals are gated via `checkApproverAuthorization`; the other write endpoints (`start_run`, `cancel_run`, `retry_stage`) are **not yet** handler-scope-enforced. That gap tracked at #402.
- Runner integration section refreshed (E19.8 / #348 has landed).
- `claude mcp add` example updated to the modern `--` separator shape.
- Troubleshooting table gains a 403 `insufficient_scope` row + the "no plan stage" case for routine_change workflows.

### Write-tool E2E test

New `TestE2E_MCPLoop_OperatorWritePath_StartRun` exercises `fishhawk_start_run` against the real backend + real DB + real `fishhawk-mcp` binary:

1. Fixture issues an operator-side `fhk_*` apitoken with `read:runs,read:audit,write:runs,write:approvals,write:stages`.
2. Spawns the mcp binary with that token in env.
3. Calls `fishhawk_start_run` via the MCP protocol.
4. Asserts the structured output carries a fresh run id + `Idempotent: false`.
5. Verifies the run row exists in Postgres directly via `runRepo.GetRun`.

Closes the gap from the retro: until now Phase A's confidence came from unit tests; this is the first wire-level exercise of a write tool end-to-end.

## Test plan

- [x] `scripts/test single ./backend/internal/integration/mcp/...` — all four E2E tests pass (the three pre-existing read/auth tests + the new write test). 7.5s wall time.
- [x] `scripts/test coverage` — aggregate 82.5% PASS.
- [x] `golangci-lint run ./backend/...` — 0 issues.
- [x] Fixture extension is backwards-compatible (existing read-only tests unchanged).

## Filed during close-out

**#402 — Enforce write scopes on /v0/runs + /v0/stages write endpoints**. Phase A's planning assumed handler-side scope enforcement existed for non-approval writes; it doesn't. Today the read-only-runner property holds by convention rather than wire enforcement. Filed as P1; out of scope for E22.6.

## Notes

**Phase A is complete.** 10 tools shipped (4 read + 6 write), full docs, one wire-tested write path. Phase B (E22.7 — runner_kind migration + plumbing) is unblocked.

The deliberate scope cut: this PR skips the "runner-side mcptoken calling a write tool gets 403" test because the gap from #402 means it wouldn't be a meaningful assertion today. Once #402 lands, that test becomes natural to add.

Closes #395

🤖 Generated with [Claude Code](https://claude.com/claude-code)