### PR TITLE
prompt: directionally-neutral calibration hint copy (#498)

### DIFF
--- a/backend/internal/prompt/prompt.go
+++ b/backend/internal/prompt/prompt.go
@@ -265,7 +265,7 @@ func buildPlan(t Trigger) string {
 		"from them. Fix: drain the pipe before calling Wait, or use io.Pipe indirection. Cited: os/exec.Cmd.Wait docs (https://pkg.go.dev/os/exec#Cmd.Wait).\n")
 	if t.CalibrationHint != nil {
 		b.WriteString("\n### Calibration hint\n\n")
-		fmt.Fprintf(&b, "Your last %d implement-stage predictions on this workflow ran %.2fx over (actual / predicted).\n",
+		fmt.Fprintf(&b, "Your last %d implement-stage predictions on this workflow: actual runtime was %.2fx of predicted (actual / predicted).\n",
 			t.CalibrationHint.Samples, t.CalibrationHint.CalibrationRatio)
 		b.WriteString("Confidence-band accuracy:\n")
 		for _, level := range []string{"high", "medium", "low"} {
@@ -276,7 +276,7 @@ func buildPlan(t Trigger) string {
 			fmt.Fprintf(&b, "- %s: %d samples, %d within 1.5x of prediction\n",
 				level, band.Samples, band.WithinScale)
 		}
-		b.WriteString("Adjust predicted_runtime_minutes to account for your historical overruns.\n")
+		fmt.Fprintf(&b, "Multiply your raw estimate by %.2f to get a calibrated value.\n", t.CalibrationHint.CalibrationRatio)
 	}
 	return b.String()
 }

--- a/backend/internal/prompt/prompt_test.go
+++ b/backend/internal/prompt/prompt_test.go
@@ -428,11 +428,12 @@ func TestBuild_Plan_CalibrationHintRendered(t *testing.T) {
 	}
 	wants := []string{
 		"### Calibration hint",
-		"1.18x",
+		"actual runtime was 1.18x of predicted",
 		"10 implement-stage",
 		"high: 4 samples, 3 within 1.5x of prediction",
 		"medium: 6 samples, 4 within 1.5x of prediction",
 		"low: 2 samples, 2 within 1.5x of prediction",
+		"Multiply your raw estimate by 1.18",
 	}
 	for _, w := range wants {
 		if !strings.Contains(got, w) {
@@ -445,6 +446,33 @@ func TestBuild_Plan_CalibrationHintRendered(t *testing.T) {
 	if hintIdx < 0 || waitIdx < 0 || hintIdx < waitIdx {
 		t.Errorf("calibration hint should appear after cmd.Wait (hintIdx=%d waitIdx=%d):\n%s",
 			hintIdx, waitIdx, got)
+	}
+}
+
+func TestBuild_Plan_CalibrationHintRendered_RatioBelowOne(t *testing.T) {
+	got, err := Build("plan", Trigger{
+		IssueNumber: 7,
+		Repo:        "x/y",
+		CalibrationHint: &CalibrationHint{
+			Samples:          5,
+			CalibrationRatio: 0.27,
+			ConfidenceBands: map[string]CalibrationBand{
+				"high": {Samples: 5, WithinScale: 2},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	// Directional words must be absent — they mislead when ratio < 1.
+	for _, bad := range []string{"overruns", "over ("} {
+		if strings.Contains(got, bad) {
+			t.Errorf("calibration hint should not contain directional word %q when ratio < 1:\n%s", bad, got)
+		}
+	}
+	// Neutral multiplier phrase must be present.
+	if !strings.Contains(got, "Multiply your raw estimate by 0.27") {
+		t.Errorf("calibration hint missing neutral multiplier phrase:\n%s", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Replaces the two directionally-inverted phrases in `buildPlan`'s calibration hint:
  - `"ran X.XXx over (actual / predicted)"` → `"actual runtime was X.XXx of predicted (actual / predicted)"`
  - `"Adjust predicted_runtime_minutes to account for your historical overruns."` → `"Multiply your raw estimate by X.XX to get a calibrated value."`
- New `TestBuild_Plan_CalibrationHintRendered_RatioBelowOne` (ratio 0.27): asserts `over (` and `overruns` are absent, `Multiply your raw estimate by 0.27` is present.
- Existing `TestBuild_Plan_CalibrationHintRendered` (ratio 1.18): wants slice updated to match the new wording. Catches regressions in either direction.

## Notes

The previous wording assumed `calibration_ratio > 1` (under-prediction). On `feature_change` today, the ratio is 0.27 (over-prediction), so the hint was reading "you've been running over budget; predict higher" — exactly backwards. The agent followed the (wrong) instruction perfectly on PR #495 — predicted 22 min for a 5 min task.

Driven through the local MCP loop (run `80aa5707`). Plan 5.7k tokens, implement **3.4k tokens** — ~3 minutes actual, well under the 8 min prediction. `fishhawk_verify_run` returned `verified=true` with 13-entry chain.

**Calibration loop end-to-end story so far**:
- 5 samples, ratio 0.27 → wrong hint → agent over-predicted (22 min for 5 min work)
- This PR fixes the wording
- Once merged, the next plan should read "multiply by 0.27" and bias predictions down

## Test plan

- [x] `scripts/test` — all gates green.
- [x] `scripts/test coverage` — aggregate 82.0% (above 80% gate).
- [x] `golangci-lint run ./backend/...` — 0 issues.
- [x] New test exercises ratio < 1; old test still passes with updated wording.
- [x] `fishhawk_verify_run` on this run: `verified=true`, chain_length=13.
- [ ] Live verification: next plan after merge should bias predictions downward when ratio < 1.

Closes #498