### PR TITLE
server: signing-key TTL tracks resolved stage budget (#482)

### DIFF
--- a/backend/internal/server/signing.go
+++ b/backend/internal/server/signing.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -42,6 +43,49 @@ const (
 	maxTTLSeconds = 3600
 )
 
+// signingKeyTTLBuffer is added to the resolved stage budget when
+// computing the server-side signing key TTL, so a stage that runs
+// its full budget still has a valid key when it uploads its trace.
+const signingKeyTTLBuffer = 5 * time.Minute
+
+// resolveSigningKeyTTL returns the TTL to use when issuing a signing
+// key for runID. It resolves the active stage's budget via
+// resolveAgentTimeout and returns max(DefaultTTL, budget + buffer).
+// Falls back to DefaultTTL when RunRepo is unconfigured, the run
+// cannot be fetched, the spec is absent, or no active stage is found.
+func (s *Server) resolveSigningKeyTTL(ctx context.Context, runID uuid.UUID) time.Duration {
+	if s.cfg.RunRepo == nil {
+		return signing.DefaultTTL
+	}
+	runRow, err := s.cfg.RunRepo.GetRun(ctx, runID)
+	if err != nil || runRow.WorkflowSpec == nil {
+		return signing.DefaultTTL
+	}
+	stages, err := s.cfg.RunRepo.ListStagesForRun(ctx, runID)
+	if err != nil {
+		return signing.DefaultTTL
+	}
+	var activeStage *run.Stage
+	for _, st := range stages {
+		if st.State == run.StageStateDispatched || st.State == run.StageStateRunning {
+			activeStage = st
+			break
+		}
+	}
+	if activeStage == nil {
+		return signing.DefaultTTL
+	}
+	budgetSeconds := s.resolveAgentTimeout(ctx, runRow, activeStage.Type)
+	if budgetSeconds == 0 {
+		return signing.DefaultTTL
+	}
+	candidate := time.Duration(budgetSeconds)*time.Second + signingKeyTTLBuffer
+	if candidate > signing.DefaultTTL {
+		return candidate
+	}
+	return signing.DefaultTTL
+}
+
 // handleIssueSigningKey implements POST /v0/runs/{run_id}/signing-key.
 //
 // AUTH: per the OpenAPI contract this endpoint requires a GitHub
@@ -71,9 +115,10 @@ func (s *Server) handleIssueSigningKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Body is optional. An empty / missing body uses the default
-	// TTL; a present body must parse cleanly.
-	ttl := signing.DefaultTTL
+	// Body is optional. An empty / missing body uses the spec-resolved
+	// TTL (max of DefaultTTL and the active stage budget + buffer);
+	// a present body must parse cleanly.
+	ttl := s.resolveSigningKeyTTL(r.Context(), runID)
 	if r.ContentLength != 0 {
 		var req signingKeyRequest
 		dec := json.NewDecoder(r.Body)

--- a/backend/internal/server/signing_test.go
+++ b/backend/internal/server/signing_test.go
@@ -316,11 +316,13 @@ func (s *stubOIDCVerifier) Verify(_ context.Context, token string, exp githuboid
 	return s.claims, nil
 }
 
-// fakeOIDCRunRepo provides GetRun for OIDC claim binding. Other
-// run.Repository methods panic so accidental calls are loud.
+// fakeOIDCRunRepo provides GetRun for OIDC claim binding and
+// ListStagesForRun for TTL resolution. Other run.Repository methods
+// return errors so accidental calls are loud.
 type fakeOIDCRunRepo struct {
 	runRow *run.Run
 	getErr error
+	stages []*run.Stage
 }
 
 func (r *fakeOIDCRunRepo) GetRun(_ context.Context, id uuid.UUID) (*run.Run, error) {
@@ -353,8 +355,8 @@ func (r *fakeOIDCRunRepo) CreateStage(context.Context, run.CreateStageParams) (*
 func (r *fakeOIDCRunRepo) GetStage(context.Context, uuid.UUID) (*run.Stage, error) {
 	return nil, errors.New("not used")
 }
-func (r *fakeOIDCRunRepo) ListStagesForRun(context.Context, uuid.UUID) ([]*run.Stage, error) {
-	return nil, errors.New("not used")
+func (r *fakeOIDCRunRepo) ListStagesForRun(_ context.Context, _ uuid.UUID) ([]*run.Stage, error) {
+	return r.stages, nil
 }
 func (r *fakeOIDCRunRepo) ListStagesAwaitingApproval(context.Context) ([]*run.Stage, error) {
 	return nil, errors.New("not used")
@@ -569,5 +571,151 @@ func TestIssueSigningKey_OIDC_VerifierWithoutRunRepo(t *testing.T) {
 	w := issueRequestWithAuth(t, s, uuid.New(), "Bearer x")
 	if w.Code != http.StatusServiceUnavailable {
 		t.Errorf("status = %d, want 503", w.Code)
+	}
+}
+
+func TestIssueSigningKey_TTLTracksStagePolicy(t *testing.T) {
+	// policy.max_stage_runtime=60m on an active plan stage → TTL = 65m.
+	spec60m := []byte(`version: "0.3"
+workflows:
+  feature_change:
+    policy:
+      max_stage_runtime: "60m"
+    stages:
+      - id: plan
+        type: plan
+        executor:
+          agent: claude-code
+        produces:
+          - artifact: plan
+            schema: standard_v1
+      - id: implement
+        type: implement
+        executor:
+          agent: claude-code
+        produces:
+          - artifact: pull_request
+`)
+	runID := uuid.New()
+	runRepo := &fakeOIDCRunRepo{
+		runRow: &run.Run{
+			ID:           runID,
+			Repo:         "kuhlman-labs/example",
+			WorkflowID:   "feature_change",
+			WorkflowSpec: spec60m,
+		},
+		stages: []*run.Stage{
+			{
+				ID:    uuid.New(),
+				RunID: runID,
+				Type:  run.StageTypePlan,
+				State: run.StageStateDispatched,
+			},
+		},
+	}
+	s := New(Config{
+		Addr:        "127.0.0.1:0",
+		SigningRepo: newFakeSigningRepo(),
+		RunRepo:     runRepo,
+	})
+
+	w := issueRequest(t, s, runID, nil)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201:\n%s", w.Code, w.Body.String())
+	}
+	var got signingKeyResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	want := 65 * time.Minute
+	if ttl := got.ExpiresAt.Sub(got.IssuedAt); ttl != want {
+		t.Errorf("TTL = %v, want %v", ttl, want)
+	}
+}
+
+func TestIssueSigningKey_TTLNeverShrinksBelowDefault(t *testing.T) {
+	// executor.timeout=5m on the plan stage → candidate = 10m < DefaultTTL → TTL = 30m.
+	spec5m := []byte(`version: "0.3"
+workflows:
+  feature_change:
+    stages:
+      - id: plan
+        type: plan
+        executor:
+          agent: claude-code
+          timeout: "5m"
+        produces:
+          - artifact: plan
+            schema: standard_v1
+      - id: implement
+        type: implement
+        executor:
+          agent: claude-code
+        produces:
+          - artifact: pull_request
+`)
+	runID := uuid.New()
+	runRepo := &fakeOIDCRunRepo{
+		runRow: &run.Run{
+			ID:           runID,
+			Repo:         "kuhlman-labs/example",
+			WorkflowID:   "feature_change",
+			WorkflowSpec: spec5m,
+		},
+		stages: []*run.Stage{
+			{
+				ID:    uuid.New(),
+				RunID: runID,
+				Type:  run.StageTypePlan,
+				State: run.StageStateDispatched,
+			},
+		},
+	}
+	s := New(Config{
+		Addr:        "127.0.0.1:0",
+		SigningRepo: newFakeSigningRepo(),
+		RunRepo:     runRepo,
+	})
+
+	w := issueRequest(t, s, runID, nil)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201:\n%s", w.Code, w.Body.String())
+	}
+	var got signingKeyResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if ttl := got.ExpiresAt.Sub(got.IssuedAt); ttl != signing.DefaultTTL {
+		t.Errorf("TTL = %v, want %v (DefaultTTL)", ttl, signing.DefaultTTL)
+	}
+}
+
+func TestIssueSigningKey_NoSpecFallsBackToDefault(t *testing.T) {
+	// WorkflowSpec=nil → DefaultTTL regardless of stage state.
+	runID := uuid.New()
+	runRepo := &fakeOIDCRunRepo{
+		runRow: &run.Run{
+			ID:           runID,
+			Repo:         "kuhlman-labs/example",
+			WorkflowID:   "feature_change",
+			WorkflowSpec: nil,
+		},
+	}
+	s := New(Config{
+		Addr:        "127.0.0.1:0",
+		SigningRepo: newFakeSigningRepo(),
+		RunRepo:     runRepo,
+	})
+
+	w := issueRequest(t, s, runID, nil)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201:\n%s", w.Code, w.Body.String())
+	}
+	var got signingKeyResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if ttl := got.ExpiresAt.Sub(got.IssuedAt); ttl != signing.DefaultTTL {
+		t.Errorf("TTL = %v, want %v (DefaultTTL)", ttl, signing.DefaultTTL)
 	}
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -129,7 +129,7 @@ The frontend (`/frontend`, planned) is its own npm workspace; it talks to the ba
 | Web UI (CSRF) | `__Host-csrf` cookie + `X-CSRF-Token` header | Tied to session row | With session |
 | CLI / programmatic API | `Authorization: Bearer <opaque-token>` | `api_tokens` row with scopes | Immediate (mark revoked) |
 | Runner → backend | GitHub OIDC token (verified per request) | Stateless | TTL ~10min from GitHub |
-| Runner trace upload | Ed25519 signature with per-run key | `signing_keys` row | TTL 30min |
+| Runner trace upload | Ed25519 signature with per-run key | `signing_keys` row | TTL = max(30m, resolved stage budget + 5m); budget sourced from `spec.ResolveStageTimeout` so timed-out stages retain a valid key long enough to upload their trace |
 
 GitHub OAuth (E4.2 / #49) is the sign-in flow that mints the cookie session. Approvers in the workflow spec resolve to GitHub team members via the GitHub App's installation token (E4.4 / #50).
 

--- a/docs/api/v0.openapi.yaml
+++ b/docs/api/v0.openapi.yaml
@@ -1648,6 +1648,15 @@ paths:
         key for the run; older rows remain so the standalone audit
         verifier can replay any signature that was valid at upload
         time. Migration 0012.
+
+        TTL: the server sets `expires_at` to
+        `max(30m, resolved_stage_budget + 5m)`, where
+        `resolved_stage_budget` is the spec-governed timeout for the
+        stage currently in `dispatched` or `running` state (sourced
+        from `spec.ResolveStageTimeout`). This ensures a stage that
+        runs its full budget still holds a valid key when it uploads
+        its trace. Runs without a workflow spec, or with no active
+        stage, default to 30m.
       tags: [runner]
       security:
         - githubOIDC: []


### PR DESCRIPTION
## Summary

- New `resolveSigningKeyTTL` helper on `*Server`: looks up the active stage's spec-resolved budget via the existing `resolveAgentTimeout` helper and returns `max(signing.DefaultTTL, resolved_budget + 5min)`.
- `handleIssueSigningKey` switches from the fixed `signing.DefaultTTL` to the resolved value when no `ttl_seconds` is supplied by the caller. Caller-supplied overrides are unchanged (subject to existing clamp).
- Fallback chain: nil RunRepo / GetRun error / WorkflowSpec=nil / no active stage / unparseable spec → `signing.DefaultTTL`. We never shrink below today's behavior.

## Notes

Driven through the local MCP loop (run `d0de0abc`) — second clean loop in a row. Implement finished in 17k tokens. The implementation is a tight extension of the existing `resolveAgentTimeout` plumbing from #459 (D1) and #483 (Trigger field population).

This unblocks trace telemetry on timed-out stages: previously the runner's `ShipTrace` would race the 30-minute key expiry on a 30-minute stage budget and lose. Now the key has a 5-minute grace window past the budget to land its trace before failing.

## Test plan

- [x] `scripts/test` — all gates green.
- [x] `scripts/test coverage` — aggregate 82.1% (above 80% gate).
- [x] `golangci-lint run ./backend/...` — 0 issues.
- [x] Three new signing_test cases cover the precedence: 60m policy budget → 65m TTL; 5m stage executor timeout → DefaultTTL wins (no shrinkage); no spec → DefaultTTL.
- [ ] Live-fire verification: next 30m timed-out stage should successfully upload its trace before key expiry.

Closes #482