### PR TITLE
spec: feature_change.policy.max_stage_runtime = 30m (#477)

### DIFF
--- a/.fishhawk/workflows.yaml
+++ b/.fishhawk/workflows.yaml
@@ -26,6 +26,8 @@ workflows:
     description: >-
       Default workflow for feature work and non-trivial changes.
       Human approves plan and PR; agent does the implementation.
+    policy:
+      max_stage_runtime: "30m"
     # Auto-retry once on CI failure (#276). The human approves the
     # plan; the agent should self-heal on a routine test or lint
     # regression without forcing the reviewer back into the loop.


### PR DESCRIPTION
## Summary

- Declare `policy.max_stage_runtime: "30m"` on the `feature_change` workflow in `.fishhawk/workflows.yaml`.
- D1 plumbed the field; D3 enforces it; the spec file never set it. Until now every stage fell back to the 15-minute backend default.

## Notes

Driven through the local MCP loop (run `5a8f11e9`) on #477. 5.7k tokens on plan + 2k on implement. Plan agent estimated within budget; D3 budget check passed cleanly; sweeper was a no-op since no decomposition. End-to-end MCP loop on the post-D4 binary — first iteration since #475 merged.

`human_led_change` and `routine_change` keep the default — neither runs long-form agent stages.

## Test plan

- [x] `check-jsonschema --schemafile docs/spec/workflow-v0.schema.json .fishhawk/workflows.yaml` — valid.
- [x] `scripts/test` — all gates green.
- [x] `golangci-lint run ./backend/...` — 0 issues.
- [ ] Live verification (post-merge): mint a new `feature_change` run and confirm `ResolveStageTimeout` returns 30m from the spec.

Closes #477