### PR TITLE
mcp: enrich fishhawk_run_stage result with diff + audit + run URL (#442)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,12 @@ node_modules/
 # Local Fishhawk runtime state (when the product can produce it)
 .fishhawk/runs/
 .fishhawk/cache/
+
+# Go build artifacts produced when running `go build` inside a module
+# subdirectory (default output is the package name as a binary in cwd).
+# Repo-canonical binaries live in /bin (already ignored above).
+backend/fishhawkd
+backend/fishhawk-mcp
+runner/fishhawk-runner
+cli/fishhawk
+verifier/fishhawk-verify

--- a/backend/cmd/fishhawk-mcp/run_stage.go
+++ b/backend/cmd/fishhawk-mcp/run_stage.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -52,6 +53,40 @@ var runStageGitRemoteOriginURL = func(dir string) (string, error) {
 // shorten it.
 var runStageGracePeriod = 30 * time.Second
 
+// runStageGitNumstat runs `git show --numstat HEAD` in dir and returns
+// the raw output. Exposed as a var so tests can inject fake output
+// without needing a real git repo.
+var runStageGitNumstat = func(dir string) (string, error) {
+	cmd := exec.Command("git", "show", "--numstat", "HEAD")
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+// DiffSummary reports the diff stats for the commit the runner made.
+// Present only when the runner emitted a git_diff event and
+// git show --numstat HEAD succeeded; nil otherwise (e.g. plan stages,
+// or runners that exited without committing).
+type DiffSummary struct {
+	FilesChanged int `json:"files_changed"`
+	Insertions   int `json:"insertions"`
+	Deletions    int `json:"deletions"`
+}
+
+// AuditPointer identifies the most-recent audit entry for the run.
+// Populated after the runner exits via GET /v0/audit?run_id=<id>&limit=1;
+// nil on any fetch failure.
+type AuditPointer struct {
+	LatestSequence int64  `json:"latest_sequence"`
+	EntryHash      string `json:"entry_hash"`
+	URL            string `json:"url"`
+}
+
 // RunStageInput is the fishhawk_run_stage tool's input schema
 // (ADR-024 / #433, impl #434). Mirrors `fishhawk runner start`'s
 // flags so an agent driving the local-runner loop end-to-end via
@@ -78,11 +113,18 @@ type RunStageInput struct {
 // lines, failed post-run stage fetch, missing github_repo, etc.
 // None of these fail the tool itself — the runner's exit is the
 // canonical outcome.
+//
+// DiffSummary, AuditPointer, and RunURL are best-effort enrichment
+// fields; they are omitted (nil / empty) when unavailable and never
+// fail the tool.
 type RunStageOutput struct {
-	ExitCode   int           `json:"exit_code"`
-	StageState string        `json:"stage_state,omitempty" jsonschema:"final stage state fetched after the runner exits; empty when the fetch failed"`
-	Events     []RunnerEvent `json:"events" jsonschema:"runner-emitted JSONL events in arrival order"`
-	Warnings   []string      `json:"warnings,omitempty"`
+	ExitCode     int           `json:"exit_code"`
+	StageState   string        `json:"stage_state,omitempty" jsonschema:"final stage state fetched after the runner exits; empty when the fetch failed"`
+	Events       []RunnerEvent `json:"events" jsonschema:"runner-emitted JSONL events in arrival order"`
+	Warnings     []string      `json:"warnings,omitempty"`
+	DiffSummary  *DiffSummary  `json:"diff_summary,omitempty" jsonschema:"present when the runner emitted a git_diff event and git show --numstat HEAD succeeded; nil for plan stages"`
+	AuditPointer *AuditPointer `json:"audit_pointer,omitempty" jsonschema:"most-recent audit entry for this run with its entry hash; nil on any fetch failure"`
+	RunURL       string        `json:"run_url,omitempty" jsonschema:"direct link to the run-detail view"`
 }
 
 // RunnerEvent wraps an unstructured runner event. Each event is the
@@ -142,6 +184,20 @@ agent-driven local-runner loop:
 Runner output streams as MCP progress notifications when the
 client provides a progress token; the final tool result carries
 the full event list plus the post-run stage state.
+
+Output fields (three additional best-effort fields, omitted when
+unavailable):
+
+  - diff_summary    — present when the runner emitted a git_diff
+                      event and 'git show --numstat HEAD' succeeded;
+                      reports files_changed, insertions, deletions.
+                      nil for plan stages and failed implement stages
+                      that did not commit.
+  - audit_pointer   — the most-recent audit entry for this run:
+                      latest_sequence, entry_hash, and a URL to the
+                      per-run audit API endpoint. nil when the
+                      best-effort fetch fails.
+  - run_url         — direct link to the run-detail view in the SPA.
 
 Cancellation: cancelling the tool call sends SIGTERM (then SIGKILL
 after a 30s grace) to the runner. Graceful cleanup requires the
@@ -374,24 +430,71 @@ func (r *runResolver) runStage(ctx context.Context, req *mcp.CallToolRequest, in
 			fmt.Sprintf("post-run stage fetch failed: %v", fetchErr))
 	}
 
+	// Populate DiffSummary: gate on the git_diff runner event being
+	// present so plan stages (which never emit git_diff) always yield
+	// nil, and failed implement stages that didn't commit also yield nil.
+	var diffSummary *DiffSummary
+	if gitDiffPayload := findGitDiffPayload(events); gitDiffPayload != nil {
+		filesChanged := 0
+		if cf, ok := gitDiffPayload["changed_files"].([]any); ok {
+			filesChanged = len(cf)
+		}
+		if numstatOut, numstatErr := runStageGitNumstat(workingDir); numstatErr == nil {
+			ins, dels := parseNumstat(numstatOut)
+			diffSummary = &DiffSummary{
+				FilesChanged: filesChanged,
+				Insertions:   ins,
+				Deletions:    dels,
+			}
+		}
+	}
+
+	// Populate AuditPointer: best-effort, 5-second timeout. Mirrors
+	// the stageState fetch pattern above. Nil on any failure — no
+	// warning per the acceptance criteria.
+	var auditPointer *AuditPointer
+	func() {
+		fetchCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		entries, aerr := r.api.ListRecentRunAudit(fetchCtx, runUUID, 1)
+		if aerr != nil || len(entries) == 0 {
+			return
+		}
+		auditPointer = &AuditPointer{
+			LatestSequence: entries[0].Sequence,
+			EntryHash:      entries[0].EntryHash,
+			URL:            r.api.baseURL + "/v0/runs/" + runUUID.String() + "/audit?limit=1",
+		}
+	}()
+
+	// RunURL is the SPA run-detail link — pure string concatenation,
+	// no failure mode.
+	runURL := r.api.baseURL + "/runs/" + runUUID.String()
+
 	// Return-cancellation signal: if the parent ctx was the reason
 	// for exit, surface a clear tool error rather than a 0 / silent
 	// success.
 	if ctx.Err() != nil {
 		return nil, RunStageOutput{
-				ExitCode:   exitCode,
-				StageState: stageState,
-				Events:     events,
-				Warnings:   warnings,
+				ExitCode:     exitCode,
+				StageState:   stageState,
+				Events:       events,
+				Warnings:     warnings,
+				DiffSummary:  diffSummary,
+				AuditPointer: auditPointer,
+				RunURL:       runURL,
 			},
 			fmt.Errorf("fishhawk_run_stage cancelled: %w", ctx.Err())
 	}
 
 	return nil, RunStageOutput{
-		ExitCode:   exitCode,
-		StageState: stageState,
-		Events:     events,
-		Warnings:   warnings,
+		ExitCode:     exitCode,
+		StageState:   stageState,
+		Events:       events,
+		Warnings:     warnings,
+		DiffSummary:  diffSummary,
+		AuditPointer: auditPointer,
+		RunURL:       runURL,
 	}, nil
 }
 
@@ -485,6 +588,51 @@ func runStageDetectGitHubRepo(workingDir string) (string, error) {
 		return "", err
 	}
 	return owner + "/" + name, nil
+}
+
+// findGitDiffPayload scans events for a runner event with
+// kind=="git_diff" and returns its payload map, or nil when absent.
+func findGitDiffPayload(events []RunnerEvent) map[string]any {
+	for _, ev := range events {
+		m, ok := ev.Payload.(map[string]any)
+		if !ok {
+			continue
+		}
+		if m["kind"] == "git_diff" {
+			return m
+		}
+	}
+	return nil
+}
+
+// parseNumstat parses `git show --numstat HEAD` output and sums
+// insertions and deletions across all file rows, skipping binary-file
+// rows where either column is '-'.
+func parseNumstat(output string) (insertions, deletions int) {
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, "\t", 3)
+		if len(parts) < 2 {
+			continue
+		}
+		if parts[0] == "-" || parts[1] == "-" {
+			continue // binary file — columns are not numeric
+		}
+		ins, err := strconv.Atoi(parts[0])
+		if err != nil {
+			continue
+		}
+		del, err := strconv.Atoi(parts[1])
+		if err != nil {
+			continue
+		}
+		insertions += ins
+		deletions += del
+	}
+	return
 }
 
 // runStageParseGitHubRemote turns a remote URL into (owner, name).

--- a/backend/cmd/fishhawk-mcp/run_stage_test.go
+++ b/backend/cmd/fishhawk-mcp/run_stage_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -714,5 +715,156 @@ func TestRunStageEventMessage_FallsBackToJSON(t *testing.T) {
 	got := runStageEventMessage(m)
 	if got == "" || !strings.Contains(got, "foo") {
 		t.Errorf("message = %q, want a JSON-ish fallback", got)
+	}
+}
+
+// --- DiffSummary, AuditPointer, RunURL enrichment (#442) ---
+
+// TestRunStage_DiffSummary_NilWhenNoGitDiffEvent verifies acceptance
+// criterion (a): when the runner emits no git_diff event (e.g. a plan
+// stage), DiffSummary is nil.
+func TestRunStage_DiffSummary_NilWhenNoGitDiffEvent(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	r := newResolver(srv, nil)
+	// Runner emits events but none are git_diff.
+	withFakeRunner(t, `printf '%s\n' '{"kind":"runner_started"}' >&2`)
+
+	runID := uuid.New()
+	stageID := uuid.New()
+	seedStage(fb, runID, stageID, "awaiting_approval")
+
+	_, out, err := r.runStage(context.Background(), nil, RunStageInput{
+		RunID:      runID.String(),
+		StageID:    stageID.String(),
+		Workflow:   "w",
+		Stage:      "plan",
+		GitHubRepo: "x/y",
+	})
+	if err != nil {
+		t.Fatalf("runStage: %v", err)
+	}
+	if out.DiffSummary != nil {
+		t.Errorf("DiffSummary should be nil when no git_diff event; got %+v", out.DiffSummary)
+	}
+}
+
+// TestRunStage_DiffSummary_PopulatedFromGitDiffEvent verifies
+// acceptance criterion (b): when the runner emits a git_diff event and
+// git show --numstat succeeds, DiffSummary is populated with correct
+// FilesChanged, Insertions, and Deletions. Binary rows are skipped.
+func TestRunStage_DiffSummary_PopulatedFromGitDiffEvent(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	r := newResolver(srv, nil)
+	// Runner emits git_diff event with two changed files.
+	withFakeRunner(t, `printf '%s\n' '{"kind":"git_diff","changed_files":["a.go","b.go"]}' >&2`)
+
+	// Inject fake numstat: two normal rows + one binary row.
+	origNumstat := runStageGitNumstat
+	runStageGitNumstat = func(_ string) (string, error) {
+		return "5\t3\ta.go\n10\t7\tb.go\n-\t-\timage.png\n", nil
+	}
+	t.Cleanup(func() { runStageGitNumstat = origNumstat })
+
+	runID := uuid.New()
+	stageID := uuid.New()
+	seedStage(fb, runID, stageID, "succeeded")
+
+	_, out, err := r.runStage(context.Background(), nil, RunStageInput{
+		RunID:      runID.String(),
+		StageID:    stageID.String(),
+		Workflow:   "w",
+		Stage:      "implement",
+		GitHubRepo: "x/y",
+	})
+	if err != nil {
+		t.Fatalf("runStage: %v", err)
+	}
+	if out.DiffSummary == nil {
+		t.Fatal("DiffSummary should be non-nil when git_diff event is present")
+	}
+	if out.DiffSummary.FilesChanged != 2 {
+		t.Errorf("FilesChanged = %d, want 2", out.DiffSummary.FilesChanged)
+	}
+	if out.DiffSummary.Insertions != 15 { // 5 + 10
+		t.Errorf("Insertions = %d, want 15 (5+10)", out.DiffSummary.Insertions)
+	}
+	if out.DiffSummary.Deletions != 10 { // 3 + 7
+		t.Errorf("Deletions = %d, want 10 (3+7)", out.DiffSummary.Deletions)
+	}
+}
+
+// TestRunStage_AuditPointer_NilOnBackend500 verifies acceptance
+// criterion (c): when the backend returns HTTP 500 for the audit
+// endpoint, AuditPointer is nil and no warning is added. Also asserts
+// the request went to /v0/audit (the cross-chain endpoint) with
+// run_id and limit=1, not /v0/runs/{id}/audit.
+func TestRunStage_AuditPointer_NilOnBackend500(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	r := newResolver(srv, nil)
+	withFakeRunner(t, "exit 0")
+
+	fb.auditStatus = http.StatusInternalServerError
+
+	runID := uuid.New()
+	stageID := uuid.New()
+	seedStage(fb, runID, stageID, "succeeded")
+
+	warningsBefore := 0
+	_, out, err := r.runStage(context.Background(), nil, RunStageInput{
+		RunID:      runID.String(),
+		StageID:    stageID.String(),
+		Workflow:   "w",
+		Stage:      "implement",
+		GitHubRepo: "x/y",
+	})
+	if err != nil {
+		t.Fatalf("runStage: %v", err)
+	}
+	if out.AuditPointer != nil {
+		t.Errorf("AuditPointer should be nil on backend 500; got %+v", out.AuditPointer)
+	}
+	// Warnings count should not grow due to the audit failure.
+	if len(out.Warnings) != warningsBefore {
+		for _, w := range out.Warnings {
+			if strings.Contains(strings.ToLower(w), "audit") {
+				t.Errorf("audit failure should not add a warning; got: %q", w)
+			}
+		}
+	}
+	// The request must have hit /v0/audit (cross-chain endpoint), not
+	// /v0/runs/{id}/audit. auditCalledByID is incremented only by
+	// the /v0/audit handler.
+	if got := fb.auditCalledByID[runID]; got == 0 {
+		t.Errorf("expected /v0/audit to be called; auditCalledByID[runID] = %d", got)
+	}
+	if fb.lastAuditLimit != "1" {
+		t.Errorf("audit limit = %q, want 1", fb.lastAuditLimit)
+	}
+}
+
+// TestRunStage_RunURL_ContainsRunID verifies acceptance criterion (d):
+// RunURL equals the server's base URL + '/runs/' + runID.
+func TestRunStage_RunURL_ContainsRunID(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	r := newResolver(srv, nil)
+	withFakeRunner(t, "exit 0")
+
+	runID := uuid.New()
+	stageID := uuid.New()
+	seedStage(fb, runID, stageID, "succeeded")
+
+	_, out, err := r.runStage(context.Background(), nil, RunStageInput{
+		RunID:      runID.String(),
+		StageID:    stageID.String(),
+		Workflow:   "w",
+		Stage:      "implement",
+		GitHubRepo: "x/y",
+	})
+	if err != nil {
+		t.Fatalf("runStage: %v", err)
+	}
+	want := srv.URL + "/runs/" + runID.String()
+	if out.RunURL != want {
+		t.Errorf("RunURL = %q, want %q", out.RunURL, want)
 	}
 }


### PR DESCRIPTION
## Summary

- `RunStageOutput` gains `DiffSummary`, `AuditPointer`, and `RunURL` — all `omitempty` so plan stages and clean trees produce sensible empty results.
- `DiffSummary` populated from `git show --numstat HEAD` when the runner emits a `git_diff` event (implement stages). Binary-file rows skipped per `git-show(1)`.
- `AuditPointer` populated from `GET /v0/audit?run_id=<id>&limit=1` after the stage transitions. Best-effort.
- `RunURL` is the SPA run-detail link.
- Tool description updated.

## Notes

Every loop iteration today required `git status --short` + `git diff --stat` + `fishhawk_list_audit` after the runner exited to assemble situational awareness. With this in place, the MCP tool result carries all three inline.

Driven through the local MCP loop (run `334f9e33`). Plan 12.2k tokens, implement 20.8k tokens, no decomposition, no timeout.

**Plan-quality note**: this was the first plan generated after PR #492 (citation rule) merged. The risks section is dense with citations — `git-show(1)` for the binary-file edge case, `client.go:27` for the private-field access, falsifying tests named for the gating assumptions, references to the existing `run_stage.go:358-375` `context.Background()` pattern. The rule is working on its very first downstream plan.

## Test plan

- [x] `scripts/test` — all gates green.
- [x] `scripts/test coverage` — aggregate 82.0% (above 80% gate).
- [x] `golangci-lint run ./backend/...` — 0 issues.
- [x] Four new test cases in `run_stage_test.go`: no git_diff event → nil DiffSummary; git_diff event + binary-file numstat row → counts correct, binary row skipped; backend audit fetch failure → nil AuditPointer, no warning; valid run_id → RunURL set correctly.
- [ ] Live verification: next implement-stage loop should return `diff_summary` + `audit_pointer` + `run_url` inline.

Closes #442