### PR TITLE
backend: write:retries scope plumbing for /v0/stages/{id}/retry (ADR-023 impl 2/3) (#534)

### DIFF
--- a/backend/cmd/fishhawkd/token.go
+++ b/backend/cmd/fishhawkd/token.go
@@ -21,6 +21,17 @@ var operatorDefaultScopes = []string{
 	"read:runs", "read:audit", "write:runs", "write:approvals", "write:stages",
 }
 
+// mcpCapabilityScopes lists the optional scopes that can be granted
+// to mcp tokens beyond the baseline "mcp:read". These are NOT in
+// the operator default set and are NOT issued via `fishhawkd token issue`.
+// They are granted by the backend at mcptoken issuance time (POST
+// /v0/runs/{id}/mcp-token) based on the workflow spec's executor
+// config — specifically, write:retries is included only when
+// executor.agent_self_retry: true is set on the executing stage.
+var mcpCapabilityScopes = []string{
+	"write:retries",
+}
+
 // runToken dispatches the `token` subcommand. v0 has one operation
 // — issue — for bootstrapping the first API token before OAuth
 // (E4.2) is wired. The CLI talks to the database directly rather

--- a/backend/internal/mcptoken/db/models.go
+++ b/backend/internal/mcptoken/db/models.go
@@ -61,6 +61,7 @@ type McpToken struct {
 	ExpiresAt  pgtype.Timestamptz `json:"expires_at"`
 	LastUsedAt pgtype.Timestamptz `json:"last_used_at"`
 	RevokedAt  pgtype.Timestamptz `json:"revoked_at"`
+	Scopes     []string           `json:"scopes"`
 }
 
 type Run struct {
@@ -122,6 +123,7 @@ type Stage struct {
 	RequiresApproval bool               `json:"requires_approval"`
 	GateType         *string            `json:"gate_type"`
 	GateApprovers    []byte             `json:"gate_approvers"`
+	SelfRetryCount   int32              `json:"self_retry_count"`
 }
 
 type StageCheck struct {

--- a/backend/internal/mcptoken/db/queries.sql.go
+++ b/backend/internal/mcptoken/db/queries.sql.go
@@ -14,9 +14,9 @@ import (
 
 const createMCPToken = `-- name: CreateMCPToken :one
 
-INSERT INTO mcp_tokens (id, run_id, token_hash, expires_at)
-VALUES ($1, $2, $3, $4)
-RETURNING id, run_id, token_hash, issued_at, expires_at, last_used_at, revoked_at
+INSERT INTO mcp_tokens (id, run_id, token_hash, expires_at, scopes)
+VALUES ($1, $2, $3, $4, $5)
+RETURNING id, run_id, token_hash, issued_at, expires_at, last_used_at, revoked_at, scopes
 `
 
 type CreateMCPTokenParams struct {
@@ -24,6 +24,7 @@ type CreateMCPTokenParams struct {
 	RunID     uuid.UUID          `json:"run_id"`
 	TokenHash string             `json:"token_hash"`
 	ExpiresAt pgtype.Timestamptz `json:"expires_at"`
+	Scopes    []string           `json:"scopes"`
 }
 
 // MCP token queries (E19.8 / #348). sqlc generates typed Go into
@@ -34,6 +35,7 @@ func (q *Queries) CreateMCPToken(ctx context.Context, arg CreateMCPTokenParams) 
 		arg.RunID,
 		arg.TokenHash,
 		arg.ExpiresAt,
+		arg.Scopes,
 	)
 	var i McpToken
 	err := row.Scan(
@@ -44,12 +46,13 @@ func (q *Queries) CreateMCPToken(ctx context.Context, arg CreateMCPTokenParams) 
 		&i.ExpiresAt,
 		&i.LastUsedAt,
 		&i.RevokedAt,
+		&i.Scopes,
 	)
 	return i, err
 }
 
 const getMCPTokenByHash = `-- name: GetMCPTokenByHash :one
-SELECT id, run_id, token_hash, issued_at, expires_at, last_used_at, revoked_at FROM mcp_tokens
+SELECT id, run_id, token_hash, issued_at, expires_at, last_used_at, revoked_at, scopes FROM mcp_tokens
  WHERE token_hash = $1
    AND revoked_at IS NULL
 `
@@ -68,12 +71,13 @@ func (q *Queries) GetMCPTokenByHash(ctx context.Context, tokenHash string) (McpT
 		&i.ExpiresAt,
 		&i.LastUsedAt,
 		&i.RevokedAt,
+		&i.Scopes,
 	)
 	return i, err
 }
 
 const getMCPTokenByID = `-- name: GetMCPTokenByID :one
-SELECT id, run_id, token_hash, issued_at, expires_at, last_used_at, revoked_at FROM mcp_tokens
+SELECT id, run_id, token_hash, issued_at, expires_at, last_used_at, revoked_at, scopes FROM mcp_tokens
  WHERE id = $1
 `
 
@@ -90,6 +94,7 @@ func (q *Queries) GetMCPTokenByID(ctx context.Context, id uuid.UUID) (McpToken, 
 		&i.ExpiresAt,
 		&i.LastUsedAt,
 		&i.RevokedAt,
+		&i.Scopes,
 	)
 	return i, err
 }
@@ -98,7 +103,7 @@ const revokeMCPToken = `-- name: RevokeMCPToken :one
 UPDATE mcp_tokens
    SET revoked_at = COALESCE(revoked_at, $2)
  WHERE id = $1
-RETURNING id, run_id, token_hash, issued_at, expires_at, last_used_at, revoked_at
+RETURNING id, run_id, token_hash, issued_at, expires_at, last_used_at, revoked_at, scopes
 `
 
 type RevokeMCPTokenParams struct {
@@ -119,6 +124,7 @@ func (q *Queries) RevokeMCPToken(ctx context.Context, arg RevokeMCPTokenParams) 
 		&i.ExpiresAt,
 		&i.LastUsedAt,
 		&i.RevokedAt,
+		&i.Scopes,
 	)
 	return i, err
 }

--- a/backend/internal/mcptoken/mcptoken.go
+++ b/backend/internal/mcptoken/mcptoken.go
@@ -88,6 +88,7 @@ type Token struct {
 	ExpiresAt  time.Time
 	LastUsedAt *time.Time
 	RevokedAt  *time.Time
+	Scopes     []string
 
 	// PlainText is the bearer string the caller hands to the
 	// agent. Set only on Issue's return value; empty for tokens
@@ -114,6 +115,9 @@ type IssueParams struct {
 	// TTL is the lifetime from now until expires_at. Zero defaults
 	// to DefaultTTL.
 	TTL time.Duration
+	// Scopes is the scope set to persist on the token row. Empty
+	// slice defaults to ["mcp:read"] at the repository layer.
+	Scopes []string
 }
 
 // Repository persists tokens.

--- a/backend/internal/mcptoken/postgres.go
+++ b/backend/internal/mcptoken/postgres.go
@@ -46,6 +46,10 @@ func (r *postgresRepo) Issue(ctx context.Context, p IssueParams) (*Token, error)
 		return nil, err
 	}
 
+	scopes := p.Scopes
+	if len(scopes) == 0 {
+		scopes = []string{"mcp:read"}
+	}
 	expiresAt := r.now().Add(ttl)
 	q := tokendb.New(r.pool)
 	row, err := q.CreateMCPToken(ctx, tokendb.CreateMCPTokenParams{
@@ -53,6 +57,7 @@ func (r *postgresRepo) Issue(ctx context.Context, p IssueParams) (*Token, error)
 		RunID:     p.RunID,
 		TokenHash: hash,
 		ExpiresAt: pgtype.Timestamptz{Time: expiresAt, Valid: true},
+		Scopes:    scopes,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("mcptoken: create: %w", err)
@@ -137,8 +142,9 @@ func (r *postgresRepo) GetByID(ctx context.Context, id uuid.UUID) (*Token, error
 
 func rowToToken(r tokendb.McpToken) *Token {
 	out := &Token{
-		ID:    r.ID,
-		RunID: r.RunID,
+		ID:     r.ID,
+		RunID:  r.RunID,
+		Scopes: append([]string(nil), r.Scopes...),
 	}
 	if r.IssuedAt.Valid {
 		out.IssuedAt = r.IssuedAt.Time

--- a/backend/internal/mcptoken/queries.sql
+++ b/backend/internal/mcptoken/queries.sql
@@ -2,8 +2,8 @@
 -- ./db per backend/sqlc.yaml.
 
 -- name: CreateMCPToken :one
-INSERT INTO mcp_tokens (id, run_id, token_hash, expires_at)
-VALUES ($1, $2, $3, $4)
+INSERT INTO mcp_tokens (id, run_id, token_hash, expires_at, scopes)
+VALUES ($1, $2, $3, $4, $5)
 RETURNING *;
 
 -- name: GetMCPTokenByHash :one

--- a/backend/internal/postgres/migrations/0027_write_retries_plumbing.down.sql
+++ b/backend/internal/postgres/migrations/0027_write_retries_plumbing.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE mcp_tokens DROP COLUMN scopes;
+ALTER TABLE stages DROP COLUMN self_retry_count;

--- a/backend/internal/postgres/migrations/0027_write_retries_plumbing.up.sql
+++ b/backend/internal/postgres/migrations/0027_write_retries_plumbing.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE mcp_tokens ADD COLUMN scopes text[] NOT NULL DEFAULT ARRAY['mcp:read'];
+ALTER TABLE stages ADD COLUMN self_retry_count int4 NOT NULL DEFAULT 0;

--- a/backend/internal/postgres/postgres_test.go
+++ b/backend/internal/postgres/postgres_test.go
@@ -202,11 +202,31 @@ func TestMigrateDown_RemovesTables(t *testing.T) {
 	}
 	defer pool.Close()
 
-	// MigrateDown rolls back one step. 0026 (#455) added the
-	// runs.decomposed_from column + awaiting_children stage state;
-	// the down migration drops both. Confirm: runs.decomposed_from
-	// is gone, but every prior migration's effect is still present
-	// (issue_context from 0025, runner_kind from 0024, etc.).
+	// MigrateDown rolls back one step. 0027 (#534) added the
+	// mcp_tokens.scopes column and stages.self_retry_count column;
+	// the down migration drops both. Confirm: those columns are gone,
+	// but every prior migration's effect is still present
+	// (decomposed_from from 0026, issue_context from 0025, etc.).
+	var selfRetryCountCol int
+	if err := pool.QueryRow(context.Background(),
+		`SELECT count(*) FROM information_schema.columns
+		 WHERE table_name = 'stages' AND column_name = 'self_retry_count'`,
+	).Scan(&selfRetryCountCol); err != nil {
+		t.Fatalf("query stages.self_retry_count column: %v", err)
+	}
+	if selfRetryCountCol != 0 {
+		t.Errorf("stages.self_retry_count count after MigrateDown = %d, want 0 (0027 down dropped it)", selfRetryCountCol)
+	}
+	var mcpScopesCol int
+	if err := pool.QueryRow(context.Background(),
+		`SELECT count(*) FROM information_schema.columns
+		 WHERE table_name = 'mcp_tokens' AND column_name = 'scopes'`,
+	).Scan(&mcpScopesCol); err != nil {
+		t.Fatalf("query mcp_tokens.scopes column: %v", err)
+	}
+	if mcpScopesCol != 0 {
+		t.Errorf("mcp_tokens.scopes count after MigrateDown = %d, want 0 (0027 down dropped it)", mcpScopesCol)
+	}
 	var decomposedFromCol int
 	if err := pool.QueryRow(context.Background(),
 		`SELECT count(*) FROM information_schema.columns
@@ -214,8 +234,8 @@ func TestMigrateDown_RemovesTables(t *testing.T) {
 	).Scan(&decomposedFromCol); err != nil {
 		t.Fatalf("query runs.decomposed_from column: %v", err)
 	}
-	if decomposedFromCol != 0 {
-		t.Errorf("runs.decomposed_from count after MigrateDown = %d, want 0 (0026 down dropped it)", decomposedFromCol)
+	if decomposedFromCol != 1 {
+		t.Errorf("runs.decomposed_from count after MigrateDown = %d, want 1 (0026 still applied; only 0027 rolled back)", decomposedFromCol)
 	}
 	var issueContextCol int
 	if err := pool.QueryRow(context.Background(),
@@ -225,7 +245,7 @@ func TestMigrateDown_RemovesTables(t *testing.T) {
 		t.Fatalf("query runs.issue_context column: %v", err)
 	}
 	if issueContextCol != 1 {
-		t.Errorf("runs.issue_context count after MigrateDown = %d, want 1 (0025 still applied; only 0026 rolled back)", issueContextCol)
+		t.Errorf("runs.issue_context count after MigrateDown = %d, want 1 (0025 still applied; only 0027 rolled back)", issueContextCol)
 	}
 	var runnerKindCol int
 	if err := pool.QueryRow(context.Background(),
@@ -235,7 +255,7 @@ func TestMigrateDown_RemovesTables(t *testing.T) {
 		t.Fatalf("query runs.runner_kind column: %v", err)
 	}
 	if runnerKindCol != 1 {
-		t.Errorf("runs.runner_kind count after MigrateDown = %d, want 1 (0024 still applied; only 0025 rolled back)", runnerKindCol)
+		t.Errorf("runs.runner_kind count after MigrateDown = %d, want 1 (0024 still applied; only 0027 rolled back)", runnerKindCol)
 	}
 	var mcpTokensTable int
 	if err := pool.QueryRow(context.Background(),
@@ -245,7 +265,7 @@ func TestMigrateDown_RemovesTables(t *testing.T) {
 		t.Fatalf("query mcp_tokens table: %v", err)
 	}
 	if mcpTokensTable != 1 {
-		t.Errorf("mcp_tokens table count after MigrateDown = %d, want 1 (0023 still applied; only 0025 rolled back)", mcpTokensTable)
+		t.Errorf("mcp_tokens table count after MigrateDown = %d, want 1 (0023 still applied; only 0027 rolled back)", mcpTokensTable)
 	}
 	var maxRetriesCol, retryAttemptCol, workflowSpecCol, gateBlockingChecksCol, requiredChecksCol, parentRunIDCol, pullRequestURLCol, stageChecksTable, gateTypeCol, requiresApprovalCol, signingIDCol, idempotencyCol, usersCount, sessionsCount, apiTokensCount, deliveriesCount, approvalsCount, runsCount int
 	if err := pool.QueryRow(context.Background(),

--- a/backend/internal/run/db/models.go
+++ b/backend/internal/run/db/models.go
@@ -123,6 +123,7 @@ type Stage struct {
 	RequiresApproval bool               `json:"requires_approval"`
 	GateType         *string            `json:"gate_type"`
 	GateApprovers    []byte             `json:"gate_approvers"`
+	SelfRetryCount   int32              `json:"self_retry_count"`
 }
 
 type StageCheck struct {

--- a/backend/internal/run/db/queries.sql.go
+++ b/backend/internal/run/db/queries.sql.go
@@ -95,7 +95,7 @@ INSERT INTO stages (
     gate_type, gate_approvers
 )
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-RETURNING id, run_id, sequence, stage_type, executor_kind, executor_ref, state, started_at, ended_at, failure_category, failure_reason, created_at, updated_at, gate_sla, requires_approval, gate_type, gate_approvers
+RETURNING id, run_id, sequence, stage_type, executor_kind, executor_ref, state, started_at, ended_at, failure_category, failure_reason, created_at, updated_at, gate_sla, requires_approval, gate_type, gate_approvers, self_retry_count
 `
 
 type CreateStageParams struct {
@@ -145,6 +145,7 @@ func (q *Queries) CreateStage(ctx context.Context, arg CreateStageParams) (Stage
 		&i.RequiresApproval,
 		&i.GateType,
 		&i.GateApprovers,
+		&i.SelfRetryCount,
 	)
 	return i, err
 }
@@ -224,7 +225,7 @@ func (q *Queries) GetRunByIdempotencyKey(ctx context.Context, arg GetRunByIdempo
 }
 
 const getStage = `-- name: GetStage :one
-SELECT id, run_id, sequence, stage_type, executor_kind, executor_ref, state, started_at, ended_at, failure_category, failure_reason, created_at, updated_at, gate_sla, requires_approval, gate_type, gate_approvers FROM stages WHERE id = $1
+SELECT id, run_id, sequence, stage_type, executor_kind, executor_ref, state, started_at, ended_at, failure_category, failure_reason, created_at, updated_at, gate_sla, requires_approval, gate_type, gate_approvers, self_retry_count FROM stages WHERE id = $1
 `
 
 func (q *Queries) GetStage(ctx context.Context, id uuid.UUID) (Stage, error) {
@@ -248,6 +249,7 @@ func (q *Queries) GetStage(ctx context.Context, id uuid.UUID) (Stage, error) {
 		&i.RequiresApproval,
 		&i.GateType,
 		&i.GateApprovers,
+		&i.SelfRetryCount,
 	)
 	return i, err
 }
@@ -337,7 +339,7 @@ func (q *Queries) ListRuns(ctx context.Context, arg ListRunsParams) ([]Run, erro
 }
 
 const listStagesAwaitingApproval = `-- name: ListStagesAwaitingApproval :many
-SELECT id, run_id, sequence, stage_type, executor_kind, executor_ref, state, started_at, ended_at, failure_category, failure_reason, created_at, updated_at, gate_sla, requires_approval, gate_type, gate_approvers FROM stages
+SELECT id, run_id, sequence, stage_type, executor_kind, executor_ref, state, started_at, ended_at, failure_category, failure_reason, created_at, updated_at, gate_sla, requires_approval, gate_type, gate_approvers, self_retry_count FROM stages
  WHERE state = 'awaiting_approval'
    AND gate_sla IS NOT NULL
  ORDER BY updated_at ASC
@@ -376,6 +378,7 @@ func (q *Queries) ListStagesAwaitingApproval(ctx context.Context) ([]Stage, erro
 			&i.RequiresApproval,
 			&i.GateType,
 			&i.GateApprovers,
+			&i.SelfRetryCount,
 		); err != nil {
 			return nil, err
 		}
@@ -388,7 +391,7 @@ func (q *Queries) ListStagesAwaitingApproval(ctx context.Context) ([]Stage, erro
 }
 
 const listStagesDispatched = `-- name: ListStagesDispatched :many
-SELECT id, run_id, sequence, stage_type, executor_kind, executor_ref, state, started_at, ended_at, failure_category, failure_reason, created_at, updated_at, gate_sla, requires_approval, gate_type, gate_approvers FROM stages
+SELECT id, run_id, sequence, stage_type, executor_kind, executor_ref, state, started_at, ended_at, failure_category, failure_reason, created_at, updated_at, gate_sla, requires_approval, gate_type, gate_approvers, self_retry_count FROM stages
  WHERE state = 'dispatched'
  ORDER BY updated_at ASC
 `
@@ -425,6 +428,7 @@ func (q *Queries) ListStagesDispatched(ctx context.Context) ([]Stage, error) {
 			&i.RequiresApproval,
 			&i.GateType,
 			&i.GateApprovers,
+			&i.SelfRetryCount,
 		); err != nil {
 			return nil, err
 		}
@@ -437,7 +441,7 @@ func (q *Queries) ListStagesDispatched(ctx context.Context) ([]Stage, error) {
 }
 
 const listStagesForRun = `-- name: ListStagesForRun :many
-SELECT id, run_id, sequence, stage_type, executor_kind, executor_ref, state, started_at, ended_at, failure_category, failure_reason, created_at, updated_at, gate_sla, requires_approval, gate_type, gate_approvers FROM stages WHERE run_id = $1 ORDER BY sequence ASC
+SELECT id, run_id, sequence, stage_type, executor_kind, executor_ref, state, started_at, ended_at, failure_category, failure_reason, created_at, updated_at, gate_sla, requires_approval, gate_type, gate_approvers, self_retry_count FROM stages WHERE run_id = $1 ORDER BY sequence ASC
 `
 
 func (q *Queries) ListStagesForRun(ctx context.Context, runID uuid.UUID) ([]Stage, error) {
@@ -467,6 +471,7 @@ func (q *Queries) ListStagesForRun(ctx context.Context, runID uuid.UUID) ([]Stag
 			&i.RequiresApproval,
 			&i.GateType,
 			&i.GateApprovers,
+			&i.SelfRetryCount,
 		); err != nil {
 			return nil, err
 		}
@@ -511,7 +516,7 @@ func (q *Queries) LockRunForUpdate(ctx context.Context, id uuid.UUID) (Run, erro
 }
 
 const lockStageForUpdate = `-- name: LockStageForUpdate :one
-SELECT id, run_id, sequence, stage_type, executor_kind, executor_ref, state, started_at, ended_at, failure_category, failure_reason, created_at, updated_at, gate_sla, requires_approval, gate_type, gate_approvers FROM stages WHERE id = $1 FOR UPDATE
+SELECT id, run_id, sequence, stage_type, executor_kind, executor_ref, state, started_at, ended_at, failure_category, failure_reason, created_at, updated_at, gate_sla, requires_approval, gate_type, gate_approvers, self_retry_count FROM stages WHERE id = $1 FOR UPDATE
 `
 
 func (q *Queries) LockStageForUpdate(ctx context.Context, id uuid.UUID) (Stage, error) {
@@ -535,12 +540,13 @@ func (q *Queries) LockStageForUpdate(ctx context.Context, id uuid.UUID) (Stage, 
 		&i.RequiresApproval,
 		&i.GateType,
 		&i.GateApprovers,
+		&i.SelfRetryCount,
 	)
 	return i, err
 }
 
 const listStagesAwaitingChildren = `-- name: ListStagesAwaitingChildren :many
-SELECT id, run_id, sequence, stage_type, executor_kind, executor_ref, state, started_at, ended_at, failure_category, failure_reason, created_at, updated_at, gate_sla, requires_approval, gate_type, gate_approvers FROM stages
+SELECT id, run_id, sequence, stage_type, executor_kind, executor_ref, state, started_at, ended_at, failure_category, failure_reason, created_at, updated_at, gate_sla, requires_approval, gate_type, gate_approvers, self_retry_count FROM stages
  WHERE state = 'awaiting_children'
  ORDER BY updated_at ASC
 `
@@ -575,6 +581,7 @@ func (q *Queries) ListStagesAwaitingChildren(ctx context.Context) ([]Stage, erro
 			&i.RequiresApproval,
 			&i.GateType,
 			&i.GateApprovers,
+			&i.SelfRetryCount,
 		); err != nil {
 			return nil, err
 		}
@@ -678,7 +685,7 @@ UPDATE stages
        failure_category = $5,
        failure_reason   = $6
  WHERE id = $1
-RETURNING id, run_id, sequence, stage_type, executor_kind, executor_ref, state, started_at, ended_at, failure_category, failure_reason, created_at, updated_at, gate_sla, requires_approval, gate_type, gate_approvers
+RETURNING id, run_id, sequence, stage_type, executor_kind, executor_ref, state, started_at, ended_at, failure_category, failure_reason, created_at, updated_at, gate_sla, requires_approval, gate_type, gate_approvers, self_retry_count
 `
 
 type UpdateStageStateParams struct {
@@ -718,6 +725,52 @@ func (q *Queries) UpdateStageState(ctx context.Context, arg UpdateStageStatePara
 		&i.RequiresApproval,
 		&i.GateType,
 		&i.GateApprovers,
+		&i.SelfRetryCount,
+	)
+	return i, err
+}
+
+const retryStageState = `-- name: RetryStageState :one
+UPDATE stages
+   SET state            = $2,
+       failure_category = NULL,
+       failure_reason   = NULL,
+       ended_at         = NULL,
+       self_retry_count = self_retry_count + 1
+ WHERE id = $1
+RETURNING id, run_id, sequence, stage_type, executor_kind, executor_ref, state, started_at, ended_at, failure_category, failure_reason, created_at, updated_at, gate_sla, requires_approval, gate_type, gate_approvers, self_retry_count
+`
+
+type RetryStageStateParams struct {
+	ID    uuid.UUID `json:"id"`
+	State string    `json:"state"`
+}
+
+// Clears failure metadata + ended_at and increments self_retry_count
+// atomically. Used by the retry handler's explicit out-of-terminal
+// transition path so retry_ordinal is always consistent.
+func (q *Queries) RetryStageState(ctx context.Context, arg RetryStageStateParams) (Stage, error) {
+	row := q.db.QueryRow(ctx, retryStageState, arg.ID, arg.State)
+	var i Stage
+	err := row.Scan(
+		&i.ID,
+		&i.RunID,
+		&i.Sequence,
+		&i.StageType,
+		&i.ExecutorKind,
+		&i.ExecutorRef,
+		&i.State,
+		&i.StartedAt,
+		&i.EndedAt,
+		&i.FailureCategory,
+		&i.FailureReason,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.GateSla,
+		&i.RequiresApproval,
+		&i.GateType,
+		&i.GateApprovers,
+		&i.SelfRetryCount,
 	)
 	return i, err
 }

--- a/backend/internal/run/postgres.go
+++ b/backend/internal/run/postgres.go
@@ -397,20 +397,14 @@ func (r *postgresRepo) RetryStage(ctx context.Context, id uuid.UUID, to StageSta
 			return InvalidTransitionError{Kind: "stage", From: string(from), To: string(to)}
 		}
 
-		// Clear failure metadata + ended_at by passing nil pointers
-		// and an invalid timestamptz — sqlc's UpdateStageState
-		// writes them through.
-		params := rundb.UpdateStageStateParams{
-			ID:              id,
-			State:           string(to),
-			FailureCategory: nil,
-			FailureReason:   nil,
-			EndedAt:         pgtype.Timestamptz{Valid: false},
-		}
-
-		updated, err := q.UpdateStageState(ctx, params)
+		// RetryStageState atomically clears failure_category,
+		// failure_reason, ended_at and increments self_retry_count.
+		updated, err := q.RetryStageState(ctx, rundb.RetryStageStateParams{
+			ID:    id,
+			State: string(to),
+		})
 		if err != nil {
-			return fmt.Errorf("update stage state: %w", err)
+			return fmt.Errorf("retry stage state: %w", err)
 		}
 		result = rowToStage(updated)
 		return nil
@@ -481,6 +475,7 @@ func rowToStage(s rundb.Stage) *Stage {
 		FailureReason:    s.FailureReason,
 		GateSLA:          s.GateSla,
 		RequiresApproval: s.RequiresApproval,
+		SelfRetryCount:   int(s.SelfRetryCount),
 		CreatedAt:        s.CreatedAt.Time,
 		UpdatedAt:        s.UpdatedAt.Time,
 	}

--- a/backend/internal/run/queries.sql
+++ b/backend/internal/run/queries.sql
@@ -114,3 +114,16 @@ UPDATE stages
        failure_reason   = $6
  WHERE id = $1
 RETURNING *;
+
+-- name: RetryStageState :one
+-- Clears failure metadata + ended_at and increments self_retry_count
+-- atomically. Used by the retry handler's explicit out-of-terminal
+-- transition path so retry_ordinal is always consistent.
+UPDATE stages
+   SET state            = $2,
+       failure_category = NULL,
+       failure_reason   = NULL,
+       ended_at         = NULL,
+       self_retry_count = self_retry_count + 1
+ WHERE id = $1
+RETURNING *;

--- a/backend/internal/run/run.go
+++ b/backend/internal/run/run.go
@@ -337,6 +337,13 @@ type Stage struct {
 	// (#213).
 	Gate *Gate
 
+	// SelfRetryCount tracks how many times this stage has been
+	// retried by an agent via POST /v0/stages/{id}/retry with the
+	// write:retries scope. Incremented atomically by RetryStageState
+	// on each retry; 0 means the stage has not been agent-retried.
+	// Used as retry_ordinal in the stage_retried audit receipt.
+	SelfRetryCount int
+
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }

--- a/backend/internal/server/mcptoken.go
+++ b/backend/internal/server/mcptoken.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kuhlman-labs/fishhawk/backend/internal/mcptoken"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/run"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/signing"
+	"github.com/kuhlman-labs/fishhawk/backend/internal/spec"
 )
 
 // CategoryMCPTokenIssued is the audit-log category for the new
@@ -97,9 +98,18 @@ func (s *Server) handleIssueMCPToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Determine scopes for the new token. Start with the baseline
+	// mcp:read and add write:retries when the executing stage's
+	// workflow spec sets executor.agent_self_retry: true.
+	scopes := []string{"mcp:read"}
+	if agentSelfRetry := s.resolveAgentSelfRetry(r, runRow); agentSelfRetry {
+		scopes = append(scopes, "write:retries")
+	}
+
 	tok, err := s.cfg.MCPTokenRepo.Issue(r.Context(), mcptoken.IssueParams{
-		RunID: runRow.ID,
-		TTL:   mcptoken.DefaultTTL,
+		RunID:  runRow.ID,
+		TTL:    mcptoken.DefaultTTL,
+		Scopes: scopes,
 	})
 	if err != nil {
 		s.writeError(w, r, http.StatusInternalServerError, "internal_error",
@@ -109,7 +119,7 @@ func (s *Server) handleIssueMCPToken(w http.ResponseWriter, r *http.Request) {
 
 	// Audit entry. Best-effort — a failure here logs but doesn't
 	// unwind the issuance. The plaintext is NEVER in the payload.
-	s.writeMCPTokenIssuedAudit(r, runID, tok)
+	s.writeMCPTokenIssuedAudit(r, runID, tok, scopes)
 
 	s.writeJSON(w, r, http.StatusCreated, mcpTokenResponse{
 		Token:     tok.PlainText,
@@ -171,7 +181,7 @@ func (s *Server) verifyMCPTokenSignature(w http.ResponseWriter, r *http.Request,
 	return true
 }
 
-func (s *Server) writeMCPTokenIssuedAudit(r *http.Request, runID uuid.UUID, tok *mcptoken.Token) {
+func (s *Server) writeMCPTokenIssuedAudit(r *http.Request, runID uuid.UUID, tok *mcptoken.Token, scopes []string) {
 	if s.cfg.AuditRepo == nil {
 		return
 	}
@@ -183,6 +193,7 @@ func (s *Server) writeMCPTokenIssuedAudit(r *http.Request, runID uuid.UUID, tok 
 		"ttl_seconds":  int(time.Until(tok.ExpiresAt).Seconds()),
 		"run_id":       runID.String(),
 		"token_prefix": mcptoken.TokenPrefix, // not the plaintext — just identifies the kind
+		"scopes":       scopes,
 	})
 	if _, err := s.cfg.AuditRepo.AppendChained(r.Context(), audit.ChainAppendParams{
 		RunID:        runID,
@@ -198,4 +209,45 @@ func (s *Server) writeMCPTokenIssuedAudit(r *http.Request, runID uuid.UUID, tok 
 			slog.String("token_id", tok.ID.String()),
 			slog.String("error", err.Error()))
 	}
+}
+
+// resolveAgentSelfRetry looks up the active stage for runRow and
+// checks whether executor.agent_self_retry is true in the workflow
+// spec. Returns false on any error (nil spec, missing stage, parse
+// failure) — the token is issued with baseline mcp:read scopes.
+func (s *Server) resolveAgentSelfRetry(r *http.Request, runRow *run.Run) bool {
+	if len(runRow.WorkflowSpec) == 0 || s.cfg.RunRepo == nil {
+		return false
+	}
+	stages, err := s.cfg.RunRepo.ListStagesForRun(r.Context(), runRow.ID)
+	if err != nil {
+		s.cfg.Logger.LogAttrs(r.Context(), slog.LevelWarn,
+			"list stages for mcp token scopes failed",
+			slog.String("run_id", runRow.ID.String()),
+			slog.String("error", err.Error()))
+		return false
+	}
+	var activeStage *run.Stage
+	for _, st := range stages {
+		if st.State == run.StageStateDispatched || st.State == run.StageStateRunning {
+			activeStage = st
+			break
+		}
+	}
+	if activeStage == nil {
+		return false
+	}
+	parsed, parseErr := spec.ParseBytes(runRow.WorkflowSpec)
+	if parseErr != nil {
+		s.cfg.Logger.LogAttrs(r.Context(), slog.LevelWarn,
+			"parse workflow spec for mcp token scopes failed",
+			slog.String("run_id", runRow.ID.String()),
+			slog.String("error", parseErr.Error()))
+		return false
+	}
+	wf, ok := parsed.Workflows[runRow.WorkflowID]
+	if !ok || activeStage.Sequence < 1 || activeStage.Sequence > len(wf.Stages) {
+		return false
+	}
+	return wf.Stages[activeStage.Sequence-1].Executor.AgentSelfRetry
 }

--- a/backend/internal/server/mcptoken_test.go
+++ b/backend/internal/server/mcptoken_test.go
@@ -393,6 +393,7 @@ func TestBearerAuth_MCPTokenRoutesToMCPAuthenticator(t *testing.T) {
 			ID:        uuid.New(),
 			RunID:     runID,
 			ExpiresAt: time.Now().UTC().Add(time.Hour),
+			Scopes:    []string{"mcp:read"},
 		},
 	}
 

--- a/backend/internal/server/middleware.go
+++ b/backend/internal/server/middleware.go
@@ -248,10 +248,7 @@ func bearerAuth(tokens apitokenAuthenticator, mcpTokens mcptokenAuthenticator, s
 								// "service:<name>" convention.
 								Subject: "mcp:run:" + rec.RunID.String(),
 								TokenID: rec.ID.String(),
-								// All MCP tokens carry one
-								// informational scope. Future per-
-								// endpoint enforcement reads this.
-								Scopes: []string{"mcp:read"},
+								Scopes:  append([]string(nil), rec.Scopes...),
 							}
 						}
 					case tokens != nil:

--- a/backend/internal/server/retry.go
+++ b/backend/internal/server/retry.go
@@ -3,8 +3,10 @@ package server
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -50,9 +52,19 @@ const CategoryStageRetried = "stage_retried"
 // the audit row is in place, the stage is in pending, an operator
 // can re-fire Advance manually if needed.
 func (s *Server) handleRetryStage(w http.ResponseWriter, r *http.Request) {
-	if !s.requireWriteScope(w, r, "write:stages") {
+	id := IdentityFrom(r.Context())
+	if id.IsAnonymous() {
+		s.writeError(w, r, http.StatusUnauthorized, "authentication_required",
+			"an authenticated token is required", nil)
 		return
 	}
+	if id.TokenID != "" && !hasScope(id, "write:stages") && !hasScope(id, "write:retries") {
+		s.writeError(w, r, http.StatusForbidden, "insufficient_scope",
+			"token is missing required scope: write:stages or write:retries",
+			map[string]any{"required_scope": "write:stages or write:retries"})
+		return
+	}
+
 	if s.cfg.RunRepo == nil || s.cfg.AuditRepo == nil {
 		s.writeError(w, r, http.StatusServiceUnavailable, "retry_unconfigured",
 			"retry endpoint requires run + audit repositories", nil)
@@ -65,6 +77,41 @@ func (s *Server) handleRetryStage(w http.ResponseWriter, r *http.Request) {
 			"stage_id must be a valid UUID",
 			map[string]any{"field": "stage_id", "got": r.PathValue("stage_id")})
 		return
+	}
+
+	// Pre-fetch the stage to get the RunID for subject-binding guard.
+	stage, err := s.cfg.RunRepo.GetStage(r.Context(), stageID)
+	if err != nil {
+		if errors.Is(err, run.ErrNotFound) {
+			s.writeError(w, r, http.StatusNotFound, "stage_not_found",
+				"no stage with that id", nil)
+			return
+		}
+		s.writeError(w, r, http.StatusInternalServerError, "internal_error",
+			"get stage failed", map[string]any{"error": err.Error()})
+		return
+	}
+
+	// Subject-binding guard: MCP tokens may only retry stages within
+	// their own run. Subject format is "mcp:run:<uuid>" (set by
+	// bearerAuth middleware at middleware.go).
+	if strings.HasPrefix(id.Subject, "mcp:run:") {
+		runIDStr := strings.TrimPrefix(id.Subject, "mcp:run:")
+		subjectRunID, parseErr := uuid.Parse(runIDStr)
+		if parseErr != nil {
+			s.writeError(w, r, http.StatusUnauthorized, "authentication_required",
+				"mcp token subject is malformed", nil)
+			return
+		}
+		if subjectRunID != stage.RunID {
+			s.writeError(w, r, http.StatusForbidden, "cross_run_retry",
+				"mcp token may only retry stages within its own run",
+				map[string]any{
+					"token_run_id": subjectRunID.String(),
+					"stage_run_id": stage.RunID.String(),
+				})
+			return
+		}
 	}
 
 	dec, err := run.RetryStage(r.Context(), s.cfg.RunRepo, stageID)
@@ -90,10 +137,23 @@ func (s *Server) handleRetryStage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Best-effort fetch run for budget info in the audit receipt.
+	// A failure here is logged and the audit receipt omits the budget
+	// fields rather than failing the request.
+	var runRow *run.Run
+	if fetched, fetchErr := s.cfg.RunRepo.GetRun(r.Context(), dec.Stage.RunID); fetchErr == nil {
+		runRow = fetched
+	} else {
+		s.cfg.Logger.LogAttrs(r.Context(), slog.LevelWarn,
+			"get run for retry receipt failed",
+			slog.String("run_id", dec.Stage.RunID.String()),
+			slog.String("error", fetchErr.Error()))
+	}
+
 	// Audit first so the retry intent is recorded even if the
 	// orchestrator handoff below fails. Same posture as the
 	// approvals handler (E7.4 / approvals.go).
-	s.writeRetryAudit(r, dec)
+	s.writeRetryAudit(r, dec, runRow)
 
 	// A/C retries land the stage in pending; hand off to the
 	// orchestrator to walk pending → dispatched and fire
@@ -129,10 +189,10 @@ func (s *Server) handleRetryStage(w http.ResponseWriter, r *http.Request) {
 }
 
 // writeRetryAudit appends a stage_retried entry capturing the
-// prior failure category + reason, plus the actor that triggered
-// the retry. Best-effort — the transition is already committed,
-// so a failure here logs but doesn't unwind.
-func (s *Server) writeRetryAudit(r *http.Request, dec *run.RetryDecision) {
+// prior failure category + reason, the retry receipt fields, and
+// the actor that triggered the retry. Best-effort — the transition
+// is already committed, so a failure here logs but doesn't unwind.
+func (s *Server) writeRetryAudit(r *http.Request, dec *run.RetryDecision, runRow *run.Run) {
 	id := IdentityFrom(r.Context())
 	subject := id.Subject
 	if subject == "" {
@@ -140,11 +200,29 @@ func (s *Server) writeRetryAudit(r *http.Request, dec *run.RetryDecision) {
 	}
 	actorKind := audit.ActorUser
 
-	payload, _ := json.Marshal(map[string]any{
-		"stage_id":       dec.Stage.ID.String(),
-		"prior_category": string(dec.PriorCategory),
-		"prior_reason":   dec.PriorReason,
-	})
+	ordinal := dec.Stage.SelfRetryCount
+
+	fields := map[string]any{
+		"stage_id":            dec.Stage.ID.String(),
+		"prior_category":      string(dec.PriorCategory),
+		"prior_reason":        dec.PriorReason,
+		"prior_failure_class": dec.PriorCategory.Description(),
+		"retry_ordinal":       ordinal,
+		"admissibility_reason": fmt.Sprintf("category %s (%s); retry %d; via %s",
+			string(dec.PriorCategory),
+			dec.PriorCategory.Description(),
+			ordinal,
+			scopeUsed(id)),
+	}
+	if runRow != nil {
+		remaining := runRow.MaxRetriesSnapshot - ordinal
+		if remaining < 0 {
+			remaining = 0
+		}
+		fields["remaining_budget"] = remaining
+	}
+
+	payload, _ := json.Marshal(fields)
 
 	if _, err := s.cfg.AuditRepo.AppendChained(r.Context(), audit.ChainAppendParams{
 		RunID:        dec.Stage.RunID,
@@ -161,4 +239,16 @@ func (s *Server) writeRetryAudit(r *http.Request, dec *run.RetryDecision) {
 			"error", err.Error(),
 		)
 	}
+}
+
+// scopeUsed returns the scope string that authorized the retry for
+// inclusion in the admissibility_reason receipt field.
+func scopeUsed(id Identity) string {
+	if hasScope(id, "write:retries") {
+		return "write:retries"
+	}
+	if hasScope(id, "write:stages") {
+		return "write:stages"
+	}
+	return "session"
 }

--- a/backend/internal/server/retry_test.go
+++ b/backend/internal/server/retry_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -241,4 +242,134 @@ func TestRetryStage_UnconfiguredReturns503(t *testing.T) {
 	if w.Code != http.StatusServiceUnavailable {
 		t.Errorf("status = %d, want 503", w.Code)
 	}
+}
+
+// withMCPRetryAuth injects an MCP identity with write:retries scope
+// bound to runID into req's context.
+func withMCPRetryAuth(req *http.Request, runID uuid.UUID) *http.Request {
+	id := Identity{
+		Subject: "mcp:run:" + runID.String(),
+		TokenID: "tok-test",
+		Scopes:  []string{"mcp:read", "write:retries"},
+	}
+	return req.WithContext(context.WithValue(req.Context(), ctxKeyIdentity, id))
+}
+
+func postRetryMCP(t *testing.T, s *Server, stageID, runID uuid.UUID) *httptest.ResponseRecorder {
+	t.Helper()
+	url := "/v0/stages/" + stageID.String() + "/retry"
+	req := httptest.NewRequest(http.MethodPost, url, nil)
+	req.SetPathValue("stage_id", stageID.String())
+	w := httptest.NewRecorder()
+	s.handleRetryStage(w, withMCPRetryAuth(req, runID))
+	return w
+}
+
+// --- Subject-binding guard ---
+
+func TestRetryStage_MCPTokenMatchingRunAllowed(t *testing.T) {
+	s, repo, au := retryServer(t)
+	stage := seedFailedStage(repo, run.FailureA, "agent crashed")
+
+	w := postRetryMCP(t, s, stage.ID, stage.RunID)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200:\n%s", w.Code, w.Body.String())
+	}
+	if len(au.appended) != 1 || au.appended[0].Category != CategoryStageRetried {
+		t.Errorf("expected one stage_retried audit entry, got %+v", au.appended)
+	}
+}
+
+func TestRetryStage_MCPTokenMismatchedRunReturns403(t *testing.T) {
+	s, repo, _ := retryServer(t)
+	stage := seedFailedStage(repo, run.FailureA, "agent crashed")
+	otherRunID := uuid.New() // does not match stage.RunID
+
+	w := postRetryMCP(t, s, stage.ID, otherRunID)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "cross_run_retry") {
+		t.Errorf("body missing cross_run_retry code: %s", w.Body.String())
+	}
+}
+
+func TestRetryStage_MCPTokenMalformedSubjectReturns401(t *testing.T) {
+	s, repo, _ := retryServer(t)
+	stage := seedFailedStage(repo, run.FailureA, "agent crashed")
+
+	// Inject an MCP identity with a malformed subject (no valid UUID suffix).
+	req := httptest.NewRequest(http.MethodPost, "/v0/stages/"+stage.ID.String()+"/retry", nil)
+	req.SetPathValue("stage_id", stage.ID.String())
+	badID := Identity{
+		Subject: "mcp:run:not-a-uuid",
+		TokenID: "tok-test",
+		Scopes:  []string{"mcp:read", "write:retries"},
+	}
+	req = req.WithContext(context.WithValue(req.Context(), ctxKeyIdentity, badID))
+	w := httptest.NewRecorder()
+	s.handleRetryStage(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", w.Code)
+	}
+}
+
+// --- Category filter with write:retries scope ---
+
+func TestRetryStage_WriteRetriesScope_BReturns422(t *testing.T) {
+	s, repo, _ := retryServer(t)
+	stage := seedFailedStage(repo, run.FailureB, "forbidden_paths violated")
+
+	w := postRetryMCP(t, s, stage.ID, stage.RunID)
+
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Errorf("status = %d, want 422", w.Code)
+	}
+}
+
+func TestRetryStage_WriteRetriesScope_DRejectedReturns422(t *testing.T) {
+	s, repo, _ := retryServer(t)
+	stage := seedFailedStage(repo, run.FailureD, "gate rejected by approver")
+
+	w := postRetryMCP(t, s, stage.ID, stage.RunID)
+
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Errorf("status = %d, want 422", w.Code)
+	}
+}
+
+// --- Receipt shape ---
+
+func TestRetryStage_AuditReceiptShape(t *testing.T) {
+	s, repo, au := retryServer(t)
+	stage := seedFailedStage(repo, run.FailureA, "agent crashed: SIGSEGV")
+
+	w := postRetry(t, s, stage.ID)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200:\n%s", w.Code, w.Body.String())
+	}
+
+	if len(au.appended) != 1 {
+		t.Fatalf("audit entries = %d, want 1", len(au.appended))
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(au.appended[0].Payload, &payload); err != nil {
+		t.Fatalf("unmarshal audit payload: %v", err)
+	}
+	for _, key := range []string{"prior_failure_class", "retry_ordinal", "admissibility_reason"} {
+		if _, ok := payload[key]; !ok {
+			t.Errorf("audit payload missing key %q; got keys: %v", key, payloadKeys(payload))
+		}
+	}
+}
+
+func payloadKeys(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
 }

--- a/docs/api/v0.openapi.yaml
+++ b/docs/api/v0.openapi.yaml
@@ -1834,7 +1834,17 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/Stage' }
         '401': { $ref: '#/components/responses/Unauthorized' }
-        '403': { $ref: '#/components/responses/Forbidden' }
+        '403':
+          description: |
+            One of two cases: (1) bearer token lacks both `write:stages`
+            and `write:retries` scope — body `error` is `insufficient_scope`;
+            (2) caller is an mcp token whose run scope does not match the
+            target stage's `run_id` — body `error` is `cross_run_retry`.
+            MCP tokens (subject `mcp:run:<uuid>`) may only retry stages
+            within their own run.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
         '404': { $ref: '#/components/responses/NotFound' }
         '422':
           description: |

--- a/docs/mcp/install.md
+++ b/docs/mcp/install.md
@@ -118,6 +118,11 @@ Two audiences with different scopes:
 - `fhm_*` mcptokens calling `fishhawk_approve_plan` / `fishhawk_reject_plan` are rejected by the backend's role check (`checkApproverAuthorization`) when `RoleResolver` is wired — the runner's `mcp:run:<id>` subject won't match any team in the gate's approver list.
 - Scope enforcement is active at the wire level for all write paths. An `fhm_*` mcptoken calling any write tool receives HTTP 403 `insufficient_scope` (implementing [#402](https://github.com/kuhlman-labs/fishhawk/issues/402)).
 
+**Runner-side scopes** (issued by the backend at stage start):
+
+- All mcptokens carry `mcp:read` (baseline; always present).
+- `write:retries` is NOT in the default set and is NOT issued via `fishhawkd token issue`. It is included in the `fhm_*` mcptoken only when the workflow spec sets `executor.agent_self_retry: true` on the executing stage. Operators opt in at the spec level. This scope allows the in-runner agent to call `POST /v0/stages/{id}/retry` (via `fishhawk_retry_stage`) to re-open its own failed stage without operator intervention — subject-bound to the token's run; cross-run retries are rejected with `cross_run_retry`.
+
 ## Local-runner mint
 
 For the local-runner flow ([E22 / #389](https://github.com/kuhlman-labs/fishhawk/issues/389)), the agent inside Claude Code can mint a real, stage-bearing run on the operator's workstation without leaving the chat. The MCP server's `fishhawk_start_run` accepts the same convenience inputs the CLI does:


### PR DESCRIPTION
## Summary

Impl 2/3 of the ADR-023 chain. Adds the `write:retries` scope, plumbs it through mcptoken issuance (gated on the workflow spec's `executor.agent_self_retry`), and extends `/v0/stages/{id}/retry` to accept mcptokens with the scope, subject-bind them to their issuing run, and record a machine-readable retry receipt.

- **Migrations 0027** — `mcp_tokens.scopes` (replaces hardcoded `['mcp:read']` middleware default) + `stages.self_retry_count` (retry ordinal for the receipt). Both use non-volatile defaults — no table rewrite.
- **mcptoken package** — `IssueParams.Scopes` + `Token.Scopes` end-to-end.
- **run package** — `Stage.SelfRetryCount` + atomic increment inside RetryStage's UPDATE.
- **Middleware** — `bearerAuth` reads stored scopes instead of hardcoding.
- **`handleRetryStage`** — dual-scope check (`write:stages` OR `write:retries`); subject-binding guard for mcptokens (`cross_run_retry` 403 on mismatch); receipt audit payload (`prior_failure_class`, `retry_ordinal`, `remaining_budget`, `admissibility_reason`). Budget cap reused from `runs.max_retries_snapshot` (#280) per ADR-023's decision.
- **`handleIssueMCPToken`** — parses the run's workflow spec, includes `write:retries` only when `executor.agent_self_retry: true` is set on the executing stage.
- **Tests, docs** — three new test groups in `retry_test.go`, OpenAPI + install.md updates.

## Notes — D4 fanout first-PR validation

This was the **first real-PR D4 decomposition run** per [ADR-025 D4](#451). The orchestrator did its job (parent_run `ada95bab` → child runs `2896d254` Part A + `271dcc61` Part B), but two observability issues surfaced that I'll file as follow-ups:

1. **Sub-plan scope hint ignored.** The Part A child run's implement-stage agent did the work for **both** Part A and Part B (full feature, 435 LoC). The sub-plan's `scope_hint` ("DB plumbing + middleware only") didn't constrain the agent's actions. The implement-stage prompt either doesn't surface the scope_hint prominently, or the agent reads it as informational rather than constraining.
2. **Parent auto-advance on children-complete didn't fire.** After both children landed `succeeded`, the parent's implement stage stayed in `awaiting_children`. The orchestrator's "all children done" transition is either gated on a sweeper that hasn't run, or has a missed callback path. Files attached to the parent run audit chain are correct (`plan_decomposed` recorded both child IDs); just the state machine didn't walk forward.

Both children succeeded after Part A's retry (initial run hit 15-min child timeout; retry recognized done work, 11k + 5k tokens). Parent + both children all return `verify_run: true` — audit integrity is sound even with the state-machine snag. The work is on disk, gates pass, the PR ships.

## Gates

- [x] `go build ./...` — clean.
- [x] `go test -race ./backend/internal/...` — pass (after a transient testcontainer port-binding flake cleared on retry).
- [x] `golangci-lint run ./backend/...` — 0 issues.
- [x] `scripts/test coverage` — aggregate **81.3%** (threshold 80%).
- [x] `fishhawk_verify_run` × 3 — parent + both children `verified=true`.

## D4 follow-ups (filing separately)

1. Sub-plan scope hint should constrain the implement-stage agent's edits. Prompt or executor change needed.
2. Parent's `awaiting_children` → `succeeded` transition needs to fire on the last child's completion. Currently parked.

Closes #534