### PR TITLE
githooks: pre-commit rejects executable binaries (#495)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -22,3 +22,23 @@ if [ "$FAIL" -eq 1 ]; then
   echo "Run scripts/sync-schemas to mirror the canonical copies, then re-stage." >&2
   exit 1
 fi
+
+# Binary-detection: reject newly-added executable binaries staged outside bin/ or .claude/
+BINARY_FAIL=0
+while IFS= read -r path; do
+  case "$path" in
+    bin/*|.claude/*) continue ;;
+  esac
+  magic=$(git show ":$path" 2>/dev/null | od -An -tx1 -N4 | tr -d ' \n')
+  case "$magic" in
+    cffaedfe*|cafebabe*|7f454c46*|4d5a*)
+      echo "pre-commit: refusing to commit binary file: $path" >&2
+      echo "  Move it to bin/ or add it to .gitignore." >&2
+      BINARY_FAIL=1
+      ;;
+  esac
+done < <(git diff --cached --name-only --diff-filter=A)
+
+if [ "$BINARY_FAIL" -eq 1 ]; then
+  exit 1
+fi

--- a/scripts/test-pre-commit-hook
+++ b/scripts/test-pre-commit-hook
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Smoke test for the binary-detection logic in .githooks/pre-commit.
+# Spins up an isolated temp git repo with core.hooksPath pointing at the
+# real .githooks directory, then exercises four cases.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PASS=0
+FAIL=0
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+git -C "$tmpdir" init -q
+git -C "$tmpdir" config user.email "test@example.com"
+git -C "$tmpdir" config user.name "Test"
+git -C "$tmpdir" config core.hooksPath "$REPO_ROOT/.githooks"
+
+# Seed an initial commit so HEAD exists (hook references git diff --cached).
+touch "$tmpdir/README"
+git -C "$tmpdir" add README
+git -C "$tmpdir" commit -q -m "init"
+
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+# Case 1: Mach-O header at repo root — must be rejected
+printf '\xcf\xfa\xed\xfe\x00\x00\x00\x00' > "$tmpdir/macho-binary"
+git -C "$tmpdir" add macho-binary
+output=$(git -C "$tmpdir" commit -m "add macho" 2>&1) && status=0 || status=$?
+if [ "$status" -ne 0 ] && echo "$output" | grep -q 'refusing to commit'; then
+  pass "Mach-O header at root is rejected"
+else
+  fail "Mach-O header at root should be rejected (status=$status, output=$output)"
+fi
+git -C "$tmpdir" restore --staged macho-binary 2>/dev/null || true
+
+# Case 2: ELF header at repo root — must be rejected
+printf '\x7f\x45\x4c\x46\x00\x00\x00\x00' > "$tmpdir/elf-binary"
+git -C "$tmpdir" add elf-binary
+output=$(git -C "$tmpdir" commit -m "add elf" 2>&1) && status=0 || status=$?
+if [ "$status" -ne 0 ] && echo "$output" | grep -q 'refusing to commit'; then
+  pass "ELF header at root is rejected"
+else
+  fail "ELF header at root should be rejected (status=$status, output=$output)"
+fi
+git -C "$tmpdir" restore --staged elf-binary 2>/dev/null || true
+
+# Case 3: Mach-O header under bin/ — must be allowed
+mkdir -p "$tmpdir/bin"
+printf '\xcf\xfa\xed\xfe\x00\x00\x00\x00' > "$tmpdir/bin/tool"
+git -C "$tmpdir" add bin/tool
+output=$(git -C "$tmpdir" commit -m "add bin/tool" 2>&1) && status=0 || status=$?
+if [ "$status" -eq 0 ]; then
+  pass "Mach-O under bin/ is allowed"
+else
+  fail "Mach-O under bin/ should be allowed (status=$status, output=$output)"
+fi
+
+# Case 4: normal Go source file — must be allowed
+cat > "$tmpdir/main.go" <<'EOF'
+package main
+
+import "fmt"
+
+func main() { fmt.Println("hello") }
+EOF
+git -C "$tmpdir" add main.go
+output=$(git -C "$tmpdir" commit -m "add main.go" 2>&1) && status=0 || status=$?
+if [ "$status" -eq 0 ]; then
+  pass "Normal source file is allowed"
+else
+  fail "Normal source file should be allowed (status=$status, output=$output)"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

- `.githooks/pre-commit` reads the first 4 bytes of each newly-added staged file and rejects Mach-O (`cffaedfe`, `cafebabe`), ELF (`7f454c46`), and PE (`4d5a`) headers.
- Skips `bin/` and `.claude/` paths (canonical artifact + worktree locations).
- New `scripts/test-pre-commit-hook` smoke test exercises four cases against a temp git repo: Mach-O at root rejected, ELF at root rejected, Mach-O under `bin/` allowed, normal `main.go` allowed. All 4 pass.
- Uses `od -An -tx1 -N4` for portability (POSIX-standard; available on macOS bash 3.2 and any Linux runner).

## Notes

Closes today's binary-leak pattern: #493 and #494 each had to add reactive `.gitignore` rules after the agent's `go build` produced a binary in cwd that `git add -A` picked up. The hook catches the *behavior* (executable magic bytes) regardless of path, so future shapes are caught the same way.

Hook is opt-in via the existing `git config core.hooksPath .githooks` documented in CLAUDE.md. No mandate; the binary-leak pattern is operator-side only.

Driven through the local MCP loop (run `d666b992`). Plan 16k tokens, implement **3.4k tokens** (smallest of the day, ~5 min actual). `fishhawk_verify_run` returned `verified=true` with 13-entry chain.

### Bonus finding — calibration hint copy is inverted (filed as #498)

This was the first run after #497 (calibration hint) merged. We had 6 samples at ratio 0.27. The hint rendered, but the agent still predicted 22 minutes — same range as pre-calibration. Inspecting the prompt copy revealed the wording was directionally inverted:

```
... ran 0.27x over (actual / predicted).
Adjust predicted_runtime_minutes to account for your historical overruns.
```

`0.27x over` is linguistically backwards (you can't "run over" by less than 1x), and "historical overruns" tells the agent to predict HIGHER when the data says it's been predicting too high already. The agent followed the (wrong) instruction perfectly — predicted high, finished in 5 minutes.

Filed as **#498** with a proposed neutral phrasing ("Multiply your raw estimate by 0.27x") plus a test that exercises ratio < 1 (the existing test used ratio 1.18, which is internally consistent).

### Plan-quality note

The plan-stage agent followed the #492 citation rule beautifully here:
- `od` portability cited to pubs.opengroup.org POSIX spec
- Pipe-subshell exit semantics cited to GNU Bash manual §3.2.2 (caught a real bug in the proposal's example code)
- macOS bash 3.2 compatibility verified
- `cafebabe` collision with Java .class files acknowledged

## Test plan

- [x] `scripts/test` — all gates green.
- [x] `scripts/test coverage` — aggregate 82.0% (above 80% gate).
- [x] `scripts/test-pre-commit-hook` — 4/4 pass.
- [x] `fishhawk_verify_run` on this run: `verified=true`, chain_length=13.
- [ ] Operator validation: `git config core.hooksPath .githooks` then try `git add fishhawk-mcp && git commit` — should be rejected with a clear message.

Closes #495