### PR TITLE
cli: doctor polish — repo bin/ fallback + warn status (#514, #515)

### DIFF
--- a/cli/cmd/fishhawk/doctor.go
+++ b/cli/cmd/fishhawk/doctor.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/kuhlman-labs/fishhawk/cli/internal/spec"
@@ -17,8 +18,8 @@ import (
 type checkResult struct {
 	label     string
 	detail    string
-	status    string // "ok" or "fail"
-	remediate string // non-empty on fail
+	status    string // "ok", "warn", or "fail"
+	remediate string // non-empty on warn or fail
 }
 
 // doctorHTTPDo is the HTTP seam for doctor checks that probe the backend.
@@ -55,7 +56,7 @@ func runDoctor(args []string, stdout, stderr io.Writer) int {
 		checkBackend(*cf.backendURL),
 		checkToken(*cf.backendURL, *cf.token),
 		checkSpec(*workingDir),
-		checkRunnerBinary(*runnerBinary),
+		checkRunnerBinary(*runnerBinary, *workingDir),
 		checkMCPRegistration(),
 		checkGitOrigin(*workingDir),
 		checkGitWorkingTree(*workingDir),
@@ -65,26 +66,43 @@ func runDoctor(args []string, stdout, stderr io.Writer) int {
 	useColor := isTerminal(stdout) && os.Getenv("NO_COLOR") == ""
 
 	failures := 0
+	warnings := 0
 	for _, r := range checks {
 		statusStr := r.status
-		if useColor && r.status == "fail" {
-			statusStr = "\033[31mfail\033[0m"
+		if useColor {
+			switch r.status {
+			case "fail":
+				statusStr = "\033[31mfail\033[0m"
+			case "warn":
+				statusStr = "\033[33mwarn\033[0m"
+			}
 		}
 		_, _ = fmt.Fprintf(stdout, "%-25s %-40s %s\n", r.label, r.detail, statusStr)
 		if r.remediate != "" {
 			_, _ = fmt.Fprintf(stdout, "  hint: %s\n", r.remediate)
 		}
-		if r.status == "fail" {
+		switch r.status {
+		case "fail":
 			failures++
+		case "warn":
+			warnings++
 		}
 	}
 
 	_, _ = fmt.Fprintln(stdout, "")
 	if failures == 0 {
-		_, _ = fmt.Fprintln(stdout, "ready for local loop")
+		if warnings == 0 {
+			_, _ = fmt.Fprintln(stdout, "ready for local loop")
+		} else {
+			_, _ = fmt.Fprintf(stdout, "ready for local loop (%d warning(s))\n", warnings)
+		}
 		return exitOK
 	}
-	_, _ = fmt.Fprintf(stdout, "%d check(s) failed — fix the above before running the loop\n", failures)
+	if warnings == 0 {
+		_, _ = fmt.Fprintf(stdout, "%d check(s) failed — fix the above before running the loop\n", failures)
+	} else {
+		_, _ = fmt.Fprintf(stdout, "%d check(s) failed, %d warning(s) — fix the above before running the loop\n", failures, warnings)
+	}
 	return exitFailure
 }
 
@@ -189,22 +207,31 @@ func checkSpec(workingDir string) checkResult {
 	return checkResult{label: label, detail: detail, status: "ok"}
 }
 
-// checkRunnerBinary resolves the fishhawk-runner binary via flag > env > PATH.
-func checkRunnerBinary(flagVal string) checkResult {
+// checkRunnerBinary resolves the fishhawk-runner binary via flag > env > PATH > repo bin/.
+func checkRunnerBinary(flagVal, workingDir string) checkResult {
 	label := "runner binary found"
 	binary := flagVal
 	if binary == "" {
 		binary = os.Getenv("FISHHAWK_RUNNER_BIN")
 	}
-	if binary == "" {
-		resolved, err := doctorLookPath("fishhawk-runner")
-		if err != nil {
-			return checkResult{label: label, detail: "not found", status: "fail",
-				remediate: "install fishhawk-runner to PATH or set $FISHHAWK_RUNNER_BIN"}
-		}
-		binary = resolved
+	if binary != "" {
+		return checkResult{label: label, detail: binary, status: "ok"}
 	}
-	return checkResult{label: label, detail: binary, status: "ok"}
+	resolved, err := doctorLookPath("fishhawk-runner")
+	if err == nil {
+		return checkResult{label: label, detail: resolved, status: "ok"}
+	}
+	for _, candidate := range []string{
+		filepath.Join(workingDir, "bin", "fishhawk-runner"),
+		filepath.Join(workingDir, "bin", "fishhawk-runner.exe"),
+	} {
+		fi, statErr := os.Stat(candidate)
+		if statErr == nil && !fi.IsDir() {
+			return checkResult{label: label, detail: candidate + " (via repo bin/)", status: "ok"}
+		}
+	}
+	return checkResult{label: label, detail: "not found", status: "fail",
+		remediate: "install fishhawk-runner to PATH or set $FISHHAWK_RUNNER_BIN"}
 }
 
 // checkMCPRegistration verifies `claude mcp get fishhawk` exits 0.
@@ -244,8 +271,8 @@ func checkGitWorkingTree(workingDir string) checkResult {
 			remediate: "ensure you are inside a git repository"}
 	}
 	if strings.TrimSpace(string(out)) != "" {
-		return checkResult{label: label, detail: "uncommitted changes", status: "fail",
-			remediate: "commit or stash changes before starting a run"}
+		return checkResult{label: label, detail: "uncommitted changes", status: "warn",
+			remediate: "in-flight changes are expected mid-loop; commit or stash before starting a new run"}
 	}
 	return checkResult{label: label, detail: "clean", status: "ok"}
 }

--- a/cli/cmd/fishhawk/doctor_test.go
+++ b/cli/cmd/fishhawk/doctor_test.go
@@ -116,7 +116,7 @@ func TestDoctorCheck_MissingRunnerBinary(t *testing.T) {
 		return "", exec.ErrNotFound
 	})
 
-	r := checkRunnerBinary("") // no flag value, no env value
+	r := checkRunnerBinary("", t.TempDir()) // no flag value, no env value, empty bin/
 	if r.status != "fail" {
 		t.Errorf("status = %q, want fail", r.status)
 	}
@@ -206,6 +206,126 @@ func TestRunDoctor_FailsAndPrintsLabel(t *testing.T) {
 	}
 	if !strings.Contains(out, "check(s) failed") {
 		t.Errorf("stdout missing failure summary: %q", out)
+	}
+}
+
+// TestCheckRunnerBinary_RepoBinFallback verifies that checkRunnerBinary
+// returns ok with a "via repo bin/" detail when LookPath misses but
+// <workingDir>/bin/fishhawk-runner exists as a regular file.
+func TestCheckRunnerBinary_RepoBinFallback(t *testing.T) {
+	withFakeDoctorLookPath(t, func(_ string) (string, error) {
+		return "", exec.ErrNotFound
+	})
+
+	dir := t.TempDir()
+	binDir := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	candidate := filepath.Join(binDir, "fishhawk-runner")
+	if err := os.WriteFile(candidate, []byte("stub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	r := checkRunnerBinary("", dir)
+	if r.status != "ok" {
+		t.Errorf("status = %q, want ok (detail: %s, remediate: %s)", r.status, r.detail, r.remediate)
+	}
+	if !strings.Contains(r.detail, "via repo bin/") {
+		t.Errorf("detail %q should contain 'via repo bin/'", r.detail)
+	}
+}
+
+// TestCheckGitWorkingTree_DirtyTree_Warn verifies that checkGitWorkingTree
+// returns status "warn" (not "fail") when the working tree has uncommitted changes.
+func TestCheckGitWorkingTree_DirtyTree_Warn(t *testing.T) {
+	dir := t.TempDir()
+
+	// Init a real git repo so git status --porcelain works.
+	for _, args := range [][]string{
+		{"init", dir},
+		{"-C", dir, "config", "user.email", "test@example.com"},
+		{"-C", dir, "config", "user.name", "Test"},
+	} {
+		if out, err := exec.Command("git", args...).CombinedOutput(); err != nil { //nolint:gosec
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	// Write an uncommitted file so the tree is dirty.
+	if err := os.WriteFile(filepath.Join(dir, "dirty.txt"), []byte("untracked"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	r := checkGitWorkingTree(dir)
+	if r.status != "warn" {
+		t.Errorf("status = %q, want warn (detail: %s)", r.status, r.detail)
+	}
+}
+
+// TestRunDoctor_DirtyTree_ExitZero verifies that runDoctor returns exitOK
+// when the only imperfect rung is a dirty working tree (which is now a warn).
+func TestRunDoctor_DirtyTree_ExitZero(t *testing.T) {
+	dir := t.TempDir()
+
+	// Init a git repo with an uncommitted file.
+	for _, args := range [][]string{
+		{"init", dir},
+		{"-C", dir, "config", "user.email", "test@example.com"},
+		{"-C", dir, "config", "user.name", "Test"},
+	} {
+		if out, err := exec.Command("git", args...).CombinedOutput(); err != nil { //nolint:gosec
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(dir, "dirty.txt"), []byte("untracked"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write a valid spec so the spec rung passes.
+	hidden := filepath.Join(dir, ".fishhawk")
+	if err := os.MkdirAll(hidden, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(hidden, "workflows.yaml"), []byte(validateValidYAML), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Stub all rungs that require network or external binaries.
+	withFakeDoctorHTTP(t, func(req *http.Request) (*http.Response, error) {
+		switch {
+		case strings.HasSuffix(req.URL.Path, "/healthz"):
+			return fakeHTTPResponse(http.StatusOK, `{"status":"ok","version":"v0.0.0-test"}`), nil
+		default:
+			return fakeHTTPResponse(http.StatusOK, `{"items":[]}`), nil
+		}
+	})
+	withFakeDoctorLookPath(t, func(_ string) (string, error) {
+		return "/usr/local/bin/fishhawk-runner", nil
+	})
+	withFakeDoctorRunOutput(t, func(name string, _ ...string) (string, error) {
+		return fmt.Sprintf("%s ok", name), nil
+	})
+	origGitRemote := gitRemoteOriginURL
+	gitRemoteOriginURL = func(_ string) (string, error) {
+		return "https://github.com/kuhlman-labs/fishhawk.git", nil
+	}
+	t.Cleanup(func() { gitRemoteOriginURL = origGitRemote })
+
+	var stdout, stderr strings.Builder
+	got := run([]string{
+		"doctor",
+		"--backend-url", "http://localhost:8080",
+		"--token", "fhk_testtoken",
+		"--working-dir", dir,
+		"--runner-binary", "/usr/local/bin/fishhawk-runner",
+	}, &stdout, &stderr)
+
+	if got != exitOK {
+		t.Errorf("run = %d, want exitOK; stdout:\n%s", got, stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "ready for local loop") {
+		t.Errorf("stdout missing 'ready for local loop': %q", stdout.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

Two follow-ups from the live test of #511, bundled into one PR (same file, related polish):

### #514 — Repo `bin/` fallback for runner-binary check

`checkRunnerBinary` falls back to `<workingDir>/bin/fishhawk-runner` (and `.exe`) when `LookPath` returns `ErrNotFound`. Detail string includes "via repo bin/" so operators see the fallback fired. Precedence chain preserved: `--runner-binary` > `$FISHHAWK_RUNNER_BIN` > `$PATH` > repo `bin/`. Same pattern as PR #457 for the MCP server.

### #515 — `warn` status distinct from `fail`

`checkResult.status` gains a "warn" value. Warn rungs render yellow (gated by `isTerminal` + `NO_COLOR`), don't drive non-zero exit, count separately in the summary ("N fail(s), M warning(s)"). `checkGitWorkingTree` demoted to warn on dirty-tree with a revised hint ("in-flight changes are expected mid-loop"). Git-error branch stays "fail" because that's a real environment problem.

## Notes

Driven through the local MCP loop as two sequential runs on the same branch:

- Run `754469cd` (#514): plan 14.8k tokens, implement **4.4k tokens (~3 min actual)** vs 6 min predicted.
- Run `1312133a` (#515): plan 6.5k tokens, implement **4.9k tokens (~3 min actual)** vs 10 min predicted.

Both well under the calibrated regime. Both `fishhawk_verify_run` calls returned `verified=true` with 13-entry chains.

**Live-tested on this branch**: rebuilt `bin/fishhawk` and ran `fishhawk doctor` — runner-binary rung shows `bin/fishhawk-runner (via repo bin/) ok` and git-working-tree shows `uncommitted changes warn` with the new hint. Summary correctly reads `1 check(s) failed, 1 warning(s)`.

## Test plan

- [x] `scripts/test` — all gates green.
- [x] `scripts/test coverage` — aggregate 82.1% (above 80% gate).
- [x] `golangci-lint run ./cli/...` — 0 issues.
- [x] New test `TestCheckRunnerBinary_RepoBinFallback` exercises the #514 path.
- [x] New tests `TestCheckGitWorkingTree_DirtyTree_Warn` + `TestRunDoctor_DirtyTree_ExitZero` exercise the #515 path.
- [x] Live test on this branch confirms both fixes visible.
- [x] `fishhawk_verify_run` on both runs: verified=true.

Closes #514
Closes #515