### PR TITLE
runner: in-band test gate before implement → succeeded (#441)

### DIFF
--- a/backend/internal/spec/schemas/workflow-v0.schema.json
+++ b/backend/internal/spec/schemas/workflow-v0.schema.json
@@ -149,6 +149,24 @@
               "type": "string",
               "pattern": "^([0-9]+(ns|us|ms|s|m|h))+$",
               "description": "Wall-clock cap for this stage's agent invocation. Overrides workflow.policy.max_stage_runtime when set. Falls back to the workflow policy or the backend default (15m) when absent. Parsed by time.ParseDuration."
+            },
+            "verify": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["command"],
+              "description": "Optional in-band test gate. When present, the runner executes the command after the agent exits cleanly. Non-zero exit demotes the run to category-A before the bundle is committed.",
+              "properties": {
+                "command": {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "Shell command run as the verify gate (executed via sh -c). Non-zero exit code demotes the run to category-A."
+                },
+                "timeout": {
+                  "type": "string",
+                  "pattern": "^([0-9]+(ns|us|ms|s|m|h))+$",
+                  "description": "Wall-clock cap on the verify command. Parsed by time.ParseDuration. Defaults to 10m when absent."
+                }
+              }
             }
           }
         },

--- a/cli/internal/spec/schemas/workflow-v0.schema.json
+++ b/cli/internal/spec/schemas/workflow-v0.schema.json
@@ -149,6 +149,24 @@
               "type": "string",
               "pattern": "^([0-9]+(ns|us|ms|s|m|h))+$",
               "description": "Wall-clock cap for this stage's agent invocation. Overrides workflow.policy.max_stage_runtime when set. Falls back to the workflow policy or the backend default (15m) when absent. Parsed by time.ParseDuration."
+            },
+            "verify": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["command"],
+              "description": "Optional in-band test gate. When present, the runner executes the command after the agent exits cleanly. Non-zero exit demotes the run to category-A before the bundle is committed.",
+              "properties": {
+                "command": {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "Shell command run as the verify gate (executed via sh -c). Non-zero exit code demotes the run to category-A."
+                },
+                "timeout": {
+                  "type": "string",
+                  "pattern": "^([0-9]+(ns|us|ms|s|m|h))+$",
+                  "description": "Wall-clock cap on the verify command. Parsed by time.ParseDuration. Defaults to 10m when absent."
+                }
+              }
             }
           }
         },

--- a/docs/spec/examples/workflow-v0-feature-change.yaml
+++ b/docs/spec/examples/workflow-v0-feature-change.yaml
@@ -51,6 +51,9 @@ workflows:
         type: implement
         executor:
           agent: claude-code
+          verify:
+            command: 'scripts/test'
+            timeout: '10m'
         inputs:
           - artifact: plan
             from_stage: plan

--- a/docs/spec/workflow-v0.md
+++ b/docs/spec/workflow-v0.md
@@ -29,6 +29,9 @@ Identifiers (`<role_id>`, `<workflow_id>`, stage `id`s) are `snake_case` — `^[
   executor: # exactly one of agent or human
     agent: claude-code # any string; v0 ships claude-code
     timeout: 10m       # optional; stage-level override for agent timeout
+    verify:            # optional; in-band test gate (see ### Verify gate)
+      command: 'scripts/test'
+      timeout: '10m'
     # OR
     human: true
   inputs: [<input>...] # optional
@@ -39,6 +42,24 @@ Identifiers (`<role_id>`, `<workflow_id>`, stage `id`s) are `snake_case` — `^[
 ```
 
 Stage `id` is unique within the workflow. The `from_stage` field on inputs cross-references it; the validator (E1.3 / #18) enforces this beyond the schema.
+
+### Verify gate
+
+An optional in-band test gate that fires after the agent exits cleanly and before the bundle is committed. When `verify` is absent, the gate is skipped.
+
+```yaml
+executor:
+  agent: claude-code
+  verify:
+    command: 'scripts/test'   # executed via sh -c; non-zero exit → category-A
+    timeout: '10m'            # optional; defaults to 10m when absent
+```
+
+The runner captures combined stdout+stderr into a `verify_run` bundle event so operators can inspect why the gate failed without re-running. Fields: `command`, `exit_code`, `output`, `outcome` (`"passed"` | `"failed"`).
+
+The gate fires only when the agent itself succeeded (i.e., `res.OK` is true) — a failing agent already produces a category-A trace, and re-running the tests against a broken working tree would be misleading.
+
+The full wiring path from spec to runner is deferred: v0 ships `verify` as a documented spec field for authoring surface. The runner reads the gate command from the `--verify-cmd` CLI flag; a follow-up issue will wire the backend to read `executor.verify.command` from the cached spec and deliver it to the runner via the prompt-fetch response.
 
 ## Inputs
 

--- a/docs/spec/workflow-v0.schema.json
+++ b/docs/spec/workflow-v0.schema.json
@@ -149,6 +149,24 @@
               "type": "string",
               "pattern": "^([0-9]+(ns|us|ms|s|m|h))+$",
               "description": "Wall-clock cap for this stage's agent invocation. Overrides workflow.policy.max_stage_runtime when set. Falls back to the workflow policy or the backend default (15m) when absent. Parsed by time.ParseDuration."
+            },
+            "verify": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["command"],
+              "description": "Optional in-band test gate. When present, the runner executes the command after the agent exits cleanly. Non-zero exit demotes the run to category-A before the bundle is committed.",
+              "properties": {
+                "command": {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "Shell command run as the verify gate (executed via sh -c). Non-zero exit code demotes the run to category-A."
+                },
+                "timeout": {
+                  "type": "string",
+                  "pattern": "^([0-9]+(ns|us|ms|s|m|h))+$",
+                  "description": "Wall-clock cap on the verify command. Parsed by time.ParseDuration. Defaults to 10m when absent."
+                }
+              }
             }
           }
         },

--- a/runner/cmd/fishhawk-runner/flags.go
+++ b/runner/cmd/fishhawk-runner/flags.go
@@ -50,6 +50,14 @@ type config struct {
 	baseBranch string
 	noPR       bool
 
+	// verifyCmd is the shell command run as the in-band test gate
+	// after the agent exits cleanly. Empty (default) skips the gate.
+	// Corresponds to executor.verify.command in the workflow spec;
+	// delivered via --verify-cmd until the backend wires the field
+	// through the prompt-fetch response.
+	verifyCmd     string
+	verifyTimeout time.Duration
+
 	// decomposedFromRunID is set at runtime (not a flag) when the
 	// fetched prompt reveals that this run is a decomposed child.
 	// Drives shared-branch routing in openPRAndShipArtifact.
@@ -102,6 +110,10 @@ func parseFlags(args []string, w io.Writer) (config, error) {
 		"base branch for the implement-stage PR; falls back to GITHUB_REF_NAME env then to 'main' when both empty")
 	fs.BoolVar(&cfg.noPR, "no-pr", false,
 		"skip the implement-stage git push + PR open; the working tree stays dirty for the operator to commit themselves. Default posture for local-runner dev loops")
+	fs.StringVar(&cfg.verifyCmd, "verify-cmd", "",
+		"shell command run as the in-band test gate after the agent exits cleanly (executed via sh -c); empty means skip. Corresponds to executor.verify.command in the workflow spec.")
+	fs.DurationVar(&cfg.verifyTimeout, "verify-timeout", 0,
+		"wall-clock cap on the verify command; 0 means fall back to 10m inside runVerifyGate")
 
 	if err := fs.Parse(args); err != nil {
 		return cfg, err

--- a/runner/cmd/fishhawk-runner/main.go
+++ b/runner/cmd/fishhawk-runner/main.go
@@ -320,6 +320,20 @@ func run(args []string, logSink io.Writer) (exitCode int) {
 		}
 	}
 
+	// Verify gate: optional in-band test gate that fires after constraint
+	// evaluation and before bundle building. Non-zero exit from the
+	// verify command demotes to category-A (#441).
+	if res.OK && cfg.verifyCmd != "" {
+		ev, demote := runVerifyGate(ctx, cfg, logSink)
+		res.Events = append(res.Events, ev)
+		if demote != nil {
+			res.OK = false
+			res.FailureCategory = "A"
+			res.FailureReason = demote.Error()
+			invokeErr = demote
+		}
+	}
+
 	// Bundle building is shared by --bundle-out and --upload-trace.
 	// We build raw + redacted variants once into memory, then write
 	// to disk and/or upload. When neither is configured, fall back
@@ -910,6 +924,65 @@ func validatePlan(path string) (agent.Event, error) {
 		Kind:    "policy_event",
 		Payload: agent.MakePayload(map[string]string{"check": "plan_validation", "outcome": "valid", "path": path}),
 	}, nil
+}
+
+// runVerifyGate runs the --verify-cmd shell command as an in-band test
+// gate after the agent exits cleanly. It captures combined output,
+// emits a verify_run event, and returns a non-nil error (which the
+// caller uses to demote the run to category-A) when the command exits
+// non-zero.
+//
+// The command runs via "sh -c <verifyCmd>" so the flag accepts any
+// shell expression. Setpgid=true places the child in a new process
+// group; cmd.Cancel kills the whole group on context cancellation so
+// grandchildren (e.g. go test subprocesses) don't keep the output
+// pipe open and block CombinedOutput.
+func runVerifyGate(ctx context.Context, cfg config, _ io.Writer) (agent.Event, error) {
+	timeout := cfg.verifyTimeout
+	if timeout == 0 {
+		timeout = 10 * time.Minute
+	}
+	childCtx, childCancel := context.WithTimeout(ctx, timeout)
+	defer childCancel()
+
+	cmd := exec.CommandContext(childCtx, "sh", "-c", cfg.verifyCmd)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process != nil {
+			_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		}
+		return nil
+	}
+
+	output, cmdErr := cmd.CombinedOutput()
+
+	exitCode := 0
+	if cmdErr != nil {
+		var exitErr *exec.ExitError
+		if errors.As(cmdErr, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		} else {
+			exitCode = -1
+		}
+	}
+
+	outcome := "passed"
+	var gateErr error
+	if exitCode != 0 {
+		outcome = "failed"
+		gateErr = fmt.Errorf("verify gate failed: %s exited %d", cfg.verifyCmd, exitCode)
+	}
+
+	ev := agent.Event{
+		Kind: "verify_run",
+		Payload: agent.MakePayload(map[string]any{
+			"command":   cfg.verifyCmd,
+			"exit_code": exitCode,
+			"output":    string(output),
+			"outcome":   outcome,
+		}),
+	}
+	return ev, gateErr
 }
 
 // emitEvents writes one JSON object per line. This is the

--- a/runner/cmd/fishhawk-runner/main_test.go
+++ b/runner/cmd/fishhawk-runner/main_test.go
@@ -2478,6 +2478,168 @@ func TestRun_ImplementStage_DecomposedSubsequentChild(t *testing.T) {
 	}
 }
 
+// --- Verify gate (#441) ---
+
+// TestVerify_NoCmd_SkipsGate confirms that when --verify-cmd is absent
+// run() returns exitOK and the bundle contains no verify_run event.
+func TestVerify_NoCmd_SkipsGate(t *testing.T) {
+	dir := t.TempDir()
+	promptPath := filepath.Join(dir, "prompt.txt")
+	bundlePath := filepath.Join(dir, "trace.jsonl.gz")
+	_ = os.WriteFile(promptPath, []byte("p"), 0o600)
+
+	withFakeInvoker(t, &fakeInvoker{canned: agent.Result{OK: true}})
+
+	var stderr strings.Builder
+	got := run([]string{
+		"--run-id", "rid", "--backend-url", "u",
+		"--workflow", "w", "--stage", "s",
+		"--prompt-file", promptPath,
+		"--bundle-out", bundlePath,
+		// --verify-cmd intentionally absent
+	}, &stderr)
+	if got != exitOK {
+		t.Fatalf("run = %d, want exitOK:\n%s", got, stderr.String())
+	}
+
+	data, err := os.ReadFile(bundlePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, events, _, err := openBundleForTest(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, ev := range events {
+		if ev.Kind == "verify_run" {
+			t.Errorf("unexpected verify_run event in bundle when --verify-cmd is absent: %+v", ev)
+		}
+	}
+}
+
+// TestVerify_Passes confirms that --verify-cmd 'true' exits 0, the
+// run succeeds, and the bundle contains a verify_run event with outcome=passed.
+func TestVerify_Passes(t *testing.T) {
+	dir := t.TempDir()
+	promptPath := filepath.Join(dir, "prompt.txt")
+	bundlePath := filepath.Join(dir, "trace.jsonl.gz")
+	_ = os.WriteFile(promptPath, []byte("p"), 0o600)
+
+	withFakeInvoker(t, &fakeInvoker{canned: agent.Result{OK: true}})
+
+	var stderr strings.Builder
+	got := run([]string{
+		"--run-id", "rid", "--backend-url", "u",
+		"--workflow", "w", "--stage", "s",
+		"--prompt-file", promptPath,
+		"--bundle-out", bundlePath,
+		"--verify-cmd", "true",
+	}, &stderr)
+	if got != exitOK {
+		t.Fatalf("run = %d, want exitOK:\n%s", got, stderr.String())
+	}
+
+	data, err := os.ReadFile(bundlePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, events, _, err := openBundleForTest(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sawPassed bool
+	for _, ev := range events {
+		if ev.Kind == "verify_run" && strings.Contains(string(ev.Data), `"outcome":"passed"`) {
+			sawPassed = true
+		}
+	}
+	if !sawPassed {
+		t.Errorf("missing verify_run outcome=passed in bundle:\n%+v", events)
+	}
+}
+
+// TestVerify_Fails confirms that --verify-cmd 'false' exits 1, the run
+// exits with exitFailure, the bundle manifest marks agent_failed=true,
+// and the bundle contains a verify_run event with outcome=failed.
+func TestVerify_Fails(t *testing.T) {
+	dir := t.TempDir()
+	promptPath := filepath.Join(dir, "prompt.txt")
+	bundlePath := filepath.Join(dir, "trace.jsonl.gz")
+	_ = os.WriteFile(promptPath, []byte("p"), 0o600)
+
+	withFakeInvoker(t, &fakeInvoker{canned: agent.Result{OK: true}})
+
+	var stderr strings.Builder
+	got := run([]string{
+		"--run-id", "rid", "--backend-url", "u",
+		"--workflow", "w", "--stage", "s",
+		"--prompt-file", promptPath,
+		"--bundle-out", bundlePath,
+		"--verify-cmd", "false",
+	}, &stderr)
+	if got != exitFailure {
+		t.Errorf("run = %d, want exitFailure", got)
+	}
+	if !strings.Contains(stderr.String(), `"category":"A"`) {
+		t.Errorf("expected category-A on verify failure, got:\n%s", stderr.String())
+	}
+
+	data, err := os.ReadFile(bundlePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest, events, _, err := openBundleForTest(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !manifest.AgentFailed {
+		t.Errorf("manifest.AgentFailed = false, want true on verify failure")
+	}
+	var sawFailed bool
+	for _, ev := range events {
+		if ev.Kind == "verify_run" && strings.Contains(string(ev.Data), `"outcome":"failed"`) {
+			sawFailed = true
+		}
+	}
+	if !sawFailed {
+		t.Errorf("missing verify_run outcome=failed in bundle:\n%+v", events)
+	}
+}
+
+// TestVerify_CtxCancelledMidGate confirms that when the runner context
+// is cancelled while the verify command is running, run() exits with
+// exitCancelled (130) and emits a runner_cancelled log line.
+func TestVerify_CtxCancelledMidGate(t *testing.T) {
+	prompt := filepath.Join(t.TempDir(), "prompt.txt")
+	_ = os.WriteFile(prompt, []byte("p"), 0o600)
+
+	// Agent returns immediately so the verify gate is reached.
+	withFakeInvoker(t, &fakeInvoker{canned: agent.Result{OK: true}})
+
+	cancel := withCancelableRunnerContext(t)
+
+	// Cancel after a brief delay so the verify command is running.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	var out strings.Builder
+	got := run([]string{
+		"--run-id", "rid", "--backend-url", "u",
+		"--workflow", "w", "--stage", "s",
+		"--prompt-file", prompt,
+		"--verify-cmd", "sleep 60",
+	}, &out)
+
+	if got != exitCancelled {
+		t.Errorf("run = %d, want exitCancelled(%d)", got, exitCancelled)
+	}
+	if !strings.Contains(out.String(), `"event":"runner_cancelled"`) {
+		t.Errorf("missing runner_cancelled log line:\n%s", out.String())
+	}
+}
+
 // TestRun_FetchPrompt_OperatorTimeoutWins verifies that when --timeout is
 // passed explicitly, the operator value wins over the server-resolved
 // AgentTimeoutSeconds, regardless of what the server returns.


### PR DESCRIPTION
## Summary

- Runner gains an in-band verify gate that fires after `Invoke` returns clean and before bundle commit. Non-zero exit demotes the implement stage to category-A with the gate's combined output as `FailureReason` and a `verify_run` event captured into the trace bundle.
- New `--verify-cmd` and `--verify-timeout` flags on the runner (default empty / 10m).
- Workflow-spec schema extended with an additive `executor.verify` object documenting the intended authoring surface. Spec-driven delivery (backend → FetchedPrompt) deferred to a follow-up; this PR uses the CLI flag.
- Four test shapes cover skip / pass / fail / cancel.
- `scripts/sync-schemas` propagates schema changes to backend + CLI embedded copies.

## Notes

This is a **three-feature validation moment** for today's quality stack:

### #491/#500 calibration hint visibly shifted prediction

The agent predicted **9 minutes** for this M-sized work (245 LoC, 6 files). Without the calibration hint (`Multiply your raw estimate by 0.20`), the raw estimate would have been ~30-45 min. The 0.20x multiplier brought it to 9. **Actual: ~6 min implement** — within the calibrated range, and dramatically more honest than yesterday's 15-25 min predictions on comparable work.

### #468 incremental verification discipline literally followed

The plan's test_strategy uses tiered checkpoints exactly as #468 prescribes:
> After step 1: check-jsonschema (cheap, validates schema)
> After step 3: go build ./runner/... (cheap, compile check)
> After step 4: go test ./runner/cmd/fishhawk-runner/... -race (focused package, existing tests)
> After step 5: go test ./runner/cmd/fishhawk-runner/... -race (focused, new tests)
> **Final**: scripts/test (aggregate) + golangci-lint

No `-count 100 -race ./...` at the end. The agent self-paced testing per the new rule.

### #447 citation rule applied throughout

Every risk assumption cited a source (Go stdlib doc URLs for `Cmd.CombinedOutput`, `SysProcAttr`, JSON Schema Draft 2020-12 backward-compat semantics) and named a falsifying test.

The full ADR-025 quality stack (calibration capture → MCP tool → prompt hint → directional fix → discipline rule + citation rule) is now end-to-end working in a single observation.

Driven through the local MCP loop (run `74ed2f06`). `fishhawk_verify_run` returned `verified=true` with 13-entry chain. Pre-commit hook (#499) active locally; passed clean.

## Test plan

- [x] `scripts/test` — all gates green.
- [x] `scripts/test coverage` — aggregate 82.1% (above 80% gate).
- [x] `golangci-lint run ./runner/...` — 0 issues.
- [x] Four runner test shapes: no gate / pass / fail / cancel-mid-gate.
- [x] `check-jsonschema` against both example workflow files — pass (additive field, no breakage).
- [x] `scripts/sync-schemas` propagated to 2 embedded mirror copies.
- [x] `fishhawk_verify_run` on this run: `verified=true`, chain_length=13.
- [ ] Live verification: an operator running `fishhawk runner start --verify-cmd scripts/test` on a broken-implementation run should see category-A with the test output captured.

Closes #441