### PR TITLE
mcp: fix cmd.Wait/scanner race + orphan-fd hang in run_stage (#446)

### DIFF
--- a/backend/cmd/fishhawk-mcp/run_stage.go
+++ b/backend/cmd/fishhawk-mcp/run_stage.go
@@ -246,6 +246,19 @@ func (r *runResolver) runStage(ctx context.Context, req *mcp.CallToolRequest, in
 	cmd := runStageCommand(binary, argv...)
 	cmd.Env = append(os.Environ(), "FISHHAWK_API_TOKEN="+r.api.token)
 
+	// Run the subprocess in its own process group so signals reach
+	// the whole tree, not just the direct child. The runner spawns
+	// further descendants (the agent it invokes, that agent's tool
+	// processes); without a group, SIGTERM/SIGKILL on the runner
+	// leaves orphans alive that inherit our stdout fd — which keeps
+	// the pipe open and prevents the bufio scanner from ever
+	// reaching EOF. Signalling -pgid hits every descendant in
+	// lockstep. The #446 plan's risk section claimed "SIGKILL
+	// handles orphans" — that's incorrect for Unix fd inheritance,
+	// surfaced by TestRunStage_ContextCancelSendsSIGTERM after the
+	// pipe-drain reorder.
+	runStageSetProcessGroup(cmd)
+
 	// (5) Wire stdout to a JSONL parser. Stderr is piped through to
 	// the operator's terminal — the runner's verbose log lines are
 	// meant for humans, not the agent.
@@ -260,30 +273,54 @@ func (r *runResolver) runStage(ctx context.Context, req *mcp.CallToolRequest, in
 	}
 
 	// Concurrently: parse stdout into events; watch ctx for
-	// cancellation and signal the child. Both feed into the
-	// wait-for-exit synchronization below.
+	// cancellation and signal the child. parseDone closes when the
+	// parser goroutine drains stdout to EOF — guaranteeing cmd.Wait
+	// is called after the pipe is fully read (#446).
 	var (
 		events    []RunnerEvent
 		eventsMu  sync.Mutex
-		parseWG   sync.WaitGroup
+		parseDone = make(chan struct{})
 		progToken any
 	)
 	if req != nil && req.Params != nil {
 		progToken = req.Params.GetProgressToken()
 	}
 
-	parseWG.Add(1)
 	go func() {
-		defer parseWG.Done()
+		defer close(parseDone)
 		runStageParseEvents(ctx, stdoutPipe, &events, &eventsMu, &warnings, req, progToken)
 	}()
 
-	// (6+7) Wait for the runner to exit, honoring context
-	// cancellation. The wait coordinator owns the single cmd.Wait
-	// call so we don't trigger "no child processes" from a stray
-	// duplicate Wait.
-	waitErr := runStageWaitForExit(ctx, cmd, runStageGracePeriod)
-	parseWG.Wait()
+	// (6) Cancellation watcher: on ctx.Done(), signal the whole
+	// process group (not just the direct child) so descendants that
+	// inherited stdout die too — only then does the pipe close and
+	// the scanner reach EOF. Escalates to SIGKILL (group-wide)
+	// after the grace period.
+	//
+	// Snapshot the grace period at entry so a test's t.Cleanup
+	// restoring runStageGracePeriod doesn't race the goroutine.
+	grace := runStageGracePeriod
+	go func() {
+		select {
+		case <-parseDone:
+			// Normal exit — subprocess closed stdout, scanner drained.
+		case <-ctx.Done():
+			runStageSignalGroup(cmd, syscall.SIGTERM)
+			select {
+			case <-parseDone:
+				// Subprocess exited within grace; scanner done.
+			case <-time.After(grace):
+				runStageSignalGroup(cmd, syscall.SIGKILL)
+				<-parseDone
+			}
+		}
+	}()
+
+	// (7) Block until the parser goroutine has fully drained stdout,
+	// then call cmd.Wait(). The pipe is guaranteed drained at this
+	// point — no scanner-vs-Wait race.
+	<-parseDone
+	waitErr := cmd.Wait()
 
 	exitCode := 0
 	switch {
@@ -416,44 +453,6 @@ func runStageEventMessage(payload any) string {
 		return string(enc[:maxLen]) + "..."
 	}
 	return string(enc)
-}
-
-// runStageWaitForExit owns the canonical cmd.Wait() and coordinates
-// cancellation. Flow:
-//
-//   - Start one goroutine doing cmd.Wait(); it's the ONLY Wait on
-//     this process. A duplicate Wait would race the kernel's
-//     wait-status collection and return "no child processes" on
-//     macOS / Linux.
-//   - Block on (waitDone OR ctx.Done()).
-//   - On ctx.Done() before the runner exits: SIGTERM, then up to
-//     grace seconds for the wait to settle, then SIGKILL, then wait
-//     unconditionally for the wait to settle.
-//
-// Returns the error from the canonical Wait — caller branches on
-// exec.ExitError to extract the exit code.
-func runStageWaitForExit(ctx context.Context, cmd *exec.Cmd, grace time.Duration) error {
-	waitDone := make(chan error, 1)
-	go func() { waitDone <- cmd.Wait() }()
-
-	select {
-	case err := <-waitDone:
-		return err
-	case <-ctx.Done():
-		// Operator cancelled; send SIGTERM and wait up to grace.
-		if cmd.Process != nil {
-			_ = cmd.Process.Signal(syscall.SIGTERM)
-		}
-		select {
-		case err := <-waitDone:
-			return err
-		case <-time.After(grace):
-			if cmd.Process != nil {
-				_ = cmd.Process.Kill()
-			}
-			return <-waitDone
-		}
-	}
 }
 
 // runStageDetectGitHubRepo mirrors the CLI's helper. Returns

--- a/backend/cmd/fishhawk-mcp/run_stage_unix.go
+++ b/backend/cmd/fishhawk-mcp/run_stage_unix.go
@@ -1,0 +1,47 @@
+//go:build !windows
+
+package main
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// runStageSetProcessGroup attaches a fresh process group to cmd
+// before Start. Unix semantics: SysProcAttr.Setpgid makes the
+// child the leader of a new group with Pgid == its own PID, so
+// `kill(-pgid, sig)` from `runStageSignalGroup` reaches the
+// child and every descendant that hasn't broken away with its
+// own setpgid.
+//
+// Test seam: exposed as `var` so the package-level setter in
+// tests can no-op it (the fake subprocess for the unit tests
+// shouldn't run in a separate group — the test parent needs to
+// be able to observe the children directly).
+var runStageSetProcessGroup = func(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setpgid = true
+}
+
+// runStageSignalGroup sends sig to the process group cmd was
+// started in. Falls back to signalling the direct child if the
+// group wasn't set up (defensive — should never fire given the
+// always-on setup in runStage).
+//
+// The minus on the PID is the POSIX convention for "signal the
+// process group with that ID." Errors are swallowed because
+// missing-process is normal (race with subprocess exit) and we
+// can't recover from EPERM anyway.
+var runStageSignalGroup = func(cmd *exec.Cmd, sig syscall.Signal) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	pgid, err := syscall.Getpgid(cmd.Process.Pid)
+	if err != nil {
+		_ = cmd.Process.Signal(sig)
+		return
+	}
+	_ = syscall.Kill(-pgid, sig)
+}

--- a/backend/cmd/fishhawk-mcp/run_stage_windows.go
+++ b/backend/cmd/fishhawk-mcp/run_stage_windows.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+package main
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// runStageSetProcessGroup is a no-op on Windows. The runner is
+// not currently supported on Windows; if/when it is, the
+// equivalent is to spawn with `CREATE_NEW_PROCESS_GROUP` via
+// SysProcAttr.CreationFlags. Keeping the stub here so the
+// non-Unix build still compiles.
+var runStageSetProcessGroup = func(_ *exec.Cmd) {}
+
+// runStageSignalGroup falls back to signalling just the direct
+// child on Windows. Same caveats as the setup stub.
+var runStageSignalGroup = func(cmd *exec.Cmd, sig syscall.Signal) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	_ = cmd.Process.Signal(sig)
+}


### PR DESCRIPTION
## Summary

Two-part fix for the `read |0: file already closed` errors that broke #438's CI on `TestRunStage_JSONLAccumulation_OrderPreserved` and `TestRunStage_NonJSONLineWarns`.

1. **Reorder: drain pipe before `cmd.Wait()`.** Spawn parser in a goroutine that closes a `parseDone` channel on EOF. Main goroutine blocks on `<-parseDone` before calling `cmd.Wait`, so the pipe is guaranteed drained. `runStageWaitForExit` is removed; cancellation logic inlines into a watcher goroutine that selects on `parseDone` vs `ctx.Done`.
2. **Process group setup.** The runner subprocess invokes the agent which spawns its own tool subprocesses. Without `Setpgid`, those descendants inherit stdout — signalling only the direct child leaves orphans holding the pipe writer fd, pipe never closes, scanner never sees EOF, `parseDone` never fires. New helpers `runStageSetProcessGroup` (Unix: `Setpgid: true`) + `runStageSignalGroup` (`kill(-pgid, sig)`) hit the whole tree in lockstep. Stubs preserve Windows-build compatibility even though the runner doesn't target Windows.

Caught a third concurrency bug under `-race -count 100`: the goroutine reading `runStageGracePeriod` raced with `withShortGrace`'s `t.Cleanup` restoring it. Fixed by snapshotting `grace := runStageGracePeriod` at `runStage` entry.

## Test plan

- [x] `go test -race -count 100 -run 'TestRunStage' ./backend/cmd/fishhawk-mcp/` — 100 iterations clean (29.8s).
- [x] `scripts/test` — full gate green.
- [x] `golangci-lint run ./backend/cmd/fishhawk-mcp/...` — 0 issues.
- [x] All four #446 acceptance criteria hit: pipe-drain ordering ✓, `TestRunStage_ContextCancelSendsSIGTERM` passes (~0.21s) ✓, accumulation tests pass under `-count 100 -race` ✓, `TestRunStage_NonZeroExitPropagated` unchanged ✓.

## Notes

- **Partially authored via the local MCP loop on run `03bbc610-b5c5-4a2e-bb56-3562ce30eafe`.** The agent produced the parseDone reorder cleanly. The agent's plan claimed "SIGKILL handles orphans via the grace-period timer" which is wrong for Unix fd inheritance — `TestRunStage_ContextCancelSendsSIGTERM` caught the regression at 10s (full sleep duration). Process-group layer added post-hoc.
- **Filed #447** on the dogfood finding: the plan-stage prompt should require citations or empirical tests for non-obvious OS / runtime semantic claims so a wrong "this is handled" assertion doesn't pass plan review unchallenged.
- **Implement-stage timeout**: the agent ran the `-count 100 -race` flake check the plan specified and didn't complete the full 15-minute window. Worth a follow-up on either the default timeout or smarter test-subset selection by the agent.
- ADR-024 Q2 cancellation contract (SIGTERM + 30s grace + SIGKILL) preserved end-to-end.

Closes #446