### PR TITLE
cli: fetch + render stage state in stage-complete comment (#420)

### DIFF
--- a/cli/cmd/fishhawk/comment.go
+++ b/cli/cmd/fishhawk/comment.go
@@ -14,6 +14,10 @@ import (
 	"github.com/kuhlman-labs/fishhawk/cli/internal/httpclient"
 )
 
+// ghPost is a test seam for maybePostLocalComment. Production wires
+// to ghcomment.Post; tests swap to capture the comment body.
+var ghPost = ghcomment.Post
+
 // maybePostLocalComment fires the CLI-side issue comment when the
 // run is the local-issue shape that warrants one — `runner_kind=local`
 // AND `issue_context` populated. All failures are best-effort: a
@@ -27,7 +31,7 @@ func maybePostLocalComment(stderr io.Writer, r *httpclient.Run, body string) {
 	if r == nil || r.RunnerKind != "local" || r.IssueContext == nil || body == "" {
 		return
 	}
-	if err := ghcomment.Post(r.Repo, r.IssueContext.Number, body); err != nil {
+	if err := ghPost(r.Repo, r.IssueContext.Number, body); err != nil {
 		if errors.Is(err, ghcomment.ErrGhNotInstalled) {
 			// Don't double-warn — the kickoff path already
 			// surfaced the missing gh; quieter on subsequent
@@ -96,4 +100,17 @@ func fetchRunForComment(ctx context.Context, client *httpclient.Client, runID uu
 		return nil
 	}
 	return r
+}
+
+// fetchStageForComment loads the stage by id. Returns nil on any
+// error (best-effort: same degradation posture as fetchRunForComment).
+func fetchStageForComment(ctx context.Context, client *httpclient.Client, stageID uuid.UUID) *httpclient.Stage {
+	if client == nil {
+		return nil
+	}
+	s, err := client.GetStage(ctx, stageID)
+	if err != nil {
+		return nil
+	}
+	return s
 }

--- a/cli/cmd/fishhawk/runner.go
+++ b/cli/cmd/fishhawk/runner.go
@@ -45,6 +45,10 @@ var runnerStartCommand = exec.Command
 // when none resolves. Test seam via `var runnerBinaryLookPath`.
 var runnerBinaryLookPath = exec.LookPath
 
+// runnerNewClient is a test seam for runRunnerStart. Production
+// wires to newClient; tests swap to point at an httptest.Server.
+var runnerNewClient = newClient
+
 // gitRemoteOriginURL returns the configured `origin` remote URL for
 // the working directory (or the absolute path it resolves to). Test
 // seam — production wires `git remote get-url origin`.
@@ -202,42 +206,48 @@ func runRunnerStart(args []string, stdout, stderr io.Writer) int {
 	// the triggering issue for local-runner runs. Best-effort —
 	// failures here do not affect the verb's exit code.
 	parsedRunID, perr := uuid.Parse(*runID)
+	var parsedStageID uuid.UUID
+	var stageParseErr error
+	if perr == nil {
+		parsedStageID, stageParseErr = uuid.Parse(*stageID)
+	}
 	prCommentPosted := false
-	if perr == nil && *stage == "implement" && !*noPR {
-		parsedStageID, serr := uuid.Parse(*stageID)
-		if serr == nil {
-			clientCtx, clientCancel := context.WithTimeout(context.Background(), *cf.timeout)
-			defer clientCancel()
-			client := newClient(cf)
-			result, autoErr := autoOpenPR(clientCtx, client, autoOpenPRArgs{
-				WorkingDir: *workingDir,
-				RunID:      parsedRunID,
-				StageID:    parsedStageID,
-				GitHubRepo: repo,
-				BaseBranch: *baseBranch,
-			})
-			if autoErr != nil {
-				_, _ = fmt.Fprintf(stderr, "fishhawk runner start: auto-PR warning: %v\n", autoErr)
-			} else {
-				if r := fetchRunForComment(clientCtx, client, parsedRunID); r != nil {
-					maybePostLocalComment(stderr, r,
-						ghcomment.RenderImplementPROpened(
-							toGhCommentRun(r, *cf.backendURL),
-							result.PRURL, result.PRNumber))
-				}
-				prCommentPosted = true
+	if perr == nil && stageParseErr == nil && *stage == "implement" && !*noPR {
+		clientCtx, clientCancel := context.WithTimeout(context.Background(), *cf.timeout)
+		defer clientCancel()
+		client := runnerNewClient(cf)
+		result, autoErr := autoOpenPR(clientCtx, client, autoOpenPRArgs{
+			WorkingDir: *workingDir,
+			RunID:      parsedRunID,
+			StageID:    parsedStageID,
+			GitHubRepo: repo,
+			BaseBranch: *baseBranch,
+		})
+		if autoErr != nil {
+			_, _ = fmt.Fprintf(stderr, "fishhawk runner start: auto-PR warning: %v\n", autoErr)
+		} else {
+			if r := fetchRunForComment(clientCtx, client, parsedRunID); r != nil {
+				maybePostLocalComment(stderr, r,
+					ghcomment.RenderImplementPROpened(
+						toGhCommentRun(r, *cf.backendURL),
+						result.PRURL, result.PRNumber))
 			}
+			prCommentPosted = true
 		}
 	}
 	if !prCommentPosted && perr == nil {
 		clientCtx, clientCancel := context.WithTimeout(context.Background(), *cf.timeout)
 		defer clientCancel()
-		client := newClient(cf)
+		client := runnerNewClient(cf)
 		if r := fetchRunForComment(clientCtx, client, parsedRunID); r != nil {
+			stateAfter := "unknown"
+			if fetched := fetchStageForComment(clientCtx, client, parsedStageID); fetched != nil {
+				stateAfter = fetched.State
+			}
 			maybePostLocalComment(stderr, r,
 				ghcomment.RenderStageComplete(
 					toGhCommentRun(r, *cf.backendURL),
-					*stage, r.State))
+					*stage, stateAfter))
 		}
 	}
 	return exitOK

--- a/cli/cmd/fishhawk/runner_test.go
+++ b/cli/cmd/fishhawk/runner_test.go
@@ -1,10 +1,19 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os/exec"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/kuhlman-labs/fishhawk/cli/internal/httpclient"
 )
 
 // withFakeRunnerSpawn patches the runner-spawn seam so tests can
@@ -389,6 +398,133 @@ func TestParseGitHubRemote_Variants(t *testing.T) {
 			}
 		})
 	}
+}
+
+// withFakeHTTPClient swaps runnerNewClient so all HTTP calls inside
+// runRunnerStart go to srv instead of the real backend.
+func withFakeHTTPClient(t *testing.T, srv *httptest.Server) {
+	t.Helper()
+	orig := runnerNewClient
+	runnerNewClient = func(_ commonFlags) *httpclient.Client {
+		return httpclient.New(srv.URL, "")
+	}
+	t.Cleanup(func() { runnerNewClient = orig })
+}
+
+// withCapturedGhPost swaps ghPost to record the body passed to
+// maybePostLocalComment without shelling to gh.
+func withCapturedGhPost(t *testing.T) *string {
+	t.Helper()
+	captured := new(string)
+	orig := ghPost
+	ghPost = func(_ string, _ int, body string) error {
+		*captured = body
+		return nil
+	}
+	t.Cleanup(func() { ghPost = orig })
+	return captured
+}
+
+func TestRunnerStart_StageCompleteComment(t *testing.T) {
+	runID := uuid.New()
+	stageID := uuid.New()
+
+	makeServer := func(t *testing.T, stageStatus int, stageState string) *httptest.Server {
+		t.Helper()
+		run := httpclient.Run{
+			ID:         runID,
+			Repo:       "x/y",
+			WorkflowID: "w",
+			State:      "running",
+			RunnerKind: "local",
+			IssueContext: &httpclient.IssueContext{
+				Title:  "test issue",
+				Body:   "body",
+				URL:    "https://github.com/x/y/issues/1",
+				Number: 1,
+			},
+			CreatedAt: time.Now().UTC(),
+			UpdatedAt: time.Now().UTC(),
+		}
+		stage := httpclient.Stage{
+			ID:        stageID,
+			RunID:     runID,
+			Sequence:  1,
+			Type:      "plan",
+			State:     stageState,
+			CreatedAt: time.Now().UTC(),
+			UpdatedAt: time.Now().UTC(),
+		}
+		mux := http.NewServeMux()
+		mux.HandleFunc("GET /v0/runs/{run_id}", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(run)
+		})
+		mux.HandleFunc("GET /v0/stages/{stage_id}", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			if stageStatus >= 400 {
+				w.WriteHeader(stageStatus)
+				_, _ = io.WriteString(w, `{"error":{"code":"internal","message":"server error"}}`)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(stage)
+		})
+		srv := httptest.NewServer(mux)
+		t.Cleanup(srv.Close)
+		return srv
+	}
+
+	t.Run("stage_state_flows_into_comment", func(t *testing.T) {
+		withFakeRunnerSpawn(t)
+		withFakeGitRemote(t, "", errors.New("no git"))
+		srv := makeServer(t, http.StatusOK, "awaiting_approval")
+		withFakeHTTPClient(t, srv)
+		capturedBody := withCapturedGhPost(t)
+
+		var stdout, stderr strings.Builder
+		got := run([]string{
+			"runner", "start",
+			"--run-id", runID.String(),
+			"--stage-id", stageID.String(),
+			"--workflow", "w",
+			"--stage", "plan",
+			"--backend-url", srv.URL,
+		}, &stdout, &stderr)
+
+		if got != exitOK {
+			t.Fatalf("exit = %d, want exitOK:\n%s", got, stderr.String())
+		}
+		if !strings.Contains(*capturedBody, "awaiting_approval") {
+			t.Errorf("comment body %q does not contain \"awaiting_approval\"", *capturedBody)
+		}
+	})
+
+	t.Run("stage_fetch_error_degrades_to_unknown", func(t *testing.T) {
+		withFakeRunnerSpawn(t)
+		withFakeGitRemote(t, "", errors.New("no git"))
+		srv := makeServer(t, http.StatusInternalServerError, "")
+		withFakeHTTPClient(t, srv)
+		capturedBody := withCapturedGhPost(t)
+
+		var stdout, stderr strings.Builder
+		got := run([]string{
+			"runner", "start",
+			"--run-id", runID.String(),
+			"--stage-id", stageID.String(),
+			"--workflow", "w",
+			"--stage", "plan",
+			"--backend-url", srv.URL,
+		}, &stdout, &stderr)
+
+		if got != exitOK {
+			t.Fatalf("exit = %d, want exitOK:\n%s", got, stderr.String())
+		}
+		if !strings.Contains(*capturedBody, "unknown") {
+			t.Errorf("comment body %q does not contain \"unknown\"", *capturedBody)
+		}
+	})
 }
 
 // contains reports whether s appears anywhere in xs.

--- a/cli/internal/httpclient/httpclient.go
+++ b/cli/internal/httpclient/httpclient.go
@@ -150,6 +150,15 @@ func (c *Client) GetRun(ctx context.Context, id uuid.UUID) (*Run, error) {
 	return &run, nil
 }
 
+// GetStage calls GET /v0/stages/{id}.
+func (c *Client) GetStage(ctx context.Context, id uuid.UUID) (*Stage, error) {
+	var stage Stage
+	if err := c.do(ctx, http.MethodGet, "/v0/stages/"+id.String(), nil, &stage); err != nil {
+		return nil, err
+	}
+	return &stage, nil
+}
+
 // ListRunsFilter scopes a ListRuns call. Empty values are dropped
 // from the query string.
 type ListRunsFilter struct {

--- a/cli/internal/httpclient/httpclient_test.go
+++ b/cli/internal/httpclient/httpclient_test.go
@@ -362,6 +362,65 @@ func TestShipLocalPullRequest_APIError(t *testing.T) {
 	}
 }
 
+func TestGetStage(t *testing.T) {
+	stageID := uuid.New()
+	runID := uuid.New()
+	tests := []struct {
+		name        string
+		status      int
+		body        string
+		wantState   string
+		wantErrCode string
+	}{
+		{
+			name:   "200 decodes stage",
+			status: http.StatusOK,
+			body: `{"id":"` + stageID.String() + `","run_id":"` + runID.String() + `",` +
+				`"sequence":1,"type":"plan","executor":{"kind":"local","ref":"v1"},` +
+				`"state":"awaiting_approval","created_at":"2024-01-01T00:00:00Z","updated_at":"2024-01-01T00:00:00Z"}`,
+			wantState: "awaiting_approval",
+		},
+		{
+			name:        "404 returns APIError",
+			status:      http.StatusNotFound,
+			body:        `{"error":{"code":"stage_not_found","message":"no stage with that id"}}`,
+			wantErrCode: "stage_not_found",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tc.status)
+				_, _ = io.WriteString(w, tc.body)
+			}))
+			t.Cleanup(srv.Close)
+
+			c := New(srv.URL, "")
+			got, err := c.GetStage(context.Background(), stageID)
+			if tc.wantErrCode != "" {
+				var apiErr *APIError
+				if !errors.As(err, &apiErr) || apiErr.Code != tc.wantErrCode {
+					t.Errorf("err = %v, want APIError %q", err, tc.wantErrCode)
+				}
+				if apiErr.StatusCode != tc.status {
+					t.Errorf("StatusCode = %d, want %d", apiErr.StatusCode, tc.status)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("GetStage: %v", err)
+			}
+			if got.ID != stageID {
+				t.Errorf("ID = %s, want %s", got.ID, stageID)
+			}
+			if got.State != tc.wantState {
+				t.Errorf("State = %q, want %q", got.State, tc.wantState)
+			}
+		})
+	}
+}
+
 func TestAPIError_Error(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## Summary

`runRunnerStart` was passing `r.State` (the run-level rollup, which still reads `pending` / `running` until later stages land) into `RenderStageComplete`'s third argument. The argument is meant to be the **stage's** own settled state. Issue threads showed:

> \`plan\` stage complete on run … — pending.
> \`implement\` stage complete on run … — running.

Both wrong. Plan-stage's actual state was `awaiting_approval`; implement was `succeeded`.

Fix:
- Add `Client.GetStage(ctx, stageID)` to `cli/internal/httpclient` mirroring the existing `GetRun` pattern.
- Add `fetchStageForComment` in `cli/cmd/fishhawk/comment.go` mirroring `fetchRunForComment` — silent best-effort.
- After the runner subprocess exits, call `fetchStageForComment` and pass the fetched stage state (or `"unknown"` on fetch failure) to `RenderStageComplete`.
- Parse `stageID` unconditionally (still guarded by `perr == nil`) so the plan-stage path also resolves it — caught preemptively in the plan's risk section.

## Test plan

- [x] `scripts/test` — full gate green.
- [x] `golangci-lint run ./cli/...` — clean.
- [x] New tests: `GetStage` 200 + 404 paths in `httpclient_test.go`; `TestRunnerStart_StageCompleteComment` sub-cases A (state flows through) + B (fetch failure degrades to `unknown` without failing the verb).

## Notes

- Authored via local MCP loop on run `79494fb8-9c6a-4542-bb42-d36a893e6068`. **This run also validated PR #457's os.Executable sibling-dir fallback** — invoked `fishhawk_run_stage` without passing `runner_binary` for the first time, and the runner spawned correctly. The dogfood feedback loop is tightening: each PR's fix shows up in the next loop's experience.
- The trade-off is one extra HTTP round-trip after the runner exits. Acceptable — the existing run-fetch (`fetchRunForComment`) already pays the same cost.
- Per yesterday's triage, this is the focused tactical fix; the bigger sticky-comment-format alignment lands separately in #428 (which now references this as the prerequisite focused fix).

Closes #420