### PR TITLE
scripts: cleanup-merged helper deletes local branches merged to main (#505)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,8 @@ When editing a schema under `docs/spec/`, run `scripts/sync-schemas` to mirror t
    - Update sibling issues if scope shifted (e.g., a CI fix bundled here means another sibling no longer needs it).
    - If an ADR was resolved, edit its body's Decision section and close.
 
+Run `scripts/cleanup-merged` to delete local branches that have been merged into `origin/main` (optional; can be wired into a post-merge git hook).
+
 Force-pushing a feature branch is fine with `--force-with-lease`; ask before force-pushing if there are review comments. Never force-push `main`.
 
 ## Project tracker (#7)

--- a/scripts/cleanup-merged
+++ b/scripts/cleanup-merged
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+git fetch origin main --quiet
+
+count=0
+while IFS= read -r branch; do
+  [ "$branch" = "main" ] && continue
+  if git merge-base --is-ancestor "$branch" origin/main 2>/dev/null; then
+    git branch -D "$branch" >/dev/null
+    echo "deleted (merged): $branch"
+    count=$((count + 1))
+  fi
+done < <(git for-each-ref --format='%(refname:short)' refs/heads/)
+
+echo "cleaned $count branch(es)"

--- a/scripts/test-cleanup-merged
+++ b/scripts/test-cleanup-merged
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Smoke test for scripts/cleanup-merged.
+# Spins up an isolated temp git repo, creates a merged and an unmerged branch,
+# runs the script, and asserts the correct branches are deleted or preserved.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PASS=0
+FAIL=0
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+git -C "$tmpdir" init -q
+git -C "$tmpdir" config user.email "test@example.com"
+git -C "$tmpdir" config user.name "Test"
+
+# Seed an initial commit on main so HEAD exists.
+touch "$tmpdir/README"
+git -C "$tmpdir" add README
+git -C "$tmpdir" commit -q -m "init"
+
+# Rename default branch to 'main' for determinism.
+git -C "$tmpdir" branch -m main
+
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+# Create a branch, commit to it, then merge it back into main.
+git -C "$tmpdir" checkout -q -b merged-branch
+echo "merged" > "$tmpdir/merged.txt"
+git -C "$tmpdir" add merged.txt
+git -C "$tmpdir" commit -q -m "merged commit"
+git -C "$tmpdir" checkout -q main
+git -C "$tmpdir" merge --no-ff -q -m "merge merged-branch" merged-branch
+
+# Create a branch with an unmerged commit.
+git -C "$tmpdir" checkout -q -b unmerged-branch
+echo "unmerged" > "$tmpdir/unmerged.txt"
+git -C "$tmpdir" add unmerged.txt
+git -C "$tmpdir" commit -q -m "unmerged commit"
+git -C "$tmpdir" checkout -q main
+
+# Point origin/main at the local main so merge-base checks work without a remote.
+git -C "$tmpdir" remote add origin "$tmpdir"
+git -C "$tmpdir" fetch -q origin main
+
+# Run the script inside the temp repo directory.
+output=$(cd "$tmpdir" && bash "$REPO_ROOT/scripts/cleanup-merged" 2>&1)
+
+# Case 1: merged-branch should have been deleted.
+if ! git -C "$tmpdir" show-ref --verify --quiet refs/heads/merged-branch; then
+  pass "merged-branch was deleted"
+else
+  fail "merged-branch should have been deleted (output: $output)"
+fi
+
+# Case 2: unmerged-branch should still exist.
+if git -C "$tmpdir" show-ref --verify --quiet refs/heads/unmerged-branch; then
+  pass "unmerged-branch was preserved"
+else
+  fail "unmerged-branch should have been preserved (output: $output)"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

- `scripts/cleanup-merged` deletes local branches whose tip is reachable from `origin/main` via `git merge-base --is-ancestor`. Skips `main`. Squash-merged branches (non-ancestor tip) are deliberately left alone per #505's out-of-scope note.
- `scripts/test-cleanup-merged` smoke test: temp repo with one merged + one unmerged branch, run the helper, assert deletion behavior. 2/2 pass.
- `CLAUDE.md` "Git flow" section gains a one-line mention of the helper as an optional post-merge step.

## Notes

First task of the day per the roadmap. The 5-command branch dance after every merge compounded across yesterday's 13 PRs — this helper replaces all of that with a single invocation.

Driven through the local MCP loop (run `649ad53d`). Plan 4.5k tokens, implement **3.4k tokens (~3 min actual)** — calibration multiplier visibly applied: predicted 4 min for a 20 min raw estimate. `fishhawk_verify_run` returned `verified=true` with 13-entry chain.

The plan and implement both followed yesterday's quality patterns:
- **Citation rule** (#492): git docs cited for `--is-ancestor`, bash 3.2 compatibility noted
- **Incremental verification** (#501): "After step 2: test-cleanup-merged. After step 4: scripts/test. No expensive gates needed for this scope."

## Test plan

- [x] `scripts/test-cleanup-merged` — 2/2 pass.
- [x] `scripts/test` — all gates green.
- [x] `fishhawk_verify_run` on this run: `verified=true`, chain_length=13.
- [ ] Operator validation: after merging this PR, run `scripts/cleanup-merged` and confirm it deletes today's just-merged feature branches.

Closes #505