### PR TITLE
backend: enforce write scopes on /v0/runs + /v0/stages write endpoints (#402)

### DIFF
--- a/backend/cmd/fishhawkd/token.go
+++ b/backend/cmd/fishhawkd/token.go
@@ -51,6 +51,10 @@ func runTokenIssue(args []string, logSink io.Writer) int {
 	}
 
 	scopes := splitCSV(*scopesCSV)
+	if len(scopes) == 0 && !strings.HasPrefix(*subject, "mcp:") {
+		scopes = []string{"read:runs", "read:audit", "write:runs", "write:approvals", "write:stages"}
+		_, _ = fmt.Fprintln(logSink, "fishhawkd token issue: applying default operator scope set")
+	}
 
 	pool, err := pgxpool.New(context.Background(), *dbURL)
 	if err != nil {

--- a/backend/internal/server/approvals.go
+++ b/backend/internal/server/approvals.go
@@ -44,6 +44,9 @@ type approvalRequest struct {
 // returns the existing approval and the current stage state with
 // a 200. The first decision wins for any_of-style gates.
 func (s *Server) handleSubmitApproval(w http.ResponseWriter, r *http.Request) {
+	if !s.requireWriteScope(w, r, "write:approvals") {
+		return
+	}
 	if s.cfg.ApprovalRepo == nil || s.cfg.RunRepo == nil || s.cfg.AuditRepo == nil {
 		s.writeError(w, r, http.StatusServiceUnavailable, "approvals_unconfigured",
 			"approvals endpoint requires approval, run, and audit repositories", nil)

--- a/backend/internal/server/approvals_test.go
+++ b/backend/internal/server/approvals_test.go
@@ -337,8 +337,9 @@ func submitApproval(t *testing.T, s *Server, stageID uuid.UUID, body string) *ht
 	url := fmt.Sprintf("/v0/stages/%s/approvals", stageID)
 	req := httptest.NewRequest(http.MethodPost, url, strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
+	req.SetPathValue("stage_id", stageID.String())
 	w := httptest.NewRecorder()
-	s.Handler().ServeHTTP(w, req)
+	s.handleSubmitApproval(w, withAuth(req))
 	return w
 }
 
@@ -429,8 +430,9 @@ func TestSubmitApproval_BadUUID(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost,
 		"/v0/stages/not-a-uuid/approvals",
 		strings.NewReader(`{"decision":"approve"}`))
+	req.SetPathValue("stage_id", "not-a-uuid")
 	w := httptest.NewRecorder()
-	s.Handler().ServeHTTP(w, req)
+	s.handleSubmitApproval(w, withAuth(req))
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", w.Code)
 	}

--- a/backend/internal/server/middleware.go
+++ b/backend/internal/server/middleware.go
@@ -87,6 +87,28 @@ func IdentityFrom(ctx context.Context) Identity {
 	return v
 }
 
+// requireWriteScope checks that the caller is authenticated and holds
+// scope. Returns true when the caller may proceed. Returns false and
+// writes a 401 (anonymous caller) or 403 (authenticated but missing
+// scope) response when the check fails. Cookie-session callers
+// (TokenID == "") bypass scope enforcement — they authenticate via
+// GitHub OAuth and carry no explicit scope list.
+func (s *Server) requireWriteScope(w http.ResponseWriter, r *http.Request, scope string) bool {
+	id := IdentityFrom(r.Context())
+	if id.IsAnonymous() {
+		s.writeError(w, r, 401, "authentication_required",
+			"an authenticated token is required", nil)
+		return false
+	}
+	if id.TokenID != "" && !hasScope(id, scope) {
+		s.writeError(w, r, 403, "insufficient_scope",
+			"token is missing required scope: "+scope,
+			map[string]any{"required_scope": scope})
+		return false
+	}
+	return true
+}
+
 const requestIDMaxLen = 64
 
 // requestID puts a per-request ID into the context and the

--- a/backend/internal/server/retry.go
+++ b/backend/internal/server/retry.go
@@ -50,6 +50,9 @@ const CategoryStageRetried = "stage_retried"
 // the audit row is in place, the stage is in pending, an operator
 // can re-fire Advance manually if needed.
 func (s *Server) handleRetryStage(w http.ResponseWriter, r *http.Request) {
+	if !s.requireWriteScope(w, r, "write:stages") {
+		return
+	}
 	if s.cfg.RunRepo == nil || s.cfg.AuditRepo == nil {
 		s.writeError(w, r, http.StatusServiceUnavailable, "retry_unconfigured",
 			"retry endpoint requires run + audit repositories", nil)

--- a/backend/internal/server/retry_test.go
+++ b/backend/internal/server/retry_test.go
@@ -45,8 +45,9 @@ func postRetry(t *testing.T, s *Server, stageID uuid.UUID) *httptest.ResponseRec
 	t.Helper()
 	url := "/v0/stages/" + stageID.String() + "/retry"
 	req := httptest.NewRequest(http.MethodPost, url, nil)
+	req.SetPathValue("stage_id", stageID.String())
 	w := httptest.NewRecorder()
-	s.Handler().ServeHTTP(w, req)
+	s.handleRetryStage(w, withAuth(req))
 	return w
 }
 

--- a/backend/internal/server/runs.go
+++ b/backend/internal/server/runs.go
@@ -133,6 +133,9 @@ var validTriggerSources = map[string]struct{}{
 // Run JSON. The state machine starts every new run in
 // run.StatePending.
 func (s *Server) handleCreateRun(w http.ResponseWriter, r *http.Request) {
+	if !s.requireWriteScope(w, r, "write:runs") {
+		return
+	}
 	if s.cfg.RunRepo == nil {
 		s.writeError(w, r, http.StatusServiceUnavailable, "run_repo_unconfigured",
 			"runs endpoint requires a configured run repository", nil)
@@ -533,6 +536,9 @@ var validRunStates = map[string]struct{}{
 // run (succeeded / failed) returns 409 because the state machine
 // rejects the transition.
 func (s *Server) handleCancelRun(w http.ResponseWriter, r *http.Request) {
+	if !s.requireWriteScope(w, r, "write:runs") {
+		return
+	}
 	if s.cfg.RunRepo == nil {
 		s.writeError(w, r, http.StatusServiceUnavailable, "run_repo_unconfigured",
 			"runs endpoint requires a configured run repository", nil)

--- a/backend/internal/server/runs_cancel_test.go
+++ b/backend/internal/server/runs_cancel_test.go
@@ -21,9 +21,10 @@ func TestCancelRun_HappyPath(t *testing.T) {
 	r := seedRun(repo, "x/y", "w", run.StatePending, t0)
 	s := newServer(t, repo)
 
+	req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/v0/runs/%s/cancel", r.ID), nil)
+	req.SetPathValue("run_id", r.ID.String())
 	w := httptest.NewRecorder()
-	s.Handler().ServeHTTP(w, httptest.NewRequest(http.MethodPost,
-		fmt.Sprintf("/v0/runs/%s/cancel", r.ID), nil))
+	s.handleCancelRun(w, withAuth(req))
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d:\n%s", w.Code, w.Body.String())
 	}
@@ -40,9 +41,10 @@ func TestCancelRun_Idempotent(t *testing.T) {
 	r := seedRun(repo, "x/y", "w", run.StateCancelled, t0)
 	s := newServer(t, repo)
 
+	req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/v0/runs/%s/cancel", r.ID), nil)
+	req.SetPathValue("run_id", r.ID.String())
 	w := httptest.NewRecorder()
-	s.Handler().ServeHTTP(w, httptest.NewRequest(http.MethodPost,
-		fmt.Sprintf("/v0/runs/%s/cancel", r.ID), nil))
+	s.handleCancelRun(w, withAuth(req))
 	if w.Code != http.StatusOK {
 		t.Errorf("idempotent cancel status = %d, want 200", w.Code)
 	}
@@ -54,9 +56,10 @@ func TestCancelRun_TerminalStateConflict(t *testing.T) {
 	r := seedRun(repo, "x/y", "w", run.StateSucceeded, t0)
 	s := newServer(t, repo)
 
+	req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/v0/runs/%s/cancel", r.ID), nil)
+	req.SetPathValue("run_id", r.ID.String())
 	w := httptest.NewRecorder()
-	s.Handler().ServeHTTP(w, httptest.NewRequest(http.MethodPost,
-		fmt.Sprintf("/v0/runs/%s/cancel", r.ID), nil))
+	s.handleCancelRun(w, withAuth(req))
 	if w.Code != http.StatusConflict {
 		t.Errorf("status = %d, want 409", w.Code)
 	}
@@ -67,9 +70,11 @@ func TestCancelRun_TerminalStateConflict(t *testing.T) {
 
 func TestCancelRun_NotFound(t *testing.T) {
 	s := newServer(t, newFakeRepo())
+	runID := uuid.New()
+	req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/v0/runs/%s/cancel", runID), nil)
+	req.SetPathValue("run_id", runID.String())
 	w := httptest.NewRecorder()
-	s.Handler().ServeHTTP(w, httptest.NewRequest(http.MethodPost,
-		fmt.Sprintf("/v0/runs/%s/cancel", uuid.New()), nil))
+	s.handleCancelRun(w, withAuth(req))
 	if w.Code != http.StatusNotFound {
 		t.Errorf("status = %d, want 404", w.Code)
 	}
@@ -77,9 +82,10 @@ func TestCancelRun_NotFound(t *testing.T) {
 
 func TestCancelRun_BadUUID(t *testing.T) {
 	s := newServer(t, newFakeRepo())
+	req := httptest.NewRequest(http.MethodPost, "/v0/runs/not-a-uuid/cancel", nil)
+	req.SetPathValue("run_id", "not-a-uuid")
 	w := httptest.NewRecorder()
-	s.Handler().ServeHTTP(w, httptest.NewRequest(http.MethodPost,
-		"/v0/runs/not-a-uuid/cancel", nil))
+	s.handleCancelRun(w, withAuth(req))
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", w.Code)
 	}
@@ -89,9 +95,11 @@ func TestCancelRun_RepoError(t *testing.T) {
 	repo := newFakeRepo()
 	repo.transitionErr = errors.New("db down")
 	s := newServer(t, repo)
+	runID := uuid.New()
+	req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/v0/runs/%s/cancel", runID), nil)
+	req.SetPathValue("run_id", runID.String())
 	w := httptest.NewRecorder()
-	s.Handler().ServeHTTP(w, httptest.NewRequest(http.MethodPost,
-		fmt.Sprintf("/v0/runs/%s/cancel", uuid.New()), nil))
+	s.handleCancelRun(w, withAuth(req))
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", w.Code)
 	}
@@ -99,9 +107,11 @@ func TestCancelRun_RepoError(t *testing.T) {
 
 func TestCancelRun_NilRepo(t *testing.T) {
 	s := New(Config{Addr: "127.0.0.1:0"})
+	runID := uuid.New()
+	req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/v0/runs/%s/cancel", runID), nil)
+	req.SetPathValue("run_id", runID.String())
 	w := httptest.NewRecorder()
-	s.Handler().ServeHTTP(w, httptest.NewRequest(http.MethodPost,
-		fmt.Sprintf("/v0/runs/%s/cancel", uuid.New()), nil))
+	s.handleCancelRun(w, withAuth(req))
 	if w.Code != http.StatusServiceUnavailable {
 		t.Errorf("status = %d, want 503", w.Code)
 	}

--- a/backend/internal/server/runs_create_issue_test.go
+++ b/backend/internal/server/runs_create_issue_test.go
@@ -34,7 +34,7 @@ func TestCreateRun_IssueContext_PersistedOnRun(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/v0/runs", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
-	s.Handler().ServeHTTP(w, req)
+	s.handleCreateRun(w, withAuth(req))
 	if w.Code != http.StatusCreated {
 		t.Fatalf("status = %d:\n%s", w.Code, w.Body.String())
 	}
@@ -77,7 +77,7 @@ func TestCreateRun_IssueContext_RejectedOnNonIssueTrigger(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/v0/runs", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
-	s.Handler().ServeHTTP(w, req)
+	s.handleCreateRun(w, withAuth(req))
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400:\n%s", w.Code, w.Body.String())
 	}

--- a/backend/internal/server/runs_create_spec_test.go
+++ b/backend/internal/server/runs_create_spec_test.go
@@ -81,7 +81,7 @@ func TestCreateRun_WorkflowSpec_CreatesStages(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/v0/runs", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
-	s.Handler().ServeHTTP(w, req)
+	s.handleCreateRun(w, withAuth(req))
 	if w.Code != http.StatusCreated {
 		t.Fatalf("status = %d:\n%s", w.Code, w.Body.String())
 	}
@@ -135,7 +135,7 @@ func TestCreateRun_WorkflowSpec_PersistsBytesAndMaxRetries(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/v0/runs", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
-	s.Handler().ServeHTTP(w, req)
+	s.handleCreateRun(w, withAuth(req))
 	if w.Code != http.StatusCreated {
 		t.Fatalf("status = %d:\n%s", w.Code, w.Body.String())
 	}
@@ -170,7 +170,7 @@ func TestCreateRun_WorkflowSpec_MalformedYAML(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/v0/runs", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
-	s.Handler().ServeHTTP(w, req)
+	s.handleCreateRun(w, withAuth(req))
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400:\n%s", w.Code, w.Body.String())
 	}
@@ -199,7 +199,7 @@ func TestCreateRun_WorkflowSpec_UnknownWorkflowID(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/v0/runs", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
-	s.Handler().ServeHTTP(w, req)
+	s.handleCreateRun(w, withAuth(req))
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400:\n%s", w.Code, w.Body.String())
 	}
@@ -229,7 +229,7 @@ func TestCreateRun_NoWorkflowSpec_LegacyPath(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/v0/runs", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
-	s.Handler().ServeHTTP(w, req)
+	s.handleCreateRun(w, withAuth(req))
 	if w.Code != http.StatusCreated {
 		t.Fatalf("status = %d:\n%s", w.Code, w.Body.String())
 	}
@@ -264,7 +264,7 @@ func TestCreateRun_WorkflowSpec_StageCreateFails_Returns500(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/v0/runs", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
-	s.Handler().ServeHTTP(w, req)
+	s.handleCreateRun(w, withAuth(req))
 	if w.Code != http.StatusInternalServerError {
 		t.Fatalf("status = %d, want 500:\n%s", w.Code, w.Body.String())
 	}
@@ -364,7 +364,7 @@ func TestCreateRun_GitHubFetch_HappyPath(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/v0/runs", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
-	s.Handler().ServeHTTP(w, req)
+	s.handleCreateRun(w, withAuth(req))
 	if w.Code != http.StatusCreated {
 		t.Fatalf("status = %d, want 201:\n%s", w.Code, w.Body.String())
 	}
@@ -424,7 +424,7 @@ func TestCreateRun_GitHubFetch_NotInstalled(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/v0/runs", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
-	s.Handler().ServeHTTP(w, req)
+	s.handleCreateRun(w, withAuth(req))
 
 	if w.Code != http.StatusUnprocessableEntity {
 		t.Fatalf("status = %d, want 422:\n%s", w.Code, w.Body.String())
@@ -456,7 +456,7 @@ func TestCreateRun_GitHubFetch_SpecNotFound(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/v0/runs", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
-	s.Handler().ServeHTTP(w, req)
+	s.handleCreateRun(w, withAuth(req))
 
 	if w.Code != http.StatusUnprocessableEntity {
 		t.Fatalf("status = %d, want 422:\n%s", w.Code, w.Body.String())
@@ -485,7 +485,7 @@ func TestCreateRun_InlineSpec_BypassesFetch(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/v0/runs", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
-	s.Handler().ServeHTTP(w, req)
+	s.handleCreateRun(w, withAuth(req))
 
 	if w.Code != http.StatusCreated {
 		t.Fatalf("status = %d, want 201:\n%s", w.Code, w.Body.String())

--- a/backend/internal/server/runs_create_test.go
+++ b/backend/internal/server/runs_create_test.go
@@ -27,7 +27,7 @@ func TestCreateRun_HappyPath(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/v0/runs", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
-	s.Handler().ServeHTTP(w, req)
+	s.handleCreateRun(w, withAuth(req))
 
 	if w.Code != http.StatusCreated {
 		t.Fatalf("status = %d, want 201:\n%s", w.Code, w.Body.String())
@@ -64,7 +64,7 @@ func TestCreateRun_OptionalTriggerRef(t *testing.T) {
 	}`
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/v0/runs", strings.NewReader(body))
-	s.Handler().ServeHTTP(w, req)
+	s.handleCreateRun(w, withAuth(req))
 
 	if w.Code != http.StatusCreated {
 		t.Fatalf("status = %d, want 201:\n%s", w.Code, w.Body.String())
@@ -80,7 +80,7 @@ func TestCreateRun_BadJSON(t *testing.T) {
 	s := newServer(t, newFakeRepo())
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/v0/runs", strings.NewReader("{not json"))
-	s.Handler().ServeHTTP(w, req)
+	s.handleCreateRun(w, withAuth(req))
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", w.Code)
 	}
@@ -94,7 +94,7 @@ func TestCreateRun_UnknownField(t *testing.T) {
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/v0/runs",
 		strings.NewReader(`{"repo":"r","workflow_id":"w","workflow_sha":"s","trigger_source":"cli","extra":"x"}`))
-	s.Handler().ServeHTTP(w, req)
+	s.handleCreateRun(w, withAuth(req))
 	// DisallowUnknownFields → 400.
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400 on unknown field", w.Code)
@@ -116,7 +116,7 @@ func TestCreateRun_MissingRequiredFields(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			w := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodPost, "/v0/runs", strings.NewReader(tc.body))
-			s.Handler().ServeHTTP(w, req)
+			s.handleCreateRun(w, withAuth(req))
 			if w.Code != http.StatusBadRequest {
 				t.Errorf("status = %d, want 400", w.Code)
 			}
@@ -132,7 +132,7 @@ func TestCreateRun_BadTriggerSource(t *testing.T) {
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/v0/runs",
 		strings.NewReader(`{"repo":"r","workflow_id":"w","workflow_sha":"s","trigger_source":"bogus"}`))
-	s.Handler().ServeHTTP(w, req)
+	s.handleCreateRun(w, withAuth(req))
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", w.Code)
 	}
@@ -145,7 +145,7 @@ func TestCreateRun_RepoError(t *testing.T) {
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/v0/runs",
 		strings.NewReader(`{"repo":"r","workflow_id":"w","workflow_sha":"s","trigger_source":"cli"}`))
-	s.Handler().ServeHTTP(w, req)
+	s.handleCreateRun(w, withAuth(req))
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", w.Code)
 	}
@@ -159,7 +159,7 @@ func TestCreateRun_NilRepoConfigured(t *testing.T) {
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/v0/runs",
 		strings.NewReader(`{"repo":"r","workflow_id":"w","workflow_sha":"s","trigger_source":"cli"}`))
-	s.Handler().ServeHTTP(w, req)
+	s.handleCreateRun(w, withAuth(req))
 	if w.Code != http.StatusServiceUnavailable {
 		t.Errorf("status = %d, want 503", w.Code)
 	}
@@ -181,7 +181,7 @@ func TestCreateRun_IdempotencyKey_Replay_Returns200(t *testing.T) {
 	req1.Header.Set("Content-Type", "application/json")
 	req1.Header.Set("Idempotency-Key", "abc123")
 	w1 := httptest.NewRecorder()
-	s.Handler().ServeHTTP(w1, req1)
+	s.handleCreateRun(w1, withAuth(req1))
 	if w1.Code != http.StatusCreated {
 		t.Fatalf("first status = %d, want 201:\n%s", w1.Code, w1.Body.String())
 	}
@@ -193,7 +193,7 @@ func TestCreateRun_IdempotencyKey_Replay_Returns200(t *testing.T) {
 	req2.Header.Set("Content-Type", "application/json")
 	req2.Header.Set("Idempotency-Key", "abc123")
 	w2 := httptest.NewRecorder()
-	s.Handler().ServeHTTP(w2, req2)
+	s.handleCreateRun(w2, withAuth(req2))
 	if w2.Code != http.StatusOK {
 		t.Fatalf("replay status = %d, want 200:\n%s", w2.Code, w2.Body.String())
 	}
@@ -218,7 +218,7 @@ func TestCreateRun_IdempotencyKey_DifferentRepo_CreatesSeparateRun(t *testing.T)
 	req1.Header.Set("Content-Type", "application/json")
 	req1.Header.Set("Idempotency-Key", "shared")
 	w1 := httptest.NewRecorder()
-	s.Handler().ServeHTTP(w1, req1)
+	s.handleCreateRun(w1, withAuth(req1))
 	if w1.Code != http.StatusCreated {
 		t.Fatalf("first status = %d", w1.Code)
 	}
@@ -228,7 +228,7 @@ func TestCreateRun_IdempotencyKey_DifferentRepo_CreatesSeparateRun(t *testing.T)
 	req2.Header.Set("Content-Type", "application/json")
 	req2.Header.Set("Idempotency-Key", "shared")
 	w2 := httptest.NewRecorder()
-	s.Handler().ServeHTTP(w2, req2)
+	s.handleCreateRun(w2, withAuth(req2))
 	if w2.Code != http.StatusCreated {
 		t.Fatalf("second status = %d, want 201 (different repo, no collision)", w2.Code)
 	}
@@ -247,7 +247,7 @@ func TestCreateRun_IdempotencyKey_DifferentKey_CreatesSeparateRun(t *testing.T) 
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("Idempotency-Key", key)
 		w := httptest.NewRecorder()
-		s.Handler().ServeHTTP(w, req)
+		s.handleCreateRun(w, withAuth(req))
 		if w.Code != http.StatusCreated {
 			t.Fatalf("status = %d for key=%s", w.Code, key)
 		}
@@ -266,7 +266,7 @@ func TestCreateRun_NoIdempotencyKey_AlwaysCreates(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/v0/runs", strings.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
 		w := httptest.NewRecorder()
-		s.Handler().ServeHTTP(w, req)
+		s.handleCreateRun(w, withAuth(req))
 		if w.Code != http.StatusCreated {
 			t.Fatalf("iter %d status = %d", i, w.Code)
 		}
@@ -285,14 +285,14 @@ func TestCreateRun_IdempotencyKey_Whitespace_Trimmed(t *testing.T) {
 	req1.Header.Set("Content-Type", "application/json")
 	req1.Header.Set("Idempotency-Key", "abc")
 	w1 := httptest.NewRecorder()
-	s.Handler().ServeHTTP(w1, req1)
+	s.handleCreateRun(w1, withAuth(req1))
 
 	// Header with surrounding whitespace should match the original.
 	req2 := httptest.NewRequest(http.MethodPost, "/v0/runs", strings.NewReader(body))
 	req2.Header.Set("Content-Type", "application/json")
 	req2.Header.Set("Idempotency-Key", "  abc  ")
 	w2 := httptest.NewRecorder()
-	s.Handler().ServeHTTP(w2, req2)
+	s.handleCreateRun(w2, withAuth(req2))
 	if w2.Code != http.StatusOK {
 		t.Errorf("whitespace-padded key didn't match original: status = %d", w2.Code)
 	}
@@ -313,7 +313,7 @@ func TestCreateRun_IdempotencyKey_LookupErrorBubbles(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Idempotency-Key", "abc")
 	w := httptest.NewRecorder()
-	s.Handler().ServeHTTP(w, req)
+	s.handleCreateRun(w, withAuth(req))
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", w.Code)
 	}
@@ -345,7 +345,7 @@ func TestCreateRun_RunnerKind_DefaultsGitHubActions(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/v0/runs", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
-	s.Handler().ServeHTTP(w, req)
+	s.handleCreateRun(w, withAuth(req))
 	if w.Code != http.StatusCreated {
 		t.Fatalf("status = %d", w.Code)
 	}
@@ -369,7 +369,7 @@ func TestCreateRun_RunnerKind_AcceptsLocal(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/v0/runs", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
-	s.Handler().ServeHTTP(w, req)
+	s.handleCreateRun(w, withAuth(req))
 	if w.Code != http.StatusCreated {
 		t.Fatalf("status = %d:\n%s", w.Code, w.Body.String())
 	}
@@ -393,7 +393,7 @@ func TestCreateRun_RunnerKind_RejectsUnknown(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/v0/runs", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
-	s.Handler().ServeHTTP(w, req)
+	s.handleCreateRun(w, withAuth(req))
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", w.Code)
 	}

--- a/backend/internal/server/runs_fake_test.go
+++ b/backend/internal/server/runs_fake_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"errors"
+	"net/http"
 	"sort"
 	"sync"
 	"testing"
@@ -271,4 +272,24 @@ func (f *fakeRepo) TransitionStage(_ context.Context, _ uuid.UUID, _ run.StageSt
 func newServer(t *testing.T, repo run.Repository) *Server {
 	t.Helper()
 	return New(Config{Addr: "127.0.0.1:0", RunRepo: repo})
+}
+
+// testOperatorIdentity returns an Identity that represents a
+// cookie-session operator (no TokenID, no Scopes). The requireWriteScope
+// guard lets cookie-session callers through unconditionally, so this
+// is the correct fixture for tests that exercise handler logic past
+// the auth gate.
+func testOperatorIdentity() Identity {
+	return Identity{
+		Subject:   "github:test-operator",
+		UserID:    "00000000-0000-0000-0000-000000000001",
+		SessionID: "00000000-0000-0000-0000-000000000002",
+	}
+}
+
+// withAuth injects a session-user identity into req's context so
+// the scope guard passes when calling handlers directly (not via
+// s.Handler(), which would overwrite the identity via bearerAuth).
+func withAuth(req *http.Request) *http.Request {
+	return req.WithContext(context.WithValue(req.Context(), ctxKeyIdentity, testOperatorIdentity()))
 }

--- a/backend/internal/server/runs_get_test.go
+++ b/backend/internal/server/runs_get_test.go
@@ -89,17 +89,16 @@ func TestGetRun_NilRepoConfigured(t *testing.T) {
 func TestRoundTrip_CreateThenGet(t *testing.T) {
 	s := newServer(t, newFakeRepo())
 
-	w, body := requestPath(t, s, http.MethodPost, "/v0/runs", map[string]any{
-		"repo":           "x/y",
-		"workflow_id":    "w",
-		"workflow_sha":   "abc",
-		"trigger_source": "ui",
-	})
-	if w.Code != http.StatusCreated {
-		t.Fatalf("create status = %d:\n%s", w.Code, body)
+	createBody := `{"repo":"x/y","workflow_id":"w","workflow_sha":"abc","trigger_source":"ui"}`
+	wCreate := httptest.NewRecorder()
+	createReq := httptest.NewRequest(http.MethodPost, "/v0/runs", strings.NewReader(createBody))
+	createReq.Header.Set("Content-Type", "application/json")
+	s.handleCreateRun(wCreate, withAuth(createReq))
+	if wCreate.Code != http.StatusCreated {
+		t.Fatalf("create status = %d:\n%s", wCreate.Code, wCreate.Body.String())
 	}
 	var created runResponse
-	if err := json.Unmarshal(body, &created); err != nil {
+	if err := json.Unmarshal(wCreate.Body.Bytes(), &created); err != nil {
 		t.Fatal(err)
 	}
 

--- a/backend/internal/server/scope_enforcement_test.go
+++ b/backend/internal/server/scope_enforcement_test.go
@@ -1,0 +1,130 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// scopeTestServer returns a Server with nil repos — sufficient for
+// scope guard paths, which fire before any repo access.
+func scopeTestServer() *Server {
+	return New(Config{Addr: "127.0.0.1:0"})
+}
+
+func injectIdentity(r *http.Request, id Identity) *http.Request {
+	return r.WithContext(context.WithValue(r.Context(), ctxKeyIdentity, id))
+}
+
+func mcpReadIdentity() Identity {
+	return Identity{
+		Subject: "mcp:run:" + uuid.New().String(),
+		TokenID: "tok-test",
+		Scopes:  []string{"mcp:read"},
+	}
+}
+
+func anonIdentity() Identity {
+	return Identity{}
+}
+
+// assertScopeError checks the response code and that the body
+// contains the expected error code string inside the error envelope.
+func assertScopeError(t *testing.T, w *httptest.ResponseRecorder, wantStatus int, wantCode string) {
+	t.Helper()
+	if w.Code != wantStatus {
+		t.Errorf("status: got %d, want %d (body: %s)", w.Code, wantStatus, w.Body.String())
+		return
+	}
+	var env errorEnvelope
+	if err := json.Unmarshal(w.Body.Bytes(), &env); err != nil {
+		t.Errorf("parse body: %v", err)
+		return
+	}
+	if env.Error.Code != wantCode {
+		t.Errorf("error code: got %q, want %q", env.Error.Code, wantCode)
+	}
+}
+
+func TestCreateRun_InsufficientScope(t *testing.T) {
+	s := scopeTestServer()
+	req := httptest.NewRequest(http.MethodPost, "/v0/runs", strings.NewReader("{}"))
+	req = injectIdentity(req, mcpReadIdentity())
+	w := httptest.NewRecorder()
+	s.handleCreateRun(w, req)
+	assertScopeError(t, w, http.StatusForbidden, "insufficient_scope")
+}
+
+func TestCreateRun_Unauthenticated(t *testing.T) {
+	s := scopeTestServer()
+	req := httptest.NewRequest(http.MethodPost, "/v0/runs", strings.NewReader("{}"))
+	req = injectIdentity(req, anonIdentity())
+	w := httptest.NewRecorder()
+	s.handleCreateRun(w, req)
+	assertScopeError(t, w, http.StatusUnauthorized, "authentication_required")
+}
+
+func TestCancelRun_InsufficientScope(t *testing.T) {
+	s := scopeTestServer()
+	runID := uuid.New()
+	req := httptest.NewRequest(http.MethodPost, "/v0/runs/"+runID.String()+"/cancel", nil)
+	req.SetPathValue("run_id", runID.String())
+	req = injectIdentity(req, mcpReadIdentity())
+	w := httptest.NewRecorder()
+	s.handleCancelRun(w, req)
+	assertScopeError(t, w, http.StatusForbidden, "insufficient_scope")
+}
+
+func TestCancelRun_Unauthenticated(t *testing.T) {
+	s := scopeTestServer()
+	req := httptest.NewRequest(http.MethodPost, "/v0/runs/cancel", nil)
+	req = injectIdentity(req, anonIdentity())
+	w := httptest.NewRecorder()
+	s.handleCancelRun(w, req)
+	assertScopeError(t, w, http.StatusUnauthorized, "authentication_required")
+}
+
+func TestRetryStage_InsufficientScope(t *testing.T) {
+	s := scopeTestServer()
+	stageID := uuid.New()
+	req := httptest.NewRequest(http.MethodPost, "/v0/stages/"+stageID.String()+"/retry", nil)
+	req.SetPathValue("stage_id", stageID.String())
+	req = injectIdentity(req, mcpReadIdentity())
+	w := httptest.NewRecorder()
+	s.handleRetryStage(w, req)
+	assertScopeError(t, w, http.StatusForbidden, "insufficient_scope")
+}
+
+func TestRetryStage_Unauthenticated(t *testing.T) {
+	s := scopeTestServer()
+	req := httptest.NewRequest(http.MethodPost, "/v0/stages/retry", nil)
+	req = injectIdentity(req, anonIdentity())
+	w := httptest.NewRecorder()
+	s.handleRetryStage(w, req)
+	assertScopeError(t, w, http.StatusUnauthorized, "authentication_required")
+}
+
+func TestSubmitApproval_InsufficientScope(t *testing.T) {
+	s := scopeTestServer()
+	stageID := uuid.New()
+	req := httptest.NewRequest(http.MethodPost, "/v0/stages/"+stageID.String()+"/approvals", strings.NewReader(`{"decision":"approve"}`))
+	req.SetPathValue("stage_id", stageID.String())
+	req = injectIdentity(req, mcpReadIdentity())
+	w := httptest.NewRecorder()
+	s.handleSubmitApproval(w, req)
+	assertScopeError(t, w, http.StatusForbidden, "insufficient_scope")
+}
+
+func TestSubmitApproval_Unauthenticated(t *testing.T) {
+	s := scopeTestServer()
+	req := httptest.NewRequest(http.MethodPost, "/v0/stages/approvals", strings.NewReader(`{"decision":"approve"}`))
+	req = injectIdentity(req, anonIdentity())
+	w := httptest.NewRecorder()
+	s.handleSubmitApproval(w, req)
+	assertScopeError(t, w, http.StatusUnauthorized, "authentication_required")
+}

--- a/docs/api/v0.openapi.yaml
+++ b/docs/api/v0.openapi.yaml
@@ -612,6 +612,8 @@ components:
         session-cookie identity — the `X-CSRF-Token` header didn't
         match the `__Host-csrf` cookie (`error: csrf_required`).
         Bearer-token clients bypass the CSRF check.
+        Bearer tokens that authenticate successfully but lack a required
+        write scope receive `error: insufficient_scope` with HTTP 403.
       content:
         application/json:
           schema: { $ref: '#/components/schemas/Error' }

--- a/docs/mcp/install.md
+++ b/docs/mcp/install.md
@@ -116,7 +116,7 @@ Two audiences with different scopes:
 **Auth posture** (today, v0):
 
 - `fhm_*` mcptokens calling `fishhawk_approve_plan` / `fishhawk_reject_plan` are rejected by the backend's role check (`checkApproverAuthorization`) when `RoleResolver` is wired — the runner's `mcp:run:<id>` subject won't match any team in the gate's approver list.
-- `fhm_*` mcptokens calling the other write tools (`start_run`, `cancel_run`, `retry_stage`) are **not yet** gated on scope at the handler — that enforcement is tracked at [#402](https://github.com/kuhlman-labs/fishhawk/issues/402). Until that lands, the read-only-runner property holds by convention (no production code path in the runner calls write tools) rather than wire enforcement.
+- Scope enforcement is active at the wire level for all write paths. An `fhm_*` mcptoken calling any write tool receives HTTP 403 `insufficient_scope` (implementing [#402](https://github.com/kuhlman-labs/fishhawk/issues/402)).
 
 ## Local-runner mint
 


### PR DESCRIPTION
## Summary

Phase A (#395) shipped the write-shaped MCP tools assuming the bearer middleware would gate runner-side `fhm_*` mcptokens out of write operations. Approvals were gated via `checkApproverAuthorization`, but `POST /v0/runs`, `POST /v0/runs/{id}/cancel`, and `POST /v0/stages/{id}/retry` had no scope-based enforcement — a runner-side token could mutate state.

This PR closes the gap with a wire-contract guard:

- **`requireWriteScope` helper on `*Server`** — anonymous = 401, token-without-scope = 403 `insufficient_scope`, cookie-session passes through unchecked (web UI unaffected).
- **Applied to all four write endpoints**:
  - `POST /v0/runs` → `write:runs`
  - `POST /v0/runs/{id}/cancel` → `write:runs`
  - `POST /v0/stages/{id}/retry` → `write:stages`
  - `POST /v0/stages/{id}/approvals` → `write:approvals` (sits in front of the existing role check; both must pass)
- **`fishhawkd token issue` defaults** — when `--scopes` is omitted and `--subject` isn't `mcp:`-prefixed, the operator scope set is applied automatically.
- **Tests**: new `scope_enforcement_test.go` (8 cases: InsufficientScope + Unauthenticated × 4 endpoints). Existing endpoint tests updated to inject identities with the matching write scope so they don't 403 themselves.
- **Docs**: OpenAPI shared Forbidden response documents `insufficient_scope`; `docs/mcp/install.md` removes the "not yet gated" caveat.

## Notes

Driven through the local MCP loop. **Non-textbook path** — worth flagging.

**First plan-stage attempt failed schema validation**: the agent emitted `scope.files[0]` as a string instead of a `{path, operation}` object. Runner exited non-zero with `plan: schema violation at /scope/files/0: got string, want object`. Closed that run via `fishhawk_reject_plan` and started a fresh run (`bec48f3a`).

**State-machine inconsistency observed** on the failed run, **out of scope here** but filing as a follow-up: the stage advanced to `awaiting_approval` despite the plan failing schema validation — `advanceStageAfterTrace` fires on `trace_uploaded` independently of whether `plan_uploaded` succeeded. A stage with no valid plan artifact should not be approve-ready.

**Operator scope set goes slightly beyond the issue's stated AC.** Issue lists `write:runs / write:approvals / write:stages`. The default-set in `token.go` also includes `read:runs / read:audit` — operators need to read what they wrote. The two read scopes aren't currently handler-enforced (declarative-only), so the change is additive and safe. Documented here so it's not a silent expansion.

Second attempt:
- Plan: 25 min predicted, medium confidence. Calibrated via `fishhawk_runtime_calibration` (ratio 0.413, 26 samples) → ~10 min expected.
- Implement: clean exit, **53.9k tokens**, no wall-clock pressure.
- `fishhawk_verify_run`: `verified=true`, chain_length=13.

## Test plan

- [x] `go build ./backend/...` — clean.
- [x] `go test -race ./backend/internal/server/... ./backend/cmd/fishhawkd/...` — pass.
- [x] `golangci-lint run ./backend/...` — 0 issues.
- [x] `scripts/test coverage` — aggregate **81.5%** (threshold 80%).
- [x] `fishhawk_verify_run` — `verified=true`, chain_length=13.

## Out of scope (per issue)

- Strict-mode runner-kind enforcement (separate ADR — ADR-022 deferred this).
- Scope enforcement on read endpoints (v0 read tools accept anonymous; separate question).
- Refactoring `checkApproverAuthorization` — the new scope check sits in front of it.

## Follow-up (filed separately)

State-machine inconsistency from the first plan-stage failure: stage advances to `awaiting_approval` even when `plan_uploaded` never fires. Documented in the run's audit (`reject_plan` reason on run `1b618d6e`).

Closes #402