### PR TITLE
mcp: read runner events from stderr (#439)

### DIFF
--- a/backend/cmd/fishhawk-mcp/run_stage.go
+++ b/backend/cmd/fishhawk-mcp/run_stage.go
@@ -68,7 +68,7 @@ type RunStageInput struct {
 // the runner's process exit code so callers can branch on failure
 // categories (the runner uses distinct codes per category).
 //
-// Warnings collects best-effort surfaces: non-JSON runner stdout
+// Warnings collects best-effort surfaces: non-JSON runner stderr
 // lines, failed post-run stage fetch, missing github_repo, etc.
 // None of these fail the tool itself — the runner's exit is the
 // canonical outcome.
@@ -259,14 +259,16 @@ func (r *runResolver) runStage(ctx context.Context, req *mcp.CallToolRequest, in
 	// pipe-drain reorder.
 	runStageSetProcessGroup(cmd)
 
-	// (5) Wire stdout to a JSONL parser. Stderr is piped through to
-	// the operator's terminal — the runner's verbose log lines are
-	// meant for humans, not the agent.
-	stdoutPipe, err := cmd.StdoutPipe()
+	// (5) Wire stderr to a JSONL parser via TeeReader so events reach
+	// the accumulator while the raw stream is also forwarded to the
+	// operator's terminal. Stdout carries no structured events when
+	// --upload-trace is set (the runner writes all JSONL to stderr /
+	// logSink), so forward it directly to the terminal.
+	stderrPipe, err := cmd.StderrPipe()
 	if err != nil {
-		return nil, RunStageOutput{}, fmt.Errorf("attach stdout: %w", err)
+		return nil, RunStageOutput{}, fmt.Errorf("attach stderr: %w", err)
 	}
-	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
 
 	if err := cmd.Start(); err != nil {
 		return nil, RunStageOutput{}, fmt.Errorf("spawn fishhawk-runner: %w", err)
@@ -288,7 +290,7 @@ func (r *runResolver) runStage(ctx context.Context, req *mcp.CallToolRequest, in
 
 	go func() {
 		defer close(parseDone)
-		runStageParseEvents(ctx, stdoutPipe, &events, &eventsMu, &warnings, req, progToken)
+		runStageParseEvents(ctx, io.TeeReader(stderrPipe, os.Stderr), &events, &eventsMu, &warnings, req, progToken)
 	}()
 
 	// (6) Cancellation watcher: on ctx.Done(), signal the whole
@@ -409,7 +411,7 @@ func runStageParseEvents(
 		var payload any
 		if perr := json.Unmarshal([]byte(line), &payload); perr != nil {
 			mu.Lock()
-			*warnings = append(*warnings, fmt.Sprintf("non-JSON runner stdout: %q", line))
+			*warnings = append(*warnings, fmt.Sprintf("non-JSON runner stderr: %q", line))
 			mu.Unlock()
 			continue
 		}
@@ -427,7 +429,7 @@ func runStageParseEvents(
 	}
 	if serr := scanner.Err(); serr != nil && !errors.Is(serr, io.EOF) {
 		mu.Lock()
-		*warnings = append(*warnings, fmt.Sprintf("scan runner stdout: %v", serr))
+		*warnings = append(*warnings, fmt.Sprintf("scan runner stderr: %v", serr))
 		mu.Unlock()
 	}
 }

--- a/backend/cmd/fishhawk-mcp/run_stage_test.go
+++ b/backend/cmd/fishhawk-mcp/run_stage_test.go
@@ -380,7 +380,7 @@ func TestRunStage_GitHubRepoAutoDetectFails_WithPushErrors(t *testing.T) {
 func TestRunStage_JSONLAccumulation_OrderPreserved(t *testing.T) {
 	fb, srv := newFakeBackend(t)
 	r := newResolver(srv, nil)
-	withFakeRunner(t, `printf '%s\n' '{"kind":"runner_started"}' '{"kind":"signing_key_issued"}' '{"kind":"trace_uploaded"}'`)
+	withFakeRunner(t, `printf '%s\n' '{"kind":"runner_started"}' '{"kind":"signing_key_issued"}' '{"kind":"trace_uploaded"}' >&2`)
 
 	runID := uuid.New()
 	stageID := uuid.New()
@@ -421,7 +421,7 @@ func TestRunStage_JSONLAccumulation_OrderPreserved(t *testing.T) {
 func TestRunStage_NonJSONLineWarns(t *testing.T) {
 	fb, srv := newFakeBackend(t)
 	r := newResolver(srv, nil)
-	withFakeRunner(t, `printf '%s\n' 'Running plan stage...' '{"kind":"runner_started"}'`)
+	withFakeRunner(t, `printf '%s\n' 'Running plan stage...' '{"kind":"runner_started"}' >&2`)
 
 	runID := uuid.New()
 	stageID := uuid.New()
@@ -457,7 +457,7 @@ func TestRunStage_NonJSONLineWarns(t *testing.T) {
 func TestRunStage_NonZeroExitPropagated(t *testing.T) {
 	fb, srv := newFakeBackend(t)
 	r := newResolver(srv, nil)
-	withFakeRunner(t, `printf '%s\n' '{"kind":"runner_started"}'; exit 7`)
+	withFakeRunner(t, `printf '%s\n' '{"kind":"runner_started"}' >&2; exit 7`)
 
 	runID := uuid.New()
 	stageID := uuid.New()


### PR DESCRIPTION
## Summary

- `fishhawk_run_stage` read from `cmd.StdoutPipe()`, but the runner writes all structured JSONL events to stderr (`logSink`) whenever `--upload-trace` is set — which the MCP tool always passes. Stdout was permanently empty, so the tool's `events` field came back `null` after every successful stage.
- Switch to `cmd.StderrPipe()` wrapped in `io.TeeReader(stderrPipe, os.Stderr)`. Accumulator sees the events; operator's terminal still gets the live tail.
- Stdout now forwards directly to `os.Stdout` (no structured content there to lose).
- Test-seam fix: fake runners in `run_stage_test.go` now write JSONL via `printf … >&2`. Without this, the tests kept silently passing on the wrong stream — same regression class that hid the bug originally.

## Test plan

- [x] `scripts/test` — full gate green.
- [x] `golangci-lint run ./backend/cmd/fishhawk-mcp/...` — clean.
- [x] `TestRunStage_JSONLAccumulation_OrderPreserved` is the primary regression guard — passes with the corrected source.
- [x] `TestRunStage_NonJSONLineWarns` — non-JSON line still surfaces as a warning.
- [x] `TestRunStage_ContextCancelSendsSIGTERM` — race-tested 100× on #446, no behavior change here.

## Notes

- Authored via the local MCP loop on run `8e0dc051-ff38-4e61-90c0-8c1aafa26136`. Plan + implement landed cleanly first try.
- Once this lands, the next loop's tool result will populate `events` with the runner's structured events — operators and agents stop needing `git status` / `fishhawk_list_audit` to confirm what happened mid-stage.
- ADR-024 Q1's progress-notification path is preserved (same scanner loop emits progress per event when a token's set).

Closes #439