### PR TITLE
planfixture: centralized test builders to prevent required-field cascade (#462)

### DIFF
--- a/backend/internal/plan/plan_test.go
+++ b/backend/internal/plan/plan_test.go
@@ -1,6 +1,7 @@
 package plan_test
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"strings"
@@ -8,6 +9,7 @@ import (
 	"time"
 
 	"github.com/kuhlman-labs/fishhawk/backend/internal/plan"
+	"github.com/kuhlman-labs/fishhawk/backend/internal/plan/planfixture"
 )
 
 func readFixture(t *testing.T, path string) []byte {
@@ -245,21 +247,14 @@ func TestSchemaError_FormatsPathAndMessage(t *testing.T) {
 	}
 }
 
-// validPlanJSON returns a minimal valid standard_v1 plan with the new required
-// runtime fields populated. Tests that need to vary one field use this as a base.
-func validPlanJSON(extras string) []byte {
-	body := `{
-  "plan_version": "standard_v1",
-  "ticket_reference": {"type": "github_issue", "url": "https://x", "id": "x"},
-  "generated_by": {"agent": "a", "model": "m", "timestamp": "2026-01-01T00:00:00Z"},
-  "summary": "x",
-  "scope": {"files": [{"path": "a.go", "operation": "create"}]},
-  "approach": [{"step": 1, "description": "x"}],
-  "verification": {"test_strategy": "x", "rollback_plan": "x"},
-  "predicted_runtime_minutes": 10,
-  "predicted_runtime_confidence": "medium"` + extras + `
-}`
-	return []byte(body)
+// marshalFixture marshals a fixture map to JSON, failing the test on error.
+func marshalFixture(t *testing.T, m map[string]any) []byte {
+	t.Helper()
+	b, err := json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
 }
 
 // --- predicted_runtime_minutes / predicted_runtime_confidence schema errors ---
@@ -324,13 +319,18 @@ func TestParse_PreD2Shape_NoRuntimeFields_IsSchemaError(t *testing.T) {
 
 func TestParse_DecompositionOneSubPlan_IsSchemaError(t *testing.T) {
 	// minItems:2 violation — a single sub-plan is rejected structurally.
-	_, err := plan.Parse(validPlanJSON(`,
-  "decomposition": {
-    "rationale": "too big",
-    "sub_plans": [
-      {"title": "Part A", "scope_hint": "first half", "predicted_runtime_minutes": 10, "predicted_runtime_confidence": "medium"}
-    ]
-  }`))
+	m := planfixture.Valid(func(m map[string]any) {
+		m["decomposition"] = map[string]any{
+			"rationale": "too big",
+			"sub_plans": []any{
+				map[string]any{
+					"title": "Part A", "scope_hint": "first half",
+					"predicted_runtime_minutes": 10, "predicted_runtime_confidence": "medium",
+				},
+			},
+		}
+	})
+	_, err := plan.Parse(marshalFixture(t, m))
 	var se *plan.SchemaError
 	if !errors.As(err, &se) {
 		t.Fatalf("err = %v, want *SchemaError", err)
@@ -340,14 +340,7 @@ func TestParse_DecompositionOneSubPlan_IsSchemaError(t *testing.T) {
 // --- decomposition happy path ---
 
 func TestParse_DecompositionTwoSubPlans_Succeeds(t *testing.T) {
-	p, err := plan.Parse(validPlanJSON(`,
-  "decomposition": {
-    "rationale": "work exceeded budget",
-    "sub_plans": [
-      {"title": "Part A", "scope_hint": "schema changes", "predicted_runtime_minutes": 8, "predicted_runtime_confidence": "high"},
-      {"title": "Part B", "scope_hint": "test updates",   "predicted_runtime_minutes": 6, "predicted_runtime_confidence": "medium"}
-    ]
-  }`))
+	p, err := plan.Parse(marshalFixture(t, planfixture.Decomposed()))
 	if err != nil {
 		t.Fatalf("Parse: %v", err)
 	}
@@ -362,14 +355,22 @@ func TestParse_DecompositionTwoSubPlans_Succeeds(t *testing.T) {
 // --- decomposition semantic errors ---
 
 func TestParse_DecompositionDuplicateTitles_IsSemanticError(t *testing.T) {
-	_, err := plan.Parse(validPlanJSON(`,
-  "decomposition": {
-    "rationale": "too big",
-    "sub_plans": [
-      {"title": "Same Title", "scope_hint": "first",  "predicted_runtime_minutes": 5, "predicted_runtime_confidence": "low"},
-      {"title": "Same Title", "scope_hint": "second", "predicted_runtime_minutes": 5, "predicted_runtime_confidence": "low"}
-    ]
-  }`))
+	m := planfixture.Valid(func(m map[string]any) {
+		m["decomposition"] = map[string]any{
+			"rationale": "too big",
+			"sub_plans": []any{
+				map[string]any{
+					"title": "Same Title", "scope_hint": "first",
+					"predicted_runtime_minutes": 5, "predicted_runtime_confidence": "low",
+				},
+				map[string]any{
+					"title": "Same Title", "scope_hint": "second",
+					"predicted_runtime_minutes": 5, "predicted_runtime_confidence": "low",
+				},
+			},
+		}
+	})
+	_, err := plan.Parse(marshalFixture(t, m))
 	var se *plan.SemanticError
 	if !errors.As(err, &se) {
 		t.Fatalf("err = %v, want *SemanticError", err)

--- a/backend/internal/plan/planfixture/planfixture.go
+++ b/backend/internal/plan/planfixture/planfixture.go
@@ -1,0 +1,86 @@
+// Package planfixture provides centralized test-fixture builders for
+// standard_v1 plan artifacts. Import in test files to avoid per-test
+// inline JSON that drifts when the schema gains required fields.
+//
+// Three entry points:
+//   - Valid returns a minimal schema-valid plan fixture.
+//   - Invalid returns Valid() minus one top-level field, for negative tests.
+//   - Decomposed returns Valid() extended with a two-sub-plan decomposition.
+//
+// All three accept optional Option values to override individual fields.
+package planfixture
+
+// Option modifies a fixture map in place. Pass to Valid, Invalid, or
+// Decomposed to override defaults for a specific test case.
+type Option func(map[string]any)
+
+// Valid returns the minimal valid standard_v1 plan fixture as a map.
+// All required schema fields are set. Apply Option values to extend or
+// override specific fields before marshalling to JSON.
+func Valid(opts ...Option) map[string]any {
+	m := map[string]any{
+		"plan_version": "standard_v1",
+		"ticket_reference": map[string]any{
+			"type": "github_issue",
+			"url":  "https://github.com/x/y/issues/1",
+			"id":   "x/y#1",
+		},
+		"generated_by": map[string]any{
+			"agent":     "claude-code",
+			"model":     "claude-opus-4-7",
+			"timestamp": "2026-01-01T00:00:00Z",
+		},
+		"summary": "Add a thing.",
+		"scope": map[string]any{
+			"files": []any{
+				map[string]any{"path": "a.go", "operation": "create"},
+			},
+		},
+		"approach": []any{
+			map[string]any{"step": 1, "description": "Do the work."},
+		},
+		"verification": map[string]any{
+			"test_strategy": "Run the tests.",
+			"rollback_plan": "Revert the PR.",
+		},
+		"predicted_runtime_minutes":    20,
+		"predicted_runtime_confidence": "medium",
+	}
+	for _, o := range opts {
+		o(m)
+	}
+	return m
+}
+
+// Invalid deep-copies Valid (applying opts first) then deletes the
+// named top-level field. Use for negative-path tests that need a plan
+// missing exactly one required field.
+func Invalid(field string, opts ...Option) map[string]any {
+	m := Valid(opts...)
+	delete(m, field)
+	return m
+}
+
+// Decomposed extends Valid with a two-sub-plan decomposition block.
+// Sub-plan titles are distinct so semantic duplicate-title checks pass.
+func Decomposed(opts ...Option) map[string]any {
+	m := Valid(opts...)
+	m["decomposition"] = map[string]any{
+		"rationale": "scope exceeded single-stage budget",
+		"sub_plans": []any{
+			map[string]any{
+				"title":                        "Part A",
+				"scope_hint":                   "first half",
+				"predicted_runtime_minutes":    10,
+				"predicted_runtime_confidence": "medium",
+			},
+			map[string]any{
+				"title":                        "Part B",
+				"scope_hint":                   "second half",
+				"predicted_runtime_minutes":    10,
+				"predicted_runtime_confidence": "medium",
+			},
+		},
+	}
+	return m
+}

--- a/backend/internal/plan/planfixture/planfixture_test.go
+++ b/backend/internal/plan/planfixture/planfixture_test.go
@@ -1,0 +1,62 @@
+package planfixture_test
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/kuhlman-labs/fishhawk/backend/internal/plan"
+	"github.com/kuhlman-labs/fishhawk/backend/internal/plan/planfixture"
+)
+
+// TestValid_SchemaCompliant is the per-module CI gate: it fails whenever
+// Valid() is missing a required field added to the standard_v1 schema.
+func TestValid_SchemaCompliant(t *testing.T) {
+	b, err := json.Marshal(planfixture.Valid())
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := plan.Validate(b); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+}
+
+func TestDecomposed_SchemaCompliant(t *testing.T) {
+	b, err := json.Marshal(planfixture.Decomposed())
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := plan.Validate(b); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+}
+
+// TestValid_ParityWithExample verifies that every top-level key in
+// Valid() is also present in testdata/valid/example.json. When a new
+// required field is added to Valid(), this test fails if example.json
+// is not updated to match.
+func TestValid_ParityWithExample(t *testing.T) {
+	b, err := json.Marshal(planfixture.Valid())
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+	var fixture map[string]any
+	if err := json.Unmarshal(b, &fixture); err != nil {
+		t.Fatalf("unmarshal fixture: %v", err)
+	}
+
+	eb, err := os.ReadFile("../testdata/valid/example.json")
+	if err != nil {
+		t.Fatalf("read example.json: %v", err)
+	}
+	var example map[string]any
+	if err := json.Unmarshal(eb, &example); err != nil {
+		t.Fatalf("unmarshal example.json: %v", err)
+	}
+
+	for key := range fixture {
+		if _, ok := example[key]; !ok {
+			t.Errorf("example.json missing key %q — update example.json when planfixture.Valid() adds a required field", key)
+		}
+	}
+}

--- a/backend/internal/plan/testdata/valid/README.md
+++ b/backend/internal/plan/testdata/valid/README.md
@@ -1,0 +1,13 @@
+# testdata/valid
+
+`example.json` is a human-readable canonical example kept for documentation and
+as a stable reference for tests that verify the documented shape (e.g.
+`TestParse_Example`).
+
+## Keeping fixtures in sync
+
+When a required schema field is added to `standard_v1`, update
+`planfixture.Valid()` in `../planfixture/planfixture.go` first — the schema
+compliance test `TestValid_SchemaCompliant` catches missing required fields.
+Then update `example.json` here to include the new field; the parity test
+`TestValid_ParityWithExample` will fail until example.json is updated.

--- a/backend/internal/server/plan_test.go
+++ b/backend/internal/server/plan_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/kuhlman-labs/fishhawk/backend/internal/plan/planfixture"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/run"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/signing"
 )
@@ -22,40 +23,11 @@ import (
 // tests so the content_hash matches.
 func validPlanBytes(t *testing.T) []byte {
 	t.Helper()
-	body, err := json.Marshal(map[string]any{
-		"plan_version": "standard_v1",
-		"ticket_reference": map[string]any{
-			"type": "github_issue",
-			"url":  "https://github.com/kuhlman-labs/fishhawk/issues/184",
-			"id":   "kuhlman-labs/fishhawk#184",
-		},
-		"generated_by": map[string]any{
-			"agent":     "claude-code",
-			"model":     "claude-opus-4-7",
-			"version":   "test",
-			"timestamp": "2026-05-06T15:04:09Z",
-		},
-		"summary": "Add a make target.",
-		"scope": map[string]any{
-			"files": []map[string]any{
-				{"path": "Makefile", "operation": "modify"},
-			},
-			"estimated_lines_changed": 10,
-		},
-		"approach": []map[string]any{
-			{"step": 1, "description": "Add a make target."},
-		},
-		"verification": map[string]any{
-			"test_strategy": "Run the target twice; second run is a no-op.",
-			"rollback_plan": "Revert the diff.",
-		},
-		"predicted_runtime_minutes":    5,
-		"predicted_runtime_confidence": "medium",
-	})
+	b, err := json.Marshal(planfixture.Valid())
 	if err != nil {
 		t.Fatal(err)
 	}
-	return body
+	return b
 }
 
 // newPlanServer wires SigningRepo + ArtifactRepo + AuditRepo + RunRepo

--- a/backend/internal/server/prompt_plan_test.go
+++ b/backend/internal/server/prompt_plan_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kuhlman-labs/fishhawk/backend/internal/artifact"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/audit"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/githubclient"
+	"github.com/kuhlman-labs/fishhawk/backend/internal/plan/planfixture"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/run"
 )
 
@@ -176,39 +177,13 @@ func (a *planAuditRepo) LastForRun(context.Context, uuid.UUID) (*audit.Entry, er
 	return nil, audit.ErrNotFound
 }
 
-// fixturePlanJSON returns a minimal-but-complete standard_v1 plan as
-// the bytes the artifact would carry. Mirrors the runner's upload.
+// fixturePlanJSON returns a minimal standard_v1 plan as the bytes an
+// artifact would carry. Uses planfixture.Valid() so all required schema
+// fields (including predicted_runtime_minutes and predicted_runtime_confidence)
+// are present.
 func fixturePlanJSON(t *testing.T) []byte {
 	t.Helper()
-	body := map[string]any{
-		"plan_version": "standard_v1",
-		"ticket_reference": map[string]any{
-			"type": "github_issue",
-			"url":  "https://github.com/kuhlman-labs/example/issues/42",
-			"id":   "kuhlman-labs/example#42",
-		},
-		"generated_by": map[string]any{
-			"agent":     "claude-code",
-			"model":     "claude-opus-4-7",
-			"timestamp": "2026-05-07T12:00:00Z",
-		},
-		"summary": "Add a foo helper to pkg/bar.",
-		"scope": map[string]any{
-			"files": []any{
-				map[string]any{"path": "pkg/bar/foo.go", "operation": "create"},
-				map[string]any{"path": "pkg/bar/bar.go", "operation": "modify"},
-			},
-		},
-		"approach": []any{
-			map[string]any{"step": 1, "description": "Define Foo on the bar.Service interface."},
-			map[string]any{"step": 2, "description": "Implement Foo with a table-driven test."},
-		},
-		"verification": map[string]any{
-			"test_strategy": "Unit tests in pkg/bar.",
-			"rollback_plan": "Revert the PR.",
-		},
-	}
-	b, err := json.Marshal(body)
+	b, err := json.Marshal(planfixture.Valid())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -289,9 +264,9 @@ func TestImplementPrompt_LeadsWithApprovedPlan(t *testing.T) {
 	}
 	for _, want := range []string{
 		"Approved plan (binding instruction)",
-		"Add a foo helper to pkg/bar.",
-		"pkg/bar/foo.go (create)",
-		"1. Define Foo on the bar.Service interface.",
+		"Add a thing.",
+		"a.go (create)",
+		"1. Do the work.",
 		"binding instruction",
 		"diverging silently",
 		// Implement-stage prompt links the issue (#244): the body
@@ -446,7 +421,7 @@ func TestImplementPrompt_WalksParentRunForRetry(t *testing.T) {
 	if !strings.Contains(resp.Prompt, "Approved plan (binding instruction)") {
 		t.Errorf("retry prompt missed parent's plan:\n%s", resp.Prompt)
 	}
-	if !strings.Contains(resp.Prompt, "Add a foo helper to pkg/bar.") {
+	if !strings.Contains(resp.Prompt, "Add a thing.") {
 		t.Errorf("retry prompt missed parent plan summary:\n%s", resp.Prompt)
 	}
 	for _, e := range au.appended {

--- a/runner/cmd/fishhawk-runner/main_test.go
+++ b/runner/cmd/fishhawk-runner/main_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kuhlman-labs/fishhawk/runner/internal/agent"
 	"github.com/kuhlman-labs/fishhawk/runner/internal/bundle"
 	"github.com/kuhlman-labs/fishhawk/runner/internal/gitops"
+	"github.com/kuhlman-labs/fishhawk/runner/internal/plan/planfixture"
 	"github.com/kuhlman-labs/fishhawk/runner/internal/upload"
 )
 
@@ -599,21 +600,17 @@ func TestRun_BundleWriteFailureSurfacesAsExitFailure(t *testing.T) {
 	}
 }
 
-// validPlanJSON returns a minimal standard_v1 plan that the
-// validator accepts. Inline rather than reading a fixture so the
-// test is self-contained.
+// validPlanJSON returns a minimal standard_v1 plan that the validator
+// accepts, sourced from planfixture.Valid() so required-field additions
+// are caught by TestValid_SchemaCompliant rather than silently breaking
+// these tests. MarshalIndent preserves the "key": "value", substring
+// format so existing strings.Replace-based tamper tests still work.
 func validPlanJSON() string {
-	return `{
-  "plan_version": "standard_v1",
-  "ticket_reference": {"type":"github_issue","url":"https://github.com/x/y/issues/1","id":"x/y#1"},
-  "generated_by": {"agent":"claude-code","model":"claude-opus-4-7","version":"build-1","timestamp":"2026-05-02T10:00:00Z"},
-  "summary": "Add a thing.",
-  "scope": {"files": [{"path":"a.go","operation":"create"}], "estimated_lines_changed": 10},
-  "approach": [{"step":1,"description":"Do."}],
-  "verification": {"test_strategy":"go test","rollback_plan":"revert PR"},
-  "predicted_runtime_minutes": 5,
-  "predicted_runtime_confidence": "medium"
-}`
+	b, err := json.MarshalIndent(planfixture.Valid(), "", "  ")
+	if err != nil {
+		panic("planfixture.Valid marshal: " + err.Error())
+	}
+	return string(b)
 }
 
 func TestRun_PlanValidationOK(t *testing.T) {

--- a/runner/internal/plan/plan_test.go
+++ b/runner/internal/plan/plan_test.go
@@ -1,24 +1,25 @@
 package plan
 
 import (
+	"encoding/json"
 	"errors"
-	"os"
 	"strings"
 	"testing"
+
+	"github.com/kuhlman-labs/fishhawk/runner/internal/plan/planfixture"
 )
 
-func mustRead(t *testing.T, path string) []byte {
+func fixtureJSON(t *testing.T, m map[string]any) []byte {
 	t.Helper()
-	b, err := os.ReadFile(path)
+	b, err := json.Marshal(m)
 	if err != nil {
-		t.Fatalf("read %s: %v", path, err)
+		t.Fatal(err)
 	}
 	return b
 }
 
 func TestValidate_Valid(t *testing.T) {
-	data := mustRead(t, "testdata/valid/example.json")
-	if err := Validate(data); err != nil {
+	if err := Validate(fixtureJSON(t, planfixture.Valid())); err != nil {
 		t.Errorf("Validate: unexpected error: %v", err)
 	}
 }
@@ -46,7 +47,7 @@ func TestValidate_MalformedJSON(t *testing.T) {
 
 func TestValidate_MissingRequired(t *testing.T) {
 	// Drop the `summary` field — schema requires it.
-	src := mustRead(t, "testdata/valid/example.json")
+	src := fixtureJSON(t, planfixture.Valid())
 	tampered := strings.Replace(string(src), `"summary":`, `"summary_renamed":`, 1)
 	var serr *SchemaError
 	err := Validate([]byte(tampered))
@@ -61,8 +62,8 @@ func TestValidate_MissingRequired(t *testing.T) {
 func TestValidate_BadEnum(t *testing.T) {
 	// scope.files[].operation only accepts a closed set; "demolish"
 	// is not a member.
-	src := mustRead(t, "testdata/valid/example.json")
-	tampered := strings.Replace(string(src), `"operation": "create"`, `"operation": "demolish"`, 1)
+	src := fixtureJSON(t, planfixture.Valid())
+	tampered := strings.Replace(string(src), `"create"`, `"demolish"`, 1)
 	var serr *SchemaError
 	err := Validate([]byte(tampered))
 	if !errors.As(err, &serr) {
@@ -75,7 +76,7 @@ func TestValidate_BadEnum(t *testing.T) {
 
 func TestValidate_BadVersion(t *testing.T) {
 	// plan_version is constrained to "standard_v1".
-	src := mustRead(t, "testdata/valid/example.json")
+	src := fixtureJSON(t, planfixture.Valid())
 	tampered := strings.Replace(string(src), `"standard_v1"`, `"standard_v2"`, 1)
 	if err := Validate([]byte(tampered)); err == nil {
 		t.Fatal("expected version error")

--- a/runner/internal/plan/planfixture/planfixture.go
+++ b/runner/internal/plan/planfixture/planfixture.go
@@ -1,0 +1,90 @@
+// Package planfixture provides centralized test-fixture builders for
+// standard_v1 plan artifacts. Import in test files to avoid per-test
+// inline JSON that drifts when the schema gains required fields.
+//
+// Mirrors backend/internal/plan/planfixture: the runner module cannot
+// import backend packages directly (Go module boundary), so the
+// minimal valid shape is duplicated here. Keep Valid() field values
+// identical to the backend copy so the two modules agree on the
+// canonical fixture. When a required field is added, update both.
+//
+// Three entry points:
+//   - Valid returns a minimal schema-valid plan fixture.
+//   - Invalid returns Valid() minus one top-level field, for negative tests.
+//   - Decomposed returns Valid() extended with a two-sub-plan decomposition.
+package planfixture
+
+// Option modifies a fixture map in place. Pass to Valid, Invalid, or
+// Decomposed to override defaults for a specific test case.
+type Option func(map[string]any)
+
+// Valid returns the minimal valid standard_v1 plan fixture as a map.
+// All required schema fields are set. Apply Option values to extend or
+// override specific fields before marshalling to JSON.
+func Valid(opts ...Option) map[string]any {
+	m := map[string]any{
+		"plan_version": "standard_v1",
+		"ticket_reference": map[string]any{
+			"type": "github_issue",
+			"url":  "https://github.com/x/y/issues/1",
+			"id":   "x/y#1",
+		},
+		"generated_by": map[string]any{
+			"agent":     "claude-code",
+			"model":     "claude-opus-4-7",
+			"timestamp": "2026-01-01T00:00:00Z",
+		},
+		"summary": "Add a thing.",
+		"scope": map[string]any{
+			"files": []any{
+				map[string]any{"path": "a.go", "operation": "create"},
+			},
+		},
+		"approach": []any{
+			map[string]any{"step": 1, "description": "Do the work."},
+		},
+		"verification": map[string]any{
+			"test_strategy": "Run the tests.",
+			"rollback_plan": "Revert the PR.",
+		},
+		"predicted_runtime_minutes":    20,
+		"predicted_runtime_confidence": "medium",
+	}
+	for _, o := range opts {
+		o(m)
+	}
+	return m
+}
+
+// Invalid deep-copies Valid (applying opts first) then deletes the
+// named top-level field. Use for negative-path tests that need a plan
+// missing exactly one required field.
+func Invalid(field string, opts ...Option) map[string]any {
+	m := Valid(opts...)
+	delete(m, field)
+	return m
+}
+
+// Decomposed extends Valid with a two-sub-plan decomposition block.
+// Sub-plan titles are distinct so semantic duplicate-title checks pass.
+func Decomposed(opts ...Option) map[string]any {
+	m := Valid(opts...)
+	m["decomposition"] = map[string]any{
+		"rationale": "scope exceeded single-stage budget",
+		"sub_plans": []any{
+			map[string]any{
+				"title":                        "Part A",
+				"scope_hint":                   "first half",
+				"predicted_runtime_minutes":    10,
+				"predicted_runtime_confidence": "medium",
+			},
+			map[string]any{
+				"title":                        "Part B",
+				"scope_hint":                   "second half",
+				"predicted_runtime_minutes":    10,
+				"predicted_runtime_confidence": "medium",
+			},
+		},
+	}
+	return m
+}

--- a/runner/internal/plan/planfixture/planfixture_test.go
+++ b/runner/internal/plan/planfixture/planfixture_test.go
@@ -1,0 +1,62 @@
+package planfixture_test
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/kuhlman-labs/fishhawk/runner/internal/plan"
+	"github.com/kuhlman-labs/fishhawk/runner/internal/plan/planfixture"
+)
+
+// TestValid_SchemaCompliant is the per-module CI gate: it fails whenever
+// Valid() is missing a required field added to the standard_v1 schema.
+func TestValid_SchemaCompliant(t *testing.T) {
+	b, err := json.Marshal(planfixture.Valid())
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := plan.Validate(b); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+}
+
+func TestDecomposed_SchemaCompliant(t *testing.T) {
+	b, err := json.Marshal(planfixture.Decomposed())
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := plan.Validate(b); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+}
+
+// TestValid_ParityWithExample verifies that every top-level key in
+// Valid() is also present in testdata/valid/example.json. When a new
+// required field is added to Valid(), this test fails if example.json
+// is not updated to match.
+func TestValid_ParityWithExample(t *testing.T) {
+	b, err := json.Marshal(planfixture.Valid())
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+	var fixture map[string]any
+	if err := json.Unmarshal(b, &fixture); err != nil {
+		t.Fatalf("unmarshal fixture: %v", err)
+	}
+
+	eb, err := os.ReadFile("../testdata/valid/example.json")
+	if err != nil {
+		t.Fatalf("read example.json: %v", err)
+	}
+	var example map[string]any
+	if err := json.Unmarshal(eb, &example); err != nil {
+		t.Fatalf("unmarshal example.json: %v", err)
+	}
+
+	for key := range fixture {
+		if _, ok := example[key]; !ok {
+			t.Errorf("example.json missing key %q — update example.json when planfixture.Valid() adds a required field", key)
+		}
+	}
+}

--- a/runner/internal/plan/testdata/valid/README.md
+++ b/runner/internal/plan/testdata/valid/README.md
@@ -1,0 +1,12 @@
+# testdata/valid
+
+`example.json` is a human-readable canonical example kept for documentation and
+as a stable reference for schema validation tests.
+
+## Keeping fixtures in sync
+
+When a required schema field is added to `standard_v1`, update
+`planfixture.Valid()` in `../planfixture/planfixture.go` first — the schema
+compliance test `TestValid_SchemaCompliant` catches missing required fields.
+Then update `example.json` here to include the new field; the parity test
+`TestValid_ParityWithExample` will fail until example.json is updated.

--- a/runner/internal/plan/testdata/valid/example.json
+++ b/runner/internal/plan/testdata/valid/example.json
@@ -31,6 +31,6 @@
     "Assumes (created_at, entry_id) is the natural sort order.",
     "Risk: very large date ranges; mitigated by per-page limit of 1000 rows."
   ],
-  "predicted_runtime_minutes": 25,
+  "predicted_runtime_minutes": 20,
   "predicted_runtime_confidence": "medium"
 }


### PR DESCRIPTION
## Summary

Sibling to #460 (just merged as #463). Same root cause — issue-body-as-spec can't enumerate every callsite — applied to test fixtures.

Two new packages + intra-module parity tests + refactor of five hand-written plan fixtures across the repo:

### Per-module fixture builders
- `backend/internal/plan/planfixture/` — `Valid()`, `Invalid(field)`, `Decomposed()` builders with `Option` functional pattern.
- `runner/internal/plan/planfixture/` — mirror package (Go module boundaries prevent cross-import).

### Intra-module parity test
Each module's `planfixture_test.go` decodes `Valid()` and `testdata/valid/example.json` to maps and compares — catches drift between the builder and the documentation file. When a required field is added to `Valid()`, the parity test fails until `example.json` is updated.

### Test refactors (5 sites collapsed to one `planfixture.Valid()` call each)
- `backend/internal/plan/plan_test.go::validPlanJSON()`
- `backend/internal/server/plan_test.go::validPlanBytes()`
- `backend/internal/server/prompt_plan_test.go::fixturePlanJSON()` — **incidentally fixes a latent D2 bug** (this fixture was missing the new required fields; tests passed only because the prompt-plan code path doesn't validate)
- `runner/internal/plan/plan_test.go` — same
- `runner/cmd/fishhawk-runner/main_test.go::validPlanJSON()` — same

### Reconciled drift
Backend's `testdata/valid/example.json` and runner's diverged on `predicted_runtime_minutes` (20 vs 25). Reconciled to 20 (backend canonical). Surfaced during planning — exactly the kind of latent drift this issue's tooling makes visible.

### Documentation
`testdata/valid/example.json` files keep as canonical "what a plan looks like" docs; new sibling `README.md` files point at the `planfixture` package as the source of truth for required-field updates.

## Test plan

- [x] `scripts/test` — full gate green.
- [x] `golangci-lint run ./backend/... ./runner/...` — clean.
- [x] Both `planfixture_test.go` files pass `TestValid_SchemaCompliant` + the intra-module parity assertion.
- [x] Manually delete `predicted_runtime_minutes` from `planfixture.Valid()` → `TestValid_SchemaCompliant` fails as expected (regression guard verified).

## Notes

**Authored via local MCP loop** on run `05535c00-14f8-45b5-af32-e00775a9ff2d`. Same pattern as #422: the implement stage timed out at 15m but the work was complete — runner staged everything via `git add -A` before exit, tests passed locally. This is the third 15m-cap encounter and reinforces #449 (configurable timeout) as the next-most-impactful methodology fix.

When the next plan-schema or workflow-spec required-field change lands, the agent's plan should be: "update the schema → update `planfixture.Valid()` in N modules → done." Versus today's: "update the schema → enumerate every test that hand-rolls a fixture → update each → hope you caught them all." That's the win.

Together with #463 (just merged): schema-touching PRs now have automatic mirror sync + automatic fixture coverage via the builder. The most common dogfood-failure class is closed.

Closes #462