### PR TITLE
cli: doctor schema-drift check reuses repo-bin fallback (#518)

### DIFF
--- a/cli/cmd/fishhawk/doctor.go
+++ b/cli/cmd/fishhawk/doctor.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -63,7 +64,7 @@ func runDoctor(args []string, stdout, stderr io.Writer) int {
 		checkGitWorkingTree(*workingDir),
 		checkGhCLI(),
 		checkBackendSHADrift(*cf.backendURL, *workingDir),
-		checkRunnerSchemaDrift(*cf.backendURL, *runnerBinary),
+		checkRunnerSchemaDrift(*cf.backendURL, *runnerBinary, *workingDir),
 		checkCLIVersion(*cf.backendURL),
 	}
 
@@ -211,19 +212,18 @@ func checkSpec(workingDir string) checkResult {
 	return checkResult{label: label, detail: detail, status: "ok"}
 }
 
-// checkRunnerBinary resolves the fishhawk-runner binary via flag > env > PATH > repo bin/.
-func checkRunnerBinary(flagVal, workingDir string) checkResult {
-	label := "runner binary found"
-	binary := flagVal
-	if binary == "" {
-		binary = os.Getenv("FISHHAWK_RUNNER_BIN")
+// resolveRunnerBinary applies the flag > env > PATH > repo bin/ precedence
+// chain for the fishhawk-runner binary. Returns the resolved path or an error
+// when all sources are exhausted.
+func resolveRunnerBinary(flagVal, workingDir string) (string, error) {
+	if flagVal != "" {
+		return flagVal, nil
 	}
-	if binary != "" {
-		return checkResult{label: label, detail: binary, status: "ok"}
+	if v := os.Getenv("FISHHAWK_RUNNER_BIN"); v != "" {
+		return v, nil
 	}
-	resolved, err := doctorLookPath("fishhawk-runner")
-	if err == nil {
-		return checkResult{label: label, detail: resolved, status: "ok"}
+	if p, err := doctorLookPath("fishhawk-runner"); err == nil {
+		return p, nil
 	}
 	for _, candidate := range []string{
 		filepath.Join(workingDir, "bin", "fishhawk-runner"),
@@ -231,11 +231,25 @@ func checkRunnerBinary(flagVal, workingDir string) checkResult {
 	} {
 		fi, statErr := os.Stat(candidate)
 		if statErr == nil && !fi.IsDir() {
-			return checkResult{label: label, detail: candidate + " (via repo bin/)", status: "ok"}
+			return candidate, nil
 		}
 	}
-	return checkResult{label: label, detail: "not found", status: "fail",
-		remediate: "install fishhawk-runner to PATH or set $FISHHAWK_RUNNER_BIN"}
+	return "", errors.New("fishhawk-runner not found in flag, env, PATH, or repo bin/")
+}
+
+// checkRunnerBinary resolves the fishhawk-runner binary via flag > env > PATH > repo bin/.
+func checkRunnerBinary(flagVal, workingDir string) checkResult {
+	label := "runner binary found"
+	resolved, err := resolveRunnerBinary(flagVal, workingDir)
+	if err != nil {
+		return checkResult{label: label, detail: "not found", status: "fail",
+			remediate: "install fishhawk-runner to PATH or set $FISHHAWK_RUNNER_BIN"}
+	}
+	detail := resolved
+	if filepath.Dir(resolved) == filepath.Join(workingDir, "bin") {
+		detail = resolved + " (via repo bin/)"
+	}
+	return checkResult{label: label, detail: detail, status: "ok"}
 }
 
 // checkMCPRegistration verifies `claude mcp get fishhawk` exits 0.
@@ -346,20 +360,11 @@ func checkBackendSHADrift(backendURL, workingDir string) checkResult {
 // schema hash (from /healthz) against the runner binary's embedded hash
 // (from 'fishhawk-runner version'). A mismatch warns that the plan schema
 // has drifted between the two binaries.
-func checkRunnerSchemaDrift(backendURL, runnerBinary string) checkResult {
+func checkRunnerSchemaDrift(backendURL, runnerBinary, workingDir string) checkResult {
 	label := "runner schema drift"
 
-	// Resolve runner binary path if not given explicitly.
-	runnerBin := runnerBinary
-	if runnerBin == "" {
-		runnerBin = os.Getenv("FISHHAWK_RUNNER_BIN")
-	}
-	if runnerBin == "" {
-		if p, err := doctorLookPath("fishhawk-runner"); err == nil {
-			runnerBin = p
-		}
-	}
-	if runnerBin == "" {
+	runnerBin, err := resolveRunnerBinary(runnerBinary, workingDir)
+	if err != nil {
 		return checkResult{label: label, detail: "runner binary not found, schema drift not checked", status: "warn",
 			remediate: "install fishhawk-runner or set $FISHHAWK_RUNNER_BIN"}
 	}

--- a/cli/cmd/fishhawk/doctor_test.go
+++ b/cli/cmd/fishhawk/doctor_test.go
@@ -362,7 +362,7 @@ func TestCheckRunnerSchemaDrift_RunnerNotFound(t *testing.T) {
 	withFakeDoctorLookPath(t, func(_ string) (string, error) {
 		return "", errors.New("not found")
 	})
-	r := checkRunnerSchemaDrift("http://localhost:8080", "")
+	r := checkRunnerSchemaDrift("http://localhost:8080", "", t.TempDir())
 	if r.status != "warn" {
 		t.Errorf("status = %q, want warn (no binary = degraded, not fail)", r.status)
 	}
@@ -377,7 +377,7 @@ func TestCheckRunnerSchemaDrift_RunnerLacksVersionSubcommand(t *testing.T) {
 	withFakeDoctorRunOutput(t, func(_ string, _ ...string) (string, error) {
 		return "", errors.New("unknown subcommand: version")
 	})
-	r := checkRunnerSchemaDrift("http://localhost:8080", "/usr/local/bin/fishhawk-runner")
+	r := checkRunnerSchemaDrift("http://localhost:8080", "/usr/local/bin/fishhawk-runner", t.TempDir())
 	if r.status != "warn" {
 		t.Errorf("status = %q, want warn (old runner = degraded, not fail)", r.status)
 	}
@@ -394,7 +394,7 @@ func TestCheckRunnerSchemaDrift_InSync(t *testing.T) {
 	withFakeDoctorRunOutput(t, func(_ string, _ ...string) (string, error) {
 		return `{"version":"v0.5.0","plan_schema_hash":"` + hash + `"}`, nil
 	})
-	r := checkRunnerSchemaDrift("http://localhost:8080", "/usr/local/bin/fishhawk-runner")
+	r := checkRunnerSchemaDrift("http://localhost:8080", "/usr/local/bin/fishhawk-runner", t.TempDir())
 	if r.status != "ok" {
 		t.Errorf("status = %q, want ok; detail: %s", r.status, r.detail)
 	}
@@ -409,12 +409,44 @@ func TestCheckRunnerSchemaDrift_Mismatch(t *testing.T) {
 	withFakeDoctorRunOutput(t, func(_ string, _ ...string) (string, error) {
 		return `{"version":"v0.5.0","plan_schema_hash":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb2222"}`, nil
 	})
-	r := checkRunnerSchemaDrift("http://localhost:8080", "/usr/local/bin/fishhawk-runner")
+	r := checkRunnerSchemaDrift("http://localhost:8080", "/usr/local/bin/fishhawk-runner", t.TempDir())
 	if r.status != "warn" {
 		t.Errorf("status = %q, want warn; detail: %s", r.status, r.detail)
 	}
 	if r.remediate == "" {
 		t.Error("remediate should be non-empty on mismatch")
+	}
+}
+
+// TestCheckRunnerSchemaDrift_RepoBinFallback verifies that checkRunnerSchemaDrift
+// resolves the runner via <workingDir>/bin/fishhawk-runner when LookPath misses
+// and no explicit binary is provided, then returns ok when schemas match.
+func TestCheckRunnerSchemaDrift_RepoBinFallback(t *testing.T) {
+	const hash = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	dir := t.TempDir()
+	binDir := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(binDir, "fishhawk-runner"), []byte("stub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	withFakeDoctorLookPath(t, func(_ string) (string, error) {
+		return "", exec.ErrNotFound
+	})
+	withFakeDoctorHTTP(t, func(_ *http.Request) (*http.Response, error) {
+		return fakeHTTPResponse(http.StatusOK,
+			`{"schemas":{"plan-standard-v1":"`+hash+`"}}`), nil
+	})
+	withFakeDoctorRunOutput(t, func(_ string, _ ...string) (string, error) {
+		return `{"version":"v0.5.0","plan_schema_hash":"` + hash + `"}`, nil
+	})
+
+	r := checkRunnerSchemaDrift("http://localhost:8080", "", dir)
+	if r.status != "ok" {
+		t.Errorf("status = %q, want ok (repo-bin fallback should resolve binary); detail: %s, remediate: %s",
+			r.status, r.detail, r.remediate)
 	}
 }
 

--- a/runner/cmd/fishhawk-runner/main.go
+++ b/runner/cmd/fishhawk-runner/main.go
@@ -159,14 +159,17 @@ func parseSemver(v string) []int {
 // captured up to the cancellation point) still packs + ships best-
 // effort if the body gets that far.
 func run(args []string, logSink io.Writer) (exitCode int) {
-	// version subcommand: emit JSON {version, plan_schema_hash} and exit.
+	// version subcommand: emit JSON {version, plan_schema_hash} to stdout
+	// and exit. Stdout (not logSink) because this is the command's primary
+	// data output, not a log line — `fishhawk doctor` and operators read it
+	// via `exec.Command().Output()` which captures stdout only.
 	// Must be checked before parseFlags, which requires run-id / backend-url.
 	if len(args) > 0 && args[0] == "version" {
 		out, _ := json.Marshal(map[string]string{
 			"version":          runnerVersion(),
 			"plan_schema_hash": plan.EmbeddedSchemaHash(),
 		})
-		_, _ = fmt.Fprintf(logSink, "%s\n", out)
+		_, _ = fmt.Fprintf(os.Stdout, "%s\n", out)
 		return exitOK
 	}
 

--- a/runner/cmd/fishhawk-runner/main_test.go
+++ b/runner/cmd/fishhawk-runner/main_test.go
@@ -2820,16 +2820,36 @@ func TestSemverLT(t *testing.T) {
 }
 
 // TestRun_VersionSubcommand verifies that 'fishhawk-runner version' emits
-// JSON with version and plan_schema_hash, then exits 0.
+// JSON with version and plan_schema_hash to STDOUT (not logSink), then
+// exits 0. stdout is the right stream because `fishhawk doctor` parses
+// the output via exec.Command().Output() which captures stdout only.
 func TestRun_VersionSubcommand(t *testing.T) {
-	var out strings.Builder
-	got := run([]string{"version"}, &out)
+	stdoutR, stdoutW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	origStdout := os.Stdout
+	os.Stdout = stdoutW
+	t.Cleanup(func() { os.Stdout = origStdout })
+
+	var logSink strings.Builder
+	got := run([]string{"version"}, &logSink)
+	if err := stdoutW.Close(); err != nil {
+		t.Fatalf("close stdout writer: %v", err)
+	}
+	stdoutBytes, err := io.ReadAll(stdoutR)
+	if err != nil {
+		t.Fatalf("read stdout: %v", err)
+	}
 	if got != exitOK {
-		t.Fatalf("run version = %d, want exitOK; output: %s", got, out.String())
+		t.Fatalf("run version = %d, want exitOK; stdout: %s; logSink: %s", got, stdoutBytes, logSink.String())
+	}
+	if logSink.Len() != 0 {
+		t.Errorf("logSink must be empty, got: %s", logSink.String())
 	}
 	var body map[string]string
-	if err := json.Unmarshal([]byte(strings.TrimSpace(out.String())), &body); err != nil {
-		t.Fatalf("version output not JSON: %v\n%s", err, out.String())
+	if err := json.Unmarshal([]byte(strings.TrimSpace(string(stdoutBytes))), &body); err != nil {
+		t.Fatalf("version output not JSON: %v\n%s", err, stdoutBytes)
 	}
 	if body["version"] == "" {
 		t.Error("version field must not be empty")


### PR DESCRIPTION
## Summary

Two related fixes, bundled because they both addressed gaps surfaced by the same live test of #517:

### Fix 1: schema-drift check reuses the repo-bin fallback (#518)

- Extracts `resolveRunnerBinary(flagVal, workingDir)` helper from `checkRunnerBinary` and wires it into `checkRunnerSchemaDrift`.
- Both rungs now follow the same precedence: `--runner-binary` flag > `$FISHHAWK_RUNNER_BIN` env > `$PATH` > `<workingDir>/bin/fishhawk-runner`.
- New `TestCheckRunnerSchemaDrift_RepoBinFallback` exercises the fallback through the schema-drift rung.

### Fix 2: runner `version` subcommand writes to stdout, not logSink

- Discovered during live test of Fix 1: the schema-drift rung found the binary but still warned "runner version output not parseable" because the runner's `version` subcommand wrote JSON to logSink (stderr), and `doctorRunOutput` reads stdout only.
- One-line fix: write to `os.Stdout` instead. The `version` subcommand's purpose is to emit data, not a log line.
- Test updated to capture `os.Stdout` via `os.Pipe` and assert `logSink` stays empty.

## End-to-end validation

After both fixes, `fishhawk doctor` on a fresh dev checkout shows:

```
runner binary found       bin/fishhawk-runner (via repo bin/)      ok
runner schema drift       schemas in sync                          ok
```

Both rungs working as designed for the local-dev install.

## Test plan

- [x] `scripts/test` — all gates green.
- [x] `scripts/test coverage` — aggregate 82.0% (above 80% gate).
- [x] `golangci-lint run ./runner/... ./cli/...` — 0 issues.
- [x] `TestCheckRunnerSchemaDrift_RepoBinFallback` exercises the fallback.
- [x] `TestRun_VersionSubcommand` updated to assert stdout (was checking buffer); confirms logSink stays empty.
- [x] Live: rebuilt CLI + runner, doctor reports "schemas in sync ok" on both rungs.

Closes #518