### PR TITLE
webhook: CI-failure retry branches on runner_kind for local runs (#445)

### DIFF
--- a/backend/internal/webhook/dispatcher.go
+++ b/backend/internal/webhook/dispatcher.go
@@ -1318,35 +1318,46 @@ func (d *Dispatcher) handleCIFailureRetry(ctx context.Context, ev Event, m Match
 		return fmt.Errorf("dispatcher: create retry stages: %w", err)
 	}
 
-	// Step 8: fire workflow_dispatch on the first retry stage.
-	repo, err := parseRepo(ev.Repo)
-	if err != nil {
-		return fmt.Errorf("dispatcher: parse repo: %w", err)
-	}
-	dispatchRef := d.DefaultRef
-	if dispatchRef == "" {
-		dispatchRef = "main"
-	}
-	actionsFile := d.ActionsWorkflowFile
-	if actionsFile == "" {
-		actionsFile = DefaultActionsWorkflowFile
-	}
+	// Step 8: fire workflow_dispatch on the first retry stage, or skip
+	// for local-runner runs — they stay in pending for the agent to
+	// discover via fishhawk_list_runs / fishhawk_verify_run (ADR-022 / #445).
 	firstStage := stages[0]
-	dispatchErr := d.GitHub.DispatchWorkflow(ctx, installationID, repo,
-		actionsFile, dispatchRef, githubclient.DispatchInputs{
-			"run_id":      child.ID.String(),
-			"stage_id":    firstStage.ID.String(),
-			"workflow_id": parent.WorkflowID,
-			"stage":       firstStage.ExecutorRef,
-		})
-	if dispatchErr == nil {
-		if _, err := d.Runs.TransitionStage(ctx, firstStage.ID,
-			run.StageStateDispatched, nil); err != nil {
-			d.logger().LogAttrs(ctx, slog.LevelWarn,
-				"ci_failure_retry: transition stage to dispatched failed",
-				slog.String("delivery_id", ev.DeliveryID),
-				slog.String("stage_id", firstStage.ID.String()),
-				slog.String("error", err.Error()))
+	var dispatchErr error
+	switch parent.RunnerKind {
+	case run.RunnerKindLocal:
+		d.logger().LogAttrs(ctx, slog.LevelInfo,
+			"ci_failure_retry: local runner — child run pending, no dispatch",
+			slog.String("delivery_id", ev.DeliveryID),
+			slog.String("run_id", child.ID.String()))
+	default:
+		repo, err := parseRepo(ev.Repo)
+		if err != nil {
+			return fmt.Errorf("dispatcher: parse repo: %w", err)
+		}
+		dispatchRef := d.DefaultRef
+		if dispatchRef == "" {
+			dispatchRef = "main"
+		}
+		actionsFile := d.ActionsWorkflowFile
+		if actionsFile == "" {
+			actionsFile = DefaultActionsWorkflowFile
+		}
+		dispatchErr = d.GitHub.DispatchWorkflow(ctx, installationID, repo,
+			actionsFile, dispatchRef, githubclient.DispatchInputs{
+				"run_id":      child.ID.String(),
+				"stage_id":    firstStage.ID.String(),
+				"workflow_id": parent.WorkflowID,
+				"stage":       firstStage.ExecutorRef,
+			})
+		if dispatchErr == nil {
+			if _, err := d.Runs.TransitionStage(ctx, firstStage.ID,
+				run.StageStateDispatched, nil); err != nil {
+				d.logger().LogAttrs(ctx, slog.LevelWarn,
+					"ci_failure_retry: transition stage to dispatched failed",
+					slog.String("delivery_id", ev.DeliveryID),
+					slog.String("stage_id", firstStage.ID.String()),
+					slog.String("error", err.Error()))
+			}
 		}
 	}
 
@@ -1565,6 +1576,7 @@ func (d *Dispatcher) writeCIRetryDispatchedAudit(ctx context.Context, ev Event, 
 		"retry_attempt": child.RetryAttempt,
 		"max_retries":   maxRetries,
 		"outcome":       outcome,
+		"runner_kind":   parent.RunnerKind,
 	}
 	if dispatchErr != nil {
 		payload["error"] = dispatchErr.Error()

--- a/backend/internal/webhook/dispatcher_test.go
+++ b/backend/internal/webhook/dispatcher_test.go
@@ -850,6 +850,7 @@ func (s *stubRuns) CreateRun(_ context.Context, p run.CreateRunParams) (*run.Run
 		WorkflowSpec:           p.WorkflowSpec,
 		RetryAttempt:           p.RetryAttempt,
 		MaxRetriesSnapshot:     p.MaxRetriesSnapshot,
+		RunnerKind:             p.RunnerKind,
 		State:                  run.StatePending,
 		CreatedAt:              time.Now().UTC(),
 		UpdatedAt:              time.Now().UTC(),
@@ -2569,6 +2570,7 @@ func seedParentRunForRetry(t *testing.T, runs *stubRuns, repo, specYAML string, 
 		WorkflowSpec:       []byte(specYAML),
 		RetryAttempt:       retryAttempt,
 		MaxRetriesSnapshot: 1, // ciRetrySpec sets max_retries: 1
+		RunnerKind:         run.RunnerKindGitHubActions,
 		State:              run.StateRunning,
 		CreatedAt:          time.Now().Add(-time.Minute).UTC(),
 		UpdatedAt:          time.Now().Add(-time.Minute).UTC(),
@@ -2778,5 +2780,93 @@ func TestHandle_CIFailureRetry_DuplicateHeadSHA_Skips(t *testing.T) {
 	}
 	if len(au.appended) != 0 {
 		t.Errorf("audit rows = %d, want 0 (dedup skipped silently)", len(au.appended))
+	}
+}
+
+func TestHandle_CIFailureRetry_LocalRunner_MintsChildSkipsDispatch(t *testing.T) {
+	d, gh, runs, au := newDispatcherWithStubs(t)
+	d.Artifacts = &stubArtifacts{}
+
+	// Seed a parent run with runner_kind=local instead of using
+	// seedParentRunForRetry so the RunnerKind is explicit.
+	prURL := "https://github.com/kuhlman-labs/fishhawk/pull/42"
+	triggerRef := "issue:1247"
+	installID := int64(42)
+	parent := &run.Run{
+		ID:             uuid.New(),
+		Repo:           "kuhlman-labs/fishhawk",
+		WorkflowID:     "feature_change",
+		WorkflowSHA:    "feedf00d",
+		TriggerSource:  run.TriggerGitHubIssue,
+		TriggerRef:     &triggerRef,
+		InstallationID: &installID,
+		PullRequestURL: &prURL,
+		RequiredChecksSnapshot: &run.RequiredChecksSnapshot{
+			Contexts: []string{"ci/build"},
+			Sources:  []string{"branch_protection"},
+		},
+		WorkflowSpec:       []byte(ciRetrySpec),
+		RetryAttempt:       0,
+		MaxRetriesSnapshot: 1,
+		RunnerKind:         run.RunnerKindLocal,
+		State:              run.StateRunning,
+		CreatedAt:          time.Now().Add(-time.Minute).UTC(),
+		UpdatedAt:          time.Now().Add(-time.Minute).UTC(),
+	}
+	runs.mu.Lock()
+	runs.created = append(runs.created, parent)
+	runs.mu.Unlock()
+
+	if err := d.Handle(context.Background(), checkRunFailedEvent(t)); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+
+	// Child run minted (parent + child = 2).
+	if len(runs.created) != 2 {
+		t.Fatalf("runs.created = %d, want 2 (parent + child)", len(runs.created))
+	}
+	child := runs.created[1]
+
+	// Child inherits runner_kind=local.
+	if child.RunnerKind != run.RunnerKindLocal {
+		t.Errorf("child.RunnerKind = %q, want local", child.RunnerKind)
+	}
+
+	// No workflow_dispatch fired for local-runner runs.
+	if gh.dispatchCalls != 0 {
+		t.Errorf("DispatchWorkflow calls = %d, want 0 (local runner)", gh.dispatchCalls)
+	}
+
+	// Child's first stage remains in pending (not transitioned to dispatched).
+	var childStages []*run.Stage
+	for _, st := range runs.createdStages {
+		if st.RunID == child.ID {
+			childStages = append(childStages, st)
+		}
+	}
+	if len(childStages) == 0 {
+		t.Fatal("no child stages created")
+	}
+	if childStages[0].State != run.StageStatePending {
+		t.Errorf("child stage state = %q, want pending (no dispatch for local)", childStages[0].State)
+	}
+
+	// One ci_failure_retry_dispatched audit row with runner_kind=local and outcome=dispatched.
+	var dispatched *audit.ChainAppendParams
+	for i := range au.appended {
+		if au.appended[i].Category == "ci_failure_retry_dispatched" {
+			dispatched = &au.appended[i]
+			break
+		}
+	}
+	if dispatched == nil {
+		t.Fatalf("expected ci_failure_retry_dispatched audit row; got %+v", au.appended)
+	}
+	payload := string(dispatched.Payload)
+	if !strings.Contains(payload, `"runner_kind":"local"`) {
+		t.Errorf("audit payload missing runner_kind:local: %s", payload)
+	}
+	if !strings.Contains(payload, `"outcome":"dispatched"`) {
+		t.Errorf("audit payload missing outcome:dispatched: %s", payload)
 	}
 }

--- a/docs/issue-comment-surfaces.md
+++ b/docs/issue-comment-surfaces.md
@@ -60,6 +60,9 @@ early. Comment posting moves to the CLI side, where the operator's authed
 | `fishhawk run cancel <run-id>` | `ghcomment.RenderRunCancelled` | cancellation accepted |
 | `fishhawk runner start --run-id …` | `ghcomment.RenderStageComplete` | runner subprocess exits cleanly |
 | `fishhawk runner start --run-id … --stage implement` | `ghcomment.RenderImplementPROpened` | auto-PR succeeded (--no-pr absent and stage type is implement) |
+| _(agent-driven — see note)_ | `ghcomment.RenderCIRetryMinted` | CI-failure auto-retry minted a new child run (`runner_kind=local`); agent posts after discovering the child via `fishhawk_verify_run` or `fishhawk_list_runs` |
+
+The CI-failure retry path (`handleCIFailureRetry`) branches on `runner_kind`: for `local` runs it mints the child run and leaves it in `pending` without firing `workflow_dispatch`. The discovery signal for the agent is a `ci_failure_retry_dispatched` audit entry whose payload contains `"runner_kind":"local"` — the agent polls for this entry, then posts the retry-minted comment via `gh issue comment` and drives the child run forward.
 
 Renderers live in `cli/internal/ghcomment`; the post step shells to
 `gh issue comment <N> --repo <owner/name> --body …`. v0 scope is append-only


### PR DESCRIPTION
## Summary

- `handleCIFailureRetry` switches on `parent.RunnerKind`:
  - `github_actions` (default): unchanged.
  - `local`: mint child run + stages + `ci_failure_retry_dispatched` audit entry, skip `DispatchWorkflow`. Child stays in `pending` for the agent to drive via `fishhawk_run_stage`.
- Audit payload gains `runner_kind` field (backward-compatible — existing GHA rows just have nil).
- `seedParentRunForRetry` test helper updated to set `RunnerKind: GitHubActions` so all 5 existing CI-retry tests now route through the explicit GHA branch.
- New `TestHandle_CIFailureRetry_LocalRunner_MintsChildSkipsDispatch` asserts: 2 runs created (parent + child), child has `runner_kind=local`, 0 dispatch calls, audit payload contains `runner_kind: local`, child's first stage in `pending` (not `dispatched`).
- `docs/issue-comment-surfaces.md` documents the "retry minted" comment as agent-driven (matches the existing local-runner pattern; backend has no installation_id for local runs).

## Notes

This was the M-L estimate from yesterday's roadmap but the agent correctly scoped it down to S (~65 LoC) by reading the issue body's Q1 design answer ("agent-driven comment is cleaner") and matching the existing local-runner no-installation-id pattern. Backend-only change, no MCP or runner work needed.

Driven through the local MCP loop (run `59490b3b`). Plan 10k tokens, implement 11.3k tokens (~9 min actual vs 12 min predicted — under prediction, good calibration sign). `fishhawk_verify_run` returned `verified=true` with 13-entry chain.

The agent-driven retry discovery path will naturally flow through `fishhawk_verify_run` (#494) — its `category_counts` shows any new audit entries since last call. A future enhancement could fold "pending retry" status into the verify response (per issue Q2) so the agent has a clear single signal, but for v0 the audit-entry discovery is sufficient.

## Test plan

- [x] `scripts/test` — all gates green.
- [x] `scripts/test coverage` — aggregate 82.1% (above 80% gate).
- [x] `golangci-lint run ./backend/...` — 0 issues.
- [x] All 5 existing CI-retry tests pass with the seed helper update.
- [x] New `LocalRunner` test confirms mint-without-dispatch.
- [x] `fishhawk_verify_run` on this run: `verified=true`, chain_length=13.
- [ ] Live verification: a `runner_kind=local` PR's CI failure should mint a pending retry run that the agent can pick up on its next `fishhawk_list_runs` call.

Closes #445