### PR TITLE
scripts+docs: local-dev ergonomics bundle (#466)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ out/
 *.swp
 *.swo
 *~
+.claude/
 
 # OS
 .DS_Store
@@ -46,6 +47,7 @@ Thumbs.db
 
 # Logs
 *.log
+logs/
 
 # Node / frontend build artifacts (will land with E7.1)
 node_modules/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,18 @@ python3 scripts/check-coverage.py --threshold 80 --exclude '/db/' "${profiles[@]
 
 When editing a schema under `docs/spec/`, run `scripts/sync-schemas` to mirror the change into all embedded copies before committing. CI fails the schema-sync gate otherwise. Opt-in local check: `git config core.hooksPath .githooks`.
 
+### Rebuild matrix
+
+`scripts/dev up` always rebuilds `fishhawkd`. A future enhancement could auto-detect which binaries need rebuilding from `git diff main...HEAD`.
+
+| If PR touches | Rebuild |
+|---|---|
+| `backend/cmd/fishhawkd/` or `backend/internal/{server,prompt,plan,spec,runner,webhook,notifier,github,storage,db,...}` | `fishhawkd` |
+| `backend/cmd/fishhawk-mcp/` | `fishhawk-mcp` |
+| `runner/cmd/fishhawk-runner/` or `runner/internal/...` | `fishhawk-runner` |
+| `cli/cmd/fishhawk/` or `cli/internal/...` | `fishhawk` CLI |
+| `backend/internal/plan/` or `backend/internal/spec/` (shared libs) | all four binaries |
+
 ## Adding a Go module
 
 1. `mkdir <name> && cd <name> && go mod init github.com/kuhlman-labs/fishhawk/<name>`

--- a/scripts/dev
+++ b/scripts/dev
@@ -1,0 +1,129 @@
+#!/usr/bin/env zsh
+# scripts/dev — start/stop the local Fishhawk dev stack
+set -euo pipefail
+
+REPO_ROOT="${0:A:h:h}"
+PID_FILE="${REPO_ROOT}/.fishhawk/dev.pid"
+LOG_DIR="${REPO_ROOT}/logs"
+LOG_FILE="${LOG_DIR}/fishhawkd.log"
+BIN="${REPO_ROOT}/bin/fishhawkd"
+
+cmd="${1:-}"
+
+_die() { print -u2 "error: $*"; exit 1 }
+
+_pg_ready() {
+  local host="${PGHOST:-localhost}"
+  local port="${PGPORT:-5432}"
+
+  # Parse host:port from DATABASE_URL if set
+  if [[ -n "${FISHHAWKD_DATABASE_URL:-}" ]]; then
+    local stripped="${FISHHAWKD_DATABASE_URL#*://}"   # drop scheme
+    stripped="${stripped#*@}"                          # drop user:pass@
+    local hostport="${stripped%%/*}"                   # take host:port before /
+    host="${hostport%%:*}"
+    port="${hostport##*:}"
+    [[ "$host" == "$port" ]] && port=5432             # no colon — default port
+  fi
+
+  if command -v pg_isready &>/dev/null; then
+    pg_isready -h "$host" -p "$port" -q
+  else
+    nc -z "$host" "$port" 2>/dev/null
+  fi
+}
+
+_minio_ready() {
+  local endpoint="${MINIO_ENDPOINT:-http://localhost:9000}"
+  curl --silent --fail --max-time 3 "${endpoint}/minio/health/live" &>/dev/null
+}
+
+cmd_up() {
+  # Idempotency: bail if already running
+  if [[ -f "$PID_FILE" ]]; then
+    local existing_pid
+    existing_pid="$(cat "$PID_FILE")"
+    if kill -0 "$existing_pid" 2>/dev/null; then
+      print "fishhawkd already running (pid ${existing_pid})"
+      return 0
+    fi
+    rm -f "$PID_FILE"
+  fi
+
+  # Logs directory
+  mkdir -p "$LOG_DIR"
+
+  # Environment
+  if [[ -f "${REPO_ROOT}/.env" ]]; then
+    set -a
+    # shellcheck disable=SC1091
+    source "${REPO_ROOT}/.env"
+    set +a
+  else
+    print "warning: .env not found — using current shell environment"
+  fi
+
+  # Dependency health checks
+  if _pg_ready; then
+    print "postgres: ready"
+  else
+    print "warning: postgres not reachable — fishhawkd may fail to start"
+  fi
+
+  if _minio_ready; then
+    print "minio: ready"
+  else
+    print "warning: minio not reachable — fishhawkd may fail to start"
+  fi
+
+  # Build
+  print "building fishhawkd..."
+  mkdir -p "${REPO_ROOT}/bin"
+  (cd "${REPO_ROOT}" && go build -o bin/fishhawkd ./backend/cmd/fishhawkd/)
+
+  # Spawn
+  mkdir -p "${REPO_ROOT}/.fishhawk"
+  "${BIN}" serve >> "$LOG_FILE" 2>&1 &
+  local pid=$!
+  print "$pid" > "$PID_FILE"
+  print "fishhawkd started (pid ${pid}) — logs: ${LOG_FILE}"
+}
+
+cmd_down() {
+  if [[ ! -f "$PID_FILE" ]]; then
+    print "fishhawkd is not running (no pid file)"
+    return 0
+  fi
+
+  local pid
+  pid="$(cat "$PID_FILE")"
+
+  if ! kill -0 "$pid" 2>/dev/null; then
+    print "fishhawkd already stopped"
+    rm -f "$PID_FILE"
+    return 0
+  fi
+
+  kill -TERM "$pid"
+
+  local i=0
+  while kill -0 "$pid" 2>/dev/null && (( i < 5 )); do
+    sleep 1
+    (( i++ ))
+  done
+
+  if kill -0 "$pid" 2>/dev/null; then
+    kill -KILL "$pid"
+    print "fishhawkd killed (SIGKILL after 5s)"
+  else
+    print "fishhawkd stopped"
+  fi
+
+  rm -f "$PID_FILE"
+}
+
+case "$cmd" in
+  up)   cmd_up ;;
+  down) cmd_down ;;
+  *)    print -u2 "usage: scripts/dev <up|down>"; exit 1 ;;
+esac

--- a/scripts/loop-run
+++ b/scripts/loop-run
@@ -1,0 +1,111 @@
+#!/usr/bin/env zsh
+# scripts/loop-run — create a branch and mint a Fishhawk run for a GitHub issue
+set -euo pipefail
+
+_die() { print -u2 "error: $*"; exit 1 }
+_usage() {
+  print -u2 "usage: scripts/loop-run <issue-number> [--repo owner/name] [--workflow id] [--backend-url URL] [--token TOKEN] [--dry-run]"
+  exit 1
+}
+
+# Defaults
+issue_number=""
+repo=""
+workflow="default"
+backend_url=""
+token=""
+dry_run=0
+
+# Argument parsing
+while (( $# > 0 )); do
+  case "$1" in
+    --repo)        repo="$2";        shift 2 ;;
+    --workflow)    workflow="$2";    shift 2 ;;
+    --backend-url) backend_url="$2"; shift 2 ;;
+    --token)       token="$2";       shift 2 ;;
+    --dry-run)     dry_run=1;        shift   ;;
+    -*)            _usage ;;
+    *)
+      if [[ -z "$issue_number" ]]; then
+        issue_number="$1"
+        shift
+      else
+        _usage
+      fi
+      ;;
+  esac
+done
+
+[[ -n "$issue_number" ]] || _usage
+[[ "$issue_number" =~ ^[0-9]+$ ]] || _die "issue-number must be a positive integer, got: ${issue_number}"
+
+# Require gh
+if ! command -v gh &>/dev/null; then
+  _die "gh CLI not found — install from https://cli.github.com"
+fi
+
+# Auto-detect repo from git remote
+if [[ -z "$repo" ]]; then
+  local origin_url
+  origin_url="$(git remote get-url origin 2>/dev/null)" || _die "could not read git remote 'origin'; pass --repo owner/name"
+
+  # Strip HTTPS: https://github.com/owner/name.git → owner/name
+  # Strip SSH:   git@github.com:owner/name.git   → owner/name
+  repo="${origin_url#https://github.com/}"
+  repo="${repo#git@github.com:}"
+  repo="${repo%.git}"
+
+  [[ "$repo" == */* ]] || _die "could not parse repo from remote URL '${origin_url}'; pass --repo owner/name"
+fi
+
+# Fetch issue title
+print "fetching issue #${issue_number} from ${repo}..."
+issue_title="$(gh issue view "$issue_number" --repo "$repo" --json title --jq .title)" \
+  || _die "gh issue view failed — check authentication and issue number"
+
+# Derive branch slug
+slug="$(
+  print -n "$issue_title" \
+    | tr '[:upper:]' '[:lower:]' \
+    | tr -cs 'a-z0-9' '-' \
+    | sed 's/^-*//' \
+    | sed 's/-*$//' \
+    | cut -c1-60
+)"
+[[ -n "$slug" ]] || _die "could not derive a slug from issue title: ${issue_title}"
+
+branch="${issue_number}-${slug}"
+
+# Validate branch name
+git check-ref-format --branch "$branch" &>/dev/null \
+  || _die "derived branch name is invalid: ${branch}"
+
+# Build the run start command for display / execution
+typeset -a run_cmd
+run_cmd=(fishhawk run start --issue "$issue_number" --repo "$repo" --workflow "$workflow" --runner-kind local)
+[[ -n "$backend_url" ]] && run_cmd+=(--backend-url "$backend_url")
+[[ -n "$token" ]]       && run_cmd+=(--token "$token")
+
+if (( dry_run )); then
+  print "dry-run mode"
+  print "  branch:  ${branch}"
+  print "  run cmd: ${run_cmd[*]}"
+  exit 0
+fi
+
+# Create branch from origin/main
+git fetch origin main
+git checkout -b "$branch" origin/main
+
+# Start the run
+print "starting Fishhawk run..."
+run_output="$("${run_cmd[@]}")" || _die "fishhawk run start failed"
+
+run_id="$(print -n "$run_output" | grep '^id:' | head -1 | awk '{print $2}')"
+[[ -n "$run_id" ]] || _die "could not extract run ID from fishhawk output:\n${run_output}"
+
+print ""
+print "branch:  ${branch}"
+print "run id:  ${run_id}"
+print ""
+print "In Claude Code: use fishhawk_run_stage with run_id=${run_id} to drive plan → implement"


### PR DESCRIPTION
## Summary

Five-item dev-ergonomics bundle from the May 22 retro:

- **`scripts/dev`** (`up`/`down`): zsh wrapper for `fishhawkd` with health probes for Postgres + MinIO, log redirect to `./logs/`, PID tracking in `.fishhawk/dev.pid`. Idempotent.
- **`.gitignore`**: `.claude/` + `logs/` patterns.
- **`scripts/loop-run`**: branches from `origin/main` with an issue-title-derived slug, invokes `fishhawk run start`, prints next-step instructions.
- **`CLAUDE.md`**: Rebuild matrix table mapping path prefixes to which binaries need rebuilding.
- **Log discoverability**: `scripts/dev` prints the log path on startup.

## Notes

Driven through the local MCP loop (run `3f04a722`). Plan 14k tokens, implement **5.8k tokens (~5 min actual)** vs 15 min predicted — well under, calibration getting tighter. `fishhawk_verify_run` returned `verified=true` with 13-entry chain.

The agent went with `scripts/loop-run` shell wrapper over a Go CLI verb per the AC's explicit "or shell wrapper acceptable for v0" option — kept scope tight. Citations to MinIO health-check docs, bash 3.2 / zsh trap from CLAUDE.md memory, POSIX tr/sed portability for BSD vs GNU.

After this lands, the per-loop dance becomes:
```
scripts/dev up
scripts/loop-run <issue-number>
# (Claude Code drives plan → approve → implement via MCP)
# (verify_run, then git push + gh pr create as before; future ticket can fold those in)
```

Replaces several pages of manual setup. Pairs naturally with #443 (fishhawk doctor) when that lands.

## Test plan

- [x] `zsh -n scripts/dev` — syntax clean.
- [x] `zsh -n scripts/loop-run` — syntax clean.
- [x] `scripts/test` — all gates green (no Go changes).
- [x] `.gitignore` excludes `.claude/` and `logs/` (verified by inspection — existing untracked `.claude/` directory is now ignored).
- [x] `fishhawk_verify_run` on this run: `verified=true`, chain_length=13.
- [ ] Live verification: stop `fishhawkd`, run `scripts/dev up`, confirm log path is printed and `curl localhost:8080/healthz` succeeds.

Closes #466