### PR TITLE
prompt: incremental verification discipline + expensive-test warning (#468)

### DIFF
--- a/backend/internal/plan/plan_test.go
+++ b/backend/internal/plan/plan_test.go
@@ -437,6 +437,60 @@ func TestWarnings_SubPlanSumGeParent_NoWarnings(t *testing.T) {
 	}
 }
 
+func TestWarnings_ExpensiveTestStrategy(t *testing.T) {
+	cases := []struct {
+		name     string
+		strategy string
+		runtime  int
+		wantWarn bool
+	}{
+		{
+			name:     "count100_race_fullrepo_low_runtime",
+			strategy: "go test -count 100 -race ./...",
+			runtime:  10,
+			wantWarn: true,
+		},
+		{
+			name:     "race_fullrepo_low_runtime",
+			strategy: "go test -race ./...",
+			runtime:  5,
+			wantWarn: true,
+		},
+		{
+			name:     "count100_high_runtime",
+			strategy: "go test -count 100 ./internal/foo/...",
+			runtime:  25,
+			wantWarn: false,
+		},
+		{
+			name:     "no_expensive_flags",
+			strategy: "go test ./internal/foo/...",
+			runtime:  5,
+			wantWarn: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &plan.Plan{
+				Verification:            plan.Verification{TestStrategy: tc.strategy},
+				PredictedRuntimeMinutes: tc.runtime,
+			}
+			warns := plan.Warnings(p)
+			hasWarn := false
+			for _, w := range warns {
+				if strings.Contains(w, "expensive gate") {
+					hasWarn = true
+					break
+				}
+			}
+			if hasWarn != tc.wantWarn {
+				t.Errorf("wantWarn=%v hasWarn=%v strategy=%q runtime=%d warns=%v",
+					tc.wantWarn, hasWarn, tc.strategy, tc.runtime, warns)
+			}
+		})
+	}
+}
+
 func TestSemanticError_FormatsMessage(t *testing.T) {
 	err := &plan.SemanticError{Message: "duplicate title \"Foo\""}
 	want := "plan: semantic: duplicate title \"Foo\""

--- a/backend/internal/plan/validate.go
+++ b/backend/internal/plan/validate.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/santhosh-tekuri/jsonschema/v6"
@@ -18,6 +20,14 @@ var schemaFS embed.FS
 // once at package init; if the embedded schema is malformed we want
 // to crash loudly at process start, not on the first call.
 var compiledSchema = mustCompileSchema()
+
+// expensiveTestRuntimeThreshold is the minimum predicted_runtime_minutes
+// value that suppresses the expensive-test-strategy advisory warning.
+// Claiming a full-repo race run finishes in under 20 minutes is suspicious.
+const expensiveTestRuntimeThreshold = 20
+
+// expensiveCountRe matches -count N and -count=N flag forms in a test strategy string.
+var expensiveCountRe = regexp.MustCompile(`(?i)-count[= ](\d+)`)
 
 func mustCompileSchema() *jsonschema.Schema {
 	const path = "schemas/plan-standard-v1.schema.json"
@@ -108,27 +118,44 @@ func semanticCheck(p *Plan) error {
 
 // Warnings returns advisory strings for a successfully-parsed Plan.
 // These are soft checks — the plan is valid but the caller may want
-// to surface the messages in review UI or logs. Currently emits one
-// warning when the sum of sub-plan predicted_runtime_minutes is less
-// than the parent's predicted_runtime_minutes (the agent may have
-// legitimately compressed work, so this is not a hard rejection).
+// to surface the messages in review UI or logs. Emits a warning when:
+//   - the sum of sub-plan predicted_runtime_minutes is less than the
+//     parent's (agent may have compressed work — soft signal for review);
+//   - test_strategy names expensive gates (-count >= 50 or full-repo
+//     -race) but predicted_runtime_minutes is below expensiveTestRuntimeThreshold
+//     (runtime budget is likely too optimistic for the stated gates).
 func Warnings(p *Plan) []string {
-	if p.Decomposition == nil || len(p.Decomposition.SubPlans) == 0 {
-		return nil
-	}
-	sum := 0
-	for _, sp := range p.Decomposition.SubPlans {
-		sum += sp.PredictedRuntimeMinutes
-	}
-	if sum < p.PredictedRuntimeMinutes {
-		return []string{
-			fmt.Sprintf(
+	var warns []string
+
+	if p.Decomposition != nil && len(p.Decomposition.SubPlans) > 0 {
+		sum := 0
+		for _, sp := range p.Decomposition.SubPlans {
+			sum += sp.PredictedRuntimeMinutes
+		}
+		if sum < p.PredictedRuntimeMinutes {
+			warns = append(warns, fmt.Sprintf(
 				"decomposition sub-plan runtime sum (%d min) is less than parent predicted_runtime_minutes (%d min); agent may have compressed scope",
 				sum, p.PredictedRuntimeMinutes,
-			),
+			))
 		}
 	}
-	return nil
+
+	strategy := p.Verification.TestStrategy
+	hasExpensiveCount := false
+	if m := expensiveCountRe.FindStringSubmatch(strategy); m != nil {
+		if n, err := strconv.Atoi(m[1]); err == nil && n >= 50 {
+			hasExpensiveCount = true
+		}
+	}
+	hasExpensiveRace := strings.Contains(strategy, "-race") && strings.Contains(strategy, "./...")
+	if (hasExpensiveCount || hasExpensiveRace) && p.PredictedRuntimeMinutes < expensiveTestRuntimeThreshold {
+		warns = append(warns, fmt.Sprintf(
+			"test_strategy contains an expensive gate but predicted_runtime_minutes (%d) is below %d; allocate explicit time for the expensive step",
+			p.PredictedRuntimeMinutes, expensiveTestRuntimeThreshold,
+		))
+	}
+
+	return warns
 }
 
 // schemaErrorFrom collapses a jsonschema.ValidationError tree to the

--- a/backend/internal/prompt/prompt.go
+++ b/backend/internal/prompt/prompt.go
@@ -263,6 +263,11 @@ func buildPlan(t Trigger) string {
 		"kill(-pgid, SIGKILL). Cited: syscall.SysProcAttr docs (https://pkg.go.dev/syscall#SysProcAttr).\n")
 	b.WriteString("- cmd.Wait and pipe-read race: cmd.Wait closes the parent-side pipe file descriptors while a goroutine is still reading " +
 		"from them. Fix: drain the pipe before calling Wait, or use io.Pipe indirection. Cited: os/exec.Cmd.Wait docs (https://pkg.go.dev/os/exec#Cmd.Wait).\n")
+	b.WriteString("\n")
+	b.WriteString("Incremental verification discipline: run relevant tests once after each batch of related changes rather than exhaustively at the end. " +
+		"Run golangci-lint on touched packages only (e.g. `golangci-lint run ./internal/foo/...`), not the whole repo. " +
+		"Reserve expensive gates (e.g. -count >= 50, full-repo -race) for the final iteration once you are confident the implementation is correct. " +
+		"If your plan commits to an expensive step, allocate explicit minutes for it in predicted_runtime_minutes.\n")
 	if t.CalibrationHint != nil {
 		b.WriteString("\n### Calibration hint\n\n")
 		fmt.Fprintf(&b, "Your last %d implement-stage predictions on this workflow: actual runtime was %.2fx of predicted (actual / predicted).\n",

--- a/backend/internal/prompt/prompt_test.go
+++ b/backend/internal/prompt/prompt_test.go
@@ -513,6 +513,20 @@ func TestBuild_Plan_CalibrationHint_Deterministic(t *testing.T) {
 	}
 }
 
+func TestBuild_Plan_ContainsIncrementalVerification(t *testing.T) {
+	got, err := Build("plan", Trigger{
+		Source:      "github_issue",
+		IssueNumber: 7,
+		Repo:        "x/y",
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if !strings.Contains(got, "Incremental verification discipline") {
+		t.Errorf("plan prompt missing 'Incremental verification discipline':\n%s", got)
+	}
+}
+
 func TestBuild_Implement_WithSparsePlan_OmitsEmptySections(t *testing.T) {
 	// A plan that fails optional sections (no scope.files, no
 	// risks) should still render cleanly — empty sections drop

--- a/docs/spec/plan-standard-v1.md
+++ b/docs/spec/plan-standard-v1.md
@@ -100,6 +100,18 @@ Ordered list of steps. Each step has a 1-indexed `step` number and a `descriptio
 
 Reviewers expect concrete tests, not "add tests." Rollback plans flag whether a change is purely additive or has data migration consequences.
 
+### Verification with tiered checkpoints
+
+Plans that include expensive test gates must allocate wall-clock time for them in `predicted_runtime_minutes`. The agent should name cheap per-batch checks separately from the expensive final pass:
+
+```json
+{
+  "test_strategy": "After each batch of changes: run unit tests for the touched package only (e.g. `go test ./internal/foo/...`). Final iteration when implementation is complete: run the full flake check (`go test -count 100 -race ./...`). The expensive final pass is estimated at 15 minutes and is included in predicted_runtime_minutes."
+}
+```
+
+Expensive gates are: `-count >= 50`, or `-race` combined with `./...` (full-repo). These are reserved for the final iteration. The advisory heuristic in `plan.Warnings` surfaces a warning when an expensive gate appears in `test_strategy` but `predicted_runtime_minutes` is below 20, flagging plans where the runtime budget is implausibly short for the stated verification approach.
+
 ### Runtime prediction
 
 Two required fields capture the agent's estimate of how long the implement stage will take.


### PR DESCRIPTION
## Summary

- `buildPlan` extended with an "Incremental verification discipline" paragraph: tests once per batch, lint touched packages only, save expensive gates (`-count >= 50`, `-race ./...`) for the final iteration, allocate explicit minutes for expensive steps.
- `plan.Warnings` gains a heuristic detector — when `test_strategy` mentions `-count >= 50` or `-race` + `./...` AND `predicted_runtime_minutes < 20`, an advisory warning surfaces. Threshold is a named constant for easy tuning.
- `docs/spec/plan-standard-v1.md` gains a "Verification with tiered checkpoints" example.
- New tests cover both the prompt-contains-discipline assertion and the four-way warning matrix (`-count 100 -race ./...` + low predicted → warn; `-race ./...` alone + low → warn; `-count 100` alone + high predicted → no warn; no expensive flags → no warn).

## Notes

**Calibration validation moment**: this was the first plan-stage run after PR #500 (calibration hint copy fix) merged. With 8 samples on `feature_change` at ratio 0.20, the new prompt now reads "Multiply your raw estimate by 0.20." The agent predicted **5 minutes (medium confidence)** — a dramatic shift from yesterday's 15-25 min range on similar prompt-package work.

Recent prompt-package predictions for comparison:
- #491 (calibration hint section, similar scope): 20 min predicted
- #492 (citation rule, similar scope): 12 min predicted
- #498 (calibration copy fix, smaller): 8 min predicted
- **#468 (this one, post-copy-fix): 5 min predicted ← 25 × 0.20 = 5**

The calibration loop is working end-to-end: data is captured (#489), surfaced to the agent (#491/#497), correctly worded (#498/#500), and **observably affecting predictions**.

Bonus: the plan that generated this PR exemplified the rule it adds — its own test_strategy named per-package incremental checks ("after steps 1-2 run prompt tests only; after steps 3-4 run plan tests only") rather than batching at the end.

Driven through the local MCP loop (run `857b883e`). Plan 6.9k tokens, implement 10k tokens, **actual ~7 min** (vs 5 min predicted — within 50%). `fishhawk_verify_run` returned `verified=true` with 13-entry chain. Pre-commit hook (#499) active locally; passed clean.

## Test plan

- [x] `scripts/test` — all gates green.
- [x] `scripts/test coverage` — aggregate 82.0% (above 80% gate).
- [x] `golangci-lint run ./backend/...` — 0 issues.
- [x] `TestBuild_Plan_ContainsIncrementalVerification` asserts the rule renders.
- [x] `TestWarnings_ExpensiveTestStrategy` 4-row matrix covers warn / no-warn cases.
- [x] `fishhawk_verify_run` on this run: `verified=true`, chain_length=13.
- [ ] Live verification: next agent attempting an expensive verification step in a low-budget plan should see a Warnings advisory.

Closes #468