### PR TITLE
mcp: os.Executable sibling-dir fallback for fishhawk-runner resolution (#440)

### DIFF
--- a/backend/cmd/fishhawk-mcp/run_stage.go
+++ b/backend/cmd/fishhawk-mcp/run_stage.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 	"syscall"
@@ -26,6 +27,11 @@ var runStageCommand = exec.Command
 // runStageLookPath looks up the fishhawk-runner binary on PATH.
 // Test seam mirroring the CLI's runnerBinaryLookPath.
 var runStageLookPath = exec.LookPath
+
+// runStageExecutable returns the path to the running binary (os.Executable).
+// Test seam: allows tests to inject a fake executable path for the
+// sibling-binary resolution rung without needing a real binary on disk.
+var runStageExecutable = os.Executable
 
 // runStageGitRemoteOriginURL returns `origin`'s URL for the working
 // dir. Mirrors the CLI's gitRemoteOriginURL — test seam.
@@ -59,7 +65,7 @@ type RunStageInput struct {
 	GitHubRepo    string `json:"github_repo,omitempty" jsonschema:"GitHub repo as owner/name; auto-detected from working_dir's origin remote when empty"`
 	BaseBranch    string `json:"base_branch,omitempty" jsonschema:"base branch for the implement-stage PR (no effect when push_and_open_pr is false); defaults to main"`
 	PushAndOpenPR bool   `json:"push_and_open_pr,omitempty" jsonschema:"when true, the implement stage pushes and opens a PR; default false (the operator commits the changes themselves)"`
-	RunnerBinary  string `json:"runner_binary,omitempty" jsonschema:"path to fishhawk-runner; defaults to FISHHAWK_RUNNER_BIN env then exec.LookPath('fishhawk-runner')"`
+	RunnerBinary  string `json:"runner_binary,omitempty" jsonschema:"path to fishhawk-runner; resolved in order: FISHHAWK_RUNNER_BIN env, then fishhawk-runner sibling to this binary (os.Executable dir), then PATH"`
 }
 
 // RunStageOutput is the structured result of one stage run. The
@@ -152,7 +158,7 @@ host; this tool is local-only by design (ADR-024 Q5).
 //
 // Composition order:
 //  1. validate the obvious inputs (run_id, stage_id, workflow, stage).
-//  2. resolve the runner binary (input > env > PATH).
+//  2. resolve the runner binary (input > FISHHAWK_RUNNER_BIN env > os.Executable sibling dir > PATH > error).
 //  3. resolve GitHub repo (input > working-dir origin remote;
 //     soft-failure when push_and_open_pr is false).
 //  4. compose argv mirroring `fishhawk runner start`.
@@ -176,6 +182,7 @@ func (r *runResolver) runStage(ctx context.Context, req *mcp.CallToolRequest, in
 	}
 
 	// (2) Resolve the runner binary.
+	// Resolution order: input > FISHHAWK_RUNNER_BIN env > os.Executable sibling dir > PATH > error.
 	binary := in.RunnerBinary
 	if binary == "" {
 		if env := r.getenv("FISHHAWK_RUNNER_BIN"); env != "" {
@@ -183,11 +190,19 @@ func (r *runResolver) runStage(ctx context.Context, req *mcp.CallToolRequest, in
 		}
 	}
 	if binary == "" {
+		if exe, exeErr := runStageExecutable(); exeErr == nil {
+			sibling := filepath.Join(filepath.Dir(exe), "fishhawk-runner")
+			if _, statErr := os.Stat(sibling); statErr == nil {
+				binary = sibling
+			}
+		}
+	}
+	if binary == "" {
 		resolved, lerr := runStageLookPath("fishhawk-runner")
 		if lerr != nil {
 			return nil, RunStageOutput{}, errors.New(
 				"fishhawk-runner not on PATH; this tool requires local MCP execution — " +
-					"pass runner_binary or set FISHHAWK_RUNNER_BIN")
+					"pass runner_binary, set FISHHAWK_RUNNER_BIN, or co-locate fishhawk-runner with fishhawk-mcp")
 		}
 		binary = resolved
 	}

--- a/backend/cmd/fishhawk-mcp/run_stage_test.go
+++ b/backend/cmd/fishhawk-mcp/run_stage_test.go
@@ -3,7 +3,9 @@ package main
 import (
 	"context"
 	"errors"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -40,6 +42,24 @@ func withFakeRunnerMissing(t *testing.T) {
 	orig := runStageLookPath
 	runStageLookPath = func(_ string) (string, error) { return "", exec.ErrNotFound }
 	t.Cleanup(func() { runStageLookPath = orig })
+}
+
+// withFakeExecutable stubs runStageExecutable to return a fake fishhawk-mcp
+// path inside dir. When withSibling is true, it also creates a fishhawk-runner
+// file in dir so the sibling-binary probe (os.Stat) succeeds.
+func withFakeExecutable(t *testing.T, dir string, withSibling bool) {
+	t.Helper()
+	if withSibling {
+		f, err := os.Create(filepath.Join(dir, "fishhawk-runner"))
+		if err != nil {
+			t.Fatalf("create fake fishhawk-runner sibling: %v", err)
+		}
+		f.Close()
+	}
+	orig := runStageExecutable
+	fakeExe := filepath.Join(dir, "fishhawk-mcp")
+	runStageExecutable = func() (string, error) { return fakeExe, nil }
+	t.Cleanup(func() { runStageExecutable = orig })
 }
 
 // withFakeGitRemote stubs the origin-detect helper.
@@ -120,6 +140,8 @@ func TestRunStage_MissingBinaryReturnsCleanError(t *testing.T) {
 	_, srv := newFakeBackend(t)
 	r := newResolver(srv, nil)
 	withFakeRunnerMissing(t)
+	// os.Executable sibling probe must also fail so we reach the error rung.
+	withFakeExecutable(t, t.TempDir(), false /* no sibling */)
 
 	_, _, err := r.runStage(context.Background(), nil, RunStageInput{
 		RunID:    uuid.NewString(),
@@ -132,6 +154,126 @@ func TestRunStage_MissingBinaryReturnsCleanError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "fishhawk-runner not on PATH") {
 		t.Errorf("err should mention PATH: %v", err)
+	}
+}
+
+// TestRunStage_RunnerBinaryInputWins verifies rung (a): a runner_binary in
+// the input beats env, sibling, and PATH.
+func TestRunStage_RunnerBinaryInputWins(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	r := newResolver(srv, map[string]string{
+		"FISHHAWK_RUNNER_BIN": "/from/env/fishhawk-runner",
+	})
+	withFakeExecutable(t, t.TempDir(), true /* sibling present — must be ignored */)
+	origLook := runStageLookPath
+	runStageLookPath = func(_ string) (string, error) { return "/from/path/fishhawk-runner", nil }
+	t.Cleanup(func() { runStageLookPath = origLook })
+
+	var capturedBinary string
+	origCmd := runStageCommand
+	runStageCommand = func(name string, _ ...string) *exec.Cmd {
+		capturedBinary = name
+		return exec.Command("sh", "-c", "exit 0")
+	}
+	t.Cleanup(func() { runStageCommand = origCmd })
+
+	runID := uuid.New()
+	stageID := uuid.New()
+	seedStage(fb, runID, stageID, "succeeded")
+
+	_, _, err := r.runStage(context.Background(), nil, RunStageInput{
+		RunID:        runID.String(),
+		StageID:      stageID.String(),
+		Workflow:     "w",
+		Stage:        "plan",
+		GitHubRepo:   "x/y",
+		RunnerBinary: "/explicit/fishhawk-runner",
+	})
+	if err != nil {
+		t.Fatalf("runStage: %v", err)
+	}
+	if capturedBinary != "/explicit/fishhawk-runner" {
+		t.Errorf("binary = %q, want /explicit/fishhawk-runner (input rung)", capturedBinary)
+	}
+}
+
+// TestRunStage_ExecutableSiblingFallback verifies rung (c): when input and env
+// are empty but fishhawk-runner lives beside fishhawk-mcp, the sibling path is
+// used even when PATH lookup would fail.
+func TestRunStage_ExecutableSiblingFallback(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	r := newResolver(srv, nil)
+
+	dir := t.TempDir()
+	withFakeExecutable(t, dir, true /* sibling present */)
+	withFakeRunnerMissing(t) // PATH lookup fails — sibling must win
+
+	var capturedBinary string
+	origCmd := runStageCommand
+	runStageCommand = func(name string, _ ...string) *exec.Cmd {
+		capturedBinary = name
+		return exec.Command("sh", "-c", "exit 0")
+	}
+	t.Cleanup(func() { runStageCommand = origCmd })
+
+	runID := uuid.New()
+	stageID := uuid.New()
+	seedStage(fb, runID, stageID, "succeeded")
+
+	_, _, err := r.runStage(context.Background(), nil, RunStageInput{
+		RunID:      runID.String(),
+		StageID:    stageID.String(),
+		Workflow:   "w",
+		Stage:      "plan",
+		GitHubRepo: "x/y",
+	})
+	if err != nil {
+		t.Fatalf("runStage: %v", err)
+	}
+	want := filepath.Join(dir, "fishhawk-runner")
+	if capturedBinary != want {
+		t.Errorf("binary = %q, want sibling %q", capturedBinary, want)
+	}
+}
+
+// TestRunStage_PathFallback verifies rung (d): when input, env, and sibling
+// are all absent, the PATH lookup result is used.
+func TestRunStage_PathFallback(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	r := newResolver(srv, nil)
+
+	// Sibling absent so the os.Executable rung falls through.
+	withFakeExecutable(t, t.TempDir(), false /* no sibling */)
+
+	var capturedBinary string
+	origCmd := runStageCommand
+	origLook := runStageLookPath
+	runStageCommand = func(name string, _ ...string) *exec.Cmd {
+		capturedBinary = name
+		return exec.Command("sh", "-c", "exit 0")
+	}
+	runStageLookPath = func(_ string) (string, error) { return "/from/path/fishhawk-runner", nil }
+	t.Cleanup(func() {
+		runStageCommand = origCmd
+		runStageLookPath = origLook
+	})
+
+	runID := uuid.New()
+	stageID := uuid.New()
+	seedStage(fb, runID, stageID, "succeeded")
+
+	_, _, err := r.runStage(context.Background(), nil, RunStageInput{
+		RunID:      runID.String(),
+		StageID:    stageID.String(),
+		Workflow:   "w",
+		Stage:      "plan",
+		GitHubRepo: "x/y",
+	})
+	if err != nil {
+		t.Fatalf("runStage: %v", err)
+	}
+	if capturedBinary != "/from/path/fishhawk-runner" {
+		t.Errorf("binary = %q, want /from/path/fishhawk-runner (PATH rung)", capturedBinary)
 	}
 }
 

--- a/docs/mcp/install.md
+++ b/docs/mcp/install.md
@@ -68,10 +68,13 @@ export FISHHAWK_BACKEND_URL="https://app.fishhawk.example.com"
 claude mcp add fishhawk \
   --env FISHHAWK_API_TOKEN=$FISHHAWK_API_TOKEN \
   --env FISHHAWK_BACKEND_URL=$FISHHAWK_BACKEND_URL \
+  --env FISHHAWK_RUNNER_BIN=/usr/local/bin/fishhawk-runner \
   -- /usr/local/bin/fishhawk-mcp
 ```
 
 `--` separates Claude Code's flags from the binary path. The exact flag shape varies by Claude Code version — `claude mcp add --help` is authoritative. Some clients prefer a config file path; some take env vars inline.
+
+`FISHHAWK_RUNNER_BIN` is required only when `fishhawk-runner` is not in system PATH and not co-located with `fishhawk-mcp`. When both binaries live in the same directory, the MCP server resolves `fishhawk-runner` automatically via its sibling-binary probe (`os.Executable` + `filepath.Dir`).
 
 ### 5. Smoke-test the registration
 
@@ -152,6 +155,7 @@ Cancellation: cancelling the `fishhawk_run_stage` tool call sends `SIGTERM` to t
 | `fishhawk: HTTP 403 (insufficient_scope)` from a write tool | The token doesn't carry the required write scope (see the Write tools table). Reissue with `--scopes` including the right write scopes. |
 | `fishhawk: HTTP 404` from `fishhawk_get_plan` | Run id valid but the plan stage hasn't terminated — the tool returns a structured `no_plan_yet` response, not an error. Other 404s usually mean the run id is wrong. |
 | `no plan stage on run …` from `fishhawk_approve_plan` | The run's workflow doesn't have a plan stage (e.g. `routine_change`). Approve at the stage level directly via the CLI / SPA. |
+| `fishhawk-runner not on PATH` from `fishhawk_run_stage` | The binary could not be resolved via any rung of the resolution chain (input → env → sibling → PATH). Remediate in order of preference: (1) install `fishhawk-runner` in the same directory as `fishhawk-mcp` — the sibling-binary probe resolves it automatically; (2) set `--env FISHHAWK_RUNNER_BIN=<path>` in `claude mcp add` (see step 4); (3) pass `runner_binary` per tool call as a last resort. |
 
 ## See also
 


### PR DESCRIPTION
## Summary

Adds a new rung between the env-var check and PATH lookup: when `fishhawk-runner` sits next to the running `fishhawk-mcp` binary (resolved via `os.Executable` + `filepath.Dir`), use it. Operators who installed both binaries side-by-side in `bin/` no longer need to pass `runner_binary` on every call or set `FISHHAWK_RUNNER_BIN`.

**Resolution order:** `runner_binary` input > `FISHHAWK_RUNNER_BIN` env > `os.Executable` sibling dir > `exec.LookPath` > error.

Graceful degradation: `os.Executable` errors on some BSDs / symlink configurations — when that happens (or the sibling isn't present), the new rung silently falls through to PATH.

Plus `docs/mcp/install.md` updates:
- `claude mcp add` example documents `FISHHAWK_RUNNER_BIN` as a recommended env var.
- Troubleshooting table gains a row for the "not on PATH" error naming all three remediation paths.

## Test plan

- [x] `scripts/test` — full gate green.
- [x] `golangci-lint run ./backend/cmd/fishhawk-mcp/...` — clean.
- [x] New tests cover all four resolution rungs: explicit input wins, env wins over sibling/PATH, sibling wins over PATH, PATH wins when nothing else, error when all four miss.

## Notes

- Authored via local MCP loop on run `8b2dfd21-7a30-46b3-9805-7a10a47016fd`. **First loop run validating #439's fix in production** — the tool result now carries the runner's full event stream (`runner_started`, `signing_key_issued`, `prompt_fetched`, `mcp_token_issued`, `trace_uploaded` x2, `plan_uploaded`, `runner_completed`). Much better observability per cycle.
- Side observation worth noting for ADR-025 D2 (#453): `runner_completed.tokens_used` is a real signal we get for free. When wiring `predicted_runtime_minutes` into the plan schema, consider also surfacing `actual_runtime_seconds` derived from the `runner_started → runner_completed` timestamp delta — closes the calibration loop.

Closes #440