### PR TITLE
scripts/dev: auto-apply pending migrations on up (#544)

### DIFF
--- a/scripts/dev
+++ b/scripts/dev
@@ -81,6 +81,10 @@ cmd_up() {
   mkdir -p "${REPO_ROOT}/bin"
   (cd "${REPO_ROOT}" && go build -o bin/fishhawkd ./backend/cmd/fishhawkd/)
 
+  # Migrate
+  print "applying migrations..."
+  "$BIN" migrate up
+
   # Spawn
   mkdir -p "${REPO_ROOT}/.fishhawk"
   "${BIN}" serve >> "$LOG_FILE" 2>&1 &


### PR DESCRIPTION
## Summary

Tiny operability fix. `scripts/dev up` now runs `fishhawkd migrate up` between the build step and the spawn, eliminating the post-merge-friction failure mode where a fresh dev-up brings backend healthy but the next write returns cryptic 500 because pending migrations weren't applied.

**The diff:**

```diff
+ # Migrate
+ print "applying migrations..."
+ "$BIN" migrate up
```

`.env` is sourced just above this block in `cmd_up`, so `FISHHAWKD_DATABASE_URL` is available without an explicit `--db` flag. `set -euo pipefail` propagates migrate failures — operator sees them directly instead of debugging a write-time 500.

## Notes

Driven through the local MCP loop. **Textbook-clean** — 3 min predicted, plan 4.8k tokens, implement **2k tokens** (smallest of the week).

Smoke-tested with the new script in the main repo against the local dev DB:

```
postgres: ready
minio: ready
building fishhawkd...
applying migrations...
INFO migrate up complete
fishhawkd started (pid …) — logs: …/fishhawkd.log
```

Two observations worth noting (neither blocks):

1. The smoke test failed when run *from a worktree* because `scripts/dev` anchors `REPO_ROOT` via `${0:A:h:h}` (the script's own path), so `.env` lookup misses the parent repo's `.env`. Pre-existing behavior; not introduced by this PR. Worth a separate ticket if worktree-rooted invocation matters operationally.
2. `migrate up complete` log line comes from `fishhawkd` itself, not from `scripts/dev`. The plan's approval-note ask about printing "migrate up: complete" turned out to be redundant — the binary already emits a structured INFO line.

## Test plan

- [x] Plan/implement clean. `verify_run=true`, chain_length=13.
- [x] Smoke test from main repo: `scripts/dev down && scripts/dev up` runs migrate (no-op on current schema) and starts fishhawkd cleanly.
- [ ] Future merge with a new migration will exercise the non-no-op path — the next migration-bearing PR is the meta-test.

## Out of scope (per issue body)

- Auto-migration in production. v0 keeps explicit migrate-up in CD pipelines.
- Migration rollback automation.
- A pre-commit hook running migrations against an ephemeral DB.

Closes #544