### PR TITLE
test: CI smoke test for local-runner plan-stage loop (#425)

### DIFF
--- a/backend/internal/integration/local-runner/e2e_test.go
+++ b/backend/internal/integration/local-runner/e2e_test.go
@@ -1,0 +1,331 @@
+// Package localrunnere2e_test is the cross-component integration test
+// for the local-runner plan-stage loop: real backend HTTP server →
+// real Postgres → real fishhawk-runner binary → fake claude shim →
+// assertions on stage state and plan artifact. Catches the two
+// regression classes from #419 (missing --plan-out and pending→
+// dispatched state-machine gap) that passed every prior unit-test gate.
+package localrunnere2e_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/testcontainers/testcontainers-go"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/kuhlman-labs/fishhawk/backend/internal/artifact"
+	"github.com/kuhlman-labs/fishhawk/backend/internal/audit"
+	"github.com/kuhlman-labs/fishhawk/backend/internal/postgres"
+	runpkg "github.com/kuhlman-labs/fishhawk/backend/internal/run"
+	"github.com/kuhlman-labs/fishhawk/backend/internal/server"
+	"github.com/kuhlman-labs/fishhawk/backend/internal/signing"
+	"github.com/kuhlman-labs/fishhawk/backend/internal/tracestore"
+)
+
+// localRunnerFixture wires every component the local-runner loop
+// needs. Built once per test via newLocalRunnerFixture; teardown is
+// handled via t.Cleanup.
+type localRunnerFixture struct {
+	url          string // httptest server URL
+	pool         *pgxpool.Pool
+	runRepo      runpkg.Repository
+	artifactRepo artifact.Repository
+	runnerBinary string // path to built fishhawk-runner
+	fakeAgentDir string // dir containing the fake claude shim
+}
+
+// cannedPlanJSON returns a minimal schema-valid standard_v1 plan
+// fixture marshalled to JSON. Pre-written to disk before the runner
+// spawns; the runner reads and validates it after the fake agent exits.
+func cannedPlanJSON(t *testing.T) []byte {
+	t.Helper()
+	m := map[string]any{
+		"plan_version": "standard_v1",
+		"ticket_reference": map[string]any{
+			"type": "github_issue",
+			"url":  "https://github.com/x/y/issues/1",
+			"id":   "x/y#1",
+		},
+		"generated_by": map[string]any{
+			"agent":     "claude-code",
+			"model":     "claude-opus-4-7",
+			"timestamp": time.Now().UTC().Format(time.RFC3339),
+		},
+		"summary": "E2E integration test plan.",
+		"scope": map[string]any{
+			"files": []any{
+				map[string]any{"path": "main.go", "operation": "create"},
+			},
+		},
+		"approach": []any{
+			map[string]any{"step": 1, "description": "Write the code."},
+		},
+		"verification": map[string]any{
+			"test_strategy": "Run go test.",
+			"rollback_plan": "Revert the commit.",
+		},
+		"predicted_runtime_minutes":    5,
+		"predicted_runtime_confidence": "high",
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal canned plan: %v", err)
+	}
+	return b
+}
+
+func newLocalRunnerFixture(t *testing.T) *localRunnerFixture {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	// 1. Spin up Postgres in a throwaway container.
+	c, err := tcpostgres.Run(ctx,
+		"postgres:16-alpine",
+		tcpostgres.WithDatabase("fishhawk"),
+		tcpostgres.WithUsername("fishhawk"),
+		tcpostgres.WithPassword("fishhawk"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(60*time.Second),
+		),
+	)
+	if err != nil {
+		if isDockerUnavailable(err) {
+			t.Skipf("Docker not available; skipping local-runner E2E: %v", err)
+		}
+		t.Fatalf("start postgres: %v", err)
+	}
+	t.Cleanup(func() {
+		shutCtx, shutCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer shutCancel()
+		_ = c.Terminate(shutCtx)
+	})
+	pgURL, err := c.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatalf("postgres connection string: %v", err)
+	}
+
+	// 2. Apply migrations + open pool.
+	if err := postgres.MigrateUp(pgURL); err != nil {
+		t.Fatalf("MigrateUp: %v", err)
+	}
+	pool, err := pgxpool.New(ctx, pgURL)
+	if err != nil {
+		t.Fatalf("pool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	// 3. Wire repos + backend server with an in-memory trace store.
+	// No Orchestrator, no notifier, no GitHub integration — all nil-
+	// guarded by the server. OIDCVerifier is nil so the signing-key
+	// endpoint is open (v0 self-execution posture per server.go doc).
+	runRepo := runpkg.NewPostgresRepository(pool)
+	signingRepo := signing.NewPostgresRepository(pool)
+	auditRepo := audit.NewPostgresRepository(pool)
+	artifactRepo := artifact.NewPostgresRepository(pool)
+	srv := server.New(server.Config{
+		Addr:         "127.0.0.1:0",
+		RunRepo:      runRepo,
+		SigningRepo:  signingRepo,
+		AuditRepo:    auditRepo,
+		ArtifactRepo: artifactRepo,
+		TraceStore:   tracestore.NewMem(),
+	})
+	httpSrv := httptest.NewServer(srv.Handler())
+	t.Cleanup(httpSrv.Close)
+
+	// 4. Build the real fishhawk-runner binary. A real binary rather
+	// than `go run` keeps the runner's stdout clean for the trace
+	// stream. Cold build is a few seconds; subsequent builds in the
+	// same test process hit the build cache.
+	binary := filepath.Join(t.TempDir(), runnerBinaryName())
+	buildCtx, buildCancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer buildCancel()
+	build := exec.CommandContext(buildCtx, "go", "build",
+		"-o", binary,
+		"github.com/kuhlman-labs/fishhawk/runner/cmd/fishhawk-runner",
+	)
+	var buildStderr bytes.Buffer
+	build.Stderr = &buildStderr
+	if err := build.Run(); err != nil {
+		t.Fatalf("build fishhawk-runner: %v\nstderr: %s", err, buildStderr.String())
+	}
+
+	// 5. Write the fake claude shim. The script prints one JSON line
+	// and exits 0 — it does NOT write the plan file. The test pre-
+	// writes the canned plan before spawning the runner so the runner
+	// reads the pre-existing file after the fake agent exits.
+	fakeDir := t.TempDir()
+	fakeScript := filepath.Join(fakeDir, "claude")
+	if runtime.GOOS == "windows" {
+		fakeScript = filepath.Join(fakeDir, "claude.bat")
+	}
+	scriptBody := "#!/bin/sh\nprintf '{\"type\":\"result\"}\\n'\n"
+	if err := os.WriteFile(fakeScript, []byte(scriptBody), 0o755); err != nil {
+		t.Fatalf("write fake claude: %v", err)
+	}
+
+	return &localRunnerFixture{
+		url:          httpSrv.URL,
+		pool:         pool,
+		runRepo:      runRepo,
+		artifactRepo: artifactRepo,
+		runnerBinary: binary,
+		fakeAgentDir: fakeDir,
+	}
+}
+
+func runnerBinaryName() string {
+	if runtime.GOOS == "windows" {
+		return "fishhawk-runner.exe"
+	}
+	return "fishhawk-runner"
+}
+
+// TestE2E_LocalRunner_PlanStage_HappyPath drives the full local-runner
+// plan-stage loop end-to-end and asserts:
+//
+//   - The runner exits 0 (agent + upload chain succeeded).
+//   - The stage transitions to awaiting_approval (pending→dispatched→
+//     running→awaiting_approval via advanceStageAfterTrace, which is the
+//     #419 state-machine fix under test).
+//   - A plan artifact exists for the stage (the --plan-out upload path
+//     fired, which was the second regression class from #419).
+func TestE2E_LocalRunner_PlanStage_HappyPath(t *testing.T) {
+	fx := newLocalRunnerFixture(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// Seed run with RunnerKind=local so advanceStageAfterTrace handles
+	// the missing workflow_dispatch step (pending→dispatched).
+	r, err := fx.runRepo.CreateRun(ctx, runpkg.CreateRunParams{
+		Repo:          "kuhlman-labs/fishhawk",
+		WorkflowID:    "feature_change",
+		WorkflowSHA:   "deadbeef-e2e",
+		TriggerSource: runpkg.TriggerCLI,
+		RunnerKind:    runpkg.RunnerKindLocal,
+	})
+	if err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+
+	// Seed plan stage with RequiresApproval=true so the trace upload
+	// drives the stage to awaiting_approval rather than succeeded.
+	stage, err := fx.runRepo.CreateStage(ctx, runpkg.CreateStageParams{
+		RunID:            r.ID,
+		Sequence:         1,
+		Type:             runpkg.StageTypePlan,
+		ExecutorKind:     runpkg.ExecutorAgent,
+		ExecutorRef:      "claude-code",
+		RequiresApproval: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateStage: %v", err)
+	}
+
+	// Pre-write the canned plan. The runner reads this file after the
+	// fake agent exits; the fake agent script does NOT write it.
+	planPath := filepath.Join(t.TempDir(), "plan.json")
+	if err := os.WriteFile(planPath, cannedPlanJSON(t), 0o600); err != nil {
+		t.Fatalf("write canned plan: %v", err)
+	}
+
+	// Write a dummy prompt file.
+	promptPath := filepath.Join(t.TempDir(), "prompt.txt")
+	if err := os.WriteFile(promptPath, []byte("analyse and plan the work"), 0o600); err != nil {
+		t.Fatalf("write prompt: %v", err)
+	}
+
+	// Spawn the runner. PATH is prepended with fakeAgentDir so the
+	// runner's claudecode adapter resolves 'claude' to our shim.
+	cmd := exec.CommandContext(ctx, fx.runnerBinary,
+		"--run-id", r.ID.String(),
+		"--backend-url", fx.url,
+		"--workflow", "feature_change",
+		"--stage", "plan",
+		"--stage-id", stage.ID.String(),
+		"--prompt-file", promptPath,
+		"--plan-out", planPath,
+		"--upload-trace",
+	)
+	// Replace PATH in the inherited environment so 'claude' resolves
+	// to the shim; other vars (HOME, TMPDIR, etc.) are inherited as-is.
+	runnerEnv := make([]string, 0, len(os.Environ()))
+	for _, e := range os.Environ() {
+		if strings.HasPrefix(e, "PATH=") {
+			e = "PATH=" + fx.fakeAgentDir + ":" + strings.TrimPrefix(e, "PATH=")
+		}
+		runnerEnv = append(runnerEnv, e)
+	}
+	cmd.Env = runnerEnv
+
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("runner exited non-zero: %v\noutput:\n%s", err, out.String())
+	}
+
+	// Assert stage reached awaiting_approval. This is the load-bearing
+	// assertion: it exercises the pending→dispatched gap fix from #419
+	// (advanceStageAfterTrace lines 311-321) that the unit-test gate
+	// could not catch.
+	got, err := fx.runRepo.GetStage(ctx, stage.ID)
+	if err != nil {
+		t.Fatalf("GetStage: %v", err)
+	}
+	if got.State != runpkg.StageStateAwaitingApproval {
+		t.Errorf("stage.State = %q, want %q\nrunner output:\n%s",
+			got.State, runpkg.StageStateAwaitingApproval, out.String())
+	}
+
+	// Assert a plan artifact was uploaded. This exercises the
+	// --plan-out upload path (the second regression class from #419).
+	artifacts, err := fx.artifactRepo.ListForStage(ctx, stage.ID)
+	if err != nil {
+		t.Fatalf("ListForStage: %v", err)
+	}
+	if len(artifacts) == 0 {
+		t.Errorf("no artifacts for stage %s; expected a plan artifact\nrunner output:\n%s",
+			stage.ID, out.String())
+	}
+}
+
+// isDockerUnavailable matches the guard pattern from
+// backend/internal/integration/mcp/e2e_test.go. FISHHAWK_SKIP_INTEGRATION
+// provides an explicit escape hatch for CI environments without Docker.
+func isDockerUnavailable(err error) bool {
+	if err == nil {
+		return false
+	}
+	if os.Getenv("FISHHAWK_SKIP_INTEGRATION") != "" {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	for _, marker := range []string{
+		"cannot connect to the docker daemon",
+		"docker: not found",
+		"executable file not found",
+		"dial unix /var/run/docker.sock",
+	} {
+		if strings.Contains(msg, strings.ToLower(marker)) {
+			return true
+		}
+	}
+	return errors.Is(err, exec.ErrNotFound)
+}

--- a/backend/internal/tracestore/mem.go
+++ b/backend/internal/tracestore/mem.go
@@ -1,0 +1,106 @@
+package tracestore
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// MemStorage is an in-memory trace bundle store. All operations are
+// mutex-guarded; safe for concurrent use from multiple goroutines
+// (e.g. an httptest.Server handling parallel raw + redacted uploads).
+// Intended for tests that cannot spin a MinIO container.
+type MemStorage struct {
+	mu   sync.Mutex
+	data map[string][]byte
+}
+
+// NewMem returns a fresh empty MemStorage.
+func NewMem() *MemStorage {
+	return &MemStorage{data: make(map[string][]byte)}
+}
+
+// Put stores the bundle bytes at ref's canonical key. Idempotent:
+// re-uploading identical bytes is a no-op at the storage layer.
+func (m *MemStorage) Put(_ context.Context, ref BundleRef, body io.Reader) error {
+	if err := ref.Validate(); err != nil {
+		return err
+	}
+	b, err := io.ReadAll(body)
+	if err != nil {
+		return fmt.Errorf("tracestore/mem: read body: %w", err)
+	}
+	m.mu.Lock()
+	m.data[ref.Key()] = b
+	m.mu.Unlock()
+	return nil
+}
+
+// Get returns a reader for the bundle at ref's canonical key.
+// Returns ErrNotFound when the key is absent.
+func (m *MemStorage) Get(_ context.Context, ref BundleRef) (io.ReadCloser, error) {
+	if err := ref.Validate(); err != nil {
+		return nil, err
+	}
+	m.mu.Lock()
+	b, ok := m.data[ref.Key()]
+	m.mu.Unlock()
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return io.NopCloser(bytes.NewReader(b)), nil
+}
+
+// Stat returns metadata for the bundle at ref's canonical key.
+// Returns ErrNotFound when the key is absent.
+func (m *MemStorage) Stat(_ context.Context, ref BundleRef) (Stat, error) {
+	if err := ref.Validate(); err != nil {
+		return Stat{}, err
+	}
+	m.mu.Lock()
+	b, ok := m.data[ref.Key()]
+	m.mu.Unlock()
+	if !ok {
+		return Stat{}, ErrNotFound
+	}
+	return Stat{
+		Size:         int64(len(b)),
+		ETag:         ref.ContentHash,
+		LastModified: time.Time{},
+	}, nil
+}
+
+// List returns all bundle refs under runID's key prefix, sorted by
+// key for stable ordering across calls.
+func (m *MemStorage) List(_ context.Context, runID uuid.UUID) ([]BundleRef, error) {
+	prefix := runID.String() + "/"
+	m.mu.Lock()
+	var refs []BundleRef
+	for k := range m.data {
+		if !strings.HasPrefix(k, prefix) {
+			continue
+		}
+		// Key layout: {run_id}/{variant}/{sha256}.jsonl.gz
+		rest := k[len(prefix):]
+		slash := strings.IndexByte(rest, '/')
+		if slash < 0 {
+			continue
+		}
+		variant := Variant(rest[:slash])
+		hashAndSuffix := rest[slash+1:]
+		hash := strings.TrimSuffix(hashAndSuffix, ".jsonl.gz")
+		refs = append(refs, BundleRef{RunID: runID, Variant: variant, ContentHash: hash})
+	}
+	m.mu.Unlock()
+	sort.Slice(refs, func(i, j int) bool {
+		return refs[i].Key() < refs[j].Key()
+	})
+	return refs, nil
+}


### PR DESCRIPTION
## Summary

Closes the integration-test gap that allowed both #419 regressions to land — the unit tests verified runner argv construction in isolation and seeded trace-handler test stages in `dispatched` directly; neither covered the actual cross-binary handshake when a stage starts in `pending`.

- **New integration test** at `backend/internal/integration/local-runner/e2e_test.go`:
  - testcontainers-postgres + httptest.Server with real run/signing/audit/artifact repos + in-memory tracestore.
  - Builds `fishhawk-runner` into `t.TempDir()` and spawns it with the production flag set.
  - Fake `claude` shim prepended to PATH (one stdout JSON line + exit 0). No `ANTHROPIC_API_KEY`, no model call.
  - Pre-writes the canned plan to a temp path; runner reads it via `--plan-out`. Separates agent invocation from plan staging.
  - Asserts exit 0, `stage.State == awaiting_approval` (the pending→dispatched gap exercised end-to-end), and `artifactRepo.ListForStage` finds the uploaded artifact (`--plan-out` upload path fired).
- **In-memory `tracestore.Storage`** at `backend/internal/tracestore/mem.go` — mutex-guarded, race-tested. Avoids spinning MinIO per-test, which would have blown the 90s budget.

## Notes

Driven through the local MCP loop (run `9a8c1ea5`). **Textbook-clean run** after yesterday's #428 timeout/retry — no recovery this time.

- Plan: 12 min predicted, medium confidence. Calibrated via `fishhawk_runtime_calibration` (ratio 0.413, 25 samples) → ~5 min expected.
- Implement: clean exit, **25.9k tokens**, no wall-clock pressure.
- `fishhawk_verify_run`: `verified=true`, chain_length=13, `runtime_observed: 1`.

Test wall-clock locally: **~4s** end-to-end. Plenty of headroom under the AC's 90s budget — full agent-test guard rails (binary build, PATH manipulation, real Postgres) still fit in single-digit seconds.

### Scope choice worth flagging

The test seeds the run + plan stage directly via `runRepo.CreateRun/CreateStage` rather than going through the `POST /v0/runs` HTTP path or the `fishhawk run start` CLI verb. Tradeoff:

- ✅ Catches both #419 regression classes (runner-side argv, trace-handler state machine) — the bugs that motivated this issue.
- ❌ Doesn't exercise the backend's HTTP run-creation handler or auto-stage-creation logic (#411/#414).

Decision: keep the narrower scope. The HTTP run-creation path has its own coverage via the recent #411/#414 work; bundling it in here would inflate the test without addressing the regression class this gate is meant to catch. Worth a follow-up only if a #419-equivalent ever surfaces in the run-creation path.

## Test plan

- [x] `go test -race -timeout 180s ./backend/internal/integration/local-runner/... ./backend/internal/tracestore/...` — pass, **3.9s** for the integration test, 7.4s for tracestore.
- [x] `golangci-lint run ./backend/...` — 0 issues.
- [x] `scripts/test coverage` — aggregate **81.5%** (threshold 80%).
- [x] `fishhawk_verify_run` — `verified=true`, chain_length=13.
- [x] CI Docker check — `ubuntu-latest` provides the Docker socket; the existing MCP E2E test already runs in this environment without a `services:` block.

Closes #425