### PR TITLE
cli: --runner-kind flag on fishhawk run start (#410)

### DIFF
--- a/cli/cmd/fishhawk/main_test.go
+++ b/cli/cmd/fishhawk/main_test.go
@@ -292,6 +292,66 @@ func TestRunStart_TriggerRefForwarded(t *testing.T) {
 	}
 }
 
+func TestRunStart_RunnerKindForwarded(t *testing.T) {
+	// E22.7 / #410: --runner-kind local should land in the wire
+	// body. Empty (omitted) leaves the field unset → backend
+	// applies its github_actions default.
+	fb, srv := newFakeBackend(t)
+	withBackend(t, srv)
+	fb.startResp = httpclient.Run{ID: uuid.New(), State: "pending", RunnerKind: "local"}
+
+	if rc := run([]string{
+		"run", "start",
+		"--repo", "x/y", "--workflow", "w", "--workflow-sha", "abc",
+		"--runner-kind", "local",
+	}, io.Discard, io.Discard); rc != exitOK {
+		t.Fatalf("status = %d", rc)
+	}
+	if fb.startedRun.RunnerKind != "local" {
+		t.Errorf("RunnerKind = %q, want local", fb.startedRun.RunnerKind)
+	}
+}
+
+func TestRunStart_RunnerKindOmitted_DefaultsAtBackend(t *testing.T) {
+	// When --runner-kind isn't set the field is empty; the
+	// httpclient's `omitempty` tag drops it from the wire JSON
+	// entirely so the backend applies its default. This test
+	// asserts the CLI layer doesn't fill in a default itself.
+	fb, srv := newFakeBackend(t)
+	withBackend(t, srv)
+	fb.startResp = httpclient.Run{ID: uuid.New(), State: "pending"}
+
+	if rc := run([]string{
+		"run", "start",
+		"--repo", "x/y", "--workflow", "w", "--workflow-sha", "abc",
+	}, io.Discard, io.Discard); rc != exitOK {
+		t.Fatalf("status = %d", rc)
+	}
+	if fb.startedRun.RunnerKind != "" {
+		t.Errorf("RunnerKind = %q, want empty (backend defaults)", fb.startedRun.RunnerKind)
+	}
+}
+
+func TestRunStart_RunnerKindShownInTextOutput(t *testing.T) {
+	// printRun surfaces runner_kind so operators see the tag on
+	// the response. Empty omits the line (legacy parity).
+	fb, srv := newFakeBackend(t)
+	withBackend(t, srv)
+	fb.startResp = httpclient.Run{ID: uuid.New(), State: "pending", RunnerKind: "local"}
+
+	var stdout strings.Builder
+	if rc := run([]string{
+		"run", "start",
+		"--repo", "x/y", "--workflow", "w", "--workflow-sha", "abc",
+		"--runner-kind", "local",
+	}, &stdout, io.Discard); rc != exitOK {
+		t.Fatalf("status = %d", rc)
+	}
+	if !strings.Contains(stdout.String(), "runner_kind:    local") {
+		t.Errorf("text output missing runner_kind line:\n%s", stdout.String())
+	}
+}
+
 func TestRunStart_MissingRequiredFlags(t *testing.T) {
 	_, srv := newFakeBackend(t)
 	withBackend(t, srv)

--- a/cli/cmd/fishhawk/run.go
+++ b/cli/cmd/fishhawk/run.go
@@ -82,6 +82,8 @@ func runStart(args []string, stdout, stderr io.Writer) int {
 	workflowID := fs.String("workflow", "", "workflow ID matching .fishhawk/workflows.yaml (required)")
 	workflowSHA := fs.String("workflow-sha", "", "git SHA of .fishhawk/workflows.yaml (required)")
 	triggerRef := fs.String("trigger-ref", "", "optional trigger reference (e.g. issue:1247)")
+	runnerKind := fs.String("runner-kind", "",
+		"execution backend tag (ADR-022): github_actions | local; empty uses the backend's default")
 	if err := fs.Parse(args); err != nil {
 		return exitUsage
 	}
@@ -96,6 +98,7 @@ func runStart(args []string, stdout, stderr io.Writer) int {
 		WorkflowID:    *workflowID,
 		WorkflowSHA:   *workflowSHA,
 		TriggerSource: "cli",
+		RunnerKind:    *runnerKind,
 	}
 	if *triggerRef != "" {
 		in.TriggerRef = triggerRef
@@ -338,6 +341,9 @@ func printRun(w io.Writer, r *httpclient.Run) {
 		_, _ = fmt.Fprintf(w, "trigger_ref:    %s\n", *r.TriggerRef)
 	}
 	_, _ = fmt.Fprintf(w, "state:          %s\n", r.State)
+	if r.RunnerKind != "" {
+		_, _ = fmt.Fprintf(w, "runner_kind:    %s\n", r.RunnerKind)
+	}
 	_, _ = fmt.Fprintf(w, "created_at:     %s\n", r.CreatedAt.Format(time.RFC3339))
 	_, _ = fmt.Fprintf(w, "updated_at:     %s\n", r.UpdatedAt.Format(time.RFC3339))
 }

--- a/cli/internal/httpclient/httpclient.go
+++ b/cli/internal/httpclient/httpclient.go
@@ -82,17 +82,23 @@ type Run struct {
 	PullRequestURL     *string    `json:"pull_request_url"`
 	RetryAttempt       int        `json:"retry_attempt"`
 	MaxRetriesSnapshot int        `json:"max_retries_snapshot"`
+	RunnerKind         string     `json:"runner_kind"`
 	CreatedAt          time.Time  `json:"created_at"`
 	UpdatedAt          time.Time  `json:"updated_at"`
 }
 
 // CreateRunInput is what StartRun marshals into the request body.
+// RunnerKind (ADR-022 / #388) is optional; empty omits the field
+// from the wire body, letting the backend apply its `github_actions`
+// default. The local-runner CLI flow (Phase C / E22) passes "local"
+// to mint a run that runs on the operator's workstation.
 type CreateRunInput struct {
 	Repo          string  `json:"repo"`
 	WorkflowID    string  `json:"workflow_id"`
 	WorkflowSHA   string  `json:"workflow_sha"`
 	TriggerSource string  `json:"trigger_source"`
 	TriggerRef    *string `json:"trigger_ref,omitempty"`
+	RunnerKind    string  `json:"runner_kind,omitempty"`
 }
 
 // StartRun calls POST /v0/runs.


### PR DESCRIPTION
## Summary

CLI gap surfaced during Phase C validation. The MCP `fishhawk_start_run` tool (#390) and the backend's `POST /v0/runs` handler (#404) both accept `runner_kind`; the CLI verb didn't. So minting a `runner_kind=local` run via the CLI required dropping to curl.

- `httpclient.CreateRunInput` gains `RunnerKind` with `omitempty` (empty → field absent from JSON → backend default).
- `httpclient.Run` (response) gains the field so the CLI surfaces what the backend assigned.
- `cli/cmd/fishhawk/run.go::runStart` adds `--runner-kind` flag.
- `printRun` surfaces `runner_kind: …` in text output when set.

## Test plan

3 new tests in `cli/cmd/fishhawk/main_test.go` + smoke-test against the live backend:

- [x] `--runner-kind local` lands in the wire body.
- [x] Empty flag → omitempty drops the field → backend default applies.
- [x] Text output carries `runner_kind:` line when set.
- [x] Smoke-tested live: `./bin/fishhawk run start --runner-kind local …` returns a run with `runner_kind: local` and the row persists in Postgres.

`scripts/test coverage` aggregate 82.6% PASS; `golangci-lint` 0 issues.

## Next

This unblocks one of the two Phase C validation gaps. The other — #411 (auto-create stage rows from the workflow spec for API-created runs) — is the bigger blocker for the end-to-end local-runner dev loop and needs a design conversation before code.

Closes #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)