### PR TITLE
plan: standard_v1 adds predicted_runtime + decomposition (ADR-025 D2, #453)

### DIFF
--- a/backend/internal/plan/errors.go
+++ b/backend/internal/plan/errors.go
@@ -36,3 +36,15 @@ type SchemaError struct {
 func (e *SchemaError) Error() string {
 	return fmt.Sprintf("plan: schema: %s: %s", e.Path, e.Message)
 }
+
+// SemanticError is returned when the plan passes schema validation but
+// violates a semantic invariant (e.g. duplicate sub-plan titles). It is
+// a hard rejection — Parse returns this error and the runner treats the
+// plan as invalid.
+type SemanticError struct {
+	Message string
+}
+
+func (e *SemanticError) Error() string {
+	return "plan: semantic: " + e.Message
+}

--- a/backend/internal/plan/plan.go
+++ b/backend/internal/plan/plan.go
@@ -12,12 +12,10 @@
 //   - Parse validates and returns the typed *Plan. Used by the
 //     backend for rendering, persistence, and audit log writes.
 //
-// Plan artifacts have no graph-shape rules the schema can't express
-// (unlike the workflow spec's stage cross-references), so there is
-// no semantic-validation layer here. Cross-document checks against
-// the producing workflow spec (e.g. scope.files paths must satisfy
-// the stage's allowed_paths constraint) live at the runner / backend
-// layer where both sides are available.
+// Semantic checks (title uniqueness within decomposition) run inside
+// Parse after JSON decode. Cross-document checks against the producing
+// workflow spec live at the runner / backend layer where both sides are
+// available.
 package plan
 
 import "time"
@@ -26,14 +24,43 @@ import "time"
 // artifact. JSON tags mirror the schema; the canonical wire format
 // is JSON.
 type Plan struct {
-	PlanVersion         string          `json:"plan_version"`
-	TicketReference     TicketReference `json:"ticket_reference"`
-	GeneratedBy         GeneratedBy     `json:"generated_by"`
-	Summary             string          `json:"summary"`
-	Scope               Scope           `json:"scope"`
-	Approach            []ApproachStep  `json:"approach"`
-	Verification        Verification    `json:"verification"`
-	RisksAndAssumptions []string        `json:"risks_and_assumptions,omitempty"`
+	PlanVersion                string            `json:"plan_version"`
+	TicketReference            TicketReference   `json:"ticket_reference"`
+	GeneratedBy                GeneratedBy       `json:"generated_by"`
+	Summary                    string            `json:"summary"`
+	Scope                      Scope             `json:"scope"`
+	Approach                   []ApproachStep    `json:"approach"`
+	Verification               Verification      `json:"verification"`
+	RisksAndAssumptions        []string          `json:"risks_and_assumptions,omitempty"`
+	PredictedRuntimeMinutes    int               `json:"predicted_runtime_minutes"`
+	PredictedRuntimeConfidence RuntimeConfidence `json:"predicted_runtime_confidence"`
+	Decomposition              *Decomposition    `json:"decomposition,omitempty"`
+}
+
+// RuntimeConfidence is the agent's confidence level in a runtime estimate.
+type RuntimeConfidence string
+
+// Runtime confidence levels per the schema.
+const (
+	RuntimeConfidenceLow    RuntimeConfidence = "low"
+	RuntimeConfidenceMedium RuntimeConfidence = "medium"
+	RuntimeConfidenceHigh   RuntimeConfidence = "high"
+)
+
+// SubPlanSummary describes one sub-plan within a Decomposition.
+type SubPlanSummary struct {
+	Title                      string            `json:"title"`
+	ScopeHint                  string            `json:"scope_hint"`
+	PredictedRuntimeMinutes    int               `json:"predicted_runtime_minutes"`
+	PredictedRuntimeConfidence RuntimeConfidence `json:"predicted_runtime_confidence"`
+}
+
+// Decomposition holds the rationale and sub-plan summaries when
+// the agent's runtime estimate exceeds the implement-stage budget.
+// Stored in the audit log but not acted upon until D3/D4.
+type Decomposition struct {
+	Rationale string           `json:"rationale"`
+	SubPlans  []SubPlanSummary `json:"sub_plans"`
 }
 
 // TicketReference identifies the originating ticket. v0 closed set:

--- a/backend/internal/plan/plan_test.go
+++ b/backend/internal/plan/plan_test.go
@@ -244,3 +244,202 @@ func TestSchemaError_FormatsPathAndMessage(t *testing.T) {
 		t.Errorf("Error() = %q, want %q", got, want)
 	}
 }
+
+// validPlanJSON returns a minimal valid standard_v1 plan with the new required
+// runtime fields populated. Tests that need to vary one field use this as a base.
+func validPlanJSON(extras string) []byte {
+	body := `{
+  "plan_version": "standard_v1",
+  "ticket_reference": {"type": "github_issue", "url": "https://x", "id": "x"},
+  "generated_by": {"agent": "a", "model": "m", "timestamp": "2026-01-01T00:00:00Z"},
+  "summary": "x",
+  "scope": {"files": [{"path": "a.go", "operation": "create"}]},
+  "approach": [{"step": 1, "description": "x"}],
+  "verification": {"test_strategy": "x", "rollback_plan": "x"},
+  "predicted_runtime_minutes": 10,
+  "predicted_runtime_confidence": "medium"` + extras + `
+}`
+	return []byte(body)
+}
+
+// --- predicted_runtime_minutes / predicted_runtime_confidence schema errors ---
+
+func TestParse_MissingPredictedRuntimeMinutes(t *testing.T) {
+	// Regression guard: plans produced before this PR (without the new required
+	// fields) fail validation after deploy — this is the intentional breaking change.
+	_, err := plan.Parse([]byte(`{
+  "plan_version": "standard_v1",
+  "ticket_reference": {"type": "github_issue", "url": "https://x", "id": "x"},
+  "generated_by": {"agent": "a", "model": "m", "timestamp": "2026-01-01T00:00:00Z"},
+  "summary": "x",
+  "scope": {"files": [{"path": "a.go", "operation": "create"}]},
+  "approach": [{"step": 1, "description": "x"}],
+  "verification": {"test_strategy": "x", "rollback_plan": "x"},
+  "predicted_runtime_confidence": "medium"
+}`))
+	var se *plan.SchemaError
+	if !errors.As(err, &se) {
+		t.Fatalf("err = %v, want *SchemaError", err)
+	}
+}
+
+func TestParse_MissingPredictedRuntimeConfidence(t *testing.T) {
+	_, err := plan.Parse([]byte(`{
+  "plan_version": "standard_v1",
+  "ticket_reference": {"type": "github_issue", "url": "https://x", "id": "x"},
+  "generated_by": {"agent": "a", "model": "m", "timestamp": "2026-01-01T00:00:00Z"},
+  "summary": "x",
+  "scope": {"files": [{"path": "a.go", "operation": "create"}]},
+  "approach": [{"step": 1, "description": "x"}],
+  "verification": {"test_strategy": "x", "rollback_plan": "x"},
+  "predicted_runtime_minutes": 10
+}`))
+	var se *plan.SchemaError
+	if !errors.As(err, &se) {
+		t.Fatalf("err = %v, want *SchemaError", err)
+	}
+}
+
+// --- Pre-D2 shape regression guard ---
+
+func TestParse_PreD2Shape_NoRuntimeFields_IsSchemaError(t *testing.T) {
+	// Explicit regression guard: the pre-D2 wire format (no predicted_runtime_minutes
+	// or predicted_runtime_confidence) must be rejected as *SchemaError after this PR.
+	_, err := plan.Parse([]byte(`{
+  "plan_version": "standard_v1",
+  "ticket_reference": {"type": "github_issue", "url": "https://x", "id": "x"},
+  "generated_by": {"agent": "a", "model": "m", "timestamp": "2026-01-01T00:00:00Z"},
+  "summary": "x",
+  "scope": {"files": [{"path": "a.go", "operation": "create"}]},
+  "approach": [{"step": 1, "description": "x"}],
+  "verification": {"test_strategy": "x", "rollback_plan": "x"}
+}`))
+	var se *plan.SchemaError
+	if !errors.As(err, &se) {
+		t.Fatalf("pre-D2 plan shape should produce *SchemaError, got %v", err)
+	}
+}
+
+// --- decomposition schema errors ---
+
+func TestParse_DecompositionOneSubPlan_IsSchemaError(t *testing.T) {
+	// minItems:2 violation — a single sub-plan is rejected structurally.
+	_, err := plan.Parse(validPlanJSON(`,
+  "decomposition": {
+    "rationale": "too big",
+    "sub_plans": [
+      {"title": "Part A", "scope_hint": "first half", "predicted_runtime_minutes": 10, "predicted_runtime_confidence": "medium"}
+    ]
+  }`))
+	var se *plan.SchemaError
+	if !errors.As(err, &se) {
+		t.Fatalf("err = %v, want *SchemaError", err)
+	}
+}
+
+// --- decomposition happy path ---
+
+func TestParse_DecompositionTwoSubPlans_Succeeds(t *testing.T) {
+	p, err := plan.Parse(validPlanJSON(`,
+  "decomposition": {
+    "rationale": "work exceeded budget",
+    "sub_plans": [
+      {"title": "Part A", "scope_hint": "schema changes", "predicted_runtime_minutes": 8, "predicted_runtime_confidence": "high"},
+      {"title": "Part B", "scope_hint": "test updates",   "predicted_runtime_minutes": 6, "predicted_runtime_confidence": "medium"}
+    ]
+  }`))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if p.Decomposition == nil {
+		t.Fatal("Decomposition should be non-nil")
+	}
+	if got, want := len(p.Decomposition.SubPlans), 2; got != want {
+		t.Errorf("sub_plans len = %d, want %d", got, want)
+	}
+}
+
+// --- decomposition semantic errors ---
+
+func TestParse_DecompositionDuplicateTitles_IsSemanticError(t *testing.T) {
+	_, err := plan.Parse(validPlanJSON(`,
+  "decomposition": {
+    "rationale": "too big",
+    "sub_plans": [
+      {"title": "Same Title", "scope_hint": "first",  "predicted_runtime_minutes": 5, "predicted_runtime_confidence": "low"},
+      {"title": "Same Title", "scope_hint": "second", "predicted_runtime_minutes": 5, "predicted_runtime_confidence": "low"}
+    ]
+  }`))
+	var se *plan.SemanticError
+	if !errors.As(err, &se) {
+		t.Fatalf("err = %v, want *SemanticError", err)
+	}
+	if !strings.Contains(se.Error(), "duplicate title") {
+		t.Errorf("SemanticError message should mention duplicate title, got %q", se.Error())
+	}
+}
+
+// --- Warnings ---
+
+func TestWarnings_SubPlanSumLessThanParent_Explicit(t *testing.T) {
+	p, err := plan.Parse([]byte(`{
+  "plan_version": "standard_v1",
+  "ticket_reference": {"type": "github_issue", "url": "https://x", "id": "x"},
+  "generated_by": {"agent": "a", "model": "m", "timestamp": "2026-01-01T00:00:00Z"},
+  "summary": "x",
+  "scope": {"files": [{"path": "a.go", "operation": "create"}]},
+  "approach": [{"step": 1, "description": "x"}],
+  "verification": {"test_strategy": "x", "rollback_plan": "x"},
+  "predicted_runtime_minutes": 30,
+  "predicted_runtime_confidence": "medium",
+  "decomposition": {
+    "rationale": "split",
+    "sub_plans": [
+      {"title": "Part A", "scope_hint": "a", "predicted_runtime_minutes": 8, "predicted_runtime_confidence": "medium"},
+      {"title": "Part B", "scope_hint": "b", "predicted_runtime_minutes": 6, "predicted_runtime_confidence": "medium"}
+    ]
+  }
+}`))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	warns := plan.Warnings(p)
+	if len(warns) == 0 {
+		t.Fatal("expected at least one warning when sub-plan sum < parent runtime")
+	}
+}
+
+func TestWarnings_SubPlanSumGeParent_NoWarnings(t *testing.T) {
+	p, err := plan.Parse([]byte(`{
+  "plan_version": "standard_v1",
+  "ticket_reference": {"type": "github_issue", "url": "https://x", "id": "x"},
+  "generated_by": {"agent": "a", "model": "m", "timestamp": "2026-01-01T00:00:00Z"},
+  "summary": "x",
+  "scope": {"files": [{"path": "a.go", "operation": "create"}]},
+  "approach": [{"step": 1, "description": "x"}],
+  "verification": {"test_strategy": "x", "rollback_plan": "x"},
+  "predicted_runtime_minutes": 10,
+  "predicted_runtime_confidence": "medium",
+  "decomposition": {
+    "rationale": "split",
+    "sub_plans": [
+      {"title": "Part A", "scope_hint": "a", "predicted_runtime_minutes": 8, "predicted_runtime_confidence": "medium"},
+      {"title": "Part B", "scope_hint": "b", "predicted_runtime_minutes": 6, "predicted_runtime_confidence": "medium"}
+    ]
+  }
+}`))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if warns := plan.Warnings(p); len(warns) != 0 {
+		t.Errorf("expected no warnings when sub-plan sum >= parent, got %v", warns)
+	}
+}
+
+func TestSemanticError_FormatsMessage(t *testing.T) {
+	err := &plan.SemanticError{Message: "duplicate title \"Foo\""}
+	want := "plan: semantic: duplicate title \"Foo\""
+	if got := err.Error(); got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+}

--- a/backend/internal/plan/schemas/plan-standard-v1.schema.json
+++ b/backend/internal/plan/schemas/plan-standard-v1.schema.json
@@ -13,7 +13,9 @@
     "summary",
     "scope",
     "approach",
-    "verification"
+    "verification",
+    "predicted_runtime_minutes",
+    "predicted_runtime_confidence"
   ],
 
   "properties": {
@@ -41,6 +43,35 @@
       "type": "array",
       "items": { "type": "string", "minLength": 1 },
       "description": "Optional. Things the agent flagged as uncertain or assumed; surfaces in the review UI."
+    },
+    "predicted_runtime_minutes": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Agent's estimate of how long the implement stage will take, in minutes. Used to surface scope problems early and to populate decomposition.sub_plans when the estimate exceeds the implement-stage budget."
+    },
+    "predicted_runtime_confidence": {
+      "type": "string",
+      "enum": ["low", "medium", "high"],
+      "description": "Agent's confidence in predicted_runtime_minutes. low = rough guess; medium = reasonably grounded; high = well-understood scope."
+    },
+    "decomposition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["rationale", "sub_plans"],
+      "description": "Optional. Populated when predicted_runtime_minutes exceeds the implement-stage budget. Stored in the audit log but not acted upon until D3/D4.",
+      "properties": {
+        "rationale": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Why the work was split and how the sub-plans relate."
+        },
+        "sub_plans": {
+          "type": "array",
+          "minItems": 2,
+          "items": { "$ref": "#/$defs/sub-plan-summary" },
+          "description": "Ordered list of sub-plans. At least two required when decomposition is present."
+        }
+      }
     }
   },
 
@@ -161,6 +192,34 @@
           "type": "string",
           "minLength": 1,
           "description": "How a regression would be undone. \"Revert PR\" is a valid answer for purely-additive changes; data migrations need more."
+        }
+      }
+    },
+
+    "sub-plan-summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["title", "scope_hint", "predicted_runtime_minutes", "predicted_runtime_confidence"],
+      "properties": {
+        "title": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200,
+          "description": "Short title for this sub-plan. Must be unique within decomposition.sub_plans."
+        },
+        "scope_hint": {
+          "type": "string",
+          "description": "Brief description of what this sub-plan covers. Helps the reviewer understand the split."
+        },
+        "predicted_runtime_minutes": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Agent's estimate of how long this sub-plan's implement stage will take."
+        },
+        "predicted_runtime_confidence": {
+          "type": "string",
+          "enum": ["low", "medium", "high"],
+          "description": "Agent's confidence in this sub-plan's predicted_runtime_minutes."
         }
       }
     }

--- a/backend/internal/plan/testdata/valid/example.json
+++ b/backend/internal/plan/testdata/valid/example.json
@@ -30,5 +30,7 @@
   "risks_and_assumptions": [
     "Assumes (created_at, entry_id) is the natural sort order.",
     "Risk: very large date ranges; mitigated by per-page limit of 1000 rows."
-  ]
+  ],
+  "predicted_runtime_minutes": 20,
+  "predicted_runtime_confidence": "medium"
 }

--- a/backend/internal/plan/validate.go
+++ b/backend/internal/plan/validate.go
@@ -67,6 +67,9 @@ func Validate(data []byte) error {
 // to calling Validate followed by json.Unmarshal — provided as a
 // single call so the backend (E2 audit log writer, plan-review UI
 // renderer) doesn't need to import encoding/json directly.
+//
+// After JSON decode, semantic checks run via semanticCheck. A non-nil
+// result is a hard rejection (*SemanticError).
 func Parse(data []byte) (*Plan, error) {
 	if err := Validate(data); err != nil {
 		return nil, err
@@ -79,7 +82,53 @@ func Parse(data []byte) (*Plan, error) {
 		// internal type-mapping bug.
 		return nil, fmt.Errorf("internal: decode to Plan: %w", err)
 	}
+	if err := semanticCheck(&p); err != nil {
+		return nil, err
+	}
 	return &p, nil
+}
+
+// semanticCheck enforces invariants that JSON Schema cannot express.
+// Currently: sub-plan titles must be unique within a decomposition.
+func semanticCheck(p *Plan) error {
+	if p.Decomposition == nil {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(p.Decomposition.SubPlans))
+	for _, sp := range p.Decomposition.SubPlans {
+		if _, dup := seen[sp.Title]; dup {
+			return &SemanticError{
+				Message: fmt.Sprintf("decomposition.sub_plans: duplicate title %q", sp.Title),
+			}
+		}
+		seen[sp.Title] = struct{}{}
+	}
+	return nil
+}
+
+// Warnings returns advisory strings for a successfully-parsed Plan.
+// These are soft checks — the plan is valid but the caller may want
+// to surface the messages in review UI or logs. Currently emits one
+// warning when the sum of sub-plan predicted_runtime_minutes is less
+// than the parent's predicted_runtime_minutes (the agent may have
+// legitimately compressed work, so this is not a hard rejection).
+func Warnings(p *Plan) []string {
+	if p.Decomposition == nil || len(p.Decomposition.SubPlans) == 0 {
+		return nil
+	}
+	sum := 0
+	for _, sp := range p.Decomposition.SubPlans {
+		sum += sp.PredictedRuntimeMinutes
+	}
+	if sum < p.PredictedRuntimeMinutes {
+		return []string{
+			fmt.Sprintf(
+				"decomposition sub-plan runtime sum (%d min) is less than parent predicted_runtime_minutes (%d min); agent may have compressed scope",
+				sum, p.PredictedRuntimeMinutes,
+			),
+		}
+	}
+	return nil
 }
 
 // schemaErrorFrom collapses a jsonschema.ValidationError tree to the

--- a/backend/internal/prompt/prompt.go
+++ b/backend/internal/prompt/prompt.go
@@ -16,9 +16,14 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/kuhlman-labs/fishhawk/backend/internal/plan"
 )
+
+// defaultStageTimeoutMinutes mirrors spec.DefaultStageTimeout (15 minutes,
+// per ADR-025 D1). If that default changes in the spec package, update here.
+const defaultStageTimeoutMinutes = 15
 
 // ErrUnsupportedStage signals the requested stage type isn't yet
 // wired for prompt construction. The handler maps this to HTTP 501.
@@ -81,6 +86,12 @@ type Trigger struct {
 	// to the issue-only prompt and a `plan_missing_for_implement`
 	// audit entry surfaces the gap (#223).
 	ApprovedPlan *plan.Plan
+	// PlanStageTimeout is the max runtime budget for the plan stage.
+	// Zero resolves to defaultStageTimeoutMinutes in buildPlan.
+	PlanStageTimeout time.Duration
+	// ImplementStageTimeout is the max runtime budget for the implement stage.
+	// Zero resolves to defaultStageTimeoutMinutes in buildPlan.
+	ImplementStageTimeout time.Duration
 }
 
 // Build returns the constructed prompt for the given stage type
@@ -180,13 +191,37 @@ func buildPlan(t Trigger) string {
 
 	writeIssueContext(&b, t)
 
+	planMins := resolveMins(t.PlanStageTimeout)
+	implMins := resolveMins(t.ImplementStageTimeout)
+	fmt.Fprintf(&b,
+		"Stage budget (ADR-025): plan stage %d minutes, implement stage %d minutes. "+
+			"Treat overrunning the budget as a scope problem, not a runtime problem — "+
+			"if your work estimate exceeds the implement-stage budget, populate decomposition.sub_plans "+
+			"so the reviewer can split the work into multiple runs.\n\n",
+		planMins, implMins,
+	)
+
 	b.WriteString("Your task: produce a `standard_v1` plan artifact describing the change. ")
 	b.WriteString("Write the plan as a single JSON object to `")
 	b.WriteString(PlanArtifactPath)
-	b.WriteString("`. The schema is documented at docs/spec/plan-standard-v1.md and required fields are: plan_version (\"standard_v1\"), ticket_reference, generated_by, summary, scope, approach, verification. ")
+	b.WriteString("`. The schema is documented at docs/spec/plan-standard-v1.md and required fields are: plan_version (\"standard_v1\"), ticket_reference, generated_by, summary, scope, approach, verification, predicted_runtime_minutes, predicted_runtime_confidence. ")
+	b.WriteString("predicted_runtime_minutes and predicted_runtime_confidence are MUST-populate fields — every plan artifact must carry your runtime estimate and confidence level. ")
+	fmt.Fprintf(&b,
+		"Populate decomposition.sub_plans if and only if your predicted_runtime_minutes estimate exceeds the implement-stage budget (%d minutes). ",
+		implMins,
+	)
 	b.WriteString("Do not echo the plan in your final response — only write it to the file. ")
 	b.WriteString("Do not modify source files in this stage — the implement stage that follows will execute the plan.\n")
 	return b.String()
+}
+
+// resolveMins converts a duration to whole minutes, returning
+// defaultStageTimeoutMinutes for zero durations.
+func resolveMins(d time.Duration) int {
+	if d <= 0 {
+		return defaultStageTimeoutMinutes
+	}
+	return int(d.Minutes())
 }
 
 // writeApprovedPlan renders a standard_v1 plan as readable prose so
@@ -246,6 +281,11 @@ func writeApprovedPlan(b *strings.Builder, p *plan.Plan) {
 			fmt.Fprintf(b, "- %s\n", r)
 		}
 		b.WriteString("\n")
+	}
+
+	if p.PredictedRuntimeMinutes > 0 {
+		fmt.Fprintf(b, "Runtime prediction: %d minutes (%s confidence)\n\n",
+			p.PredictedRuntimeMinutes, p.PredictedRuntimeConfidence)
 	}
 }
 

--- a/backend/internal/prompt/prompt_test.go
+++ b/backend/internal/prompt/prompt_test.go
@@ -332,6 +332,50 @@ func TestBuild_Implement_WithApprovedPlan_IsDeterministic(t *testing.T) {
 	}
 }
 
+func TestBuild_Plan_BudgetHintWithTimeouts(t *testing.T) {
+	got, err := Build("plan", Trigger{
+		IssueNumber:           7,
+		IssueTitle:            "Plan a refactor",
+		Repo:                  "x/y",
+		PlanStageTimeout:      30 * time.Minute,
+		ImplementStageTimeout: 60 * time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	wants := []string{
+		"30 minutes",
+		"60 minutes",
+		"ADR-025",
+		"decomposition.sub_plans",
+		"predicted_runtime_minutes",
+		"predicted_runtime_confidence",
+	}
+	for _, w := range wants {
+		if !strings.Contains(got, w) {
+			t.Errorf("plan prompt missing %q\n---\n%s", w, got)
+		}
+	}
+}
+
+func TestBuild_Plan_BudgetHintDefaultFallback(t *testing.T) {
+	// Zero durations should resolve to the default (15 minutes).
+	got, err := Build("plan", Trigger{
+		IssueNumber: 7,
+		IssueTitle:  "Plan a refactor",
+		Repo:        "x/y",
+		// PlanStageTimeout and ImplementStageTimeout intentionally zero.
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	// Both slots should show the default value.
+	count := strings.Count(got, "15 minutes")
+	if count < 2 {
+		t.Errorf("expected 'plan stage 15 minutes, implement stage 15 minutes' in default prompt, got count=%d\n---\n%s", count, got)
+	}
+}
+
 func TestBuild_Implement_WithSparsePlan_OmitsEmptySections(t *testing.T) {
 	// A plan that fails optional sections (no scope.files, no
 	// risks) should still render cleanly — empty sections drop

--- a/backend/internal/server/plan_test.go
+++ b/backend/internal/server/plan_test.go
@@ -49,6 +49,8 @@ func validPlanBytes(t *testing.T) []byte {
 			"test_strategy": "Run the target twice; second run is a no-op.",
 			"rollback_plan": "Revert the diff.",
 		},
+		"predicted_runtime_minutes":    5,
+		"predicted_runtime_confidence": "medium",
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/docs/spec/examples/plan-standard-v1-example.json
+++ b/docs/spec/examples/plan-standard-v1-example.json
@@ -45,5 +45,7 @@
   "risks_and_assumptions": [
     "Assumes audit_entries (created_at, entry_id) is the natural sort order; if a future migration adds an `inserted_at` distinct from `created_at` the cursor format will need to be revisited.",
     "Risk: very large date ranges (months) could pull millions of rows; mitigated by the per-page cap of 1000 rows and a server-side total cap of 100k rows per request, with a clear error advising the caller to narrow the range."
-  ]
+  ],
+  "predicted_runtime_minutes": 45,
+  "predicted_runtime_confidence": "medium"
 }

--- a/docs/spec/plan-standard-v1.md
+++ b/docs/spec/plan-standard-v1.md
@@ -20,7 +20,11 @@ The canonical schema is [`plan-standard-v1.schema.json`](plan-standard-v1.schema
   "approach":     [ { "step": 1, "description": "..." }, ... ],
   "verification": { "test_strategy": "...", "rollback_plan": "..." },
 
-  "risks_and_assumptions": ["..."]
+  "predicted_runtime_minutes":    20,
+  "predicted_runtime_confidence": "medium",
+
+  "risks_and_assumptions": ["..."],
+  "decomposition": { "rationale": "...", "sub_plans": [...] }
 }
 ```
 
@@ -96,6 +100,26 @@ Ordered list of steps. Each step has a 1-indexed `step` number and a `descriptio
 
 Reviewers expect concrete tests, not "add tests." Rollback plans flag whether a change is purely additive or has data migration consequences.
 
+### Runtime prediction
+
+Two required fields capture the agent's estimate of how long the implement stage will take.
+
+#### `predicted_runtime_minutes`
+
+Integer ≥ 1. The agent's estimate in minutes. Used to surface scope problems early: if the estimate exceeds the implement-stage budget (per ADR-025), the agent must also populate `decomposition.sub_plans`.
+
+#### `predicted_runtime_confidence`
+
+One of `"low"`, `"medium"`, or `"high"`.
+
+| Value | Meaning |
+|---|---|
+| `low` | Rough guess; significant unknowns remain |
+| `medium` | Reasonably grounded; agent has read the relevant code |
+| `high` | Well-understood scope; agent has high certainty |
+
+These fields are MUST-populate: every `standard_v1` artifact must carry an estimate. The plan-stage prompt instructs the agent accordingly (ADR-025 D1 framing).
+
 ## Optional fields
 
 ### `risks_and_assumptions`
@@ -109,6 +133,51 @@ Reviewers expect concrete tests, not "add tests." Rollback plans flag whether a 
 
 Free-form strings. The plan-review UI surfaces these in a sidebar. Useful for the agent to flag uncertainty rather than over-claim confidence.
 
+### Decomposition
+
+Populated when `predicted_runtime_minutes` exceeds the implement-stage budget. Signals that the agent believes the work should be split across multiple runs.
+
+```json
+{
+  "decomposition": {
+    "rationale": "Estimated runtime (90 min) exceeds the 60-minute implement-stage budget. Splitting into schema migration (Part A) and application logic + tests (Part B).",
+    "sub_plans": [
+      {
+        "title": "Part A: schema migration",
+        "scope_hint": "Add the new columns and indexes; no application code changes.",
+        "predicted_runtime_minutes": 20,
+        "predicted_runtime_confidence": "high"
+      },
+      {
+        "title": "Part B: application logic and tests",
+        "scope_hint": "Wire up the new columns in service layer and add integration tests.",
+        "predicted_runtime_minutes": 55,
+        "predicted_runtime_confidence": "medium"
+      }
+    ]
+  }
+}
+```
+
+#### `decomposition.rationale`
+
+Required when `decomposition` is present. Explains why the work was split and how the sub-plans relate.
+
+#### `decomposition.sub_plans`
+
+Required array with at least two entries. Each entry is a `SubPlanSummary`:
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `title` | string (1–200 chars) | yes | Must be unique within the array |
+| `scope_hint` | string | yes | What this sub-plan covers |
+| `predicted_runtime_minutes` | integer ≥ 1 | yes | Estimate for this sub-plan's implement stage |
+| `predicted_runtime_confidence` | `"low"` / `"medium"` / `"high"` | yes | Confidence in the sub-plan estimate |
+
+**Runtime-sum invariant**: the validator warns (but does not reject) when the sum of `sub_plans[*].predicted_runtime_minutes` is less than the parent `predicted_runtime_minutes`. The agent may legitimately compress work when breaking it into smaller pieces; the soft warning surfaces the gap for human review.
+
+**Lifecycle note**: `decomposition` is validated and stored in the audit log but not acted upon until D3/D4 (automated run splitting is out of scope for D1/D2). Plans with a populated `decomposition` block pass through approval and arrive at the implement stage unchanged; no mechanism routes sub-plans to child runs yet.
+
 ## Validation rules beyond the schema
 
 JSON Schema enforces structure. The validator (E1.5 / #20) layers on:
@@ -116,6 +185,7 @@ JSON Schema enforces structure. The validator (E1.5 / #20) layers on:
 - `scope.files[].path` matches at least one of the stage's `allowed_paths` (when set) and none of the `forbidden_paths`.
 - `generated_by.timestamp` is within the run's wall-clock window (catches clock-skew or replay).
 - `generated_by.agent` matches the workflow spec's `executor.agent` for the active stage.
+- `decomposition.sub_plans[*].title` must be unique within the array (semantic check in the plan package; returns `*SemanticError` on violation).
 
 These cross-references aren't expressible in JSON Schema cleanly.
 
@@ -135,3 +205,4 @@ The runner ships the canonical JSON to the backend; the backend renders the Mark
 - `MVP_SPEC.md` §4.3 — original specification of required and optional fields.
 - `MVP_SPEC.md` §4.4 — audit log persistence.
 - `workflow-v0.md` — the workflow spec that produces these artifacts.
+- ADR-025 — stage budget framing and the `predicted_runtime_minutes` requirement.

--- a/docs/spec/plan-standard-v1.schema.json
+++ b/docs/spec/plan-standard-v1.schema.json
@@ -13,7 +13,9 @@
     "summary",
     "scope",
     "approach",
-    "verification"
+    "verification",
+    "predicted_runtime_minutes",
+    "predicted_runtime_confidence"
   ],
 
   "properties": {
@@ -41,6 +43,35 @@
       "type": "array",
       "items": { "type": "string", "minLength": 1 },
       "description": "Optional. Things the agent flagged as uncertain or assumed; surfaces in the review UI."
+    },
+    "predicted_runtime_minutes": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Agent's estimate of how long the implement stage will take, in minutes. Used to surface scope problems early and to populate decomposition.sub_plans when the estimate exceeds the implement-stage budget."
+    },
+    "predicted_runtime_confidence": {
+      "type": "string",
+      "enum": ["low", "medium", "high"],
+      "description": "Agent's confidence in predicted_runtime_minutes. low = rough guess; medium = reasonably grounded; high = well-understood scope."
+    },
+    "decomposition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["rationale", "sub_plans"],
+      "description": "Optional. Populated when predicted_runtime_minutes exceeds the implement-stage budget. Stored in the audit log but not acted upon until D3/D4.",
+      "properties": {
+        "rationale": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Why the work was split and how the sub-plans relate."
+        },
+        "sub_plans": {
+          "type": "array",
+          "minItems": 2,
+          "items": { "$ref": "#/$defs/sub-plan-summary" },
+          "description": "Ordered list of sub-plans. At least two required when decomposition is present."
+        }
+      }
     }
   },
 
@@ -161,6 +192,34 @@
           "type": "string",
           "minLength": 1,
           "description": "How a regression would be undone. \"Revert PR\" is a valid answer for purely-additive changes; data migrations need more."
+        }
+      }
+    },
+
+    "sub-plan-summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["title", "scope_hint", "predicted_runtime_minutes", "predicted_runtime_confidence"],
+      "properties": {
+        "title": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200,
+          "description": "Short title for this sub-plan. Must be unique within decomposition.sub_plans."
+        },
+        "scope_hint": {
+          "type": "string",
+          "description": "Brief description of what this sub-plan covers. Helps the reviewer understand the split."
+        },
+        "predicted_runtime_minutes": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Agent's estimate of how long this sub-plan's implement stage will take."
+        },
+        "predicted_runtime_confidence": {
+          "type": "string",
+          "enum": ["low", "medium", "high"],
+          "description": "Agent's confidence in this sub-plan's predicted_runtime_minutes."
         }
       }
     }

--- a/runner/cmd/fishhawk-runner/main_test.go
+++ b/runner/cmd/fishhawk-runner/main_test.go
@@ -610,7 +610,9 @@ func validPlanJSON() string {
   "summary": "Add a thing.",
   "scope": {"files": [{"path":"a.go","operation":"create"}], "estimated_lines_changed": 10},
   "approach": [{"step":1,"description":"Do."}],
-  "verification": {"test_strategy":"go test","rollback_plan":"revert PR"}
+  "verification": {"test_strategy":"go test","rollback_plan":"revert PR"},
+  "predicted_runtime_minutes": 5,
+  "predicted_runtime_confidence": "medium"
 }`
 }
 

--- a/runner/internal/plan/schemas/plan-standard-v1.schema.json
+++ b/runner/internal/plan/schemas/plan-standard-v1.schema.json
@@ -13,7 +13,9 @@
     "summary",
     "scope",
     "approach",
-    "verification"
+    "verification",
+    "predicted_runtime_minutes",
+    "predicted_runtime_confidence"
   ],
 
   "properties": {
@@ -41,6 +43,35 @@
       "type": "array",
       "items": { "type": "string", "minLength": 1 },
       "description": "Optional. Things the agent flagged as uncertain or assumed; surfaces in the review UI."
+    },
+    "predicted_runtime_minutes": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Agent's estimate of how long the implement stage will take, in minutes. Used to surface scope problems early and to populate decomposition.sub_plans when the estimate exceeds the implement-stage budget."
+    },
+    "predicted_runtime_confidence": {
+      "type": "string",
+      "enum": ["low", "medium", "high"],
+      "description": "Agent's confidence in predicted_runtime_minutes. low = rough guess; medium = reasonably grounded; high = well-understood scope."
+    },
+    "decomposition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["rationale", "sub_plans"],
+      "description": "Optional. Populated when predicted_runtime_minutes exceeds the implement-stage budget. Stored in the audit log but not acted upon until D3/D4.",
+      "properties": {
+        "rationale": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Why the work was split and how the sub-plans relate."
+        },
+        "sub_plans": {
+          "type": "array",
+          "minItems": 2,
+          "items": { "$ref": "#/$defs/sub-plan-summary" },
+          "description": "Ordered list of sub-plans. At least two required when decomposition is present."
+        }
+      }
     }
   },
 
@@ -161,6 +192,34 @@
           "type": "string",
           "minLength": 1,
           "description": "How a regression would be undone. \"Revert PR\" is a valid answer for purely-additive changes; data migrations need more."
+        }
+      }
+    },
+
+    "sub-plan-summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["title", "scope_hint", "predicted_runtime_minutes", "predicted_runtime_confidence"],
+      "properties": {
+        "title": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200,
+          "description": "Short title for this sub-plan. Must be unique within decomposition.sub_plans."
+        },
+        "scope_hint": {
+          "type": "string",
+          "description": "Brief description of what this sub-plan covers. Helps the reviewer understand the split."
+        },
+        "predicted_runtime_minutes": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Agent's estimate of how long this sub-plan's implement stage will take."
+        },
+        "predicted_runtime_confidence": {
+          "type": "string",
+          "enum": ["low", "medium", "high"],
+          "description": "Agent's confidence in this sub-plan's predicted_runtime_minutes."
         }
       }
     }

--- a/runner/internal/plan/testdata/valid/example.json
+++ b/runner/internal/plan/testdata/valid/example.json
@@ -30,5 +30,7 @@
   "risks_and_assumptions": [
     "Assumes (created_at, entry_id) is the natural sort order.",
     "Risk: very large date ranges; mitigated by per-page limit of 1000 rows."
-  ]
+  ],
+  "predicted_runtime_minutes": 25,
+  "predicted_runtime_confidence": "medium"
 }


### PR DESCRIPTION
## Summary

D2 of [ADR-025 (#451)](https://github.com/kuhlman-labs/fishhawk/issues/451). Extends `standard_v1` plan schema with required runtime predictions and optional decomposition — the foundation for D3's approval-time budget check (#454) and D4's fanout orchestration (#455).

### Schema additions (stays `standard_v1`, additive)
- `predicted_runtime_minutes` (int ≥1, **required**)
- `predicted_runtime_confidence` (enum `low|medium|high`, **required**)
- `decomposition` (optional): `{ rationale, sub_plans: [SubPlanSummary] }` with `minItems: 2`
- `SubPlanSummary` `$defs`: `{ title, scope_hint, predicted_runtime_minutes, predicted_runtime_confidence }`, all required

### Validator (`backend/internal/plan/validate.go`)
- `SemanticError` typed for hard violations (duplicate sub_plan titles → reject)
- `Warnings(p *Plan) []string` for soft advisories (sub_plan runtime sum < parent → warn but don't reject)

### Plan-stage prompt (`backend/internal/prompt/prompt.go`)
- New `PlanStageTimeout` + `ImplementStageTimeout` fields on `Trigger`
- `buildPlan` emits a budget block citing ADR-025's framing ("treat overrunning the budget as a scope problem, not a runtime problem")
- Instructs agent to populate the two new required fields, and propose `decomposition.sub_plans` iff its estimate exceeds the implement-stage budget
- `defaultStageTimeoutMinutes = 15` mirrors `spec.DefaultStageTimeout`; documented coupling

### Test fixtures
- `backend/internal/plan/testdata/valid/example.json` + `docs/spec/examples/plan-standard-v1-example.json` updated with the new required fields
- 8 new test cases in `plan_test.go` (missing-required, decomposition shape, semantic checks, regression guard for pre-D2 plan shape)
- 2 new prompt tests (budget hint with explicit timeouts + default fallback)
- **Fixup commit:** `backend/internal/server/plan_test.go` sample plan also needed the new fields (caught locally before push)

## Test plan

- [x] `scripts/test` — full gate green.
- [x] `golangci-lint run ./backend/... ./runner/...` — 0 issues.
- [x] Schema-sync gate (`docs/spec/` ↔ `backend/internal/plan/schemas/` ↔ `runner/internal/plan/schemas/`) — all three files identical.

## Notes

**Authored via local MCP loop** on run `71fcc101-5d32-459a-bc32-9bb8cef7c840`. The agent's plan correctly handled the bulk of D2 but **missed the `runner/internal/plan/schemas/` mirror** — same trap as yesterday's #459 (just like the cli/internal/spec/schemas/ miss). Same one-shot `cp` fixup, plus a tiny extra fixup for the server-side test fixture that hit the new required fields. This is the second instance of the four-way-mirror gap, validating [#460's tooling-vs-enumeration argument](https://github.com/kuhlman-labs/fishhawk/issues/460).

**Breaking change to `standard_v1`** (acknowledged in the ADR): pre-D2 plans without the new required fields will fail validation. The prompt update ships in the same PR so the agent immediately produces compliant plans post-deploy. In-flight runs at deploy time get the new prompt; no audit records mutated.

`decomposition` is structurally validated here but not acted upon — D3 (#454) handles the budget check at approval, D4 (#455) handles the fanout.

Closes #453