### PR TITLE
runner: detect cat-A/C failures and self-retry via /v0/stages/{id}/retry (ADR-023 impl 3/3) (#535)

### DIFF
--- a/backend/internal/server/prompt.go
+++ b/backend/internal/server/prompt.go
@@ -44,6 +44,16 @@ type promptResponse struct {
 	// Runners that are older than this should exit with a version-skew error
 	// rather than proceeding to invoke the agent.
 	MinRunnerVersion string `json:"min_runner_version,omitempty"`
+	// AgentSelfRetry is true when the workflow spec opts the stage into
+	// ADR-023 runner-side self-retry on category-A/C failures.
+	AgentSelfRetry bool `json:"agent_self_retry,omitempty"`
+	// MaxRetriesSnapshot is the run's max_retries_snapshot at prompt-fetch
+	// time. Together with RetryAttempt it lets the runner compute the
+	// remaining self-retry budget without a separate API call.
+	MaxRetriesSnapshot int `json:"max_retries_snapshot,omitempty"`
+	// RetryAttempt is the run's current retry_attempt counter. 0 for
+	// original runs; incremented by the backend on each auto-retry.
+	RetryAttempt int `json:"retry_attempt,omitempty"`
 }
 
 // issueGetter is the slice of githubclient.Client the prompt
@@ -201,6 +211,9 @@ func (s *Server) handleGetStagePrompt(w http.ResponseWriter, r *http.Request) {
 		VerifyCommand:        verifyCmd,
 		VerifyTimeoutSeconds: verifyTimeoutSecs,
 		MinRunnerVersion:     version.MinRunnerVersion,
+		AgentSelfRetry:       s.resolveAgentSelfRetryForStage(r.Context(), runRow, stage.Type),
+		MaxRetriesSnapshot:   runRow.MaxRetriesSnapshot,
+		RetryAttempt:         runRow.RetryAttempt,
 	}
 	if runRow.DecomposedFrom != nil {
 		resp.DecomposedFromRunID = runRow.DecomposedFrom.String()
@@ -341,6 +354,9 @@ func (s *Server) handleGetStagePromptRender(w http.ResponseWriter, r *http.Reque
 		VerifyCommand:        verifyCmd,
 		VerifyTimeoutSeconds: verifyTimeoutSecs,
 		MinRunnerVersion:     version.MinRunnerVersion,
+		AgentSelfRetry:       s.resolveAgentSelfRetryForStage(r.Context(), runRow, stage.Type),
+		MaxRetriesSnapshot:   runRow.MaxRetriesSnapshot,
+		RetryAttempt:         runRow.RetryAttempt,
 	}
 	if runRow.DecomposedFrom != nil {
 		resp.DecomposedFromRunID = runRow.DecomposedFrom.String()
@@ -771,6 +787,45 @@ func parseRepoOwnerName(s string) (githubclient.RepoRef, error) {
 		return githubclient.RepoRef{}, fmt.Errorf("repo %q is not owner/name", s)
 	}
 	return githubclient.RepoRef{Owner: parts[0], Name: parts[1]}, nil
+}
+
+// resolveAgentSelfRetryForStage returns whether the workflow spec opts the
+// given stage type into runner-side self-retry on category-A/C failures
+// (ADR-023). Mirrors resolveVerifyConfig's parse + lookup pattern. Returns
+// false on any error (nil spec, missing workflow, parse failure) so the
+// runner degrades gracefully to the pre-ADR-023 behavior.
+func (s *Server) resolveAgentSelfRetryForStage(ctx context.Context, runRow *run.Run, stageType run.StageType) bool {
+	if runRow.WorkflowSpec == nil {
+		return false
+	}
+	parsed, err := spec.ParseBytes(runRow.WorkflowSpec)
+	if err != nil {
+		s.cfg.Logger.LogAttrs(ctx, slog.LevelWarn, "prompt: parse workflow spec for agent_self_retry",
+			slog.String("run_id", runRow.ID.String()),
+			slog.String("error", err.Error()),
+		)
+		return false
+	}
+	wf, ok := parsed.Workflows[runRow.WorkflowID]
+	if !ok {
+		return false
+	}
+	var specStage spec.Stage
+	for _, st := range wf.Stages {
+		if st.ID == string(stageType) {
+			specStage = st
+			break
+		}
+	}
+	if specStage.ID == "" {
+		for _, st := range wf.Stages {
+			if string(st.Type) == string(stageType) {
+				specStage = st
+				break
+			}
+		}
+	}
+	return specStage.Executor.AgentSelfRetry
 }
 
 // loadLastDecomposeRejectionReason scans the run's approval_submitted

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -61,6 +61,19 @@ Per `docs/MVP_SPEC.md` §5.2. Concrete realization in this codebase:
 
 Failure categories (per §6) are captured in the `audit_entries` table with `category` ∈ {A: agent, B: constraint, C: infra, D: approval timeout}. Re-execution is allowed for all four; idempotency keys prevent double-fire.
 
+### 4.1 Self-retry decision tree (ADR-023)
+
+When `executor.agent_self_retry: true` is set on a stage in the workflow spec, the runner applies a four-gate decision after each invocation before exiting with failure:
+
+1. **Spec opt-in** — `cfg.agentSelfRetry == true` (surfaced via the prompt-fetch response). Stages without the flag always exit on failure.
+2. **Signing key available** — `issuedKey != nil`. Only the `--fetch-prompt` path issues the key before the invoke loop; without it the gate closes and no retry fires. Guarantees the runner can authenticate the POST.
+3. **Remaining budget > 0** — `maxRetriesSnapshot - retryAttempt - selfRetryCount > 0`. `maxRetriesSnapshot` and `retryAttempt` are snapshotted from the run row at prompt-fetch time and returned in the prompt response. `selfRetryCount` tracks in-process retries on the current runner invocation.
+4. **Failure category A or C** — category B (constraint/policy) and D (approval timeout) are not retried in-process; those require a spec change or human action.
+
+**Call path on retry**: runner calls `POST /v0/stages/{id}/retry` (signed with the Ed25519 per-run key, same mechanism as trace upload). The backend transitions the stage `failed → pending` and the orchestrator fires `workflow_dispatch`, launching a second GitHub Actions runner. Meanwhile the current runner process emits a `stage_self_retry` log line, resets its result state, and re-invokes the agent in the same for-loop iteration.
+
+**Known v0 limitation**: the `workflow_dispatch` fires a second GHA runner that also fetches the stage prompt (the dispatched state is not blocked by the prompt handler's state guard) and begins a concurrent agent invocation. The two agents race; whichever uploads its trace bundle last wins at the backend's idempotent-store layer. No v0 guard prevents this; the orphaned runner's trace upload races with the winner's. An integration test asserting only one trace-upload call per retried stage is deliberately deferred.
+
 ## 5. Storage model
 
 ### 5.1 Postgres (`fishhawkd` schema)

--- a/runner/cmd/fishhawk-runner/flags.go
+++ b/runner/cmd/fishhawk-runner/flags.go
@@ -62,6 +62,14 @@ type config struct {
 	// fetched prompt reveals that this run is a decomposed child.
 	// Drives shared-branch routing in openPRAndShipArtifact.
 	decomposedFromRunID string
+
+	// agentSelfRetry, maxRetriesSnapshot, and retryAttempt are set at
+	// runtime from the fetched prompt response (ADR-023). Not CLI flags.
+	// agentSelfRetry gates the retry loop; the other two compute the
+	// remaining budget (maxRetriesSnapshot - retryAttempt).
+	agentSelfRetry     bool
+	maxRetriesSnapshot int
+	retryAttempt       int
 }
 
 // parseFlags reads args and populates a config. Returns a usage

--- a/runner/cmd/fishhawk-runner/main.go
+++ b/runner/cmd/fishhawk-runner/main.go
@@ -81,6 +81,7 @@ type uploadClient interface {
 	FetchPrompt(ctx context.Context, args upload.FetchPromptArgs) (*upload.FetchedPrompt, error)
 	FetchInstallationToken(ctx context.Context, args upload.FetchInstallationTokenArgs) (*upload.FetchInstallationTokenResult, error)
 	FetchMCPToken(ctx context.Context, args upload.FetchMCPTokenArgs) (*upload.FetchMCPTokenResult, error)
+	RetryStage(ctx context.Context, args upload.RetryStageArgs) error
 }
 
 // newUploadClient returns the production uploadClient for the
@@ -233,7 +234,7 @@ func run(args []string, logSink io.Writer) (exitCode int) {
 			return exitFailure
 		}
 		issuedKey = key
-		path, sType, agentTimeoutSecs, specVerifyCmd, specVerifyTimeoutSecs, decomposedFromRunID, minRunnerVersion, fetchErr := fetchPromptToFile(ctx, client, cfg, key, logSink)
+		path, sType, agentTimeoutSecs, specVerifyCmd, specVerifyTimeoutSecs, decomposedFromRunID, minRunnerVersion, agentSelfRetry, maxRetriesSnapshot, retryAttempt, fetchErr := fetchPromptToFile(ctx, client, cfg, key, logSink)
 		if fetchErr != nil {
 			_, _ = fmt.Fprintf(logSink,
 				`{"event":"runner_failed","reason":"fetch_prompt","detail":%q}`+"\n", fetchErr.Error())
@@ -262,6 +263,10 @@ func run(args []string, logSink io.Writer) (exitCode int) {
 		if cfg.verifyTimeout == 0 && specVerifyTimeoutSecs > 0 {
 			cfg.verifyTimeout = time.Duration(specVerifyTimeoutSecs) * time.Second
 		}
+		// ADR-023 self-retry fields — set from prompt response, not CLI flags.
+		cfg.agentSelfRetry = agentSelfRetry
+		cfg.maxRetriesSnapshot = maxRetriesSnapshot
+		cfg.retryAttempt = retryAttempt
 	}
 
 	if cfg.promptFile == "" {
@@ -321,96 +326,147 @@ func run(args []string, logSink io.Writer) (exitCode int) {
 	}
 
 	invoker := newInvoker(os.Getenv("ANTHROPIC_API_KEY"))
-	res, invokeErr := invoker.Invoke(ctx, inv)
 
-	// Plan validation runs only if the agent itself succeeded —
-	// no point re-stating "your plan is malformed" when the
-	// agent already failed. A plan-validation failure overrides
-	// res.OK and demotes the run to category-B (constraint /
-	// policy violation per MVP_SPEC §6).
-	//
-	// Gated on stageType to skip implement / review stages where
-	// the agent legitimately produces no plan file. Empty
-	// stageType (local replay without --fetch-prompt) preserves
-	// the historical behavior: operator's --plan-out flag drives
-	// validation directly.
-	if res.OK && cfg.planOut != "" && stageType != "implement" && stageType != "review" {
-		if ev, demote := validatePlan(cfg.planOut); demote != nil {
+	// selfRetryBudget is the number of additional in-process retries the
+	// runner may attempt before giving up. Clamped to 0 when negative
+	// (retryAttempt >= maxRetriesSnapshot, e.g. because a prior GHA runner
+	// already exhausted the budget at the orchestration layer).
+	selfRetryBudget := cfg.maxRetriesSnapshot - cfg.retryAttempt
+	if selfRetryBudget < 0 {
+		selfRetryBudget = 0
+	}
+	selfRetryCount := 0
+
+	var (
+		res       agent.Result
+		invokeErr error
+		diff      *constraint.Diff
+		diffErr   error
+	)
+
+	for {
+		res, invokeErr = invoker.Invoke(ctx, inv)
+
+		// Plan validation runs only if the agent itself succeeded —
+		// no point re-stating "your plan is malformed" when the
+		// agent already failed. A plan-validation failure overrides
+		// res.OK and demotes the run to category-B (constraint /
+		// policy violation per MVP_SPEC §6).
+		//
+		// Gated on stageType to skip implement / review stages where
+		// the agent legitimately produces no plan file. Empty
+		// stageType (local replay without --fetch-prompt) preserves
+		// the historical behavior: operator's --plan-out flag drives
+		// validation directly.
+		if res.OK && cfg.planOut != "" && stageType != "implement" && stageType != "review" {
+			if ev, demote := validatePlan(cfg.planOut); demote != nil {
+				res.Events = append(res.Events, ev)
+				res.OK = false
+				res.FailureCategory = "B"
+				res.FailureReason = demote.Error()
+				invokeErr = demote
+			} else {
+				res.Events = append(res.Events, ev)
+			}
+		}
+
+		// Diff emission: when --check-base-ref is set, compute the
+		// stage's git diff and emit a git_diff event into the bundle.
+		// The backend's policy re-evaluation (E3.13) reads this event
+		// regardless of whether the runner does its own in-band
+		// constraint check; decoupling emission from enforcement (#247)
+		// means the SPA's policy section works even for customers who
+		// don't pass --constraints-file.
+		//
+		// A diff failure on its own doesn't demote res.OK — when the
+		// customer didn't pass constraints-file we have nothing to
+		// enforce. The in-band constraint check below treats a failed
+		// diff as fatal IF constraints-file is set (preserves the
+		// pre-#247 "couldn't enforce constraints → category-B" semantic).
+		diff = nil
+		diffErr = nil
+		if cfg.checkBaseRef != "" {
+			d, ev, err := computeAndEmitDiff(cfg)
 			res.Events = append(res.Events, ev)
-			res.OK = false
-			res.FailureCategory = "B"
-			res.FailureReason = demote.Error()
-			invokeErr = demote
-		} else {
+			if err == nil {
+				diff = &d
+			} else {
+				diffErr = err
+			}
+		}
+
+		// Constraint evaluation: same demotion rules as plan
+		// validation. Only runs if everything before it succeeded so
+		// we don't double-stamp a category-A failure as B.
+		//
+		// Requires both flags. --constraints-file alone is a silent
+		// skip (legitimate for stages that don't produce diffs); the
+		// customer can pass it as a default in their action and only
+		// add --check-base-ref to stages that emit a diff. A diff
+		// failure when both flags are set is fatal — preserves the
+		// pre-#247 "couldn't enforce constraints → category-B"
+		// semantic.
+		if res.OK && cfg.constraintsFile != "" && cfg.checkBaseRef != "" {
+			if diff == nil {
+				res.OK = false
+				res.FailureCategory = "B"
+				res.FailureReason = diffErr.Error()
+				invokeErr = diffErr
+			} else if evs, demote := enforceConstraints(cfg, *diff); demote != nil {
+				res.Events = append(res.Events, evs...)
+				res.OK = false
+				res.FailureCategory = "B"
+				res.FailureReason = demote.Error()
+				invokeErr = demote
+			} else {
+				res.Events = append(res.Events, evs...)
+			}
+		}
+
+		// Verify gate: optional in-band test gate that fires after constraint
+		// evaluation and before bundle building. Non-zero exit from the
+		// verify command demotes to category-A (#441).
+		if res.OK && cfg.verifyCmd != "" {
+			ev, demote := runVerifyGate(ctx, cfg, logSink)
 			res.Events = append(res.Events, ev)
+			if demote != nil {
+				res.OK = false
+				res.FailureCategory = "A"
+				res.FailureReason = demote.Error()
+				invokeErr = demote
+			}
 		}
-	}
 
-	// Diff emission: when --check-base-ref is set, compute the
-	// stage's git diff and emit a git_diff event into the bundle.
-	// The backend's policy re-evaluation (E3.13) reads this event
-	// regardless of whether the runner does its own in-band
-	// constraint check; decoupling emission from enforcement (#247)
-	// means the SPA's policy section works even for customers who
-	// don't pass --constraints-file.
-	//
-	// A diff failure on its own doesn't demote res.OK — when the
-	// customer didn't pass constraints-file we have nothing to
-	// enforce. The in-band constraint check below treats a failed
-	// diff as fatal IF constraints-file is set (preserves the
-	// pre-#247 "couldn't enforce constraints → category-B" semantic).
-	var diff *constraint.Diff
-	var diffErr error
-	if cfg.checkBaseRef != "" {
-		d, ev, err := computeAndEmitDiff(cfg)
-		res.Events = append(res.Events, ev)
-		if err == nil {
-			diff = &d
-		} else {
-			diffErr = err
+		// ADR-023 self-retry: when the stage fails with category A or C,
+		// the spec opts in with agent_self_retry:true, and the budget is
+		// not exhausted, call POST /v0/stages/{id}/retry and re-invoke.
+		// issuedKey != nil guarantees client is non-nil (key comes from
+		// the fetch-prompt path which always constructs the client first).
+		if !res.OK &&
+			(res.FailureCategory == "A" || res.FailureCategory == "C") &&
+			cfg.agentSelfRetry && issuedKey != nil && selfRetryCount < selfRetryBudget {
+			retryErr := client.RetryStage(ctx, upload.RetryStageArgs{
+				StageID:    cfg.stageID,
+				PrivateKey: issuedKey.PrivateKey,
+			})
+			if retryErr == nil {
+				_, _ = fmt.Fprintf(logSink,
+					`{"event":"stage_self_retry","run_id":%q,"stage_id":%q,"attempt":%d}`+"\n",
+					cfg.runID, cfg.stageID, selfRetryCount+1)
+				selfRetryCount++
+				// Reset per-attempt state; the next iteration's agent
+				// invocation re-populates res and invokeErr. diff and
+				// diffErr are recomputed inside the loop body too, so
+				// no explicit reset is needed.
+				res = agent.Result{}
+				invokeErr = nil
+				continue
+			}
+			_, _ = fmt.Fprintf(logSink,
+				`{"event":"retry_stage_failed","run_id":%q,"stage_id":%q,"detail":%q}`+"\n",
+				cfg.runID, cfg.stageID, retryErr.Error())
 		}
-	}
-
-	// Constraint evaluation: same demotion rules as plan
-	// validation. Only runs if everything before it succeeded so
-	// we don't double-stamp a category-A failure as B.
-	//
-	// Requires both flags. --constraints-file alone is a silent
-	// skip (legitimate for stages that don't produce diffs); the
-	// customer can pass it as a default in their action and only
-	// add --check-base-ref to stages that emit a diff. A diff
-	// failure when both flags are set is fatal — preserves the
-	// pre-#247 "couldn't enforce constraints → category-B"
-	// semantic.
-	if res.OK && cfg.constraintsFile != "" && cfg.checkBaseRef != "" {
-		if diff == nil {
-			res.OK = false
-			res.FailureCategory = "B"
-			res.FailureReason = diffErr.Error()
-			invokeErr = diffErr
-		} else if evs, demote := enforceConstraints(cfg, *diff); demote != nil {
-			res.Events = append(res.Events, evs...)
-			res.OK = false
-			res.FailureCategory = "B"
-			res.FailureReason = demote.Error()
-			invokeErr = demote
-		} else {
-			res.Events = append(res.Events, evs...)
-		}
-	}
-
-	// Verify gate: optional in-band test gate that fires after constraint
-	// evaluation and before bundle building. Non-zero exit from the
-	// verify command demotes to category-A (#441).
-	if res.OK && cfg.verifyCmd != "" {
-		ev, demote := runVerifyGate(ctx, cfg, logSink)
-		res.Events = append(res.Events, ev)
-		if demote != nil {
-			res.OK = false
-			res.FailureCategory = "A"
-			res.FailureReason = demote.Error()
-			invokeErr = demote
-		}
+		break
 	}
 
 	// Bundle building is shared by --bundle-out and --upload-trace.
@@ -733,7 +789,8 @@ func issueSigningKey(ctx context.Context, client uploadClient, cfg config, logSi
 // fetchPromptToFile pulls the constructed prompt from the backend,
 // writes it to a temp file, and returns the path, stage type,
 // agent_timeout_seconds, verify_command, verify_timeout_seconds,
-// decomposed_from_run_id, and min_runner_version from the response.
+// decomposed_from_run_id, min_runner_version, agent_self_retry,
+// max_retries_snapshot, and retry_attempt from the response.
 // stageType drives per-stage post-processing (plan validation + upload
 // for plan stages, commit+push+PR upload for implement stages).
 // agentTimeoutSecs is the spec-resolved wall-clock cap; 0 means the
@@ -743,17 +800,18 @@ func issueSigningKey(ctx context.Context, client uploadClient, cfg config, logSi
 // declares none. decomposedFromRunID is non-empty when this run is a
 // decomposed child. minRunnerVersion is non-empty when the backend
 // requires a minimum runner version; the caller checks it against
-// runnerVersion() before proceeding.
+// runnerVersion() before proceeding. agentSelfRetry, maxRetriesSnapshot,
+// and retryAttempt drive the ADR-023 self-retry loop.
 // The temp file is 0o600 — bundle-style defense in depth, since prompts
 // may include issue bodies that the customer would prefer not to leave on
 // the runner's filesystem world-readable.
-func fetchPromptToFile(ctx context.Context, client uploadClient, cfg config, key *upload.IssuedKey, logSink io.Writer) (path string, stageType string, agentTimeoutSecs int, verifyCmd string, verifyTimeoutSecs int, decomposedFromRunID string, minRunnerVersion string, err error) {
+func fetchPromptToFile(ctx context.Context, client uploadClient, cfg config, key *upload.IssuedKey, logSink io.Writer) (path string, stageType string, agentTimeoutSecs int, verifyCmd string, verifyTimeoutSecs int, decomposedFromRunID string, minRunnerVersion string, agentSelfRetry bool, maxRetriesSnapshot int, retryAttempt int, err error) {
 	got, fetchErr := client.FetchPrompt(ctx, upload.FetchPromptArgs{
 		StageID:    cfg.stageID,
 		PrivateKey: key.PrivateKey,
 	})
 	if fetchErr != nil {
-		return "", "", 0, "", 0, "", "", fetchErr
+		return "", "", 0, "", 0, "", "", false, 0, 0, fetchErr
 	}
 	_, _ = fmt.Fprintf(logSink,
 		`{"event":"prompt_fetched","stage_id":%q,"stage_type":%q,"prompt_hash":%q,"prompt_bytes":%d}`+"\n",
@@ -761,20 +819,20 @@ func fetchPromptToFile(ctx context.Context, client uploadClient, cfg config, key
 	)
 	tmp, tmpErr := os.CreateTemp("", "fishhawk-prompt-*.txt")
 	if tmpErr != nil {
-		return "", "", 0, "", 0, "", "", fmt.Errorf("create prompt temp file: %w", tmpErr)
+		return "", "", 0, "", 0, "", "", false, 0, 0, fmt.Errorf("create prompt temp file: %w", tmpErr)
 	}
 	if err := os.Chmod(tmp.Name(), 0o600); err != nil {
 		_ = tmp.Close()
-		return "", "", 0, "", 0, "", "", fmt.Errorf("chmod prompt temp file: %w", err)
+		return "", "", 0, "", 0, "", "", false, 0, 0, fmt.Errorf("chmod prompt temp file: %w", err)
 	}
 	if _, err := tmp.WriteString(got.Prompt); err != nil {
 		_ = tmp.Close()
-		return "", "", 0, "", 0, "", "", fmt.Errorf("write prompt temp file: %w", err)
+		return "", "", 0, "", 0, "", "", false, 0, 0, fmt.Errorf("write prompt temp file: %w", err)
 	}
 	if err := tmp.Close(); err != nil {
-		return "", "", 0, "", 0, "", "", fmt.Errorf("close prompt temp file: %w", err)
+		return "", "", 0, "", 0, "", "", false, 0, 0, fmt.Errorf("close prompt temp file: %w", err)
 	}
-	return tmp.Name(), got.StageType, got.AgentTimeoutSeconds, got.VerifyCommand, got.VerifyTimeoutSeconds, got.DecomposedFromRunID, got.MinRunnerVersion, nil
+	return tmp.Name(), got.StageType, got.AgentTimeoutSeconds, got.VerifyCommand, got.VerifyTimeoutSeconds, got.DecomposedFromRunID, got.MinRunnerVersion, got.AgentSelfRetry, got.MaxRetriesSnapshot, got.RetryAttempt, nil
 }
 
 func logStartup(w io.Writer, cfg config) {

--- a/runner/cmd/fishhawk-runner/main_test.go
+++ b/runner/cmd/fishhawk-runner/main_test.go
@@ -46,6 +46,10 @@ func openBundleForTest(data []byte) (bundle.ManifestData, []bundle.Line, bundle.
 
 // fakeInvoker lets tests drive run() without spawning a child
 // process. Returning (canned, returnErr) keeps the seam tiny.
+//
+// For sequence tests (e.g. self-retry): set cannedSeq + errSeq instead
+// of canned + returnErr. Each Invoke call consumes the next entry; the
+// last entry repeats after the slice is exhausted.
 type fakeInvoker struct {
 	canned    agent.Result
 	returnErr error
@@ -53,11 +57,29 @@ type fakeInvoker struct {
 	// gotInv captures the Invocation the harness handed in, so
 	// tests can assert on plumbed Env (E19.8 / #348 wiring).
 	gotInv *agent.Invocation
+
+	// cannedSeq / errSeq support tests that need different results per
+	// call. When cannedSeq is non-nil it takes precedence over canned.
+	cannedSeq []agent.Result
+	errSeq    []error
+	callIdx   int
 }
 
 func (f *fakeInvoker) Invoke(_ context.Context, inv agent.Invocation) (agent.Result, error) {
 	i := inv
 	f.gotInv = &i
+	if len(f.cannedSeq) > 0 {
+		idx := f.callIdx
+		if idx >= len(f.cannedSeq) {
+			idx = len(f.cannedSeq) - 1
+		}
+		f.callIdx++
+		var err error
+		if idx < len(f.errSeq) {
+			err = f.errSeq[idx]
+		}
+		return f.cannedSeq[idx], err
+	}
 	return f.canned, f.returnErr
 }
 
@@ -79,13 +101,14 @@ func withFakeInvoker(t *testing.T, fake *fakeInvoker) {
 // assertions can confirm the runner wired the right
 // run/stage/variant/bundle.
 type fakeUploader struct {
-	issueErr     error
-	shipErr      error
-	promptErr    error
-	planErr      error
-	prErr        error
-	instTokenErr error
-	mcpTokenErr  error
+	issueErr      error
+	shipErr       error
+	promptErr     error
+	planErr       error
+	prErr         error
+	instTokenErr  error
+	mcpTokenErr   error
+	retryStageErr error
 
 	// Recorded calls.
 	gotIssueRunID string
@@ -103,6 +126,7 @@ type fakeUploader struct {
 	gotPRArgs        *upload.ShipPullRequestArgs
 	gotInstTokenArgs *upload.FetchInstallationTokenArgs
 	gotMCPTokenArgs  *upload.FetchMCPTokenArgs
+	gotRetryArgs     []upload.RetryStageArgs
 
 	// Canned prompt response. If nil, FetchPrompt returns a default
 	// one matching the requested stage_id.
@@ -233,6 +257,11 @@ func (f *fakeUploader) FetchMCPToken(_ context.Context, args upload.FetchMCPToke
 		RunID:     args.RunID,
 		ExpiresAt: time.Now().Add(time.Hour),
 	}, nil
+}
+
+func (f *fakeUploader) RetryStage(_ context.Context, args upload.RetryStageArgs) error {
+	f.gotRetryArgs = append(f.gotRetryArgs, args)
+	return f.retryStageErr
 }
 
 // withFakeUploader swaps newUploadClient. Caller restores via
@@ -2894,5 +2923,179 @@ func TestRun_VersionSkewDetected(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), `"min_required":"v0.5.0"`) {
 		t.Errorf("missing min_required in log:\n%s", stderr.String())
+	}
+}
+
+// selfRetryPromptResp is the promptResp used by ADR-023 self-retry tests.
+// agentSelfRetry:true, budget=1 (maxRetriesSnapshot=1, retryAttempt=0).
+func selfRetryPromptResp(stageID string) *upload.FetchedPrompt {
+	return &upload.FetchedPrompt{
+		StageID:            stageID,
+		StageType:          "plan",
+		Prompt:             "retry test prompt",
+		PromptHash:         "deadbeef",
+		AgentSelfRetry:     true,
+		MaxRetriesSnapshot: 1,
+		RetryAttempt:       0,
+	}
+}
+
+const selfRetryStageID = "22222222-3333-4444-5555-666666666666"
+const selfRetryRunID = "11111111-2222-3333-4444-555555555555"
+
+// selfRetryArgs returns the common run() flags for the self-retry tests.
+func selfRetryArgs() []string {
+	return []string{
+		"--run-id", selfRetryRunID,
+		"--backend-url", "https://api.fishhawk.test",
+		"--workflow", "w", "--stage", "s",
+		"--stage-id", selfRetryStageID,
+		"--fetch-prompt",
+	}
+}
+
+// TestRun_SelfRetry_CategoryA_ThenSuccess verifies the happy path:
+// a category-A failure on the first invoke, RetryStage succeeds,
+// the second invoke succeeds → exit 0, RetryStage called exactly once.
+func TestRun_SelfRetry_CategoryA_ThenSuccess(t *testing.T) {
+	invoker := &fakeInvoker{
+		cannedSeq: []agent.Result{
+			{OK: false, FailureCategory: "A", FailureReason: "agent crash",
+				Events: []agent.Event{{Kind: "invocation_start"}}},
+			{OK: true, TokensUsed: 5,
+				Events: []agent.Event{{Kind: "invocation_start"}}},
+		},
+		errSeq: []error{agent.ErrAgentFailed, nil},
+	}
+	withFakeInvoker(t, invoker)
+	fu := newFakeUploader(t)
+	fu.promptResp = selfRetryPromptResp(selfRetryStageID)
+	withFakeUploader(t, fu)
+
+	var stderr strings.Builder
+	got := run(selfRetryArgs(), &stderr)
+	if got != exitOK {
+		t.Fatalf("run = %d, want exitOK:\n%s", got, stderr.String())
+	}
+	if len(fu.gotRetryArgs) != 1 {
+		t.Errorf("RetryStage calls = %d, want 1", len(fu.gotRetryArgs))
+	}
+	if fu.gotRetryArgs[0].StageID != selfRetryStageID {
+		t.Errorf("RetryStage StageID = %q, want %q", fu.gotRetryArgs[0].StageID, selfRetryStageID)
+	}
+	if !strings.Contains(stderr.String(), `"event":"stage_self_retry"`) {
+		t.Errorf("missing stage_self_retry log:\n%s", stderr.String())
+	}
+	if invoker.callIdx != 2 {
+		t.Errorf("Invoke call count = %d, want 2", invoker.callIdx)
+	}
+}
+
+// TestRun_SelfRetry_CategoryB_NoRetry verifies that category-B failures
+// do not trigger a self-retry even when agent_self_retry is true.
+func TestRun_SelfRetry_CategoryB_NoRetry(t *testing.T) {
+	withFakeInvoker(t, &fakeInvoker{
+		canned:    agent.Result{OK: false, FailureCategory: "B", FailureReason: "constraint violated"},
+		returnErr: nil,
+	})
+	fu := newFakeUploader(t)
+	fu.promptResp = selfRetryPromptResp(selfRetryStageID)
+	withFakeUploader(t, fu)
+
+	var stderr strings.Builder
+	got := run(selfRetryArgs(), &stderr)
+	if got != exitFailure {
+		t.Errorf("run = %d, want exitFailure", got)
+	}
+	if len(fu.gotRetryArgs) != 0 {
+		t.Errorf("RetryStage should not be called for category-B failure; got %d calls", len(fu.gotRetryArgs))
+	}
+}
+
+// TestRun_SelfRetry_ZeroBudget_NoRetry verifies that a zero retry budget
+// (maxRetriesSnapshot == retryAttempt) prevents self-retry even on A failures.
+func TestRun_SelfRetry_ZeroBudget_NoRetry(t *testing.T) {
+	withFakeInvoker(t, &fakeInvoker{
+		canned:    agent.Result{OK: false, FailureCategory: "A", FailureReason: "agent crash"},
+		returnErr: agent.ErrAgentFailed,
+	})
+	fu := newFakeUploader(t)
+	fu.promptResp = &upload.FetchedPrompt{
+		StageID:            selfRetryStageID,
+		StageType:          "plan",
+		Prompt:             "test",
+		PromptHash:         "h",
+		AgentSelfRetry:     true,
+		MaxRetriesSnapshot: 1,
+		RetryAttempt:       1, // budget = 0
+	}
+	withFakeUploader(t, fu)
+
+	var stderr strings.Builder
+	got := run(selfRetryArgs(), &stderr)
+	if got != exitFailure {
+		t.Errorf("run = %d, want exitFailure", got)
+	}
+	if len(fu.gotRetryArgs) != 0 {
+		t.Errorf("RetryStage should not be called when budget is exhausted; got %d calls", len(fu.gotRetryArgs))
+	}
+}
+
+// TestRun_SelfRetry_Disabled_NoRetry verifies that agent_self_retry:false
+// prevents self-retry on category-A failures.
+func TestRun_SelfRetry_Disabled_NoRetry(t *testing.T) {
+	withFakeInvoker(t, &fakeInvoker{
+		canned:    agent.Result{OK: false, FailureCategory: "A", FailureReason: "agent crash"},
+		returnErr: agent.ErrAgentFailed,
+	})
+	fu := newFakeUploader(t)
+	fu.promptResp = &upload.FetchedPrompt{
+		StageID:            selfRetryStageID,
+		StageType:          "plan",
+		Prompt:             "test",
+		PromptHash:         "h",
+		AgentSelfRetry:     false, // opt-out
+		MaxRetriesSnapshot: 1,
+		RetryAttempt:       0,
+	}
+	withFakeUploader(t, fu)
+
+	var stderr strings.Builder
+	got := run(selfRetryArgs(), &stderr)
+	if got != exitFailure {
+		t.Errorf("run = %d, want exitFailure", got)
+	}
+	if len(fu.gotRetryArgs) != 0 {
+		t.Errorf("RetryStage should not be called when agent_self_retry is false; got %d calls", len(fu.gotRetryArgs))
+	}
+}
+
+// TestRun_SelfRetry_RetryStage422_ExitsWithOriginalFailure verifies that
+// when RetryStage returns ErrRetryNotApplicable (422) the runner does not
+// loop and exits with the original category-A failure.
+func TestRun_SelfRetry_RetryStage422_ExitsWithOriginalFailure(t *testing.T) {
+	withFakeInvoker(t, &fakeInvoker{
+		canned:    agent.Result{OK: false, FailureCategory: "A", FailureReason: "agent crash"},
+		returnErr: agent.ErrAgentFailed,
+	})
+	fu := newFakeUploader(t)
+	fu.promptResp = selfRetryPromptResp(selfRetryStageID)
+	fu.retryStageErr = upload.ErrRetryNotApplicable
+	withFakeUploader(t, fu)
+
+	var stderr strings.Builder
+	got := run(selfRetryArgs(), &stderr)
+	if got != exitFailure {
+		t.Errorf("run = %d, want exitFailure", got)
+	}
+	// RetryStage was called once (the 422 path), then the loop broke.
+	if len(fu.gotRetryArgs) != 1 {
+		t.Errorf("RetryStage calls = %d, want 1 (called but not looped)", len(fu.gotRetryArgs))
+	}
+	if !strings.Contains(stderr.String(), `"event":"retry_stage_failed"`) {
+		t.Errorf("missing retry_stage_failed log:\n%s", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), `"category":"A"`) {
+		t.Errorf("original category-A must be preserved:\n%s", stderr.String())
 	}
 }

--- a/runner/internal/upload/upload.go
+++ b/runner/internal/upload/upload.go
@@ -65,6 +65,11 @@ var (
 	// for this stage type. Non-retryable; the runner should fail
 	// the stage rather than guess.
 	ErrUnsupportedStage = errors.New("upload: backend does not support this stage type")
+	// ErrRetryNotApplicable is returned by RetryStage when the backend
+	// responds 422 (retry_not_applicable). The stage's failure category
+	// does not permit a retry (e.g., category-B). Non-retryable; the
+	// runner should exit with the original failure.
+	ErrRetryNotApplicable = errors.New("upload: retry not applicable for this stage")
 )
 
 // Client wraps a net/http.Client with a base URL. Construct via
@@ -315,6 +320,13 @@ type FetchedPrompt struct {
 	// this against its own version and exits with exitVersionSkew when it is
 	// older than required.
 	MinRunnerVersion string `json:"min_runner_version,omitempty"`
+	// AgentSelfRetry is true when the workflow spec opts the stage into
+	// ADR-023 runner-side self-retry on category-A/C failures.
+	AgentSelfRetry bool `json:"agent_self_retry,omitempty"`
+	// MaxRetriesSnapshot and RetryAttempt let the runner compute the
+	// remaining self-retry budget without an additional API call.
+	MaxRetriesSnapshot int `json:"max_retries_snapshot,omitempty"`
+	RetryAttempt       int `json:"retry_attempt,omitempty"`
 }
 
 // FetchPrompt calls GET /v0/stages/{stage_id}/prompt with an
@@ -840,5 +852,65 @@ func (c *Client) FetchInstallationToken(ctx context.Context, args FetchInstallat
 		return nil, fmt.Errorf("upload: installation-token: GitHub rejected App JWT or installation: %s", readBriefBody(resp))
 	default:
 		return nil, statusError("fetch installation token", resp)
+	}
+}
+
+// RetryStageArgs collects the inputs for RetryStage.
+type RetryStageArgs struct {
+	StageID    string
+	PrivateKey ed25519.PrivateKey
+}
+
+// RetryStage calls POST /v0/stages/{stage_id}/retry using the same
+// Ed25519 signing-key auth as FetchInstallationToken — signs over the
+// empty body to prove key possession. Single-attempt; the caller
+// decides whether to surface the error as a hard failure or log and
+// break the retry loop.
+//
+//   - 200 → nil (stage transitioned; orchestrator will dispatch)
+//   - 403 → descriptive non-nil error
+//   - 422 (retry_not_applicable) → ErrRetryNotApplicable sentinel
+//   - 404 / 5xx → generic error via statusError
+func (c *Client) RetryStage(ctx context.Context, args RetryStageArgs) error {
+	if args.StageID == "" {
+		return errors.New("upload: stage_id required")
+	}
+	if len(args.PrivateKey) != ed25519.PrivateKeySize {
+		return errors.New("upload: invalid private key length")
+	}
+
+	body := []byte{}
+	digest := sha256.Sum256(body)
+	signature := ed25519.Sign(args.PrivateKey, digest[:])
+	sigHex := hex.EncodeToString(signature)
+
+	endpoint := fmt.Sprintf("%s/v0/stages/%s/retry",
+		c.BaseURL, url.PathEscape(args.StageID))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("upload: build retry request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Fishhawk-Signature", sigHex)
+	req.Header.Set("Accept", "application/json")
+	req.ContentLength = 0
+
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return fmt.Errorf("upload: retry stage: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return nil
+	case http.StatusForbidden:
+		detail := readBriefBody(resp)
+		return fmt.Errorf("upload: retry stage: forbidden: %s", detail)
+	case http.StatusUnprocessableEntity:
+		return ErrRetryNotApplicable
+	default:
+		return statusError("retry stage", resp)
 	}
 }


### PR DESCRIPTION
## Summary

Closes the ADR-023 chain: with the workflow-spec field (#533) and backend `write:retries` plumbing (#534) in place, the runner now actually uses the capability — detects category-A/C failures and self-retries via the existing retry endpoint, bounded by `max_retries_snapshot`.

- **Backend prompt response** — three new fields: `agent_self_retry`, `max_retries_snapshot`, `retry_attempt`. `resolveAgentSelfRetry` follows the `resolveVerifyConfig` precedent for spec parsing.
- **Runner upload package** — `Client.RetryStage` signs an empty body with the Ed25519 signing key and POSTs `/v0/stages/{stage_id}/retry`. Uses the same auth path as `FetchInstallationToken` / `ShipPlan` (signing-key auth bypasses #534's scope gate — the runner authoritatively identifies itself per-run).
- **Runner main.go** — invoke section restructured into a for-loop. Four gates: spec opt-in, signing key present, budget remaining, category A or C. Bundle build + upload stay outside the loop and operate on the final attempt's state.
- **Tests** — five branches covered: A-then-success, B never retries, zero-budget, opt-out, `RetryStage` 422 falls through.
- **Docs** — `ARCHITECTURE.md` self-retry decision tree subsection.

## Notes

Driven through the local MCP loop. **Mostly textbook** — one operational stumble at the start (backend was rebuilt after #540's merge but `scripts/dev up` doesn't auto-migrate; first `fishhawk_start_run` returned `500 create stages failed` because migration 0027 hadn't applied). Filing as an operability follow-up.

Plan/implement clean: 20.6k tokens plan, 42k implement, `verify_run=true` (chain_length 13). Two minor in-loop fixes after the agent finished: a `gofmt` whitespace issue and an `ineffassign` warning on dead `diff = nil` resets. Both ~5 LoC patches.

## Concurrency limitation (acknowledged)

For `runner_kind: github_actions`, calling `POST /v0/stages/{id}/retry` fires `Orchestrator.Advance` which dispatches a second GitHub Actions runner. The original runner's retry loop continues in-process; the second GHA runner ALSO fetches the prompt (the prompt-handler's state guard doesn't block `dispatched`) and invokes the agent. Two concurrent agents per retried stage. Acceptable for v0; the dogfood loop today is local-only so this risk is theoretical until design-partners. Documented in the architecture doc.

For `runner_kind: local`, the retry loop runs in-process — no concurrent-runner risk.

## Out of scope

- `auto_retry_on_transient` MCP hint on `fishhawk_run_stage`. The spec field is the authoritative opt-in; per-call override is a future tightening if operators want it.
- Soft cap (don't retry > N times in M seconds). Issue listed it as out-of-scope for v0 unless thrashing is observed.
- Cancel parity (`write:cancels`). Excluded per ADR-023.

## Test plan

- [x] `go build ./...` — clean.
- [x] `go test -race ./backend/internal/server/... ./runner/internal/upload/... ./runner/cmd/fishhawk-runner/...` — pass.
- [x] `golangci-lint run ./backend/... ./runner/...` — 0 issues (after gofmt + ineffassign fixes).
- [x] `scripts/test coverage` — aggregate **81.1%** (threshold 80%).
- [x] `fishhawk_verify_run` — `verified=true`, chain_length=13.

## Follow-up

- `scripts/dev up` doesn't run pending migrations. Backend started fine but the first write fails cryptically as "create stages failed" until `fishhawkd migrate up --db ...` runs manually. Worth a tiny addition to scripts/dev.

Closes #535
Completes the ADR-023 (#401) chain.