### PR TITLE
prompt: citation-or-test rule for plan-stage risks (#447)

### DIFF
--- a/backend/internal/prompt/prompt.go
+++ b/backend/internal/prompt/prompt.go
@@ -227,6 +227,17 @@ func buildPlan(t Trigger) string {
 	b.WriteString("\n")
 	b.WriteString("If your plan scope includes any file under docs/spec/, the verification steps must include: " +
 		"run scripts/sync-schemas after editing the canonical copy; CI schema-sync gate will catch embedded copies that drift.\n")
+	b.WriteString("\n")
+	b.WriteString("Citation-or-test rule: for every non-obvious OS, runtime, network, or third-party-API semantic claim in risks_and_assumptions, " +
+		"the entry MUST include either a citation (URL, man page, RFC number) or a concrete test that would fail if the assumption is wrong. " +
+		"An unsupported claim that looks well-reasoned disarms the reviewer's check reflex — if it sounds plausible, reviewers stop verifying.\n")
+	b.WriteString("\n")
+	b.WriteString("Counter-examples from production bugs:\n")
+	b.WriteString("- SIGKILL and orphan file descriptors: SIGKILL kills only the direct child process; grandchildren that inherited stdout " +
+		"via fork keep the pipe writer alive, preventing EOF on the reader. Fix: set syscall.SysProcAttr Setpgid:true and send " +
+		"kill(-pgid, SIGKILL). Cited: syscall.SysProcAttr docs (https://pkg.go.dev/syscall#SysProcAttr).\n")
+	b.WriteString("- cmd.Wait and pipe-read race: cmd.Wait closes the parent-side pipe file descriptors while a goroutine is still reading " +
+		"from them. Fix: drain the pipe before calling Wait, or use io.Pipe indirection. Cited: os/exec.Cmd.Wait docs (https://pkg.go.dev/os/exec#Cmd.Wait).\n")
 	return b.String()
 }
 

--- a/backend/internal/prompt/prompt_test.go
+++ b/backend/internal/prompt/prompt_test.go
@@ -158,6 +158,7 @@ func TestBuild_Plan(t *testing.T) {
 		"standard_v1",
 		"scripts/sync-schemas",
 		"docs/spec/",
+		"citation",
 	}
 	for _, w := range wants {
 		if !strings.Contains(got, w) {
@@ -327,6 +328,30 @@ func TestBuild_Implement_WithApprovedPlan_IsDeterministic(t *testing.T) {
 	b, _ := Build("implement", tr)
 	if a != b {
 		t.Error("Build with ApprovedPlan is non-deterministic across calls")
+	}
+}
+
+func TestBuild_Plan_CitationOrTestRule(t *testing.T) {
+	got, err := Build("plan", Trigger{
+		IssueNumber: 7,
+		IssueTitle:  "Plan a refactor",
+		Repo:        "x/y",
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	wants := []string{
+		"citation",
+		"test",
+		"risks_and_assumptions",
+		"SIGKILL",
+		"cmd.Wait",
+		"syscall.SysProcAttr",
+	}
+	for _, w := range wants {
+		if !strings.Contains(got, w) {
+			t.Errorf("plan prompt missing citation-or-test rule string %q\n---\n%s", w, got)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- `backend/internal/prompt/buildPlan` gains a citation-or-test paragraph: for any non-obvious OS/runtime/API semantic claim in `risks_and_assumptions`, the agent must either cite the supporting source (docs URL, RFC, stdlib reference) or propose a concrete test that would fail if the assumption is wrong.
- Two grounded examples baked into the prompt text — the SIGKILL/orphan-fd case and the `cmd.Wait`/pipe-read race — so the agent reads real failure modes, not just abstract rules.
- New `TestBuild_Plan_CitationOrTestRule` asserts the load-bearing strings stay in the rendered prompt; extends `TestBuild_Plan` wants slice with `citation` so a silent regression fails an existing test.

## Notes

The smallest loop of the day — 6k tokens plan, 4.4k tokens implement, 38 LoC. Driven through the local MCP loop (run `e3672243`).

**Meta detail worth flagging**: the plan that generated this PR exemplifies the rule it adds. Its own `risks_and_assumptions` section cites the exact two Go stdlib docs (`syscall.SysProcAttr` and `os/exec#Cmd.Wait`) it then bakes into the prompt as examples. Self-validating.

The rule is forward-looking: existing finished plans (#424, #438, etc.) are unaffected. The next plan-stage run will see the new prompt.

## Test plan

- [x] `scripts/test` — all gates green.
- [x] `scripts/test coverage` — aggregate 82.2% (above 80% gate).
- [x] `golangci-lint run ./backend/...` — 0 issues.
- [x] `TestBuild_Plan_CitationOrTestRule` validates the new section is present.
- [x] Extended `TestBuild_Plan` wants slice catches silent removal of the citation requirement.
- [ ] Live verification: next plan-stage run should show a citation or empirical test for any OS-semantic claim it makes.

Closes #447