### PR TITLE
plan: server-side coercion for string-elision schema violations (#537)

### DIFF
--- a/backend/internal/plan/coerce.go
+++ b/backend/internal/plan/coerce.go
@@ -1,0 +1,123 @@
+package plan
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// Coercion records one field-level coercion applied by TryCoerce.
+type Coercion struct {
+	FieldPath     string `json:"field_path"`
+	OriginalType  string `json:"original_type"`
+	OriginalValue any    `json:"original_value"`
+	CoercedTo     any    `json:"coerced_to"`
+}
+
+// TryCoerce attempts to fix the known string-elision class of plan schema
+// violations: cases where an agent emits a bare string where the schema
+// expects an object at /generated_by, /scope/files[], or
+// /decomposition/sub_plans[].
+//
+// Returns (coercedBytes, coercions, nil) when coercion produces a valid plan.
+// Returns (nil, nil, nil) when no string-valued nested-object fields are
+// detected AND the original data already validates — caller keeps original
+// bytes. Returns (nil, nil, err) when coercions were applied but re-validation
+// still fails, or when no coercions apply and the original data is invalid —
+// either way the caller should fall through to the 400 path.
+func TryCoerce(data []byte, now time.Time) ([]byte, []Coercion, error) {
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, nil, nil
+	}
+
+	var coercions []Coercion
+
+	// /generated_by: coerce bare string to canonical object shape.
+	if v, ok := m["generated_by"]; ok {
+		if s, ok := v.(string); ok {
+			coerced := map[string]any{
+				"agent":     s,
+				"model":     "unknown",
+				"timestamp": now.UTC().Format(time.RFC3339),
+			}
+			coercions = append(coercions, Coercion{
+				FieldPath:     "/generated_by",
+				OriginalType:  "string",
+				OriginalValue: s,
+				CoercedTo:     coerced,
+			})
+			m["generated_by"] = coerced
+		}
+	}
+
+	// /scope/files[]: coerce each bare string element to {path, operation}.
+	if scope, ok := m["scope"].(map[string]any); ok {
+		if files, ok := scope["files"].([]any); ok {
+			for i, f := range files {
+				if s, ok := f.(string); ok {
+					coerced := map[string]any{
+						"path":      s,
+						"operation": "modify",
+					}
+					coercions = append(coercions, Coercion{
+						FieldPath:     fmt.Sprintf("/scope/files/%d", i),
+						OriginalType:  "string",
+						OriginalValue: s,
+						CoercedTo:     coerced,
+					})
+					files[i] = coerced
+				}
+			}
+			scope["files"] = files
+		}
+	}
+
+	// /decomposition/sub_plans[]: coerce each bare string element to the
+	// sentinel default shape. scope_hint is intentionally empty — the
+	// coercion is a robustness aid, not a way to hide missing agent output.
+	if decomp, ok := m["decomposition"].(map[string]any); ok {
+		if subPlans, ok := decomp["sub_plans"].([]any); ok {
+			for i, sp := range subPlans {
+				if s, ok := sp.(string); ok {
+					coerced := map[string]any{
+						"title":                        s,
+						"scope_hint":                   "",
+						"predicted_runtime_minutes":    1,
+						"predicted_runtime_confidence": "low",
+					}
+					coercions = append(coercions, Coercion{
+						FieldPath:     fmt.Sprintf("/decomposition/sub_plans/%d", i),
+						OriginalType:  "string",
+						OriginalValue: s,
+						CoercedTo:     coerced,
+					})
+					subPlans[i] = coerced
+				}
+			}
+			decomp["sub_plans"] = subPlans
+		}
+	}
+
+	if len(coercions) == 0 {
+		// No string-valued nested-object fields were detected. If the
+		// original data is already valid, signal the caller to keep it
+		// unchanged. If invalid, propagate the failure so the caller can
+		// fall through to the 400 path.
+		if err := Validate(data); err != nil {
+			return nil, nil, err
+		}
+		return nil, nil, nil
+	}
+
+	coercedBytes, err := json.Marshal(m)
+	if err != nil {
+		return nil, nil, fmt.Errorf("coerce: marshal: %w", err)
+	}
+
+	if err := Validate(coercedBytes); err != nil {
+		return nil, nil, err
+	}
+
+	return coercedBytes, coercions, nil
+}

--- a/backend/internal/plan/coerce_test.go
+++ b/backend/internal/plan/coerce_test.go
@@ -1,0 +1,166 @@
+package plan_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/kuhlman-labs/fishhawk/backend/internal/plan"
+	"github.com/kuhlman-labs/fishhawk/backend/internal/plan/planfixture"
+)
+
+var testNow = time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC)
+
+func marshal(t *testing.T, m map[string]any) []byte {
+	t.Helper()
+	b, err := json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+// TestTryCoerce_GeneratedByString verifies that a bare string at /generated_by
+// is wrapped into the canonical generated_by object shape.
+func TestTryCoerce_GeneratedByString(t *testing.T) {
+	m := planfixture.Valid()
+	m["generated_by"] = "my-agent"
+	data := marshal(t, m)
+
+	coercedBytes, coercions, err := plan.TryCoerce(data, testNow)
+	if err != nil {
+		t.Fatalf("TryCoerce: unexpected error: %v", err)
+	}
+	if len(coercions) != 1 {
+		t.Fatalf("coercions = %d, want 1", len(coercions))
+	}
+	if got := coercions[0].FieldPath; got != "/generated_by" {
+		t.Errorf("FieldPath = %q, want /generated_by", got)
+	}
+	if got := coercions[0].OriginalType; got != "string" {
+		t.Errorf("OriginalType = %q, want string", got)
+	}
+	if got, ok := coercions[0].OriginalValue.(string); !ok || got != "my-agent" {
+		t.Errorf("OriginalValue = %v, want string \"my-agent\"", coercions[0].OriginalValue)
+	}
+	if coercedBytes == nil {
+		t.Fatal("coercedBytes is nil")
+	}
+	if err := plan.Validate(coercedBytes); err != nil {
+		t.Errorf("coerced plan does not validate: %v", err)
+	}
+}
+
+// TestTryCoerce_ScopeFileString verifies that a bare string at /scope/files[0]
+// is wrapped into {path, operation:"modify"}.
+func TestTryCoerce_ScopeFileString(t *testing.T) {
+	m := planfixture.Valid()
+	scope := m["scope"].(map[string]any)
+	scope["files"] = []any{"a.go"}
+	data := marshal(t, m)
+
+	coercedBytes, coercions, err := plan.TryCoerce(data, testNow)
+	if err != nil {
+		t.Fatalf("TryCoerce: unexpected error: %v", err)
+	}
+	if len(coercions) != 1 {
+		t.Fatalf("coercions = %d, want 1", len(coercions))
+	}
+	if got := coercions[0].FieldPath; got != "/scope/files/0" {
+		t.Errorf("FieldPath = %q, want /scope/files/0", got)
+	}
+	if got := coercions[0].OriginalType; got != "string" {
+		t.Errorf("OriginalType = %q, want string", got)
+	}
+	if got, ok := coercions[0].OriginalValue.(string); !ok || got != "a.go" {
+		t.Errorf("OriginalValue = %v, want string \"a.go\"", coercions[0].OriginalValue)
+	}
+	if coercedBytes == nil {
+		t.Fatal("coercedBytes is nil")
+	}
+	if err := plan.Validate(coercedBytes); err != nil {
+		t.Errorf("coerced plan does not validate: %v", err)
+	}
+}
+
+// TestTryCoerce_SubPlanString verifies that a bare string at
+// /decomposition/sub_plans[0] is wrapped into the sentinel default shape.
+func TestTryCoerce_SubPlanString(t *testing.T) {
+	m := planfixture.Valid(func(m map[string]any) {
+		m["decomposition"] = map[string]any{
+			"rationale": "scope too large",
+			"sub_plans": []any{
+				"Part A", // bare string — subject of coercion
+				map[string]any{
+					"title":                        "Part B",
+					"scope_hint":                   "second half",
+					"predicted_runtime_minutes":    10,
+					"predicted_runtime_confidence": "medium",
+				},
+			},
+		}
+	})
+	data := marshal(t, m)
+
+	coercedBytes, coercions, err := plan.TryCoerce(data, testNow)
+	if err != nil {
+		t.Fatalf("TryCoerce: unexpected error: %v", err)
+	}
+	if len(coercions) != 1 {
+		t.Fatalf("coercions = %d, want 1", len(coercions))
+	}
+	if got := coercions[0].FieldPath; got != "/decomposition/sub_plans/0" {
+		t.Errorf("FieldPath = %q, want /decomposition/sub_plans/0", got)
+	}
+	if got := coercions[0].OriginalType; got != "string" {
+		t.Errorf("OriginalType = %q, want string", got)
+	}
+	if got, ok := coercions[0].OriginalValue.(string); !ok || got != "Part A" {
+		t.Errorf("OriginalValue = %v, want string \"Part A\"", coercions[0].OriginalValue)
+	}
+	if coercedBytes == nil {
+		t.Fatal("coercedBytes is nil")
+	}
+	if err := plan.Validate(coercedBytes); err != nil {
+		t.Errorf("coerced plan does not validate: %v", err)
+	}
+}
+
+// TestTryCoerce_IntegerScopeFile verifies that a non-string type at
+// /scope/files[0] (an integer) is not coercible and propagates a non-nil
+// error — the caller falls through to the existing 400 path.
+func TestTryCoerce_IntegerScopeFile(t *testing.T) {
+	m := planfixture.Valid()
+	scope := m["scope"].(map[string]any)
+	scope["files"] = []any{42}
+	data := marshal(t, m)
+
+	coercedBytes, coercions, err := plan.TryCoerce(data, testNow)
+	if coercedBytes != nil {
+		t.Errorf("coercedBytes = non-nil, want nil for non-coercible type")
+	}
+	if len(coercions) != 0 {
+		t.Errorf("coercions = %d, want 0", len(coercions))
+	}
+	if err == nil {
+		t.Error("err = nil, want non-nil: integer is not coercible and original schema error should propagate")
+	}
+}
+
+// TestTryCoerce_AlreadyValid verifies that a plan that already satisfies the
+// schema produces (nil, nil, nil) — the caller must keep the original bytes
+// unchanged so the content hash is stable.
+func TestTryCoerce_AlreadyValid(t *testing.T) {
+	data := marshal(t, planfixture.Valid())
+
+	coercedBytes, coercions, err := plan.TryCoerce(data, testNow)
+	if coercedBytes != nil {
+		t.Errorf("coercedBytes = non-nil on already-valid plan")
+	}
+	if len(coercions) != 0 {
+		t.Errorf("coercions = %d, want 0", len(coercions))
+	}
+	if err != nil {
+		t.Errorf("err = %v, want nil", err)
+	}
+}

--- a/backend/internal/server/plan.go
+++ b/backend/internal/server/plan.go
@@ -129,35 +129,65 @@ func (s *Server) handleShipPlan(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate payload against standard_v1. Schema errors are 400 so
-	// the runner maps them to category-B (constraint failure) rather
-	// than retrying — the agent's output is bad and re-shipping the
-	// same bytes won't help.
+	// Validate payload against standard_v1. For the known string-elision
+	// class of schema violations, attempt coercion before returning 400.
+	// For all other errors, category-B maps the failure so the runner
+	// doesn't retry — the agent's output is bad and re-shipping won't help.
 	if err := plan.Validate(body); err != nil {
-		// Transition the plan stage to failed-B so the run reflects
-		// the bad output rather than getting stuck in `running` (#527).
-		// The trace handler defers plan-stage transitions to this
-		// handler; we are the only place that knows plan validation
-		// failed. Best-effort: a TransitionStage error logs but
-		// doesn't change the upload response — the operator's signal
-		// is the 400, not the audit row.
-		cat := run.FailureB
-		reason := "plan_invalid: " + err.Error()
-		if _, terr := s.cfg.RunRepo.TransitionStage(r.Context(), stageID,
-			run.StageStateFailed, &run.StageCompletion{
-				FailureCategory: &cat,
-				FailureReason:   &reason,
-			}); terr != nil {
-			s.cfg.Logger.LogAttrs(r.Context(), slog.LevelWarn,
-				"plan upload: transition to failed-B after validation error failed",
-				slog.String("run_id", runID.String()),
-				slog.String("stage_id", stageID.String()),
-				slog.String("error", terr.Error()))
+		coercionOK := false
+		var schemaErr *plan.SchemaError
+		if errors.As(err, &schemaErr) {
+			coercedBytes, coercions, coerceErr := plan.TryCoerce(body, time.Now().UTC())
+			if coerceErr == nil && len(coercions) > 0 {
+				// Coercion produced a valid plan. Record it before
+				// artifact storage so a spike in plan_coerced entries
+				// is visible as a prompt-quality signal.
+				coercionPayload, _ := json.Marshal(map[string]any{
+					"run_id":    runID.String(),
+					"stage_id":  stageID.String(),
+					"coercions": coercions,
+				})
+				systemKind := audit.ActorKind("system")
+				if _, aerr := s.cfg.AuditRepo.AppendChained(r.Context(), audit.ChainAppendParams{
+					RunID:     runID,
+					StageID:   &stageID,
+					Timestamp: time.Now().UTC(),
+					Category:  "plan_coerced",
+					ActorKind: &systemKind,
+					Payload:   coercionPayload,
+				}); aerr != nil {
+					s.writeError(w, r, http.StatusInternalServerError, "internal_error",
+						"append coercion audit entry failed", map[string]any{"error": aerr.Error()})
+					return
+				}
+				body = coercedBytes
+				coercionOK = true
+			}
 		}
-		s.writeError(w, r, http.StatusBadRequest, "plan_invalid",
-			"plan does not validate against standard_v1",
-			map[string]any{"error": err.Error()})
-		return
+		if !coercionOK {
+			// Coercion could not help (non-string type or re-validation
+			// still fails). Transition the stage to failed-B so the run
+			// reflects the bad output rather than getting stuck in
+			// `running` (#527). Best-effort: a TransitionStage error
+			// logs but doesn't change the upload response.
+			cat := run.FailureB
+			reason := "plan_invalid: " + err.Error()
+			if _, terr := s.cfg.RunRepo.TransitionStage(r.Context(), stageID,
+				run.StageStateFailed, &run.StageCompletion{
+					FailureCategory: &cat,
+					FailureReason:   &reason,
+				}); terr != nil {
+				s.cfg.Logger.LogAttrs(r.Context(), slog.LevelWarn,
+					"plan upload: transition to failed-B after validation error failed",
+					slog.String("run_id", runID.String()),
+					slog.String("stage_id", stageID.String()),
+					slog.String("error", terr.Error()))
+			}
+			s.writeError(w, r, http.StatusBadRequest, "plan_invalid",
+				"plan does not validate against standard_v1",
+				map[string]any{"error": err.Error()})
+			return
+		}
 	}
 
 	contentHash := sha256Hex(body)

--- a/backend/internal/server/plan_test.go
+++ b/backend/internal/server/plan_test.go
@@ -138,6 +138,79 @@ func TestShipPlan_Idempotent_SecondUploadReturnsExisting(t *testing.T) {
 	}
 }
 
+func TestShipPlan_CoercibleSchemaError_Returns201(t *testing.T) {
+	runID, stageID := uuid.New(), uuid.New()
+	s, sf, ar, au, rr := newPlanServer(t, runID, stageID)
+	priv, _ := sf.issue(t, runID)
+
+	// Build a plan where generated_by is a bare string (coercible schema error).
+	m := planfixture.Valid()
+	m["generated_by"] = "my-agent"
+	body, err := json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := shipPlanRequest(t, s, runID, stageID, priv, body, "")
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201 (coercion should succeed):\n%s", w.Code, w.Body.String())
+	}
+
+	// Coerced plan should still produce an artifact row.
+	if len(ar.all) != 1 {
+		t.Errorf("artifacts = %d, want 1", len(ar.all))
+	}
+
+	// Two audit entries: plan_coerced then plan_generated.
+	if len(au.appended) != 2 {
+		t.Fatalf("audit entries = %d, want 2 (plan_coerced + plan_generated)", len(au.appended))
+	}
+	if got := au.appended[0].Category; got != "plan_coerced" {
+		t.Errorf("audit[0].category = %q, want plan_coerced", got)
+	}
+	if got := au.appended[1].Category; got != "plan_generated" {
+		t.Errorf("audit[1].category = %q, want plan_generated", got)
+	}
+
+	// Coerced plans must NOT transition to failed-B.
+	if len(rr.transitionStageCalls) != 0 {
+		t.Errorf("transitionStage calls = %d, want 0 (coercion succeeded)", len(rr.transitionStageCalls))
+	}
+}
+
+func TestShipPlan_NonCoercibleSchemaError_400(t *testing.T) {
+	runID, stageID := uuid.New(), uuid.New()
+	s, sf, ar, _, rr := newPlanServer(t, runID, stageID)
+	priv, _ := sf.issue(t, runID)
+
+	// Build a plan where scope.files[0] is an integer — not coercible.
+	m := planfixture.Valid()
+	scope := m["scope"].(map[string]any)
+	scope["files"] = []any{42}
+	body, err := json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := shipPlanRequest(t, s, runID, stageID, priv, body, "")
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400:\n%s", w.Code, w.Body.String())
+	}
+	if len(ar.all) != 0 {
+		t.Errorf("artifacts = %d, want 0 on non-coercible schema fail", len(ar.all))
+	}
+
+	// Non-coercible failures must still transition to failed-B.
+	if len(rr.transitionStageCalls) != 1 {
+		t.Fatalf("transitionStage calls = %d, want 1", len(rr.transitionStageCalls))
+	}
+	call := rr.transitionStageCalls[0]
+	if call.Completion == nil || call.Completion.FailureCategory == nil ||
+		*call.Completion.FailureCategory != run.FailureB {
+		t.Errorf("FailureCategory = %v, want B", call.Completion.FailureCategory)
+	}
+}
+
 func TestShipPlan_SchemaInvalid_400(t *testing.T) {
 	runID, stageID := uuid.New(), uuid.New()
 	s, sf, ar, _, rr := newPlanServer(t, runID, stageID)

--- a/docs/spec/plan-standard-v1.md
+++ b/docs/spec/plan-standard-v1.md
@@ -220,6 +220,39 @@ JSON Schema enforces structure. The validator (E1.5 / #20) layers on:
 
 These cross-references aren't expressible in JSON Schema cleanly.
 
+### Server-side coercion
+
+The backend applies a narrow set of coercions when an agent emits a bare string where the schema expects an object — a class of elision errors seen when agents omit wrapper keys. Coercion fires only after schema validation fails with a `*SchemaError`; `*ParseError` and semantic errors bypass it entirely.
+
+**Covered paths and default shapes:**
+
+| Path | Coerced to |
+|---|---|
+| `/generated_by` (bare string `s`) | `{"agent": s, "model": "unknown", "timestamp": "<upload-time>"}` |
+| `/scope/files[i]` (bare string `s`) | `{"path": s, "operation": "modify"}` |
+| `/decomposition/sub_plans[i]` (bare string `s`) | `{"title": s, "scope_hint": "", "predicted_runtime_minutes": 1, "predicted_runtime_confidence": "low"}` |
+
+After coercions are applied, the plan is re-validated against the full schema. If it passes, the coerced bytes are stored as the artifact (not the agent's original bytes) and a `plan_coerced` audit entry is appended with:
+
+```json
+{
+  "run_id": "...",
+  "stage_id": "...",
+  "coercions": [
+    {
+      "field_path": "/generated_by",
+      "original_type": "string",
+      "original_value": "claude-code",
+      "coerced_to": { "agent": "claude-code", "model": "unknown", "timestamp": "2026-05-26T12:00:00Z" }
+    }
+  ]
+}
+```
+
+If re-validation still fails (e.g., the plan has a non-string type at a coercible location, or other schema violations persist), the upload returns 400 and the stage transitions to failed-B as normal.
+
+**Rationale and compliance.** Coercion is a robustness mechanism, not a way to hide bad agent output. A spike in `plan_coerced` audit entries is a prompt-quality signal: the plan-stage prompt is not instructing the agent to emit the correct wrapper structure. Operators should treat rising `plan_coerced` rates as a cue to improve the prompt, not as an acceptable steady state. The coerced artifact is stored verbatim so the audit log reflects what was actually persisted.
+
 ## Persistence
 
 Per `MVP_SPEC.md` §4.3:

--- a/runner/cmd/fishhawk-runner/main.go
+++ b/runner/cmd/fishhawk-runner/main.go
@@ -998,15 +998,41 @@ func validatePlan(path string) (agent.Event, error) {
 			Payload: agent.MakePayload(map[string]string{"check": "plan_validation", "outcome": "missing", "path": path, "error": err.Error()}),
 		}, fmt.Errorf("plan: read %s: %w", path, err)
 	}
+
+	// Attempt structural coercion (#537) for the known string-elision
+	// failure class — when the agent emits a bare string where the schema
+	// requires an object at /generated_by, /scope/files[], or
+	// /decomposition/sub_plans[]. TryCoerce returns the coerced bytes when
+	// it could fix the plan; the file is rewritten so the subsequent
+	// uploadPlan reads the corrected payload and the backend sees a clean
+	// (already-validated) artifact. The backend's mirror coercion is a
+	// belt-and-suspenders fallback for cases where this runner skips coercion
+	// (older binary, future code path).
+	coercedBytes, coercions, coerceErr := plan.TryCoerce(data, time.Now().UTC())
+	if coerceErr == nil && len(coercions) > 0 {
+		if err := os.WriteFile(path, coercedBytes, 0o600); err != nil {
+			return agent.Event{
+				Kind:    "policy_event",
+				Payload: agent.MakePayload(map[string]string{"check": "plan_validation", "outcome": "coerce_write_failed", "path": path, "error": err.Error()}),
+			}, fmt.Errorf("plan: write coerced %s: %w", path, err)
+		}
+		data = coercedBytes
+	}
+
 	if vErr := plan.Validate(data); vErr != nil {
 		return agent.Event{
 			Kind:    "policy_event",
 			Payload: agent.MakePayload(map[string]string{"check": "plan_validation", "outcome": "invalid", "path": path, "error": vErr.Error()}),
 		}, vErr
 	}
+
+	outcomePayload := map[string]string{"check": "plan_validation", "outcome": "valid", "path": path}
+	if len(coercions) > 0 {
+		outcomePayload["coerced"] = fmt.Sprintf("%d field(s)", len(coercions))
+	}
 	return agent.Event{
 		Kind:    "policy_event",
-		Payload: agent.MakePayload(map[string]string{"check": "plan_validation", "outcome": "valid", "path": path}),
+		Payload: agent.MakePayload(outcomePayload),
 	}, nil
 }
 

--- a/runner/internal/plan/coerce.go
+++ b/runner/internal/plan/coerce.go
@@ -1,0 +1,133 @@
+package plan
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// Coercion records one field-level coercion applied by TryCoerce.
+//
+// Mirrors backend/internal/plan.Coercion. The runner module cannot import
+// backend packages (Go internal-package boundary), so the type is duplicated
+// here. Keep field tags and semantics identical to the backend copy so the
+// runner's structured logs match what compliance will see in the backend's
+// plan_coerced audit entries.
+type Coercion struct {
+	FieldPath     string `json:"field_path"`
+	OriginalType  string `json:"original_type"`
+	OriginalValue any    `json:"original_value"`
+	CoercedTo     any    `json:"coerced_to"`
+}
+
+// TryCoerce attempts to fix the known string-elision class of plan schema
+// violations: cases where an agent emits a bare string where the schema
+// expects an object at /generated_by, /scope/files[], or
+// /decomposition/sub_plans[].
+//
+// Returns (coercedBytes, coercions, nil) when coercion produces a valid plan.
+// Returns (nil, nil, nil) when no string-valued nested-object fields are
+// detected AND the original data already validates — caller keeps original
+// bytes (content_hash stability for the signed upload). Returns (nil, nil, err)
+// when coercions were applied but re-validation still fails, or when no
+// coercions apply and the original data is invalid — either way the caller
+// should fall through to the existing rejection path.
+//
+// Mirror of backend/internal/plan.TryCoerce. Both packages must apply the same
+// defaults so the runner-coerced bytes pass the backend's Validate cleanly
+// (idempotent — backend re-coercion finds nothing to fix).
+func TryCoerce(data []byte, now time.Time) ([]byte, []Coercion, error) {
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, nil, nil
+	}
+
+	var coercions []Coercion
+
+	// /generated_by: coerce bare string to canonical object shape.
+	if v, ok := m["generated_by"]; ok {
+		if s, ok := v.(string); ok {
+			coerced := map[string]any{
+				"agent":     s,
+				"model":     "unknown",
+				"timestamp": now.UTC().Format(time.RFC3339),
+			}
+			coercions = append(coercions, Coercion{
+				FieldPath:     "/generated_by",
+				OriginalType:  "string",
+				OriginalValue: s,
+				CoercedTo:     coerced,
+			})
+			m["generated_by"] = coerced
+		}
+	}
+
+	// /scope/files[]: coerce each bare string element to {path, operation}.
+	if scope, ok := m["scope"].(map[string]any); ok {
+		if files, ok := scope["files"].([]any); ok {
+			for i, f := range files {
+				if s, ok := f.(string); ok {
+					coerced := map[string]any{
+						"path":      s,
+						"operation": "modify",
+					}
+					coercions = append(coercions, Coercion{
+						FieldPath:     fmt.Sprintf("/scope/files/%d", i),
+						OriginalType:  "string",
+						OriginalValue: s,
+						CoercedTo:     coerced,
+					})
+					files[i] = coerced
+				}
+			}
+			scope["files"] = files
+		}
+	}
+
+	// /decomposition/sub_plans[]: coerce each bare string element to the
+	// sentinel default shape. scope_hint intentionally empty — the coercion
+	// is a robustness aid, not a way to hide missing agent output.
+	if decomp, ok := m["decomposition"].(map[string]any); ok {
+		if subPlans, ok := decomp["sub_plans"].([]any); ok {
+			for i, sp := range subPlans {
+				if s, ok := sp.(string); ok {
+					coerced := map[string]any{
+						"title":                        s,
+						"scope_hint":                   "",
+						"predicted_runtime_minutes":    1,
+						"predicted_runtime_confidence": "low",
+					}
+					coercions = append(coercions, Coercion{
+						FieldPath:     fmt.Sprintf("/decomposition/sub_plans/%d", i),
+						OriginalType:  "string",
+						OriginalValue: s,
+						CoercedTo:     coerced,
+					})
+					subPlans[i] = coerced
+				}
+			}
+			decomp["sub_plans"] = subPlans
+		}
+	}
+
+	if len(coercions) == 0 {
+		// No string-valued nested-object fields detected. If the original
+		// data already validates, signal the caller to keep it unchanged
+		// (content_hash stability). If invalid, propagate the failure.
+		if err := Validate(data); err != nil {
+			return nil, nil, err
+		}
+		return nil, nil, nil
+	}
+
+	coercedBytes, err := json.Marshal(m)
+	if err != nil {
+		return nil, nil, fmt.Errorf("coerce: marshal: %w", err)
+	}
+
+	if err := Validate(coercedBytes); err != nil {
+		return nil, nil, err
+	}
+
+	return coercedBytes, coercions, nil
+}

--- a/runner/internal/plan/coerce_test.go
+++ b/runner/internal/plan/coerce_test.go
@@ -1,0 +1,165 @@
+package plan_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/kuhlman-labs/fishhawk/runner/internal/plan"
+	"github.com/kuhlman-labs/fishhawk/runner/internal/plan/planfixture"
+)
+
+var testNow = time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC)
+
+func marshal(t *testing.T, m map[string]any) []byte {
+	t.Helper()
+	b, err := json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+// TestTryCoerce_GeneratedByString verifies bare string at /generated_by is
+// wrapped into the canonical generated_by object shape.
+func TestTryCoerce_GeneratedByString(t *testing.T) {
+	m := planfixture.Valid()
+	m["generated_by"] = "my-agent"
+	data := marshal(t, m)
+
+	coercedBytes, coercions, err := plan.TryCoerce(data, testNow)
+	if err != nil {
+		t.Fatalf("TryCoerce: unexpected error: %v", err)
+	}
+	if len(coercions) != 1 {
+		t.Fatalf("coercions = %d, want 1", len(coercions))
+	}
+	if got := coercions[0].FieldPath; got != "/generated_by" {
+		t.Errorf("FieldPath = %q, want /generated_by", got)
+	}
+	if got := coercions[0].OriginalType; got != "string" {
+		t.Errorf("OriginalType = %q, want string", got)
+	}
+	if got, ok := coercions[0].OriginalValue.(string); !ok || got != "my-agent" {
+		t.Errorf("OriginalValue = %v, want string \"my-agent\"", coercions[0].OriginalValue)
+	}
+	if coercedBytes == nil {
+		t.Fatal("coercedBytes is nil")
+	}
+	if err := plan.Validate(coercedBytes); err != nil {
+		t.Errorf("coerced plan does not validate: %v", err)
+	}
+}
+
+// TestTryCoerce_ScopeFileString verifies bare string at /scope/files[0] is
+// wrapped into {path, operation:"modify"}.
+func TestTryCoerce_ScopeFileString(t *testing.T) {
+	m := planfixture.Valid()
+	scope := m["scope"].(map[string]any)
+	scope["files"] = []any{"a.go"}
+	data := marshal(t, m)
+
+	coercedBytes, coercions, err := plan.TryCoerce(data, testNow)
+	if err != nil {
+		t.Fatalf("TryCoerce: unexpected error: %v", err)
+	}
+	if len(coercions) != 1 {
+		t.Fatalf("coercions = %d, want 1", len(coercions))
+	}
+	if got := coercions[0].FieldPath; got != "/scope/files/0" {
+		t.Errorf("FieldPath = %q, want /scope/files/0", got)
+	}
+	if got := coercions[0].OriginalType; got != "string" {
+		t.Errorf("OriginalType = %q, want string", got)
+	}
+	if got, ok := coercions[0].OriginalValue.(string); !ok || got != "a.go" {
+		t.Errorf("OriginalValue = %v, want string \"a.go\"", coercions[0].OriginalValue)
+	}
+	if coercedBytes == nil {
+		t.Fatal("coercedBytes is nil")
+	}
+	if err := plan.Validate(coercedBytes); err != nil {
+		t.Errorf("coerced plan does not validate: %v", err)
+	}
+}
+
+// TestTryCoerce_SubPlanString verifies bare string at
+// /decomposition/sub_plans[0] is wrapped into the sentinel default shape.
+func TestTryCoerce_SubPlanString(t *testing.T) {
+	m := planfixture.Valid(func(m map[string]any) {
+		m["decomposition"] = map[string]any{
+			"rationale": "scope too large",
+			"sub_plans": []any{
+				"Part A", // bare string — subject of coercion
+				map[string]any{
+					"title":                        "Part B",
+					"scope_hint":                   "second half",
+					"predicted_runtime_minutes":    10,
+					"predicted_runtime_confidence": "medium",
+				},
+			},
+		}
+	})
+	data := marshal(t, m)
+
+	coercedBytes, coercions, err := plan.TryCoerce(data, testNow)
+	if err != nil {
+		t.Fatalf("TryCoerce: unexpected error: %v", err)
+	}
+	if len(coercions) != 1 {
+		t.Fatalf("coercions = %d, want 1", len(coercions))
+	}
+	if got := coercions[0].FieldPath; got != "/decomposition/sub_plans/0" {
+		t.Errorf("FieldPath = %q, want /decomposition/sub_plans/0", got)
+	}
+	if got := coercions[0].OriginalType; got != "string" {
+		t.Errorf("OriginalType = %q, want string", got)
+	}
+	if got, ok := coercions[0].OriginalValue.(string); !ok || got != "Part A" {
+		t.Errorf("OriginalValue = %v, want string \"Part A\"", coercions[0].OriginalValue)
+	}
+	if coercedBytes == nil {
+		t.Fatal("coercedBytes is nil")
+	}
+	if err := plan.Validate(coercedBytes); err != nil {
+		t.Errorf("coerced plan does not validate: %v", err)
+	}
+}
+
+// TestTryCoerce_IntegerScopeFile verifies non-string types are not coercible
+// and the original schema error propagates to the caller.
+func TestTryCoerce_IntegerScopeFile(t *testing.T) {
+	m := planfixture.Valid()
+	scope := m["scope"].(map[string]any)
+	scope["files"] = []any{42}
+	data := marshal(t, m)
+
+	coercedBytes, coercions, err := plan.TryCoerce(data, testNow)
+	if coercedBytes != nil {
+		t.Errorf("coercedBytes = non-nil, want nil for non-coercible type")
+	}
+	if len(coercions) != 0 {
+		t.Errorf("coercions = %d, want 0", len(coercions))
+	}
+	if err == nil {
+		t.Error("err = nil, want non-nil: integer is not coercible and original schema error should propagate")
+	}
+}
+
+// TestTryCoerce_AlreadyValid verifies a plan that already satisfies the
+// schema produces (nil, nil, nil) — caller MUST keep the original bytes
+// unchanged so the content hash signed by the runner remains stable.
+func TestTryCoerce_AlreadyValid(t *testing.T) {
+	data := marshal(t, planfixture.Valid())
+
+	coercedBytes, coercions, err := plan.TryCoerce(data, testNow)
+	if coercedBytes != nil {
+		t.Errorf("coercedBytes = non-nil on already-valid plan")
+	}
+	if len(coercions) != 0 {
+		t.Errorf("coercions = %d, want 0", len(coercions))
+	}
+	if err != nil {
+		t.Errorf("err = %v, want nil", err)
+	}
+}


### PR DESCRIPTION
## Summary

Closes a recurring loop-blocker: Sonnet intermittently emits nested-object plan fields as bare strings, failing schema validation. #532 (yesterday) patched the prompt for `scope.files` specifically — today's #534 attempt proved the same pattern recurs on `generated_by` (~80k tokens burned before workaround). Adds defensive coercion at **both** validation points so the known string-elision class never reaches the operator as a rejection.

- **Backend** (`backend/internal/plan/coerce.go` + `handleShipPlan`): new `TryCoerce` walks three known coercible paths (`/generated_by`, `/scope/files[]`, `/decomposition/sub_plans[]`), wraps bare strings into canonical object shapes, re-validates, and emits a `plan_coerced` audit entry with full provenance (`field_path`, `original_type`, `original_value`, `coerced_to`).
- **Runner** (`runner/internal/plan/coerce.go` + `validatePlan`): mirror of the backend coercion. `validatePlan` runs `TryCoerce` before `plan.Validate` and rewrites the `--plan-out` file with the corrected payload so the subsequent upload sends valid bytes. Runner-side coercion was the load-bearing addition — without it, the runner rejects locally before the backend ever sees the upload.
- **Belt-and-suspenders**: when the runner coerces, the backend's mirror is idempotent (finds no coercible strings, returns input unchanged). When the runner skips coercion (older binary, future code path), the backend catches it as a fallback.
- **Content-hash stability**: `TryCoerce` returns `(nil, nil, nil)` on already-valid input so callers keep the original signed bytes — critical for the upload signature contract. Pinned by the `AlreadyValid` test case in both packages.

## Notes

Heavily non-textbook loop. Three forks worth flagging.

1. **The plan-stage agent itself hit the bug 2/3 times** while trying to plan this fix. Run `8503288c` (42k tokens), `b56300f6` (38k tokens) both failed on `/generated_by` schema violation. Run `72c56f82` succeeded but proposed D4 decomposition (38 min predicted > 30 min budget); rejected to avoid first-time D4 fanout on top of an already-shaky loop. Run `d60d1f5f` (this PR's run) finally succeeded clean at 12.5k tokens.

2. **First plan only covered backend.** I rejected `66df9446` because it missed the runner-side validator (`runner/internal/plan/plan.go:115`) — confirmed by today's failure pattern showing `runner_completed:failed` with no `plan_uploaded` audit (runner rejects locally). Re-planned run (`d60d1f5f`) **also scoped to backend only** because my rejection feedback didn't propagate to the new run's plan-stage prompt (only audit-logged on the prior run). Approved with a CRITICAL instruction; agent implemented backend only anyway. Added the runner mirror in-loop per `feedback-in-loop-bugs-same-pr`.

3. **Calibration**: implement was 36k tokens, no wall-clock pressure. `fishhawk_verify_run`: `verified=true`, chain_length=13.

## Methodology follow-up

The "approval feedback doesn't propagate across runs" pattern is worth a separate ticket. When a plan is rejected with detailed reasoning, that reasoning is only visible inside the failed run's audit log. The NEXT run on the same issue gets a fresh plan-stage prompt with no awareness of why the prior attempt was rejected. For non-trivial scope adjustments this means the same plan emerges twice and the operator either approves-and-patches-in-loop (what I did here) or rejects-and-hopes-the-prompt-channel-this-time. Will file.

## Coverage detail

After this lands, plan stages should fail on `plan_invalid` only for genuinely-malformed payloads (e.g. integer-where-object). The three known string-elision paths become silent coercions with audit visibility.

Spike monitoring: if `plan_coerced` audit entries trend high over time, that's the signal to revisit prompt-side mitigations (#532 was scope.files-specific; could extend to generated_by, etc.) or consider a schema-aware retry hint (ADR-023 proposal C, currently gated on category-B retry).

## Test plan

- [x] `go build ./...` — clean.
- [x] `go test -race ./backend/internal/plan/... ./backend/internal/server/... ./runner/internal/plan/... ./runner/cmd/fishhawk-runner/...` — pass.
- [x] `golangci-lint run ./backend/... ./runner/...` — 0 issues.
- [x] `scripts/test coverage` — aggregate **81.5%** (threshold 80%). One transient FAIL on first run, cleared on re-run (recurring gitops 1Password flake from #524, not related).
- [x] `fishhawk_verify_run` — `verified=true`, chain_length=13.
- [ ] Meta-validation: retry #534 after this lands. The flat-string failure mode should no longer wedge the loop.

## Out of scope

- Prompt-side mitigation for additional fields (kept #532's `scope.files` WRONG/RIGHT as defense-in-depth; not extending to other fields — coercion is the more durable answer).
- Schema-aware retry hint (ADR-023 proposal C, blocked on category-B retry policy).
- Switching plan-stage executor model (separate cost/quality discussion).

Closes #537