### PR TITLE
local-runner: complete plan→approve→implement loop

### DIFF
--- a/backend/internal/server/trace.go
+++ b/backend/internal/server/trace.go
@@ -296,6 +296,24 @@ func (s *Server) advanceStageAfterTrace(r *http.Request, runID, stageID uuid.UUI
 		return
 	}
 
+	// Local-runner runs skip the GHA dispatcher's
+	// pending → dispatched step (there's no workflow_dispatch fire
+	// to gate on), so the stage arrives here in `pending`. Walk it
+	// through dispatched first so the rest of the chain — which
+	// the state machine forbids from pending — stays uniform.
+	if stage.State == run.StageStatePending {
+		if _, err := s.cfg.RunRepo.TransitionStage(r.Context(), stageID,
+			run.StageStateDispatched, nil); err != nil {
+			s.cfg.Logger.LogAttrs(r.Context(), slog.LevelWarn,
+				"trace upload: transition to dispatched failed",
+				slog.String("run_id", runID.String()),
+				slog.String("stage_id", stageID.String()),
+				slog.String("error", err.Error()),
+			)
+			return
+		}
+	}
+
 	if _, err := s.cfg.RunRepo.TransitionStage(r.Context(), stageID,
 		run.StageStateRunning, nil); err != nil {
 		s.cfg.Logger.LogAttrs(r.Context(), slog.LevelWarn,

--- a/backend/internal/server/trace_test.go
+++ b/backend/internal/server/trace_test.go
@@ -451,6 +451,69 @@ func TestShipTrace_TransitionsStageToAwaitingApproval(t *testing.T) {
 	}
 }
 
+// TestShipTrace_PendingStage_WalksThroughDispatched is the
+// local-runner counterpart to the GHA flow (#416-followup): the
+// GHA dispatcher transitions pending → dispatched after firing
+// workflow_dispatch, but the local-runner path skips that step
+// (there's no workflow_dispatch fire). Without this branch the
+// trace handler's pending → running transition would be rejected
+// by the state machine and the stage would stay in pending
+// forever. The handler walks pending → dispatched first when it
+// finds the stage in pending, then continues the normal chain.
+func TestShipTrace_PendingStage_WalksThroughDispatched(t *testing.T) {
+	s, sf, _, _ := newTraceServer(t)
+	rr := newApprovalRunRepo()
+	stage := rr.seedStage(run.StageStatePending) // the local-runner shape
+	s.cfg.RunRepo = rr
+
+	priv, _ := sf.issue(t, stage.RunID)
+	w := shipRequest(t, s, stage.RunID, stage.ID, "raw", priv, []byte("b"), "")
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d:\n%s", w.Code, w.Body.String())
+	}
+	if rr.stages[stage.ID].State != run.StageStateAwaitingApproval {
+		t.Errorf("stage state = %q, want awaiting_approval (pending start should still reach the terminal)",
+			rr.stages[stage.ID].State)
+	}
+	// Three-step walk: pending → dispatched → running → awaiting_approval.
+	if len(rr.transitions) != 3 {
+		t.Fatalf("transitions = %d, want 3 (the extra step is pending → dispatched):\n%+v",
+			len(rr.transitions), rr.transitions)
+	}
+	if rr.transitions[0].To != run.StageStateDispatched {
+		t.Errorf("transitions[0] = %q, want dispatched (the new step)", rr.transitions[0].To)
+	}
+	if rr.transitions[1].To != run.StageStateRunning {
+		t.Errorf("transitions[1] = %q, want running", rr.transitions[1].To)
+	}
+	if rr.transitions[2].To != run.StageStateAwaitingApproval {
+		t.Errorf("transitions[2] = %q, want awaiting_approval", rr.transitions[2].To)
+	}
+}
+
+// TestShipTrace_DispatchedStage_SkipsExtraStep guards the
+// regression direction: when the stage IS already in dispatched
+// (the GHA happy path), we don't accidentally walk it through
+// dispatched again — same-state is a no-op but the audit chain
+// shouldn't grow extra rows.
+func TestShipTrace_DispatchedStage_SkipsExtraStep(t *testing.T) {
+	s, sf, _, _ := newTraceServer(t)
+	rr := newApprovalRunRepo()
+	stage := rr.seedStage(run.StageStateDispatched)
+	s.cfg.RunRepo = rr
+
+	priv, _ := sf.issue(t, stage.RunID)
+	w := shipRequest(t, s, stage.RunID, stage.ID, "raw", priv, []byte("b"), "")
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d:\n%s", w.Code, w.Body.String())
+	}
+	// Still the original two-step walk for the GHA shape.
+	if len(rr.transitions) != 2 {
+		t.Errorf("transitions = %d, want 2 (GHA path is unchanged):\n%+v",
+			len(rr.transitions), rr.transitions)
+	}
+}
+
 func TestShipTrace_GatelessStage_TransitionsStraightToSucceeded(t *testing.T) {
 	// Implement stages have no approval gate per workflows.yaml.
 	// The trace upload handler must walk dispatched → running →

--- a/cli/cmd/fishhawk/runner.go
+++ b/cli/cmd/fishhawk/runner.go
@@ -147,6 +147,16 @@ func runRunnerStart(args []string, stdout, stderr io.Writer) int {
 		"--fetch-prompt",
 		"--upload-trace",
 	}
+	// For plan stages, the agent's prompt instructs it to write
+	// the plan to /tmp/fishhawk-plan.json (backend's
+	// prompt.PlanArtifactPath). The runner only validates and
+	// uploads when --plan-out is set; without it the agent
+	// writes the file but the stage never transitions to
+	// awaiting_approval. Mirror the GHA action.yml's default so
+	// the local loop matches.
+	if *stage == "plan" {
+		argv = append(argv, "--plan-out", "/tmp/fishhawk-plan.json")
+	}
 	if repo != "" {
 		argv = append(argv, "--github-repo", repo)
 	}

--- a/cli/cmd/fishhawk/runner_test.go
+++ b/cli/cmd/fishhawk/runner_test.go
@@ -110,6 +110,61 @@ func TestRunnerStart_HappyPath_BuildsExpectedArgv(t *testing.T) {
 	}
 }
 
+// TestRunnerStart_PlanStage_PassesPlanOut exercises the
+// local-runner plan-validation wiring: when --stage plan, the CLI
+// auto-appends --plan-out /tmp/fishhawk-plan.json so the runner
+// validates + uploads the plan artifact the agent produces. The
+// GHA action.yml passes the same path; we mirror it here. Without
+// this flag the plan stage uploads a trace but the artifact never
+// lands and the stage is stuck.
+func TestRunnerStart_PlanStage_PassesPlanOut(t *testing.T) {
+	cap := withFakeRunnerSpawn(t)
+	withFakeGitRemote(t, "https://github.com/kuhlman-labs/fishhawk.git", nil)
+
+	var stdout, stderr strings.Builder
+	got := run([]string{
+		"runner", "start",
+		"--run-id", "11111111-2222-3333-4444-555555555555",
+		"--stage-id", "22222222-3333-4444-5555-666666666666",
+		"--workflow", "feature_change",
+		"--stage", "plan",
+	}, &stdout, &stderr)
+	if got != exitOK {
+		t.Fatalf("run = %d, want exitOK:\n%s", got, stderr.String())
+	}
+	if !contains(cap.args, "--plan-out") {
+		t.Errorf("plan-stage argv missing --plan-out: %v", cap.args)
+	}
+	if !contains(cap.args, "/tmp/fishhawk-plan.json") {
+		t.Errorf("plan-stage argv missing /tmp/fishhawk-plan.json: %v", cap.args)
+	}
+}
+
+// TestRunnerStart_NonPlanStage_OmitsPlanOut pins the negative: for
+// implement / review the wrapper does NOT pass --plan-out. The
+// runner only validates + uploads when --plan-out is set; passing
+// it for stages that don't produce a plan would either silently
+// no-op or warn.
+func TestRunnerStart_NonPlanStage_OmitsPlanOut(t *testing.T) {
+	for _, stage := range []string{"implement", "review"} {
+		t.Run(stage, func(t *testing.T) {
+			cap := withFakeRunnerSpawn(t)
+			withFakeGitRemote(t, "https://github.com/x/y.git", nil)
+			got := run([]string{
+				"runner", "start",
+				"--run-id", "1", "--stage-id", "2",
+				"--workflow", "w", "--stage", stage,
+			}, &strings.Builder{}, &strings.Builder{})
+			if got != exitOK {
+				t.Fatalf("run = %d", got)
+			}
+			if contains(cap.args, "--plan-out") {
+				t.Errorf("%s-stage argv should NOT include --plan-out: %v", stage, cap.args)
+			}
+		})
+	}
+}
+
 func TestRunnerStart_GithubRepoFlag_OverridesAutoDetect(t *testing.T) {
 	cap := withFakeRunnerSpawn(t)
 	// Auto-detect would return one repo; the explicit flag should win.


### PR DESCRIPTION
## Summary

Two gaps surfaced during the first end-to-end local-runner test on PR #418's branch. Both are scoped to the local-runner flow; the GHA path is byte-identical.

**1. `fishhawk runner start` didn't pass `--plan-out`** (gap in #407 / E22.9). The agent's prompt instructs it to write the plan to `/tmp/fishhawk-plan.json`, and the runner only validates+uploads when `--plan-out` is set. Without it, the agent wrote the file but the artifact never landed and the stage couldn't transition. The GHA action.yml passes the same path; this PR mirrors that for the local CLI.

**2. Stage stayed in `pending` after the trace upload.** The local-runner path skips the GHA dispatcher's `pending → dispatched` step (there's no `workflow_dispatch` fire to gate on), and the trace handler's first transition (`pending → running`) is rejected by the state machine. The handler now walks `pending → dispatched` first when it finds the stage in `pending`; GHA-dispatched runs (which arrive in `dispatched`) keep the original two-step walk.

Together these unblock the headline workflow: trigger a local run from a GitHub issue → plan stage runs → artifact lands → state transitions to `awaiting_approval` → `fishhawk plan approve` advances to implement.

## Test plan

- [x] `scripts/test` — backend / cli / runner / verifier all green
- [x] `scripts/test coverage` — aggregate 82.8% ≥ 80% threshold
- [x] `golangci-lint run ./backend/... ./cli/...` — 0 issues
- [x] New tests:
  - `TestRunnerStart_PlanStage_PassesPlanOut` — argv carries `--plan-out /tmp/fishhawk-plan.json` for plan stages
  - `TestRunnerStart_NonPlanStage_OmitsPlanOut` — implement / review do NOT get the flag
  - `TestShipTrace_PendingStage_WalksThroughDispatched` — pending-start runs reach `awaiting_approval` via the three-step walk
  - `TestShipTrace_DispatchedStage_SkipsExtraStep` — GHA path stays two-step (regression guard)
- [ ] Manual end-to-end smoke against the running local backend (immediately after merge — this PR is the precondition for the smoke test resuming)

## Notes

- Discovered live during testing of #417 + #418 (issue-context cache + CLI gh comments). Filing inline as a bundled fix since both gaps are simple and block the same flow.
- No spec / schema / migration changes. Behavior change is scoped to the local-runner branches of two files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)