### PR TITLE
server: propagate plan-rejection rationale to next run's plan-stage prompt (#539)

### DIFF
--- a/backend/internal/prompt/prompt.go
+++ b/backend/internal/prompt/prompt.go
@@ -135,6 +135,12 @@ type Trigger struct {
 	// threshold of implement-stage executions have been recorded (mirrors
 	// the DecomposeRequired pattern for plan-stage hint injection).
 	CalibrationHint *CalibrationHint
+	// PriorRejectionFeedback is the operator's rationale from the most
+	// recent rejection of a plan for the same trigger_ref. When non-nil
+	// and non-empty, buildPlan injects a binding "you MUST address this"
+	// section so the agent knows why the previous attempt was rejected.
+	// Nil when no prior rejection exists or the comment was empty.
+	PriorRejectionFeedback *string
 	// PredictionContext carries runtime prediction data for the implement-
 	// stage prompt. When non-nil, buildImplement appends a Budget context
 	// section surfacing predicted_runtime_minutes, predicted_runtime_confidence,
@@ -260,6 +266,18 @@ func buildPlan(t Trigger) string {
 		b.WriteString("IMPORTANT: Your previous plan was rejected because predicted_runtime_minutes " +
 			"exceeded the implement-stage budget without a decomposition block. " +
 			"You MUST populate decomposition.sub_plans in this plan — omitting it will block approval again.\n\n")
+	}
+
+	if t.PriorRejectionFeedback != nil && *t.PriorRejectionFeedback != "" {
+		feedback := *t.PriorRejectionFeedback
+		const maxFeedbackBytes = 4000
+		if len(feedback) > maxFeedbackBytes {
+			feedback = feedback[:maxFeedbackBytes] + "...[truncated]"
+		}
+		b.WriteString("### Prior plan-stage rejection feedback\n\n")
+		b.WriteString("The operator rejected the most recent plan for this issue with the following rationale. You MUST address this feedback in your new plan:\n\n")
+		b.WriteString(feedback)
+		b.WriteString("\n\n")
 	}
 
 	writeIssueContext(&b, t)

--- a/backend/internal/prompt/prompt_test.go
+++ b/backend/internal/prompt/prompt_test.go
@@ -607,6 +607,65 @@ func TestBuild_Implement_BudgetContext_DefaultBudget(t *testing.T) {
 	}
 }
 
+func TestBuild_Plan_PriorRejectionFeedback_Rendered(t *testing.T) {
+	feedback := "The plan lacked sufficient test coverage for edge cases."
+	got, err := Build("plan", Trigger{
+		IssueNumber:            7,
+		Repo:                   "x/y",
+		PriorRejectionFeedback: &feedback,
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	wants := []string{
+		"### Prior plan-stage rejection feedback",
+		"The operator rejected the most recent plan for this issue",
+		"You MUST address this feedback in your new plan",
+		feedback,
+	}
+	for _, w := range wants {
+		if !strings.Contains(got, w) {
+			t.Errorf("plan prompt missing %q:\n%s", w, got)
+		}
+	}
+}
+
+func TestBuild_Plan_PriorRejectionFeedback_Nil_SectionAbsent(t *testing.T) {
+	got, err := Build("plan", Trigger{
+		IssueNumber: 7,
+		Repo:        "x/y",
+		// PriorRejectionFeedback deliberately nil.
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if strings.Contains(got, "### Prior plan-stage rejection feedback") {
+		t.Errorf("plan prompt should not contain rejection feedback section when nil:\n%s", got)
+	}
+}
+
+func TestBuild_Plan_PriorRejectionFeedback_Truncated(t *testing.T) {
+	// Input of 5000 bytes should be capped at 4000 bytes with the truncation suffix.
+	// Cap is 4000 (not 2000) because real rejection rationales run 2-4KB —
+	// substantive operator feedback shouldn't lose its actionable tail.
+	longFeedback := strings.Repeat("x", 5000)
+	got, err := Build("plan", Trigger{
+		IssueNumber:            7,
+		Repo:                   "x/y",
+		PriorRejectionFeedback: &longFeedback,
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if !strings.Contains(got, "...[truncated]") {
+		t.Errorf("plan prompt missing truncation suffix:\n%s", got)
+	}
+	// The full 5000-char string must not appear verbatim.
+	if strings.Contains(got, longFeedback) {
+		t.Errorf("untruncated long feedback appeared in prompt")
+	}
+}
+
 func TestBuild_Implement_WithSparsePlan_OmitsEmptySections(t *testing.T) {
 	// A plan that fails optional sections (no scope.files, no
 	// risks) should still render cleanly — empty sections drop

--- a/backend/internal/server/approvals.go
+++ b/backend/internal/server/approvals.go
@@ -410,6 +410,9 @@ func (s *Server) writeApprovalAudit(r *http.Request, stage *run.Stage, app *appr
 	if app.Decision == approval.DecisionReject && strings.Contains(comment, "--decompose") {
 		auditPayload["reject_reason"] = "decompose_required"
 	}
+	if app.Decision == approval.DecisionReject && comment != "" {
+		auditPayload["rejection_comment"] = comment
+	}
 	payload, _ := json.Marshal(auditPayload)
 
 	approver := app.ApproverSubject

--- a/backend/internal/server/approvals_test.go
+++ b/backend/internal/server/approvals_test.go
@@ -1274,6 +1274,62 @@ func TestSubmitApproval_BudgetCheck_WithinBudget_Proceeds(t *testing.T) {
 	}
 }
 
+func TestSubmitApproval_Reject_RejectionCommentInAuditPayload(t *testing.T) {
+	// Reject with non-empty comment → approval_submitted payload carries rejection_comment.
+	s, _, rr, au := newApprovalServer(t)
+	stage := rr.seedStage(run.StageStateAwaitingApproval)
+
+	w := submitApproval(t, s, stage.ID, `{"decision":"reject","comment":"plan needs more detail"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200:\n%s", w.Code, w.Body.String())
+	}
+
+	var foundSubmitted bool
+	for _, e := range au.appended {
+		if e.Category != "approval_submitted" {
+			continue
+		}
+		foundSubmitted = true
+		var payload map[string]any
+		if err := json.Unmarshal(e.Payload, &payload); err != nil {
+			t.Fatalf("unmarshal audit payload: %v", err)
+		}
+		got, ok := payload["rejection_comment"]
+		if !ok {
+			t.Errorf("rejection_comment missing from payload: %v", payload)
+		} else if got != "plan needs more detail" {
+			t.Errorf("rejection_comment = %v, want 'plan needs more detail'", got)
+		}
+	}
+	if !foundSubmitted {
+		t.Errorf("expected approval_submitted audit entry, got %+v", au.appended)
+	}
+}
+
+func TestSubmitApproval_Reject_EmptyComment_NoRejectionCommentInPayload(t *testing.T) {
+	// Reject with no comment → approval_submitted payload must not have rejection_comment.
+	s, _, rr, au := newApprovalServer(t)
+	stage := rr.seedStage(run.StageStateAwaitingApproval)
+
+	w := submitApproval(t, s, stage.ID, `{"decision":"reject"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200:\n%s", w.Code, w.Body.String())
+	}
+
+	for _, e := range au.appended {
+		if e.Category != "approval_submitted" {
+			continue
+		}
+		var payload map[string]any
+		if err := json.Unmarshal(e.Payload, &payload); err != nil {
+			t.Fatalf("unmarshal audit payload: %v", err)
+		}
+		if _, ok := payload["rejection_comment"]; ok {
+			t.Errorf("rejection_comment must not appear when comment is empty; payload: %v", payload)
+		}
+	}
+}
+
 func TestSubmitApproval_Reject_DecomposeComment_SetsRejectReason(t *testing.T) {
 	// Reject with "--decompose" in comment → approval_submitted payload
 	// contains reject_reason=decompose_required.

--- a/backend/internal/server/issue_approval.go
+++ b/backend/internal/server/issue_approval.go
@@ -175,7 +175,7 @@ func (s *Server) HandleApprovalCommand(ctx context.Context, p webhook.ApprovalCo
 		return nil
 	}
 
-	s.writeSlashApprovalAudit(ctx, advanced, res.Approval)
+	s.writeSlashApprovalAudit(ctx, advanced, res.Approval, p.Comment)
 
 	if s.cfg.Orchestrator != nil {
 		if _, err := s.cfg.Orchestrator.Advance(ctx, advanced.RunID); err != nil {
@@ -310,15 +310,19 @@ func (s *Server) authorizeSlashApprover(ctx context.Context, stage *run.Stage, s
 // writeSlashApprovalAudit mirrors writeApprovalAudit's chain entry
 // — same category, same payload shape — so audit consumers don't
 // care which surface produced the row.
-func (s *Server) writeSlashApprovalAudit(ctx context.Context, stage *run.Stage, app *approval.Approval) {
+func (s *Server) writeSlashApprovalAudit(ctx context.Context, stage *run.Stage, app *approval.Approval, comment string) {
 	systemKind := audit.ActorKind("user")
 	approver := app.ApproverSubject
-	payload, _ := json.Marshal(map[string]any{
+	auditPayload := map[string]any{
 		"stage_id": stage.ID.String(),
 		"decision": string(app.Decision),
 		"surface":  string(app.Surface),
 		"approver": approver,
-	})
+	}
+	if app.Decision == approval.DecisionReject && comment != "" {
+		auditPayload["rejection_comment"] = comment
+	}
+	payload, _ := json.Marshal(auditPayload)
 	if _, err := s.cfg.AuditRepo.AppendChained(ctx, audit.ChainAppendParams{
 		RunID:        stage.RunID,
 		StageID:      &stage.ID,

--- a/backend/internal/server/prompt.go
+++ b/backend/internal/server/prompt.go
@@ -182,6 +182,9 @@ func (s *Server) handleGetStagePrompt(w http.ResponseWriter, r *http.Request) {
 		} else {
 			trigger.CalibrationHint = hint
 		}
+		if runRow.TriggerRef != nil {
+			trigger.PriorRejectionFeedback = s.loadPriorRejectionFeedback(r.Context(), runRow.Repo, *runRow.TriggerRef, runRow.ID)
+		}
 	}
 
 	trigger.PlanStageTimeout = time.Duration(s.resolveAgentTimeout(r.Context(), runRow, run.StageTypePlan)) * time.Second
@@ -324,6 +327,9 @@ func (s *Server) handleGetStagePromptRender(w http.ResponseWriter, r *http.Reque
 			slog.WarnContext(r.Context(), "calibration hint resolution failed", "error", err)
 		} else {
 			trigger.CalibrationHint = hint
+		}
+		if runRow.TriggerRef != nil {
+			trigger.PriorRejectionFeedback = s.loadPriorRejectionFeedback(r.Context(), runRow.Repo, *runRow.TriggerRef, runRow.ID)
 		}
 	}
 
@@ -826,6 +832,74 @@ func (s *Server) resolveAgentSelfRetryForStage(ctx context.Context, runRow *run.
 		}
 	}
 	return specStage.Executor.AgentSelfRetry
+}
+
+// loadPriorRejectionFeedback searches the most-recent prior runs for
+// the same trigger_ref and returns the rejection_comment from the newest
+// approval_submitted audit entry where decision=reject and
+// rejection_comment is non-empty. Returns nil when there is no matching
+// prior rejection, when RunRepo or AuditRepo is unconfigured, or on any
+// error (best-effort, same posture as CalibrationHint). At most 3 prior
+// runs are inspected to bound audit fan-out; at most 10 runs are fetched
+// from the repo in total (Limit=10).
+func (s *Server) loadPriorRejectionFeedback(ctx context.Context, repo, triggerRef string, currentRunID uuid.UUID) *string {
+	if s.cfg.RunRepo == nil || s.cfg.AuditRepo == nil {
+		return nil
+	}
+	ref := triggerRef
+	runs, err := s.cfg.RunRepo.ListRuns(ctx, run.ListRunsFilter{
+		Repo:       repo,
+		TriggerRef: &ref,
+		Limit:      10,
+	})
+	if err != nil {
+		s.cfg.Logger.LogAttrs(ctx, slog.LevelWarn, "prompt: list runs for prior rejection failed",
+			slog.String("trigger_ref", triggerRef),
+			slog.String("error", err.Error()),
+		)
+		return nil
+	}
+
+	checked := 0
+	for _, r := range runs {
+		if r.ID == currentRunID {
+			continue
+		}
+		if checked >= 3 {
+			break
+		}
+		checked++
+
+		entries, err := s.cfg.AuditRepo.ListForRunByCategory(ctx, r.ID, "approval_submitted")
+		if err != nil {
+			s.cfg.Logger.LogAttrs(ctx, slog.LevelWarn, "prompt: list approval_submitted for prior run failed",
+				slog.String("run_id", r.ID.String()),
+				slog.String("error", err.Error()),
+			)
+			continue
+		}
+
+		// Scan newest-first (ListForRunByCategory returns entries ordered ASC by ts).
+		for i := len(entries) - 1; i >= 0; i-- {
+			var payload struct {
+				Decision         string `json:"decision"`
+				RejectionComment string `json:"rejection_comment"`
+			}
+			if err := json.Unmarshal(entries[i].Payload, &payload); err != nil {
+				continue
+			}
+			if payload.Decision == "reject" && payload.RejectionComment != "" {
+				c := payload.RejectionComment
+				s.cfg.Logger.LogAttrs(ctx, slog.LevelInfo,
+					"prompt: loaded prior rejection feedback into plan prompt",
+					slog.String("prior_run_id", r.ID.String()),
+					slog.Int("comment_bytes", len(c)),
+				)
+				return &c
+			}
+		}
+	}
+	return nil
 }
 
 // loadLastDecomposeRejectionReason scans the run's approval_submitted

--- a/backend/internal/server/prompt_test.go
+++ b/backend/internal/server/prompt_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/kuhlman-labs/fishhawk/backend/internal/audit"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/githubclient"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/run"
 )
@@ -1142,5 +1143,156 @@ func TestGetStagePrompt_VerifyConfig_Absent(t *testing.T) {
 	}
 	if strings.Contains(body, "verify_timeout_seconds") {
 		t.Errorf("response JSON should not contain verify_timeout_seconds when spec has none:\n%s", body)
+	}
+}
+
+// --- loadPriorRejectionFeedback unit tests ---
+
+// feedbackRunRepo wraps promptRunRepo to supply canned ListRuns results.
+type feedbackRunRepo struct {
+	*promptRunRepo
+	listResult []*run.Run
+	listErr    error
+}
+
+func (r *feedbackRunRepo) ListRuns(_ context.Context, _ run.ListRunsFilter) ([]*run.Run, error) {
+	if r.listErr != nil {
+		return nil, r.listErr
+	}
+	return r.listResult, nil
+}
+
+// feedbackAuditRepo is a minimal audit.Repository for loadPriorRejectionFeedback tests.
+type feedbackAuditRepo struct {
+	byRunID map[uuid.UUID][]*audit.Entry
+	listErr error
+}
+
+func (f *feedbackAuditRepo) Append(_ context.Context, _ audit.AppendParams) (*audit.Entry, error) {
+	return nil, errors.New("not used")
+}
+func (f *feedbackAuditRepo) AppendChained(_ context.Context, p audit.ChainAppendParams) (*audit.Entry, error) {
+	rid := p.RunID
+	return &audit.Entry{ID: uuid.New(), RunID: &rid}, nil
+}
+func (f *feedbackAuditRepo) AppendGlobalChained(_ context.Context, _ audit.GlobalChainAppendParams) (*audit.Entry, error) {
+	return nil, errors.New("not used")
+}
+func (f *feedbackAuditRepo) Get(_ context.Context, _ uuid.UUID) (*audit.Entry, error) {
+	return nil, errors.New("not used")
+}
+func (f *feedbackAuditRepo) ListForRun(_ context.Context, _ uuid.UUID) ([]*audit.Entry, error) {
+	return nil, errors.New("not used")
+}
+func (f *feedbackAuditRepo) ListGlobal(_ context.Context) ([]*audit.Entry, error) {
+	return nil, nil
+}
+func (f *feedbackAuditRepo) LastForRun(_ context.Context, _ uuid.UUID) (*audit.Entry, error) {
+	return nil, errors.New("not used")
+}
+func (f *feedbackAuditRepo) ListForRunByCategory(_ context.Context, runID uuid.UUID, _ string) ([]*audit.Entry, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return f.byRunID[runID], nil
+}
+func (f *feedbackAuditRepo) ListAll(_ context.Context, _ audit.ListAllParams) ([]*audit.Entry, error) {
+	return nil, nil
+}
+func (f *feedbackAuditRepo) ChainsByParent(_ context.Context, _ uuid.UUID, _ bool) ([]*audit.Entry, error) {
+	return nil, nil
+}
+
+func newFeedbackServer(t *testing.T, runs []*run.Run, auditByRun map[uuid.UUID][]*audit.Entry) *Server {
+	t.Helper()
+	rr := &feedbackRunRepo{
+		promptRunRepo: newPromptRunRepo(),
+		listResult:    runs,
+	}
+	ar := &feedbackAuditRepo{byRunID: auditByRun}
+	return New(Config{
+		Addr:      "127.0.0.1:0",
+		RunRepo:   rr,
+		AuditRepo: ar,
+	})
+}
+
+func makeRejectionEntry(runID uuid.UUID, comment string) *audit.Entry {
+	payload, _ := json.Marshal(map[string]any{
+		"decision":          "reject",
+		"rejection_comment": comment,
+	})
+	rid := runID
+	return &audit.Entry{ID: uuid.New(), RunID: &rid, Payload: payload}
+}
+
+func makeApproveEntry(runID uuid.UUID) *audit.Entry {
+	payload, _ := json.Marshal(map[string]any{"decision": "approve"})
+	rid := runID
+	return &audit.Entry{ID: uuid.New(), RunID: &rid, Payload: payload}
+}
+
+func TestLoadPriorRejectionFeedback_NoPriorRuns_ReturnsNil(t *testing.T) {
+	s := newFeedbackServer(t, nil, nil)
+	got := s.loadPriorRejectionFeedback(context.Background(), "x/y", "issue:42", uuid.New())
+	if got != nil {
+		t.Errorf("got %q, want nil (no prior runs)", *got)
+	}
+}
+
+func TestLoadPriorRejectionFeedback_PriorRunNoRejection_ReturnsNil(t *testing.T) {
+	priorID := uuid.New()
+	currentID := uuid.New()
+	s := newFeedbackServer(t,
+		[]*run.Run{{ID: priorID}},
+		map[uuid.UUID][]*audit.Entry{priorID: {makeApproveEntry(priorID)}},
+	)
+	got := s.loadPriorRejectionFeedback(context.Background(), "x/y", "issue:42", currentID)
+	if got != nil {
+		t.Errorf("got %q, want nil (no rejection in prior run)", *got)
+	}
+}
+
+func TestLoadPriorRejectionFeedback_PriorRunRejectionEmptyComment_ReturnsNil(t *testing.T) {
+	priorID := uuid.New()
+	currentID := uuid.New()
+	payload, _ := json.Marshal(map[string]any{"decision": "reject", "rejection_comment": ""})
+	rid := priorID
+	s := newFeedbackServer(t,
+		[]*run.Run{{ID: priorID}},
+		map[uuid.UUID][]*audit.Entry{priorID: {{ID: uuid.New(), RunID: &rid, Payload: payload}}},
+	)
+	got := s.loadPriorRejectionFeedback(context.Background(), "x/y", "issue:42", currentID)
+	if got != nil {
+		t.Errorf("got %q, want nil (rejection with empty comment)", *got)
+	}
+}
+
+func TestLoadPriorRejectionFeedback_PriorRunRejectionNonEmptyComment_ReturnsComment(t *testing.T) {
+	priorID := uuid.New()
+	currentID := uuid.New()
+	s := newFeedbackServer(t,
+		[]*run.Run{{ID: priorID}},
+		map[uuid.UUID][]*audit.Entry{priorID: {makeRejectionEntry(priorID, "plan is too vague")}},
+	)
+	got := s.loadPriorRejectionFeedback(context.Background(), "x/y", "issue:42", currentID)
+	if got == nil {
+		t.Fatal("got nil, want comment")
+	}
+	if *got != "plan is too vague" {
+		t.Errorf("got %q, want 'plan is too vague'", *got)
+	}
+}
+
+func TestLoadPriorRejectionFeedback_CurrentRunIDExcluded(t *testing.T) {
+	currentID := uuid.New()
+	// The only run in the list is the current one — must be skipped.
+	s := newFeedbackServer(t,
+		[]*run.Run{{ID: currentID}},
+		map[uuid.UUID][]*audit.Entry{currentID: {makeRejectionEntry(currentID, "do not return this")}},
+	)
+	got := s.loadPriorRejectionFeedback(context.Background(), "x/y", "issue:42", currentID)
+	if got != nil {
+		t.Errorf("got %q, want nil (current run should be excluded)", *got)
 	}
 }


### PR DESCRIPTION
## Summary

Closes the UX gap that cost the operator extra loop time on multiple PRs yesterday (#534, #538). When `fishhawk_reject_plan` is called with a substantive rationale, the next run's plan-stage agent now sees that rationale verbatim in its prompt — the operator's most expressive signal stops being silently dropped at the run boundary.

- **Persistence**: `rejection_comment` added to the existing `approval_submitted` audit payload (additive, backward-compatible). Both the MCP path (`approvals.go`) and the slash-command path (`issue_approval.go`) updated symmetrically.
- **Prompt rendering**: `Trigger.PriorRejectionFeedback *string` + `buildPlan` renders a `### Prior plan-stage rejection feedback` section with operator-facing framing. Capped at **4000 bytes** with truncation suffix (substantive rejections run 2-4KB; 2KB was too aggressive).
- **Server helper**: `loadPriorRejectionFeedback` queries up to 3 prior runs sharing `trigger_ref`, scans each run's `approval_submitted` audit entries newest-first, returns the most-recent non-empty rejection. Best-effort posture matches `CalibrationHint`. Info log on successful load (`loaded prior rejection feedback into plan prompt`) so the operator can see propagation firing.

## Notes

Driven through the local MCP loop. **One stumble + clean recovery**:

- First plan-stage attempt failed schema validation on `/ticket_reference: got string, want object` — a NEW field hitting the same string-elision pattern from #530/#537 but not in #538's coercion whitelist. Filed as a follow-up class observation; retried; second attempt succeeded clean (8k tokens).
- Plan/implement otherwise clean. `verify_run=true`, chain_length=13.

Two minor in-loop patches per `feedback-in-loop-bugs-same-pr`:

- Agent set `maxFeedbackBytes = 2000` despite my approval ask for 4000. Patched.
- Agent emitted Warn logs on errors but no Info log on successful feedback load. Added. The audit log shows propagation but a dev-mode log line helps the operator see it in real time.

## Behavior

```
# Operator rejects run-A's plan with substantive feedback:
fishhawk_reject_plan --reason "The runner has its own validator at runner/internal/plan/plan.go:115 — your plan misses it..."

# Operator starts run-B on the same issue:
fishhawk_start_run --issue 537

# run-B's plan-stage prompt now contains:
#
#   ### Prior plan-stage rejection feedback
#
#   The operator rejected the most recent plan for this issue with the
#   following rationale. You MUST address this feedback in your new plan:
#
#   The runner has its own validator at runner/internal/plan/plan.go:115...
```

## Test plan

- [x] `go test -race ./backend/internal/server/... ./backend/internal/prompt/...` — pass.
- [x] `golangci-lint run ./backend/...` — 0 issues.
- [x] `scripts/test coverage` — aggregate **81.2%** (threshold 80%).
- [x] `fishhawk_verify_run` — `verified=true`, chain_length=13.
- [ ] Meta: validate with a real reject-then-replan cycle on the next non-trivial PR.

## Out of scope (per issue body)

- Cross-run plan-context inheritance via explicit `prior_run_id` (Option B). Defer until A doesn't suffice.
- Promote rejection to a first-class re-plan path (Option C). Larger semantic change.
- Cross-issue feedback inheritance. Falls into prompt-template territory.

## Follow-up

Ticket-reference coercion gap (and the broader "per-field coercion whitelist isn't sufficient"): worth a follow-up to make coercion schema-aware. Will file as next loop's mini-retro item.

Closes #539