### PR TITLE
plan: schema-aware coercion via x-coerce-principal/x-coerce-defaults annotations (#547)

### DIFF
--- a/backend/internal/plan/coerce.go
+++ b/backend/internal/plan/coerce.go
@@ -3,6 +3,7 @@ package plan
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -14,10 +15,163 @@ type Coercion struct {
 	CoercedTo     any    `json:"coerced_to"`
 }
 
+// coercionEntry describes how to coerce a bare string at a given schema path.
+type coercionEntry struct {
+	isArrayItem bool
+	principal   string         // field that receives the bare string value
+	defaults    map[string]any // non-principal defaults; "<<runtime:now>>" is substituted at coercion time
+}
+
+// coercionAnnotation holds the x-coerce-* data extracted from a $defs entry.
+type coercionAnnotation struct {
+	principal string
+	defaults  map[string]any
+}
+
+// coercionRegistry is the schema-derived set of paths that TryCoerce handles,
+// built once at package init by parsing the embedded schema.
+var coercionRegistry map[string]coercionEntry
+
+func init() {
+	coercionRegistry = buildCoercionRegistry()
+}
+
+func buildCoercionRegistry() map[string]coercionEntry {
+	const schemaPath = "schemas/plan-standard-v1.schema.json"
+	data, err := schemaFS.ReadFile(schemaPath)
+	if err != nil {
+		panic(fmt.Sprintf("plan: coerce: read schema %s: %v", schemaPath, err))
+	}
+	var schema map[string]any
+	if err := json.Unmarshal(data, &schema); err != nil {
+		panic(fmt.Sprintf("plan: coerce: parse schema %s: %v", schemaPath, err))
+	}
+
+	defs, _ := schema["$defs"].(map[string]any)
+
+	// Collect x-coerce-* annotations from $defs entries.
+	annotByDef := make(map[string]coercionAnnotation)
+	for name, raw := range defs {
+		def, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		principal, ok := def["x-coerce-principal"].(string)
+		if !ok {
+			continue
+		}
+		defaultsRaw, _ := def["x-coerce-defaults"].(map[string]any)
+		defaults := make(map[string]any, len(defaultsRaw))
+		for k, v := range defaultsRaw {
+			defaults[k] = v
+		}
+		annotByDef[name] = coercionAnnotation{principal, defaults}
+	}
+
+	reg := make(map[string]coercionEntry)
+	if props, ok := schema["properties"].(map[string]any); ok {
+		walkSchemaProps(props, "", defs, annotByDef, reg)
+	}
+	return reg
+}
+
+// walkSchemaProps recursively walks a JSON Schema properties map and populates
+// reg with coercionEntry values for every annotated path discovered.
+func walkSchemaProps(props map[string]any, prefix string, defs map[string]any, annotByDef map[string]coercionAnnotation, reg map[string]coercionEntry) {
+	for key, propRaw := range props {
+		prop, ok := propRaw.(map[string]any)
+		if !ok {
+			continue
+		}
+		path := prefix + "/" + key
+
+		if ref, ok := prop["$ref"].(string); ok {
+			defName := defNameFromRef(ref)
+			if ann, ok := annotByDef[defName]; ok {
+				reg[path] = coercionEntry{isArrayItem: false, principal: ann.principal, defaults: ann.defaults}
+			} else if defName != "" {
+				// Recurse into the referenced def's own properties.
+				if def, ok := defs[defName].(map[string]any); ok {
+					if nested, ok := def["properties"].(map[string]any); ok {
+						walkSchemaProps(nested, path, defs, annotByDef, reg)
+					}
+				}
+			}
+			continue
+		}
+
+		propType, _ := prop["type"].(string)
+		if propType == "array" {
+			if items, ok := prop["items"].(map[string]any); ok {
+				if ref, ok := items["$ref"].(string); ok {
+					defName := defNameFromRef(ref)
+					if ann, ok := annotByDef[defName]; ok {
+						reg[path] = coercionEntry{isArrayItem: true, principal: ann.principal, defaults: ann.defaults}
+					}
+				}
+			}
+			continue
+		}
+
+		if nested, ok := prop["properties"].(map[string]any); ok {
+			walkSchemaProps(nested, path, defs, annotByDef, reg)
+		}
+	}
+}
+
+// defNameFromRef extracts the $defs name from a JSON Pointer $ref.
+// "#/$defs/ticket-reference" → "ticket-reference".
+func defNameFromRef(ref string) string {
+	const prefix = "#/$defs/"
+	if strings.HasPrefix(ref, prefix) {
+		return ref[len(prefix):]
+	}
+	return ""
+}
+
+// buildCoerced constructs the replacement object for a bare string, applying
+// defaults and substituting the <<runtime:now>> sentinel with now.
+func buildCoerced(entry coercionEntry, value string, now time.Time) map[string]any {
+	coerced := make(map[string]any, len(entry.defaults)+1)
+	for k, v := range entry.defaults {
+		if s, ok := v.(string); ok && s == "<<runtime:now>>" {
+			coerced[k] = now.UTC().Format(time.RFC3339)
+		} else {
+			coerced[k] = v
+		}
+	}
+	coerced[entry.principal] = value
+	return coerced
+}
+
+// navigateTo walks a path segment slice through a map[string]any tree and
+// returns the value at the final segment's parent map plus the final key.
+// Returns (nil, "", false) when any intermediate level is missing or not a map.
+func navigateTo(m map[string]any, parts []string) (map[string]any, string, bool) {
+	if len(parts) == 0 {
+		return nil, "", false
+	}
+	parent := m
+	for _, seg := range parts[:len(parts)-1] {
+		child, ok := parent[seg]
+		if !ok {
+			return nil, "", false
+		}
+		childMap, ok := child.(map[string]any)
+		if !ok {
+			return nil, "", false
+		}
+		parent = childMap
+	}
+	return parent, parts[len(parts)-1], true
+}
+
 // TryCoerce attempts to fix the known string-elision class of plan schema
 // violations: cases where an agent emits a bare string where the schema
-// expects an object at /generated_by, /scope/files[], or
-// /decomposition/sub_plans[].
+// expects an object. The set of coercible paths is derived at init time from
+// the x-coerce-principal / x-coerce-defaults annotations in the embedded
+// schema — no per-field code changes are required when the schema gains a new
+// annotated $defs entry.
 //
 // Returns (coercedBytes, coercions, nil) when coercion produces a valid plan.
 // Returns (nil, nil, nil) when no string-valued nested-object fields are
@@ -33,69 +187,53 @@ func TryCoerce(data []byte, now time.Time) ([]byte, []Coercion, error) {
 
 	var coercions []Coercion
 
-	// /generated_by: coerce bare string to canonical object shape.
-	if v, ok := m["generated_by"]; ok {
-		if s, ok := v.(string); ok {
-			coerced := map[string]any{
-				"agent":     s,
-				"model":     "unknown",
-				"timestamp": now.UTC().Format(time.RFC3339),
+	for path, entry := range coercionRegistry {
+		parts := strings.Split(strings.TrimPrefix(path, "/"), "/")
+
+		if entry.isArrayItem {
+			parent, arrayKey, ok := navigateTo(m, parts)
+			if !ok {
+				continue
 			}
+			slice, ok := parent[arrayKey].([]any)
+			if !ok {
+				continue
+			}
+			for i, elem := range slice {
+				s, ok := elem.(string)
+				if !ok {
+					continue
+				}
+				coerced := buildCoerced(entry, s, now)
+				coercions = append(coercions, Coercion{
+					FieldPath:     fmt.Sprintf("%s/%d", path, i),
+					OriginalType:  "string",
+					OriginalValue: s,
+					CoercedTo:     coerced,
+				})
+				slice[i] = coerced
+			}
+			parent[arrayKey] = slice
+		} else {
+			if len(parts) != 1 {
+				continue
+			}
+			v, ok := m[parts[0]]
+			if !ok {
+				continue
+			}
+			s, ok := v.(string)
+			if !ok {
+				continue
+			}
+			coerced := buildCoerced(entry, s, now)
 			coercions = append(coercions, Coercion{
-				FieldPath:     "/generated_by",
+				FieldPath:     path,
 				OriginalType:  "string",
 				OriginalValue: s,
 				CoercedTo:     coerced,
 			})
-			m["generated_by"] = coerced
-		}
-	}
-
-	// /scope/files[]: coerce each bare string element to {path, operation}.
-	if scope, ok := m["scope"].(map[string]any); ok {
-		if files, ok := scope["files"].([]any); ok {
-			for i, f := range files {
-				if s, ok := f.(string); ok {
-					coerced := map[string]any{
-						"path":      s,
-						"operation": "modify",
-					}
-					coercions = append(coercions, Coercion{
-						FieldPath:     fmt.Sprintf("/scope/files/%d", i),
-						OriginalType:  "string",
-						OriginalValue: s,
-						CoercedTo:     coerced,
-					})
-					files[i] = coerced
-				}
-			}
-			scope["files"] = files
-		}
-	}
-
-	// /decomposition/sub_plans[]: coerce each bare string element to the
-	// sentinel default shape. scope_hint is intentionally empty — the
-	// coercion is a robustness aid, not a way to hide missing agent output.
-	if decomp, ok := m["decomposition"].(map[string]any); ok {
-		if subPlans, ok := decomp["sub_plans"].([]any); ok {
-			for i, sp := range subPlans {
-				if s, ok := sp.(string); ok {
-					coerced := map[string]any{
-						"title":                        s,
-						"scope_hint":                   "",
-						"predicted_runtime_minutes":    1,
-						"predicted_runtime_confidence": "low",
-					}
-					coercions = append(coercions, Coercion{
-						FieldPath:     fmt.Sprintf("/decomposition/sub_plans/%d", i),
-						OriginalType:  "string",
-						OriginalValue: s,
-						CoercedTo:     coerced,
-					})
-					subPlans[i] = coerced
-				}
-			}
-			decomp["sub_plans"] = subPlans
+			m[parts[0]] = coerced
 		}
 	}
 

--- a/backend/internal/plan/coerce_test.go
+++ b/backend/internal/plan/coerce_test.go
@@ -147,6 +147,71 @@ func TestTryCoerce_IntegerScopeFile(t *testing.T) {
 	}
 }
 
+// TestTryCoerce_TicketReferenceString verifies that a bare URL string at
+// /ticket_reference is wrapped into the canonical ticket_reference object shape.
+func TestTryCoerce_TicketReferenceString(t *testing.T) {
+	m := planfixture.Valid()
+	m["ticket_reference"] = "https://github.com/x/y/issues/547"
+	data := marshal(t, m)
+
+	coercedBytes, coercions, err := plan.TryCoerce(data, testNow)
+	if err != nil {
+		t.Fatalf("TryCoerce: unexpected error: %v", err)
+	}
+	if len(coercions) != 1 {
+		t.Fatalf("coercions = %d, want 1", len(coercions))
+	}
+	if got := coercions[0].FieldPath; got != "/ticket_reference" {
+		t.Errorf("FieldPath = %q, want /ticket_reference", got)
+	}
+	if got := coercions[0].OriginalType; got != "string" {
+		t.Errorf("OriginalType = %q, want string", got)
+	}
+	if got, ok := coercions[0].OriginalValue.(string); !ok || got != "https://github.com/x/y/issues/547" {
+		t.Errorf("OriginalValue = %v, want string \"https://github.com/x/y/issues/547\"", coercions[0].OriginalValue)
+	}
+	if coercedBytes == nil {
+		t.Fatal("coercedBytes is nil")
+	}
+	if err := plan.Validate(coercedBytes); err != nil {
+		t.Errorf("coerced plan does not validate: %v", err)
+	}
+	var result map[string]any
+	if err := json.Unmarshal(coercedBytes, &result); err != nil {
+		t.Fatalf("unmarshal coerced: %v", err)
+	}
+	tr, _ := result["ticket_reference"].(map[string]any)
+	if tr["url"] != "https://github.com/x/y/issues/547" {
+		t.Errorf("ticket_reference.url = %v, want https://github.com/x/y/issues/547", tr["url"])
+	}
+	if tr["type"] != "github_issue" {
+		t.Errorf("ticket_reference.type = %v, want github_issue", tr["type"])
+	}
+	if tr["id"] != "unknown" {
+		t.Errorf("ticket_reference.id = %v, want unknown", tr["id"])
+	}
+}
+
+// TestTryCoerce_IntegerTicketReference verifies that a non-string type at
+// /ticket_reference (an integer) is not coercible and propagates a non-nil
+// error — the caller falls through to the existing 400 path.
+func TestTryCoerce_IntegerTicketReference(t *testing.T) {
+	m := planfixture.Valid()
+	m["ticket_reference"] = 42
+	data := marshal(t, m)
+
+	coercedBytes, coercions, err := plan.TryCoerce(data, testNow)
+	if coercedBytes != nil {
+		t.Errorf("coercedBytes = non-nil, want nil for non-coercible type")
+	}
+	if len(coercions) != 0 {
+		t.Errorf("coercions = %d, want 0", len(coercions))
+	}
+	if err == nil {
+		t.Error("err = nil, want non-nil: integer is not coercible and original schema error should propagate")
+	}
+}
+
 // TestTryCoerce_AlreadyValid verifies that a plan that already satisfies the
 // schema produces (nil, nil, nil) — the caller must keep the original bytes
 // unchanged so the content hash is stable.

--- a/backend/internal/plan/schemas/plan-standard-v1.schema.json
+++ b/backend/internal/plan/schemas/plan-standard-v1.schema.json
@@ -80,6 +80,8 @@
       "type": "object",
       "additionalProperties": false,
       "required": ["type", "url", "id"],
+      "x-coerce-principal": "url",
+      "x-coerce-defaults": {"type": "github_issue", "id": "unknown"},
       "properties": {
         "type": {
           "type": "string",
@@ -103,6 +105,8 @@
       "type": "object",
       "additionalProperties": false,
       "required": ["agent", "model", "timestamp"],
+      "x-coerce-principal": "agent",
+      "x-coerce-defaults": {"model": "unknown", "timestamp": "<<runtime:now>>"},
       "properties": {
         "agent": {
           "type": "string",
@@ -149,6 +153,8 @@
       "type": "object",
       "additionalProperties": false,
       "required": ["path", "operation"],
+      "x-coerce-principal": "path",
+      "x-coerce-defaults": {"operation": "modify"},
       "properties": {
         "path": {
           "type": "string",
@@ -200,6 +206,8 @@
       "type": "object",
       "additionalProperties": false,
       "required": ["title", "scope_hint", "predicted_runtime_minutes", "predicted_runtime_confidence"],
+      "x-coerce-principal": "title",
+      "x-coerce-defaults": {"scope_hint": "", "predicted_runtime_minutes": 1, "predicted_runtime_confidence": "low"},
       "properties": {
         "title": {
           "type": "string",

--- a/docs/spec/plan-standard-v1.md
+++ b/docs/spec/plan-standard-v1.md
@@ -23,6 +23,25 @@ The canonical schema is [`plan-standard-v1.schema.json`](plan-standard-v1.schema
 
 This annotation does not affect validation (see §10.3). It is a contract signal for schema authors: the soak period during which the field is optional must be declared in the introducing PR body before the required promotion is merged.
 
+**`x-coerce-principal` / `x-coerce-defaults` annotations** — non-standard JSON Schema keywords on `$defs` entries that opt a definition into server-side coercion. When a bare string appears where the schema expects an object, `TryCoerce` uses these annotations to reconstruct the object automatically:
+
+- `x-coerce-principal` (string): the property name that receives the bare string value.
+- `x-coerce-defaults` (object): default values for all other required properties. The sentinel `"<<runtime:now>>"` on any string value is replaced with the upload timestamp at runtime.
+
+Example — adding coercion to a new `$defs` entry:
+
+```json
+"my-object": {
+  "type": "object",
+  "required": ["name", "kind"],
+  "x-coerce-principal": "name",
+  "x-coerce-defaults": {"kind": "default"},
+  "properties": { ... }
+}
+```
+
+Any property whose `$ref` (or array `items.$ref`) points to an annotated `$defs` entry is automatically registered at package init — no code change to `TryCoerce` is required. Both `x-coerce-principal` and `x-coerce-defaults` are collected as annotations per JSON Schema Draft 2020-12 §10.3 and do not affect validation.
+
 **Removals** follow a longer deprecation window — duration TBD. No fields have been removed from `standard_v1`.
 
 ## Top-level shape
@@ -228,6 +247,7 @@ The backend applies a narrow set of coercions when an agent emits a bare string 
 
 | Path | Coerced to |
 |---|---|
+| `/ticket_reference` (bare string `s`) | `{"type": "github_issue", "url": s, "id": "unknown"}` |
 | `/generated_by` (bare string `s`) | `{"agent": s, "model": "unknown", "timestamp": "<upload-time>"}` |
 | `/scope/files[i]` (bare string `s`) | `{"path": s, "operation": "modify"}` |
 | `/decomposition/sub_plans[i]` (bare string `s`) | `{"title": s, "scope_hint": "", "predicted_runtime_minutes": 1, "predicted_runtime_confidence": "low"}` |

--- a/docs/spec/plan-standard-v1.schema.json
+++ b/docs/spec/plan-standard-v1.schema.json
@@ -80,6 +80,8 @@
       "type": "object",
       "additionalProperties": false,
       "required": ["type", "url", "id"],
+      "x-coerce-principal": "url",
+      "x-coerce-defaults": {"type": "github_issue", "id": "unknown"},
       "properties": {
         "type": {
           "type": "string",
@@ -103,6 +105,8 @@
       "type": "object",
       "additionalProperties": false,
       "required": ["agent", "model", "timestamp"],
+      "x-coerce-principal": "agent",
+      "x-coerce-defaults": {"model": "unknown", "timestamp": "<<runtime:now>>"},
       "properties": {
         "agent": {
           "type": "string",
@@ -149,6 +153,8 @@
       "type": "object",
       "additionalProperties": false,
       "required": ["path", "operation"],
+      "x-coerce-principal": "path",
+      "x-coerce-defaults": {"operation": "modify"},
       "properties": {
         "path": {
           "type": "string",
@@ -200,6 +206,8 @@
       "type": "object",
       "additionalProperties": false,
       "required": ["title", "scope_hint", "predicted_runtime_minutes", "predicted_runtime_confidence"],
+      "x-coerce-principal": "title",
+      "x-coerce-defaults": {"scope_hint": "", "predicted_runtime_minutes": 1, "predicted_runtime_confidence": "low"},
       "properties": {
         "title": {
           "type": "string",

--- a/runner/internal/plan/coerce.go
+++ b/runner/internal/plan/coerce.go
@@ -3,6 +3,7 @@ package plan
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -20,10 +21,168 @@ type Coercion struct {
 	CoercedTo     any    `json:"coerced_to"`
 }
 
+// coercionEntry describes how to coerce a bare string at a given schema path.
+type coercionEntry struct {
+	isArrayItem bool
+	principal   string         // field that receives the bare string value
+	defaults    map[string]any // non-principal defaults; "<<runtime:now>>" is substituted at coercion time
+}
+
+// coercionAnnotation holds the x-coerce-* data extracted from a $defs entry.
+type coercionAnnotation struct {
+	principal string
+	defaults  map[string]any
+}
+
+// coercionRegistry is the schema-derived set of paths that TryCoerce handles,
+// built once at package init by parsing the embedded schema.
+//
+// Mirror of backend/internal/plan.coercionRegistry. Both packages must derive
+// the same registry from the same embedded schema so runner-coerced bytes pass
+// the backend's Validate cleanly (idempotent — backend re-coercion finds
+// nothing to fix).
+var coercionRegistry map[string]coercionEntry
+
+func init() {
+	coercionRegistry = buildCoercionRegistry()
+}
+
+func buildCoercionRegistry() map[string]coercionEntry {
+	const schemaPath = "schemas/plan-standard-v1.schema.json"
+	data, err := schemaFS.ReadFile(schemaPath)
+	if err != nil {
+		panic(fmt.Sprintf("plan: coerce: read schema %s: %v", schemaPath, err))
+	}
+	var schema map[string]any
+	if err := json.Unmarshal(data, &schema); err != nil {
+		panic(fmt.Sprintf("plan: coerce: parse schema %s: %v", schemaPath, err))
+	}
+
+	defs, _ := schema["$defs"].(map[string]any)
+
+	// Collect x-coerce-* annotations from $defs entries.
+	annotByDef := make(map[string]coercionAnnotation)
+	for name, raw := range defs {
+		def, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		principal, ok := def["x-coerce-principal"].(string)
+		if !ok {
+			continue
+		}
+		defaultsRaw, _ := def["x-coerce-defaults"].(map[string]any)
+		defaults := make(map[string]any, len(defaultsRaw))
+		for k, v := range defaultsRaw {
+			defaults[k] = v
+		}
+		annotByDef[name] = coercionAnnotation{principal, defaults}
+	}
+
+	reg := make(map[string]coercionEntry)
+	if props, ok := schema["properties"].(map[string]any); ok {
+		walkSchemaProps(props, "", defs, annotByDef, reg)
+	}
+	return reg
+}
+
+// walkSchemaProps recursively walks a JSON Schema properties map and populates
+// reg with coercionEntry values for every annotated path discovered.
+func walkSchemaProps(props map[string]any, prefix string, defs map[string]any, annotByDef map[string]coercionAnnotation, reg map[string]coercionEntry) {
+	for key, propRaw := range props {
+		prop, ok := propRaw.(map[string]any)
+		if !ok {
+			continue
+		}
+		path := prefix + "/" + key
+
+		if ref, ok := prop["$ref"].(string); ok {
+			defName := defNameFromRef(ref)
+			if ann, ok := annotByDef[defName]; ok {
+				reg[path] = coercionEntry{isArrayItem: false, principal: ann.principal, defaults: ann.defaults}
+			} else if defName != "" {
+				// Recurse into the referenced def's own properties.
+				if def, ok := defs[defName].(map[string]any); ok {
+					if nested, ok := def["properties"].(map[string]any); ok {
+						walkSchemaProps(nested, path, defs, annotByDef, reg)
+					}
+				}
+			}
+			continue
+		}
+
+		propType, _ := prop["type"].(string)
+		if propType == "array" {
+			if items, ok := prop["items"].(map[string]any); ok {
+				if ref, ok := items["$ref"].(string); ok {
+					defName := defNameFromRef(ref)
+					if ann, ok := annotByDef[defName]; ok {
+						reg[path] = coercionEntry{isArrayItem: true, principal: ann.principal, defaults: ann.defaults}
+					}
+				}
+			}
+			continue
+		}
+
+		if nested, ok := prop["properties"].(map[string]any); ok {
+			walkSchemaProps(nested, path, defs, annotByDef, reg)
+		}
+	}
+}
+
+// defNameFromRef extracts the $defs name from a JSON Pointer $ref.
+// "#/$defs/ticket-reference" → "ticket-reference".
+func defNameFromRef(ref string) string {
+	const prefix = "#/$defs/"
+	if strings.HasPrefix(ref, prefix) {
+		return ref[len(prefix):]
+	}
+	return ""
+}
+
+// buildCoerced constructs the replacement object for a bare string, applying
+// defaults and substituting the <<runtime:now>> sentinel with now.
+func buildCoerced(entry coercionEntry, value string, now time.Time) map[string]any {
+	coerced := make(map[string]any, len(entry.defaults)+1)
+	for k, v := range entry.defaults {
+		if s, ok := v.(string); ok && s == "<<runtime:now>>" {
+			coerced[k] = now.UTC().Format(time.RFC3339)
+		} else {
+			coerced[k] = v
+		}
+	}
+	coerced[entry.principal] = value
+	return coerced
+}
+
+// navigateTo walks a path segment slice through a map[string]any tree and
+// returns the value at the final segment's parent map plus the final key.
+// Returns (nil, "", false) when any intermediate level is missing or not a map.
+func navigateTo(m map[string]any, parts []string) (map[string]any, string, bool) {
+	if len(parts) == 0 {
+		return nil, "", false
+	}
+	parent := m
+	for _, seg := range parts[:len(parts)-1] {
+		child, ok := parent[seg]
+		if !ok {
+			return nil, "", false
+		}
+		childMap, ok := child.(map[string]any)
+		if !ok {
+			return nil, "", false
+		}
+		parent = childMap
+	}
+	return parent, parts[len(parts)-1], true
+}
+
 // TryCoerce attempts to fix the known string-elision class of plan schema
 // violations: cases where an agent emits a bare string where the schema
-// expects an object at /generated_by, /scope/files[], or
-// /decomposition/sub_plans[].
+// expects an object. The set of coercible paths is derived at init time from
+// the x-coerce-principal / x-coerce-defaults annotations in the embedded
+// schema — no per-field code changes are required when the schema gains a new
+// annotated $defs entry.
 //
 // Returns (coercedBytes, coercions, nil) when coercion produces a valid plan.
 // Returns (nil, nil, nil) when no string-valued nested-object fields are
@@ -44,69 +203,53 @@ func TryCoerce(data []byte, now time.Time) ([]byte, []Coercion, error) {
 
 	var coercions []Coercion
 
-	// /generated_by: coerce bare string to canonical object shape.
-	if v, ok := m["generated_by"]; ok {
-		if s, ok := v.(string); ok {
-			coerced := map[string]any{
-				"agent":     s,
-				"model":     "unknown",
-				"timestamp": now.UTC().Format(time.RFC3339),
+	for path, entry := range coercionRegistry {
+		parts := strings.Split(strings.TrimPrefix(path, "/"), "/")
+
+		if entry.isArrayItem {
+			parent, arrayKey, ok := navigateTo(m, parts)
+			if !ok {
+				continue
 			}
+			slice, ok := parent[arrayKey].([]any)
+			if !ok {
+				continue
+			}
+			for i, elem := range slice {
+				s, ok := elem.(string)
+				if !ok {
+					continue
+				}
+				coerced := buildCoerced(entry, s, now)
+				coercions = append(coercions, Coercion{
+					FieldPath:     fmt.Sprintf("%s/%d", path, i),
+					OriginalType:  "string",
+					OriginalValue: s,
+					CoercedTo:     coerced,
+				})
+				slice[i] = coerced
+			}
+			parent[arrayKey] = slice
+		} else {
+			if len(parts) != 1 {
+				continue
+			}
+			v, ok := m[parts[0]]
+			if !ok {
+				continue
+			}
+			s, ok := v.(string)
+			if !ok {
+				continue
+			}
+			coerced := buildCoerced(entry, s, now)
 			coercions = append(coercions, Coercion{
-				FieldPath:     "/generated_by",
+				FieldPath:     path,
 				OriginalType:  "string",
 				OriginalValue: s,
 				CoercedTo:     coerced,
 			})
-			m["generated_by"] = coerced
-		}
-	}
-
-	// /scope/files[]: coerce each bare string element to {path, operation}.
-	if scope, ok := m["scope"].(map[string]any); ok {
-		if files, ok := scope["files"].([]any); ok {
-			for i, f := range files {
-				if s, ok := f.(string); ok {
-					coerced := map[string]any{
-						"path":      s,
-						"operation": "modify",
-					}
-					coercions = append(coercions, Coercion{
-						FieldPath:     fmt.Sprintf("/scope/files/%d", i),
-						OriginalType:  "string",
-						OriginalValue: s,
-						CoercedTo:     coerced,
-					})
-					files[i] = coerced
-				}
-			}
-			scope["files"] = files
-		}
-	}
-
-	// /decomposition/sub_plans[]: coerce each bare string element to the
-	// sentinel default shape. scope_hint intentionally empty — the coercion
-	// is a robustness aid, not a way to hide missing agent output.
-	if decomp, ok := m["decomposition"].(map[string]any); ok {
-		if subPlans, ok := decomp["sub_plans"].([]any); ok {
-			for i, sp := range subPlans {
-				if s, ok := sp.(string); ok {
-					coerced := map[string]any{
-						"title":                        s,
-						"scope_hint":                   "",
-						"predicted_runtime_minutes":    1,
-						"predicted_runtime_confidence": "low",
-					}
-					coercions = append(coercions, Coercion{
-						FieldPath:     fmt.Sprintf("/decomposition/sub_plans/%d", i),
-						OriginalType:  "string",
-						OriginalValue: s,
-						CoercedTo:     coerced,
-					})
-					subPlans[i] = coerced
-				}
-			}
-			decomp["sub_plans"] = subPlans
+			m[parts[0]] = coerced
 		}
 	}
 

--- a/runner/internal/plan/coerce_test.go
+++ b/runner/internal/plan/coerce_test.go
@@ -146,6 +146,71 @@ func TestTryCoerce_IntegerScopeFile(t *testing.T) {
 	}
 }
 
+// TestTryCoerce_TicketReferenceString verifies that a bare URL string at
+// /ticket_reference is wrapped into the canonical ticket_reference object shape.
+func TestTryCoerce_TicketReferenceString(t *testing.T) {
+	m := planfixture.Valid()
+	m["ticket_reference"] = "https://github.com/x/y/issues/547"
+	data := marshal(t, m)
+
+	coercedBytes, coercions, err := plan.TryCoerce(data, testNow)
+	if err != nil {
+		t.Fatalf("TryCoerce: unexpected error: %v", err)
+	}
+	if len(coercions) != 1 {
+		t.Fatalf("coercions = %d, want 1", len(coercions))
+	}
+	if got := coercions[0].FieldPath; got != "/ticket_reference" {
+		t.Errorf("FieldPath = %q, want /ticket_reference", got)
+	}
+	if got := coercions[0].OriginalType; got != "string" {
+		t.Errorf("OriginalType = %q, want string", got)
+	}
+	if got, ok := coercions[0].OriginalValue.(string); !ok || got != "https://github.com/x/y/issues/547" {
+		t.Errorf("OriginalValue = %v, want string \"https://github.com/x/y/issues/547\"", coercions[0].OriginalValue)
+	}
+	if coercedBytes == nil {
+		t.Fatal("coercedBytes is nil")
+	}
+	if err := plan.Validate(coercedBytes); err != nil {
+		t.Errorf("coerced plan does not validate: %v", err)
+	}
+	var result map[string]any
+	if err := json.Unmarshal(coercedBytes, &result); err != nil {
+		t.Fatalf("unmarshal coerced: %v", err)
+	}
+	tr, _ := result["ticket_reference"].(map[string]any)
+	if tr["url"] != "https://github.com/x/y/issues/547" {
+		t.Errorf("ticket_reference.url = %v, want https://github.com/x/y/issues/547", tr["url"])
+	}
+	if tr["type"] != "github_issue" {
+		t.Errorf("ticket_reference.type = %v, want github_issue", tr["type"])
+	}
+	if tr["id"] != "unknown" {
+		t.Errorf("ticket_reference.id = %v, want unknown", tr["id"])
+	}
+}
+
+// TestTryCoerce_IntegerTicketReference verifies that a non-string type at
+// /ticket_reference (an integer) is not coercible and propagates a non-nil
+// error — the caller falls through to the existing rejection path.
+func TestTryCoerce_IntegerTicketReference(t *testing.T) {
+	m := planfixture.Valid()
+	m["ticket_reference"] = 42
+	data := marshal(t, m)
+
+	coercedBytes, coercions, err := plan.TryCoerce(data, testNow)
+	if coercedBytes != nil {
+		t.Errorf("coercedBytes = non-nil, want nil for non-coercible type")
+	}
+	if len(coercions) != 0 {
+		t.Errorf("coercions = %d, want 0", len(coercions))
+	}
+	if err == nil {
+		t.Error("err = nil, want non-nil: integer is not coercible and original schema error should propagate")
+	}
+}
+
 // TestTryCoerce_AlreadyValid verifies a plan that already satisfies the
 // schema produces (nil, nil, nil) — caller MUST keep the original bytes
 // unchanged so the content hash signed by the runner remains stable.

--- a/runner/internal/plan/schemas/plan-standard-v1.schema.json
+++ b/runner/internal/plan/schemas/plan-standard-v1.schema.json
@@ -80,6 +80,8 @@
       "type": "object",
       "additionalProperties": false,
       "required": ["type", "url", "id"],
+      "x-coerce-principal": "url",
+      "x-coerce-defaults": {"type": "github_issue", "id": "unknown"},
       "properties": {
         "type": {
           "type": "string",
@@ -103,6 +105,8 @@
       "type": "object",
       "additionalProperties": false,
       "required": ["agent", "model", "timestamp"],
+      "x-coerce-principal": "agent",
+      "x-coerce-defaults": {"model": "unknown", "timestamp": "<<runtime:now>>"},
       "properties": {
         "agent": {
           "type": "string",
@@ -149,6 +153,8 @@
       "type": "object",
       "additionalProperties": false,
       "required": ["path", "operation"],
+      "x-coerce-principal": "path",
+      "x-coerce-defaults": {"operation": "modify"},
       "properties": {
         "path": {
           "type": "string",
@@ -200,6 +206,8 @@
       "type": "object",
       "additionalProperties": false,
       "required": ["title", "scope_hint", "predicted_runtime_minutes", "predicted_runtime_confidence"],
+      "x-coerce-principal": "title",
+      "x-coerce-defaults": {"scope_hint": "", "predicted_runtime_minutes": 1, "predicted_runtime_confidence": "low"},
       "properties": {
         "title": {
           "type": "string",


### PR DESCRIPTION
## Summary

Replaces #538's per-field coercion whitelist with a schema-driven registry. Future required-object fields that the agent occasionally flattens to a string are now handled by adding two annotations to the schema — no code change required.

- **Schema annotations** (`docs/spec/plan-standard-v1.schema.json`) — four `$defs` entries (`ticket-reference`, `generated-by`, `scope-file`, `sub-plan-summary`) get `x-coerce-principal` (the string field that receives the agent's emitted string) and `x-coerce-defaults` (the other required fields' defaults). `<<runtime:now>>` sentinel substitutes the upload timestamp.
- **Backend + runner** mirrors get the same `TryCoerce` rewrite — `init()` parses the embedded schema once, builds the registry, panics on misconfig.
- **All existing tests pass unchanged** — annotation defaults exactly mirror #538's hardcoded values, so the round-trip is identical.
- **New tests**: `TicketReferenceString` (bare URL → `{type, url, id}`), `IntegerTicketReference` (non-string still 400s).
- **Docs**: `plan-standard-v1.md` gets a "Schema annotation protocol" subsection documenting the convention. Follows ADR-026's `x-intended-required` precedent.

## Notes

Driven through the local MCP loop. **Textbook-clean** — first plan succeeded (15.8k tokens), implement clean (29.5k tokens), `fishhawk_verify_run: verified=true, chain_length=13`.

This PR was started immediately after #546's `propagate rejection feedback` landed. The propagation mechanism didn't fire on this run (no prior rejection), but the first non-trivial rejection from here forward will exercise it.

## Sample annotation

```json
"$defs": {
  "ticket-reference": {
    "type": "object",
    "x-coerce-principal": "url",
    "x-coerce-defaults": {"type": "github_issue", "id": "unknown"},
    "properties": {
      "type": { "type": "string", "enum": [...] },
      "url":  { "type": "string", "minLength": 1 },
      "id":   { "type": "string", "minLength": 1 }
    }
  }
}
```

## Adding a new coercible field

For future schema authors, the protocol is:

1. Add `x-coerce-principal: "<field-name>"` to the `$defs` entry.
2. Add `x-coerce-defaults: { ...other-required-fields-with-defaults }`.
3. Run `scripts/sync-schemas` to mirror.
4. No code change in `coerce.go` — registry picks it up at next init.

## Test plan

- [x] `bash scripts/sync-schemas` — clean, 3 mirrors byte-identical.
- [x] `go test -race ./backend/internal/plan/... ./runner/internal/plan/...` — pass (existing + new cases).
- [x] `golangci-lint run ./backend/internal/plan/... ./runner/internal/plan/...` — 0 issues.
- [x] `scripts/test coverage` — aggregate **81.3%** (threshold 80%).
- [x] `fishhawk_verify_run` — `verified=true`, chain_length=13.
- [ ] Meta: next plan-stage that hits a previously-uncovered string-elision field will validate that coercion fires without a code-side update.

## Out of scope (per issue body)

- Coercion for non-object expected types (e.g., string-where-array). Same principle, different defaults; defer until observed.
- Prompt-side tightening for ALL fields. Already rejected — #532 proved per-field prompt fixes don't scale.

Closes #547