### PR TITLE
spec: workflow-v0 executor.agent_self_retry boolean (ADR-023 impl 1/3) (#533)

### DIFF
--- a/backend/internal/spec/schemas/workflow-v0.schema.json
+++ b/backend/internal/spec/schemas/workflow-v0.schema.json
@@ -167,6 +167,10 @@
                   "description": "Wall-clock cap on the verify command. Parsed by time.ParseDuration. Defaults to 10m when absent."
                 }
               }
+            },
+            "agent_self_retry": {
+              "type": "boolean",
+              "description": "Opt-in flag (default false, per ADR-023) that tells the runner to allow the agent one self-initiated retry when it detects a recoverable failure before yielding to the workflow's on_ci_failure policy. Only meaningful on agent-executed stages; setting it on a human executor is a schema error (the field is declared in the agent branch only, so unevaluatedProperties rejects it on the human branch)."
             }
           }
         },

--- a/backend/internal/spec/spec.go
+++ b/backend/internal/spec/spec.go
@@ -164,10 +164,11 @@ const (
 // Executor describes what runs the stage. Exactly one of Agent or
 // Human is set. The schema enforces the mutual exclusion.
 type Executor struct {
-	Agent   string        `json:"agent,omitempty" yaml:"agent,omitempty"`
-	Human   bool          `json:"human,omitempty" yaml:"human,omitempty"`
-	Timeout Duration      `json:"timeout,omitempty" yaml:"timeout,omitempty"`
-	Verify  *VerifyConfig `json:"verify,omitempty" yaml:"verify,omitempty"`
+	Agent          string        `json:"agent,omitempty" yaml:"agent,omitempty"`
+	Human          bool          `json:"human,omitempty" yaml:"human,omitempty"`
+	Timeout        Duration      `json:"timeout,omitempty" yaml:"timeout,omitempty"`
+	Verify         *VerifyConfig `json:"verify,omitempty" yaml:"verify,omitempty"`
+	AgentSelfRetry bool          `json:"agent_self_retry,omitempty" yaml:"agent_self_retry,omitempty"`
 }
 
 // VerifyConfig holds the optional in-band test gate for a stage.

--- a/backend/internal/spec/spec_test.go
+++ b/backend/internal/spec/spec_test.go
@@ -569,6 +569,102 @@ func TestResolveStageTimeout(t *testing.T) {
 	}
 }
 
+// --- agent_self_retry (ADR-023 / #533) ---
+
+func TestParse_AgentSelfRetry_Absent(t *testing.T) {
+	// Omitted field defaults to false — the zero value.
+	yml := []byte(`
+version: "0.3"
+workflows:
+  trivial:
+    stages:
+      - id: implement
+        type: implement
+        executor:
+          agent: claude-code
+        produces:
+          - artifact: pull_request
+`)
+	s, err := spec.ParseBytes(yml)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	ex := s.Workflows["trivial"].Stages[0].Executor
+	if ex.AgentSelfRetry {
+		t.Errorf("AgentSelfRetry = true, want false when field is absent")
+	}
+}
+
+func TestParse_AgentSelfRetry_True(t *testing.T) {
+	yml := []byte(`
+version: "0.3"
+workflows:
+  trivial:
+    stages:
+      - id: implement
+        type: implement
+        executor:
+          agent: claude-code
+          agent_self_retry: true
+        produces:
+          - artifact: pull_request
+`)
+	s, err := spec.ParseBytes(yml)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	ex := s.Workflows["trivial"].Stages[0].Executor
+	if !ex.AgentSelfRetry {
+		t.Errorf("AgentSelfRetry = false, want true")
+	}
+}
+
+func TestParse_AgentSelfRetry_ExplicitFalse(t *testing.T) {
+	yml := []byte(`
+version: "0.3"
+workflows:
+  trivial:
+    stages:
+      - id: implement
+        type: implement
+        executor:
+          agent: claude-code
+          agent_self_retry: false
+        produces:
+          - artifact: pull_request
+`)
+	s, err := spec.ParseBytes(yml)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	ex := s.Workflows["trivial"].Stages[0].Executor
+	if ex.AgentSelfRetry {
+		t.Errorf("AgentSelfRetry = true, want false when explicitly set to false")
+	}
+}
+
+func TestParse_AgentSelfRetry_WrongType(t *testing.T) {
+	// "yes" is a string, not a boolean — schema rejects it.
+	yml := []byte(`
+version: "0.3"
+workflows:
+  trivial:
+    stages:
+      - id: implement
+        type: implement
+        executor:
+          agent: claude-code
+          agent_self_retry: "yes"
+        produces:
+          - artifact: pull_request
+`)
+	_, err := spec.ParseBytes(yml)
+	var se *spec.SchemaError
+	if !errors.As(err, &se) {
+		t.Fatalf("err = %v, want *SchemaError", err)
+	}
+}
+
 // --- Parse via io.Reader ---
 
 func TestParse_ReaderRoundTrip(t *testing.T) {

--- a/cli/internal/spec/schemas/workflow-v0.schema.json
+++ b/cli/internal/spec/schemas/workflow-v0.schema.json
@@ -167,6 +167,10 @@
                   "description": "Wall-clock cap on the verify command. Parsed by time.ParseDuration. Defaults to 10m when absent."
                 }
               }
+            },
+            "agent_self_retry": {
+              "type": "boolean",
+              "description": "Opt-in flag (default false, per ADR-023) that tells the runner to allow the agent one self-initiated retry when it detects a recoverable failure before yielding to the workflow's on_ci_failure policy. Only meaningful on agent-executed stages; setting it on a human executor is a schema error (the field is declared in the agent branch only, so unevaluatedProperties rejects it on the human branch)."
             }
           }
         },

--- a/cli/internal/spec/spec_test.go
+++ b/cli/internal/spec/spec_test.go
@@ -128,6 +128,75 @@ func TestParseError_ErrorString(t *testing.T) {
 	}
 }
 
+// --- agent_self_retry (ADR-023 / #533) ---
+
+func TestValidateBytes_AgentSelfRetry_True(t *testing.T) {
+	yml := `
+version: "0.3"
+workflows:
+  trivial:
+    stages:
+      - id: implement
+        type: implement
+        executor:
+          agent: claude-code
+          agent_self_retry: true
+        produces:
+          - artifact: pull_request
+`
+	if err := spec.ValidateBytes([]byte(yml)); err != nil {
+		t.Errorf("expected valid spec with agent_self_retry: true, got: %v", err)
+	}
+}
+
+func TestValidateBytes_AgentSelfRetry_WrongType(t *testing.T) {
+	yml := `
+version: "0.3"
+workflows:
+  trivial:
+    stages:
+      - id: implement
+        type: implement
+        executor:
+          agent: claude-code
+          agent_self_retry: "yes"
+        produces:
+          - artifact: pull_request
+`
+	err := spec.ValidateBytes([]byte(yml))
+	var ve *spec.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("err = %v, want *ValidationError", err)
+	}
+}
+
+// TestValidateBytes_AgentSelfRetry_RejectedOnHumanExecutor pins the
+// contract that agent_self_retry is only allowed inside the agent
+// branch of the executor oneOf. The field is declared in the agent
+// branch and the executor uses unevaluatedProperties: false, so it
+// is rejected when the human branch matches. Catches a future schema
+// refactor that loosens unevaluatedProperties and silently changes
+// the semantic. (ADR-023.)
+func TestValidateBytes_AgentSelfRetry_RejectedOnHumanExecutor(t *testing.T) {
+	yml := `
+version: "0.3"
+workflows:
+  trivial:
+    stages:
+      - id: review
+        type: review
+        executor:
+          human: true
+          agent_self_retry: true
+        produces: []
+`
+	err := spec.ValidateBytes([]byte(yml))
+	var ve *spec.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("err = %v, want *ValidationError (agent_self_retry must be rejected on a human executor)", err)
+	}
+}
+
 func messageStrings(ve *spec.ValidationError) []string {
 	out := make([]string, 0, len(ve.Errors))
 	for _, e := range ve.Errors {

--- a/docs/spec/workflow-v0.md
+++ b/docs/spec/workflow-v0.md
@@ -35,11 +35,12 @@ Identifiers (`<role_id>`, `<workflow_id>`, stage `id`s) are `snake_case` — `^[
 - id: plan
   type: plan | implement | review # closed set; no custom types
   executor: # exactly one of agent or human
-    agent: claude-code # any string; v0 ships claude-code
-    timeout: 10m       # optional; stage-level override for agent timeout
-    verify:            # optional; in-band test gate (see ### Verify gate)
+    agent: claude-code        # any string; v0 ships claude-code
+    timeout: 10m              # optional; stage-level override for agent timeout
+    verify:                   # optional; in-band test gate (see ### Verify gate)
       command: 'scripts/test'
       timeout: '10m'
+    agent_self_retry: false   # optional; opt-in per ADR-023 (see ### Agent self-retry)
     # OR
     human: true
   inputs: [<input>...] # optional
@@ -68,6 +69,19 @@ The runner captures combined stdout+stderr into a `verify_run` bundle event so o
 The gate fires only when the agent itself succeeded (i.e., `res.OK` is true) — a failing agent already produces a category-A trace, and re-running the tests against a broken working tree would be misleading.
 
 The full wiring path from spec to runner is deferred: v0 ships `verify` as a documented spec field for authoring surface. The runner reads the gate command from the `--verify-cmd` CLI flag; a follow-up issue will wire the backend to read `executor.verify.command` from the cached spec and deliver it to the runner via the prompt-fetch response.
+
+### Agent self-retry
+
+An opt-in boolean (default `false`, per ADR-023) that enables the agent to perform one self-initiated retry when it detects a recoverable failure, before the workflow's `on_ci_failure` policy kicks in.
+
+```yaml
+executor:
+  agent: claude-code
+  agent_self_retry: true  # opt in; default false
+```
+
+- **Only valid on agent-executed stages.** Declaring `agent_self_retry` on a `human: true` executor is a schema error — the field lives in the agent branch of the executor `oneOf`, so `unevaluatedProperties: false` rejects it on the human branch.
+- **Backend plumbing and runner detection** are handled by separate follow-up tickets. This field documents the authoring surface and is parsed by both the backend and CLI validators; runner behavior is not yet wired.
 
 ## Inputs
 
@@ -238,6 +252,7 @@ Per-workflow auto-retry policy (#276 / E16). When a required CI check fails on t
 | Member refs                 | `^@[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)?$`                                    | GitHub user or team                                                                                 |
 | Stage `type`                | `plan` \| `implement` \| `review`                                            | closed set                                                                                          |
 | Executor                    | `agent: <string>` xor `human: true`                                          | mutually exclusive                                                                                  |
+| `executor.agent_self_retry` | `true` \| `false` (default `false`)                                          | agent branch only; schema error on human executor                                                   |
 | Input `source`              | `github_issue` \| `pull_request`                                             | v0; v0.x adds Linear/Jira                                                                           |
 | Artifact                    | `plan` \| `pull_request`                                                     | closed set                                                                                          |
 | Persistence target          | `originating_issue` \| `fishhawk_audit_log`                                  | closed set                                                                                          |

--- a/docs/spec/workflow-v0.schema.json
+++ b/docs/spec/workflow-v0.schema.json
@@ -167,6 +167,10 @@
                   "description": "Wall-clock cap on the verify command. Parsed by time.ParseDuration. Defaults to 10m when absent."
                 }
               }
+            },
+            "agent_self_retry": {
+              "type": "boolean",
+              "description": "Opt-in flag (default false, per ADR-023) that tells the runner to allow the agent one self-initiated retry when it detects a recoverable failure before yielding to the workflow's on_ci_failure policy. Only meaningful on agent-executed stages; setting it on a human executor is a schema error (the field is declared in the agent branch only, so unevaluatedProperties rejects it on the human branch)."
             }
           }
         },


### PR DESCRIPTION
## Summary

Impl 1/3 of the ADR-023 chain (#401 resolved this morning). Adds an opt-in boolean field to the workflow-v0 schema; consumers come in #534 (backend) and #535 (runner).

- **Schema** — `agent_self_retry` (optional bool, default `false`) inside the agent branch of the executor `oneOf`. Field placement matters: `unevaluatedProperties: false` rejects it when the human branch matches, so setting it on a human executor is automatically a schema error (no extra validation code needed).
- **Synced across the three mirrors** via `scripts/sync-schemas` (canonical in `docs/spec/`, embedded in `backend/internal/spec/schemas/` and `cli/internal/spec/schemas/`). CI schema-sync gate keeps them byte-identical.
- **Go struct** — `AgentSelfRetry bool` added to `Executor` in `backend/internal/spec/spec.go`.
- **Tests** — parse round-trip (absent/true/explicit-false/wrong-type) + ValidateBytes round-trip (valid true / invalid wrong-type / **cross-branch rejection** on human executor).
- **Docs** — `docs/spec/workflow-v0.md` field reference.

Additive within workflow-v0.x per the discipline from ADR-026 (#472) — no major version bump.

## Notes

Driven through the local MCP loop. **Textbook-clean** — fifth in a row.

- Plan: 7 min predicted, medium confidence. Calibration via `fishhawk_runtime_calibration` (ratio 0.42, 30 samples) → ~3 min expected.
- Implement: clean exit, **7k tokens**, no wall-clock pressure.
- `fishhawk_verify_run`: `verified=true`, chain_length=13.

One small in-loop polish: the agent skipped my approval ask for the cross-branch rejection test (`human: true` + `agent_self_retry: true` → schema error). Added inline — 20 LoC test that pins the `unevaluatedProperties: false` contract so a future schema refactor that loosens it can't silently change the semantic.

## Sample valid spec

```yaml
version: "0.3"
workflows:
  feature_change_self_retry:
    stages:
      - id: implement
        type: implement
        executor:
          agent: claude-code
          agent_self_retry: true   # opt-in; consumer wiring lands in #534/#535
        produces:
          - artifact: pull_request
```

## Test plan

- [x] `scripts/sync-schemas` — clean exit; all three mirrors byte-identical.
- [x] `go test -race ./backend/internal/spec/... ./cli/internal/spec/...` — pass (new + existing).
- [x] `golangci-lint run ./backend/internal/spec/... ./cli/internal/spec/...` — 0 issues.
- [x] `scripts/test coverage` — aggregate **81.4%** (threshold 80%).
- [x] `fishhawk_verify_run` — `verified=true`, chain_length=13.

## Out of scope (per ADR-023 + the issue body)

- Backend handler enforcement of the field (#534 picks it up).
- Runner-side detection + self-retry call (#535).
- Default-on policy change. Deferred per ADR-023; revisit after soak time.

## Related

- #401 / ADR-023 — the resolving decision.
- #472 / ADR-026 — the schema-evolution discipline this follows.
- #534, #535 — implementation siblings.

Closes #533