### PR TITLE
docs+scripts: codify ADR-026 schema backward-compat discipline (#472)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,27 @@ python3 scripts/check-coverage.py --threshold 80 --exclude '/db/' "${profiles[@]
 
 When editing a schema under `docs/spec/`, run `scripts/sync-schemas` to mirror the change into all embedded copies before committing. CI fails the schema-sync gate otherwise. Opt-in local check: `git config core.hooksPath .githooks`.
 
+### Schema change checklist
+
+Before opening a PR that adds or modifies a field in `docs/spec/`:
+
+1. **Additive or breaking?** New optional fields within the current major version (e.g., `standard_v1.x`, `workflow-v0.x`) are additive — proceed. A new *required* field in an existing major version is a breaking change and must be avoided: bump the major version instead (`standard_v2`, `workflow-v1`). Use the `x-intended-required` annotation (see below) to signal a field whose required promotion is deferred through a soak period.
+
+2. **Soak period.** When a field is introduced as optional but is intended to become required in a future version, declare the soak window in the PR body under `## Notes`. The soak period duration is determined per-PR; no minimum is set yet (TBD in a follow-up issue). During the soak, both the old and new schema versions are validated by the backend.
+
+3. **Version advertising.** After the schema change merges, update every surface that advertises supported schema versions:
+   - Plan validator (`backend/internal/plan/`) — add the new version string to the recognized set.
+   - Runner `/healthz` schema-versions endpoint (once #466 lands) — add the new version to the advertised list.
+
+4. **`x-intended-required` annotation.** When a field is optional now but will become required in the next major version, annotate it in the JSON Schema:
+   ```json
+   "some_field": {
+     "type": "string",
+     "x-intended-required": true
+   }
+   ```
+   JSON Schema Draft 2020-12 §10.3 collects unknown keywords as annotations without affecting validation, so this annotation is safe to add to any schema without breaking existing validators.
+
 ### Rebuild matrix
 
 `scripts/dev up` always rebuilds `fishhawkd`. A future enhancement could auto-detect which binaries need rebuilding from `git diff main...HEAD`.

--- a/docs/spec/plan-standard-v1.md
+++ b/docs/spec/plan-standard-v1.md
@@ -6,6 +6,25 @@ The canonical schema is [`plan-standard-v1.schema.json`](plan-standard-v1.schema
 
 > **Frozen at Day 21** of the v0 build. Old plans in the audit log remain readable forever — never break this schema in place. Future versions land as `standard_v2` etc., and the plan validator (E1.5 / #20) keeps every version readable.
 
+### Schema evolution policy
+
+`standard_v1.x` is **additive-only**. New fields must be optional; the existing required-field set is frozen. Clients that validate against `standard_v1` must tolerate unknown fields (they are collected as annotations per JSON Schema Draft 2020-12 §10.3 and must not cause validation failure).
+
+**Required-field promotion** requires a major version bump (`standard_v2`). During the deprecation window, the plan validator accepts both `standard_v1` and `standard_v2` artifacts and routes each to its respective schema. The backend advertises which versions it can validate via the `/healthz` schema-versions endpoint (once #466 lands).
+
+**`x-intended-required` annotation** — a non-standard JSON Schema keyword used to signal that a field is currently optional but is a candidate for required promotion in the next major version. Example:
+
+```json
+"some_field": {
+  "type": "string",
+  "x-intended-required": true
+}
+```
+
+This annotation does not affect validation (see §10.3). It is a contract signal for schema authors: the soak period during which the field is optional must be declared in the introducing PR body before the required promotion is merged.
+
+**Removals** follow a longer deprecation window — duration TBD. No fields have been removed from `standard_v1`.
+
 ## Top-level shape
 
 ```json

--- a/docs/spec/workflow-v0.md
+++ b/docs/spec/workflow-v0.md
@@ -4,6 +4,14 @@ Reference for `.fishhawk/workflows.yaml`. The canonical schema is [`workflow-v0.
 
 > **Frozen at Day 21** of the v0 build (MVP_SPEC.md §8). Old workflow runs in the audit log remain readable forever; never break this schema in place — bump to a new spec version (`workflow-v1`, `workflow-v2`...) instead.
 
+### Schema evolution policy
+
+`workflow-v0.x` is **additive-only**. New fields are optional; the existing required-field set is frozen. Validators must tolerate unknown fields (JSON Schema Draft 2020-12 §10.3).
+
+**Breaking additions** (required new fields, renamed fields, removed fields, changed semantics of existing fields) require a version bump to `workflow-v1`. During the deprecation window, the backend accepts both `v0` and `v1` workflow specs simultaneously — the version string in the YAML routes each spec to its respective schema and execution path.
+
+**`x-intended-required`** may annotate optional fields that are candidates for required promotion in `workflow-v1`. Annotation semantics and soak-period rules match those in `plan-standard-v1.md`.
+
 ## Top-level shape
 
 ```yaml

--- a/scripts/sync-schemas
+++ b/scripts/sync-schemas
@@ -3,13 +3,21 @@ set -eu
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
-cp "$REPO_ROOT/docs/spec/workflow-v0.schema.json" \
-   "$REPO_ROOT/backend/internal/spec/schemas/workflow-v0.schema.json"
-cp "$REPO_ROOT/docs/spec/workflow-v0.schema.json" \
-   "$REPO_ROOT/cli/internal/spec/schemas/workflow-v0.schema.json"
-cp "$REPO_ROOT/docs/spec/plan-standard-v1.schema.json" \
-   "$REPO_ROOT/backend/internal/plan/schemas/plan-standard-v1.schema.json"
-cp "$REPO_ROOT/docs/spec/plan-standard-v1.schema.json" \
-   "$REPO_ROOT/runner/internal/plan/schemas/plan-standard-v1.schema.json"
+for schema in "$REPO_ROOT"/docs/spec/*.schema.json; do
+  base="$(basename "$schema")"
+  case "$base" in
+    plan-standard-*.schema.json)
+      cp "$schema" "$REPO_ROOT/backend/internal/plan/schemas/$base"
+      cp "$schema" "$REPO_ROOT/runner/internal/plan/schemas/$base"
+      ;;
+    workflow-v*.schema.json)
+      cp "$schema" "$REPO_ROOT/backend/internal/spec/schemas/$base"
+      cp "$schema" "$REPO_ROOT/cli/internal/spec/schemas/$base"
+      ;;
+    *)
+      echo "sync-schemas: unrecognized schema file '$base' — skipping (add a case to route it)" >&2
+      ;;
+  esac
+done
 
 echo "schemas synced from docs/spec/"


### PR DESCRIPTION
## Summary

Operationalizes ADR-026's policy where contributors actually read it:

- **CLAUDE.md `Schema change checklist`**: decision tree (optional vs major bump), soak-period declaration, version-advertising surfaces, `x-intended-required` annotation usage.
- **`docs/spec/plan-standard-v1.md` Schema evolution policy**: standard_v1.x additive-only; required-field additions land in standard_v2; dual-version validation during deprecation.
- **`docs/spec/workflow-v0.md` parallel evolution-policy note** for workflow-spec.
- **`scripts/sync-schemas` rewritten as version-aware**: globs `docs/spec/*.schema.json`, routes via filename prefix to embedded copies. Future versioned schemas (`plan-standard-v2`, `workflow-v1`) sync automatically.

## Notes

The agent took a pragmatic shape — instead of dropping a freestanding `docs/adr/026.md` (which would duplicate the issue body), it embedded the policy in the surfaces where contributors think about schema changes. CLAUDE.md is read whenever the agent plans a schema-touching PR; the spec docs are read when editing the schema itself.

Driven through the local MCP loop (run `3b5a519c`). Plan 6.1k tokens, implement **4.6k tokens (~3 min actual)** vs 12 min predicted — well under (the docs+script scope was tighter than the M estimate suggested). `fishhawk_verify_run` returned `verified=true` with 13-entry chain.

Sync-schemas rewrite validated: byte-identical output for the four existing embedded copies (`plan-standard-v1`, `workflow-v0` × 2 destinations each).

## Open design questions (per ADR body)

Both deferred to follow-ups:
- Specific soak-period duration (30/90 days? customer-survey driven?). PR codifies "declared in the change PR" as placeholder.
- Field-removal deprecation policy (likely longer than addition).

Worth filing once we have a concrete schema change that needs the rule.

## Followup (post-merge)

Per CLAUDE.md ADR convention: add a Decision section to the #472 issue body summarizing the chosen approach (recommendation in the issue body becomes the Decision). One-comment task.

## Test plan

- [x] `bash scripts/sync-schemas` — exits clean.
- [x] `diff docs/spec/<schema> <each embedded copy>` — byte-identical for all 4 mirror pairs.
- [x] `scripts/test` — all gates green (no Go changes).
- [x] `fishhawk_verify_run` on this run: `verified=true`, chain_length=13.

Closes #472