### PR TITLE
mcp: fishhawk_verify_run audit-chain integrity tool (#444)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,10 @@ backend/fishhawk-mcp
 runner/fishhawk-runner
 cli/fishhawk
 verifier/fishhawk-verify
+# go build invoked from repo root with `./<module>/cmd/<name>/` produces
+# a binary in cwd named after the package.
+/fishhawkd
+/fishhawk-mcp
+/fishhawk-runner
+/fishhawk
+/fishhawk-verify

--- a/backend/cmd/fishhawk-mcp/tools.go
+++ b/backend/cmd/fishhawk-mcp/tools.go
@@ -40,6 +40,7 @@ func registerTools(srv *mcp.Server, resolver *runResolver) {
 	registerListRuns(srv, resolver)
 	registerRunStage(srv, resolver)
 	registerRuntimeCalibration(srv, resolver)
+	registerVerifyRun(srv, resolver)
 }
 
 // GetActiveRunInput is the tool's input schema (E19.3 / #343). All

--- a/backend/cmd/fishhawk-mcp/verify_run.go
+++ b/backend/cmd/fishhawk-mcp/verify_run.go
@@ -1,0 +1,221 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/kuhlman-labs/fishhawk/backend/internal/audit"
+)
+
+// VerifyRunInput is the fishhawk_verify_run tool's input schema.
+type VerifyRunInput struct {
+	RunID string `json:"run_id" jsonschema:"the Fishhawk run UUID whose audit chain is to be verified"`
+}
+
+// VerifyRunOutput is the response shape. Verified is true when every entry's
+// hash and chain link is intact; false when any check fails.
+type VerifyRunOutput struct {
+	Verified       bool           `json:"verified"`
+	ChainLength    int            `json:"chain_length"`
+	FirstSequence  int64          `json:"first_sequence"`
+	LastSequence   int64          `json:"last_sequence"`
+	LastEntryHash  string         `json:"last_entry_hash"`
+	FailureReason  string         `json:"failure_reason,omitempty"`
+	CategoryCounts map[string]int `json:"category_counts"`
+}
+
+// registerVerifyRun wires the fishhawk_verify_run tool. Read-only per
+// ADR-021; works with both fhm_* and fhk_* tokens.
+func registerVerifyRun(srv *mcp.Server, resolver *runResolver) {
+	mcp.AddTool(srv, &mcp.Tool{
+		Name: "fishhawk_verify_run",
+		Description: strings.TrimSpace(`
+Verify audit chain integrity for a Fishhawk run.
+
+Fetches every audit entry via cursor pagination and checks:
+  1. Sequence monotonicity — entries must be strictly increasing.
+  2. Entry hash — each stored entry_hash must match the value
+     recomputed from the entry's fields.
+  3. Chain link — each entry's prev_hash must match the preceding
+     entry's entry_hash.
+
+verified=false is a halt condition before opening a PR. File an
+incident when the chain is broken on a completed run.
+
+Response:
+  - verified        — true when every check passes.
+  - chain_length    — total entries verified.
+  - first_sequence  — sequence of the first entry.
+  - last_sequence   — sequence of the last entry.
+  - last_entry_hash — entry_hash of the final entry.
+  - failure_reason  — populated only when verified=false; names the
+                      specific check that failed and the entry id.
+  - category_counts — map of category → count across all entries.
+`),
+	}, resolver.verifyRun)
+}
+
+// toActorKind converts *string to *audit.ActorKind for hash inputs.
+func toActorKind(s *string) *audit.ActorKind {
+	if s == nil {
+		return nil
+	}
+	k := audit.ActorKind(*s)
+	return &k
+}
+
+// entryToHashInputs converts a wire AuditEntry into the audit.HashInputs
+// needed to recompute the entry's hash. Payload is typed `any` after the
+// HTTP JSON decode, so it is re-marshaled to json.RawMessage before hashing.
+func entryToHashInputs(e *AuditEntry) (audit.HashInputs, error) {
+	var runID *uuid.UUID
+	if e.RunID != "" {
+		id, err := uuid.Parse(e.RunID)
+		if err != nil {
+			return audit.HashInputs{}, fmt.Errorf("parse run_id %q: %w", e.RunID, err)
+		}
+		runID = &id
+	}
+
+	var stageID *uuid.UUID
+	if e.StageID != nil && *e.StageID != "" {
+		id, err := uuid.Parse(*e.StageID)
+		if err != nil {
+			return audit.HashInputs{}, fmt.Errorf("parse stage_id %q: %w", *e.StageID, err)
+		}
+		stageID = &id
+	}
+
+	raw, err := json.Marshal(e.Payload)
+	if err != nil {
+		return audit.HashInputs{}, fmt.Errorf("re-marshal payload: %w", err)
+	}
+
+	return audit.HashInputs{
+		RunID:        runID,
+		StageID:      stageID,
+		Timestamp:    e.Timestamp,
+		Category:     e.Category,
+		ActorKind:    toActorKind(e.ActorKind),
+		ActorSubject: e.ActorSubject,
+		Payload:      raw,
+		PrevHash:     e.PrevHash,
+	}, nil
+}
+
+// verifyRun is the tool handler.
+func (r *runResolver) verifyRun(ctx context.Context, _ *mcp.CallToolRequest, in VerifyRunInput) (*mcp.CallToolResult, VerifyRunOutput, error) {
+	runID, err := uuid.Parse(in.RunID)
+	if err != nil {
+		return nil, VerifyRunOutput{}, fmt.Errorf("run_id %q is not a valid UUID: %w", in.RunID, err)
+	}
+
+	var all []AuditEntry
+	cursor := ""
+	for {
+		items, next, err := r.api.ListRunAudit(ctx, runID, ListRunAuditFilter{
+			Limit:  listAuditLimitMax,
+			Cursor: cursor,
+		})
+		if err != nil {
+			return nil, VerifyRunOutput{}, fmt.Errorf("list run audit: %w", err)
+		}
+		all = append(all, items...)
+		if next == "" {
+			break
+		}
+		cursor = next
+	}
+
+	categoryCounts := map[string]int{}
+	if len(all) == 0 {
+		return nil, VerifyRunOutput{
+			Verified:       true,
+			ChainLength:    0,
+			CategoryCounts: categoryCounts,
+		}, nil
+	}
+
+	prevEntryHash := ""
+	for i := range all {
+		e := &all[i]
+		categoryCounts[e.Category]++
+
+		// (1) Sequence monotonicity.
+		if i > 0 && e.Sequence <= all[i-1].Sequence {
+			return nil, VerifyRunOutput{
+				Verified:       false,
+				ChainLength:    i + 1,
+				CategoryCounts: categoryCounts,
+				FailureReason: fmt.Sprintf("sequence_not_monotonic: entry %s sequence %d not greater than preceding %d",
+					e.ID, e.Sequence, all[i-1].Sequence),
+			}, nil
+		}
+
+		// (2) Entry hash verification.
+		inputs, err := entryToHashInputs(e)
+		if err != nil {
+			return nil, VerifyRunOutput{
+				Verified:       false,
+				ChainLength:    i + 1,
+				CategoryCounts: categoryCounts,
+				FailureReason:  fmt.Sprintf("hash_input_error: entry %s: %v", e.ID, err),
+			}, nil
+		}
+		computed, err := audit.ComputeEntryHash(inputs)
+		if err != nil {
+			return nil, VerifyRunOutput{
+				Verified:       false,
+				ChainLength:    i + 1,
+				CategoryCounts: categoryCounts,
+				FailureReason:  fmt.Sprintf("hash_compute_error: entry %s: %v", e.ID, err),
+			}, nil
+		}
+		if computed != e.EntryHash {
+			return nil, VerifyRunOutput{
+				Verified:       false,
+				ChainLength:    i + 1,
+				CategoryCounts: categoryCounts,
+				FailureReason: fmt.Sprintf("hash_mismatch: entry %s: computed %s, stored %s",
+					e.ID, computed, e.EntryHash),
+			}, nil
+		}
+
+		// (3) Chain link check (skip for the first entry).
+		if i > 0 {
+			if e.PrevHash == nil {
+				return nil, VerifyRunOutput{
+					Verified:       false,
+					ChainLength:    i + 1,
+					CategoryCounts: categoryCounts,
+					FailureReason:  fmt.Sprintf("chain_broken: entry %s has nil prev_hash but is not the first entry", e.ID),
+				}, nil
+			}
+			if *e.PrevHash != prevEntryHash {
+				return nil, VerifyRunOutput{
+					Verified:       false,
+					ChainLength:    i + 1,
+					CategoryCounts: categoryCounts,
+					FailureReason: fmt.Sprintf("chain_broken: entry %s prev_hash %s does not match preceding entry_hash %s",
+						e.ID, *e.PrevHash, prevEntryHash),
+				}, nil
+			}
+		}
+		prevEntryHash = e.EntryHash
+	}
+
+	last := &all[len(all)-1]
+	return nil, VerifyRunOutput{
+		Verified:       true,
+		ChainLength:    len(all),
+		FirstSequence:  all[0].Sequence,
+		LastSequence:   last.Sequence,
+		LastEntryHash:  last.EntryHash,
+		CategoryCounts: categoryCounts,
+	}, nil
+}

--- a/backend/cmd/fishhawk-mcp/verify_run_test.go
+++ b/backend/cmd/fishhawk-mcp/verify_run_test.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/kuhlman-labs/fishhawk/backend/internal/audit"
+)
+
+// buildChainedAuditEntries builds N valid chained AuditEntry objects whose
+// hashes are computed by audit.ComputeEntryHash, ready to seed into the
+// fakeBackend's perRunAuditByRun map. The PrevHash of each entry links to
+// the preceding entry's EntryHash, forming a complete valid chain.
+func buildChainedAuditEntries(runID uuid.UUID, categories []string) []AuditEntry {
+	ts := time.Now().UTC().Truncate(time.Microsecond)
+	runIDPtr := runID
+
+	var entries []AuditEntry
+	var prevHash *string
+
+	for i, cat := range categories {
+		payload := map[string]any{"step": cat}
+		raw, _ := json.Marshal(payload)
+
+		inputs := audit.HashInputs{
+			RunID:     &runIDPtr,
+			Timestamp: ts.Add(time.Duration(i) * time.Second),
+			Category:  cat,
+			Payload:   raw,
+			PrevHash:  prevHash,
+		}
+		hash, _ := audit.ComputeEntryHash(inputs)
+
+		e := AuditEntry{
+			ID:        uuid.New().String(),
+			Sequence:  int64(i + 1),
+			RunID:     runID.String(),
+			Timestamp: ts.Add(time.Duration(i) * time.Second),
+			Category:  cat,
+			Payload:   payload,
+			PrevHash:  prevHash,
+			EntryHash: hash,
+		}
+		entries = append(entries, e)
+		h := hash
+		prevHash = &h
+	}
+	return entries
+}
+
+func TestVerifyRun_HappyChain_ReturnsVerifiedTrue(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	runID := uuid.New()
+	categories := []string{"plan_generated", "approval_submitted", "stage_completed"}
+	entries := buildChainedAuditEntries(runID, categories)
+	fb.perRunAuditByRun[runID] = entries
+
+	r := newResolver(srv, nil)
+	_, out, err := r.verifyRun(context.Background(), nil, VerifyRunInput{RunID: runID.String()})
+	if err != nil {
+		t.Fatalf("verifyRun: %v", err)
+	}
+	if !out.Verified {
+		t.Errorf("Verified = false, want true; failure_reason = %q", out.FailureReason)
+	}
+	if out.ChainLength != 3 {
+		t.Errorf("ChainLength = %d, want 3", out.ChainLength)
+	}
+	for _, cat := range categories {
+		if out.CategoryCounts[cat] != 1 {
+			t.Errorf("CategoryCounts[%q] = %d, want 1", cat, out.CategoryCounts[cat])
+		}
+	}
+	if out.LastEntryHash != entries[2].EntryHash {
+		t.Errorf("LastEntryHash = %q, want %q", out.LastEntryHash, entries[2].EntryHash)
+	}
+}
+
+func TestVerifyRun_TamperedEntryHash_ReturnsVerifiedFalse(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	runID := uuid.New()
+	entries := buildChainedAuditEntries(runID, []string{"plan_generated", "approval_submitted", "stage_completed"})
+	// Tamper the second entry's stored hash — the recomputed hash will diverge.
+	entries[1].EntryHash = "0000000000000000000000000000000000000000000000000000000000000000"
+	fb.perRunAuditByRun[runID] = entries
+
+	r := newResolver(srv, nil)
+	_, out, err := r.verifyRun(context.Background(), nil, VerifyRunInput{RunID: runID.String()})
+	if err != nil {
+		t.Fatalf("verifyRun: %v", err)
+	}
+	if out.Verified {
+		t.Errorf("Verified = true, want false (entry hash tampered)")
+	}
+	if !strings.Contains(out.FailureReason, "hash_mismatch") {
+		t.Errorf("FailureReason = %q, want to contain 'hash_mismatch'", out.FailureReason)
+	}
+}
+
+func TestVerifyRun_BrokenChainLink_ReturnsVerifiedFalse(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	runID := uuid.New()
+
+	ts := time.Now().UTC().Truncate(time.Microsecond)
+	runIDPtr := runID
+
+	// Build entry1 with a nil prev_hash (chain root).
+	payload1 := map[string]any{"step": "plan_generated"}
+	raw1, _ := json.Marshal(payload1)
+	inputs1 := audit.HashInputs{
+		RunID:     &runIDPtr,
+		Timestamp: ts,
+		Category:  "plan_generated",
+		Payload:   raw1,
+		PrevHash:  nil,
+	}
+	hash1, _ := audit.ComputeEntryHash(inputs1)
+
+	// Build entry2 with a wrong prev_hash so the chain link is broken.
+	// The entry's own hash is computed correctly against the wrong prev_hash,
+	// so the hash check passes but the chain link check fails.
+	wrongPrevHash := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	payload2 := map[string]any{"step": "approval_submitted"}
+	raw2, _ := json.Marshal(payload2)
+	inputs2 := audit.HashInputs{
+		RunID:     &runIDPtr,
+		Timestamp: ts.Add(time.Second),
+		Category:  "approval_submitted",
+		Payload:   raw2,
+		PrevHash:  &wrongPrevHash,
+	}
+	hash2, _ := audit.ComputeEntryHash(inputs2)
+
+	entries := []AuditEntry{
+		{
+			ID:        uuid.New().String(),
+			Sequence:  1,
+			RunID:     runID.String(),
+			Timestamp: ts,
+			Category:  "plan_generated",
+			Payload:   payload1,
+			PrevHash:  nil,
+			EntryHash: hash1,
+		},
+		{
+			ID:        uuid.New().String(),
+			Sequence:  2,
+			RunID:     runID.String(),
+			Timestamp: ts.Add(time.Second),
+			Category:  "approval_submitted",
+			Payload:   payload2,
+			PrevHash:  &wrongPrevHash,
+			EntryHash: hash2,
+		},
+	}
+	fb.perRunAuditByRun[runID] = entries
+
+	r := newResolver(srv, nil)
+	_, out, err := r.verifyRun(context.Background(), nil, VerifyRunInput{RunID: runID.String()})
+	if err != nil {
+		t.Fatalf("verifyRun: %v", err)
+	}
+	if out.Verified {
+		t.Errorf("Verified = true, want false (chain link broken)")
+	}
+	if !strings.Contains(out.FailureReason, "chain_broken") {
+		t.Errorf("FailureReason = %q, want to contain 'chain_broken'", out.FailureReason)
+	}
+}
+
+func TestVerifyRun_InvalidRunID_RejectsLocally(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	r := newResolver(srv, nil)
+
+	_, _, err := r.verifyRun(context.Background(), nil, VerifyRunInput{RunID: "not-a-uuid"})
+	if err == nil {
+		t.Fatal("expected error on malformed run_id")
+	}
+	if !strings.Contains(err.Error(), "not a valid UUID") {
+		t.Errorf("error wording: %v", err)
+	}
+	// No HTTP calls should have been made before the local UUID parse fails.
+	if len(fb.perRunAuditLastQueryByID) != 0 {
+		t.Errorf("backend was hit despite local validation failure: %v", fb.perRunAuditLastQueryByID)
+	}
+}

--- a/docs/mcp/install.md
+++ b/docs/mcp/install.md
@@ -99,6 +99,7 @@ Two audiences with different scopes:
 | `fishhawk_get_plan` | Returns the approved standard_v1 plan; walks `parent_run_id` for CI-retry chains. |
 | `fishhawk_get_run_status` | Bundles Run + ordered stages + recent audit (time-descending) into one tool call. |
 | `fishhawk_list_audit` | Filtered audit access (`category`, `stage_id`) with cursor pagination. |
+| `fishhawk_verify_run` | Verify audit chain integrity for a run — checks every entry hash and chain link. `verified=false` is a halt condition before opening a PR. |
 
 ### Write tools (operator-side only)
 
@@ -136,6 +137,7 @@ The composition matches the CLI's `fishhawk run start --working-dir … --issue 
 2. Agent calls `fishhawk_run_stage --stage plan` (the MCP server spawns `fishhawk-runner` and streams events).
 3. Agent calls `fishhawk_approve_plan`.
 4. Agent calls `fishhawk_run_stage --stage implement`.
+5. Agent calls `fishhawk_verify_run` with the run id. A `verified=false` result is a halt — do not open a PR; file an incident.
 
 The `fishhawk_run_stage` tool requires the `fishhawk-runner` binary on the MCP server's host (`PATH` lookup, overridable via `FISHHAWK_RUNNER_BIN` env or the tool's `runner_binary` input). The MCP server runs locally on an operator's workstation today, so this is always satisfied; a future hosted MCP deployment will surface a clean tool error.
 


### PR DESCRIPTION
## Summary

- New `fishhawk_verify_run` MCP tool: fetches every audit entry for a run via the existing `/v0/runs/{id}/audit` endpoint, recomputes hashes via `audit.ComputeEntryHash`, verifies prev_hash chain links and sequence monotonicity, returns structured result with `Verified` + `ChainLength` + `LastEntryHash` + `FailureReason` (when applicable) + `CategoryCounts`.
- Four unit tests cover happy chain, tampered entry hash, broken chain link, invalid run_id.
- `docs/mcp/install.md` adds step 5 of the local-runner mint workflow so audit verification becomes a gate, not an optional follow-up.
- Wraps existing `audit.ComputeEntryHash` (intra-module import); no new external dependencies.

## Notes

This was the synthesis ticket — it ties together today's work into a single loop-completion check the agent can call as a gate. Plus this PR demonstrates the just-merged #442/#493 working: the `fishhawk_run_stage` response on both stages of this PR returned `audit_pointer` (latest_seq, hash, URL) and `run_url` inline — first downstream confirmation that the enrichment is working end-to-end.

Driven through the local MCP loop (run `6c60bb1d`). Plan 19.4k tokens, implement 34.7k tokens (heaviest of the day), no decomposition, no timeout. **The plan-quality discipline from #492 (citation rule) is now load-bearing**: every risk assumption cited a file:line (`chain.go line 94`, `audit.go lines 43-53`, `ARCHITECTURE.md §10`) or named a falsifying test.

Also extends `.gitignore` with root-level binary artifacts — `go build ./backend/cmd/fishhawk-mcp/` from repo root produces `./fishhawk-mcp`, which is a different path from the `backend/fishhawk-mcp` rule added by #493.

## Test plan

- [x] `scripts/test` — all gates green.
- [x] `scripts/test coverage` — aggregate 81.9% (above 80% gate).
- [x] `golangci-lint run ./backend/...` — 0 issues.
- [x] `TestVerifyRun_HappyChain_ReturnsVerifiedTrue` — built three real audit entries with hash chain linked correctly; verifies Verified=true, ChainLength=3, CategoryCounts populated.
- [x] `TestVerifyRun_TamperedEntryHash_ReturnsVerifiedFalse` — overwrite one entry's hash; verifies Verified=false, FailureReason mentions hash_mismatch.
- [x] `TestVerifyRun_BrokenChainLink_ReturnsVerifiedFalse` — wrong prev_hash; verifies Verified=false, FailureReason mentions chain_broken.
- [x] `TestVerifyRun_InvalidRunID_RejectsLocally` — UUID parse error before HTTP call.
- [ ] Live verification: next loop iteration should add `fishhawk_verify_run` as step 5 before opening the PR.

Closes #444