### PR TITLE
scripts/sync-schemas: tooling to prevent embedded-schema drift (#460)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Activate with: git config core.hooksPath .githooks
+set -eu
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+FAIL=0
+
+check() {
+  local src="$1" dst="$2"
+  if ! diff -u "$REPO_ROOT/$src" "$REPO_ROOT/$dst" > /dev/null 2>&1; then
+    echo "schema-sync: $dst is out of sync with $src" >&2
+    FAIL=1
+  fi
+}
+
+check docs/spec/workflow-v0.schema.json backend/internal/spec/schemas/workflow-v0.schema.json
+check docs/spec/workflow-v0.schema.json cli/internal/spec/schemas/workflow-v0.schema.json
+check docs/spec/plan-standard-v1.schema.json backend/internal/plan/schemas/plan-standard-v1.schema.json
+check docs/spec/plan-standard-v1.schema.json runner/internal/plan/schemas/plan-standard-v1.schema.json
+
+if [ "$FAIL" -eq 1 ]; then
+  echo "Run scripts/sync-schemas to mirror the canonical copies, then re-stage." >&2
+  exit 1
+fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,8 @@ done < <(go work edit -json | jq -r '.Use[].DiskPath')
 python3 scripts/check-coverage.py --threshold 80 --exclude '/db/' "${profiles[@]}"
 ```
 
+When editing a schema under `docs/spec/`, run `scripts/sync-schemas` to mirror the change into all embedded copies before committing. CI fails the schema-sync gate otherwise. Opt-in local check: `git config core.hooksPath .githooks`.
+
 ## Adding a Go module
 
 1. `mkdir <name> && cd <name> && go mod init github.com/kuhlman-labs/fishhawk/<name>`

--- a/backend/internal/prompt/prompt.go
+++ b/backend/internal/prompt/prompt.go
@@ -212,6 +212,9 @@ func buildPlan(t Trigger) string {
 	)
 	b.WriteString("Do not echo the plan in your final response — only write it to the file. ")
 	b.WriteString("Do not modify source files in this stage — the implement stage that follows will execute the plan.\n")
+	b.WriteString("\n")
+	b.WriteString("If your plan scope includes any file under docs/spec/, the verification steps must include: " +
+		"run scripts/sync-schemas after editing the canonical copy; CI schema-sync gate will catch embedded copies that drift.\n")
 	return b.String()
 }
 

--- a/backend/internal/prompt/prompt_test.go
+++ b/backend/internal/prompt/prompt_test.go
@@ -150,21 +150,19 @@ func TestBuild_Plan(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
-	if !strings.Contains(got, "implementation plan") {
-		t.Errorf("plan prompt missing 'implementation plan':\n%s", got)
+	wants := []string{
+		"implementation plan",
+		"Do not modify source files",
+		"Triggering issue: #7",
+		PlanArtifactPath,
+		"standard_v1",
+		"scripts/sync-schemas",
+		"docs/spec/",
 	}
-	if !strings.Contains(got, "Do not modify source files") {
-		t.Errorf("plan prompt missing read-only directive:\n%s", got)
-	}
-	if !strings.Contains(got, "Triggering issue: #7") {
-		t.Errorf("plan prompt missing issue ref:\n%s", got)
-	}
-	if !strings.Contains(got, PlanArtifactPath) {
-		t.Errorf("plan prompt missing PlanArtifactPath %q so the runner and agent can't agree on where the plan goes:\n%s",
-			PlanArtifactPath, got)
-	}
-	if !strings.Contains(got, "standard_v1") {
-		t.Errorf("plan prompt missing schema version reference:\n%s", got)
+	for _, w := range wants {
+		if !strings.Contains(got, w) {
+			t.Errorf("plan prompt missing %q:\n%s", w, got)
+		}
 	}
 }
 

--- a/scripts/sync-schemas
+++ b/scripts/sync-schemas
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -eu
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+cp "$REPO_ROOT/docs/spec/workflow-v0.schema.json" \
+   "$REPO_ROOT/backend/internal/spec/schemas/workflow-v0.schema.json"
+cp "$REPO_ROOT/docs/spec/workflow-v0.schema.json" \
+   "$REPO_ROOT/cli/internal/spec/schemas/workflow-v0.schema.json"
+cp "$REPO_ROOT/docs/spec/plan-standard-v1.schema.json" \
+   "$REPO_ROOT/backend/internal/plan/schemas/plan-standard-v1.schema.json"
+cp "$REPO_ROOT/docs/spec/plan-standard-v1.schema.json" \
+   "$REPO_ROOT/runner/internal/plan/schemas/plan-standard-v1.schema.json"
+
+echo "schemas synced from docs/spec/"


### PR DESCRIPTION
## Summary

Embedded JSON Schema files have **four** copies across the repo (canonical `docs/spec/` + three module-embedded mirrors). The CI gate diffs all four pairs; an agent or operator that updates only the canonical copy ships drift. Hit twice in the last 24h (#459 and #461 both needed schema-sync fixup commits).

Three pieces in this PR:

1. **`scripts/sync-schemas`** — bash script (POSIX-compatible, macOS bash 3.2 safe per CLAUDE.md trap) that mirrors `docs/spec/*.schema.json` into every embedded location. Idempotent — running twice produces no diff.

2. **`.githooks/pre-commit`** — opt-in pre-commit hook (`git config core.hooksPath .githooks`) running the same four `diff -u` checks as the CI gate. Names the divergent file + points at `scripts/sync-schemas` as remediation.

3. **Prompt + CLAUDE.md surfacing**:
   - `backend/internal/prompt/prompt.go::buildPlan` appends a "if you touch `docs/spec/*.schema.json`, run `scripts/sync-schemas` after editing" hint to every plan-stage prompt.
   - CLAUDE.md "Build, test, lint" section documents both the script and the opt-in hook.

## Test plan

- [x] `scripts/sync-schemas` runs idempotently from the repo root (verified twice — second run produces no `git diff` change).
- [x] `.githooks/pre-commit` exits 0 on clean schemas, exits 1 with named-file diagnostic when any mirror is out of sync.
- [x] `scripts/test` — full gate green.
- [x] `golangci-lint run ./backend/...` — clean.

## Notes

**Authored via the local MCP loop** on run `971261bd-e01c-4b77-a63c-6e61c91c5ec1`. The first attempt failed because the rebuilt runner emitted plans with #461's new required fields while the running `fishhawkd` was still the pre-#461 binary — surfaced a real operator footgun: **rebuilt runner + stale backend = plan rejection on every upload**. Worth folding into #443 (`fishhawk doctor`) as a coupled-binary-version check. Re-minted after backend restart and the second loop completed cleanly.

When this merges, the next schema-touching PR's plan should reference `scripts/sync-schemas` and the agent will pick it up via the new prompt hint. Closes the most common failure mode #460 was filed to address; #462 picks up the sibling fixture-cascade gap.

Closes #460