### PR TITLE
prompt: render sub-plan scope_hint as binding SCOPE CONSTRAINT for decomposed children (#541)

### DIFF
--- a/backend/internal/prompt/prompt.go
+++ b/backend/internal/prompt/prompt.go
@@ -78,6 +78,20 @@ type PredictionContext struct {
 	StageBudgetMinutes  int
 }
 
+// ScopeConstraint narrows a decomposed child run's implement stage to
+// a specific sub-plan scope. When non-nil, buildImplement prepends a
+// binding SCOPE CONSTRAINT block so the agent doesn't drift into
+// sibling sub-plans. Nil for standalone (non-decomposed) runs.
+type ScopeConstraint struct {
+	// ScopeHint is this child's scope_hint verbatim from the parent plan.
+	ScopeHint string
+	// ParentRunID is the UUID string of the parent decomposed run.
+	ParentRunID string
+	// SiblingHints are the scope_hints of all other sub-plans in the
+	// parent decomposition (all sub-plans except this child's).
+	SiblingHints []string
+}
+
 // Trigger captures the bits of the originating event needed to
 // construct an issue-driven prompt. Empty IssueTitle / IssueBody
 // for non-issue triggers; for v0, those triggers all come from
@@ -146,6 +160,11 @@ type Trigger struct {
 	// section surfacing predicted_runtime_minutes, predicted_runtime_confidence,
 	// and the spec-resolved stage budget. Nil → section omitted (#503).
 	PredictionContext *PredictionContext
+	// ScopeConstraint narrows the implement stage to a specific sub-plan
+	// when this run is a decomposed child. When non-nil, buildImplement
+	// prepends a binding SCOPE CONSTRAINT block before the plan and
+	// issue sections. Nil for standalone runs (#541).
+	ScopeConstraint *ScopeConstraint
 }
 
 // Build returns the constructed prompt for the given stage type
@@ -173,6 +192,33 @@ func buildImplement(t Trigger) string {
 	b.WriteString("You are implementing a change in the repository ")
 	b.WriteString(quoteRepo(t.Repo))
 	b.WriteString(".\n\n")
+
+	// Scope constraint (#541): for decomposed child runs, inject a
+	// binding SCOPE CONSTRAINT block before the plan and issue sections.
+	// The constraint names this child's scope_hint and lists sibling
+	// hints so the agent knows where NOT to touch code.
+	if t.ScopeConstraint != nil {
+		sc := t.ScopeConstraint
+		b.WriteString("SCOPE CONSTRAINT (binding — read before writing any code)\n")
+		b.WriteString("=========================================================\n\n")
+		fmt.Fprintf(&b, "This run is a decomposed child of parent run %s.\n\n", sc.ParentRunID)
+		b.WriteString("Your scope for this child run:\n\n")
+		b.WriteString(sc.ScopeHint)
+		b.WriteString("\n\n")
+		if len(sc.SiblingHints) > 0 {
+			b.WriteString("do NOT modify code in sibling scope. Sibling scopes are owned by other child runs:\n\n")
+			for _, hint := range sc.SiblingHints {
+				b.WriteString("- ")
+				b.WriteString(hint)
+				b.WriteString("\n")
+			}
+			b.WriteString("\n")
+		}
+		b.WriteString("Step zero — before writing any code: list the files you intend to modify. " +
+			"If any file falls outside your scope above, STOP and surface that the boundary is wrong " +
+			"rather than expanding scope. If you find yourself wanting to work in a sibling's area, " +
+			"STOP and signal completion instead.\n\n")
+	}
 
 	// Plan-as-contract (#223): when the plan stage produced a
 	// standard_v1 artifact and a human approved it, that plan is

--- a/backend/internal/prompt/prompt_test.go
+++ b/backend/internal/prompt/prompt_test.go
@@ -666,6 +666,96 @@ func TestBuild_Plan_PriorRejectionFeedback_Truncated(t *testing.T) {
 	}
 }
 
+func TestBuild_Implement_ScopeConstraint_Rendered(t *testing.T) {
+	got, err := Build("implement", Trigger{
+		Repo:         "o/r",
+		ApprovedPlan: fixturePlan(),
+		ScopeConstraint: &ScopeConstraint{
+			ScopeHint:   "Implement the foo helper in pkg/bar.",
+			ParentRunID: "00000000-0000-0000-0000-000000000001",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	wants := []string{
+		"SCOPE CONSTRAINT",
+		"00000000-0000-0000-0000-000000000001",
+		"Implement the foo helper in pkg/bar.",
+		"Step zero",
+		"list the files you intend to modify",
+		"STOP and surface that the boundary is wrong",
+	}
+	for _, w := range wants {
+		if !strings.Contains(got, w) {
+			t.Errorf("prompt missing %q\n---\n%s", w, got)
+		}
+	}
+}
+
+func TestBuild_Implement_ScopeConstraint_SiblingHints(t *testing.T) {
+	got, err := Build("implement", Trigger{
+		Repo:         "o/r",
+		ApprovedPlan: fixturePlan(),
+		ScopeConstraint: &ScopeConstraint{
+			ScopeHint:    "Implement Part A in pkg/a.",
+			ParentRunID:  "00000000-0000-0000-0000-000000000002",
+			SiblingHints: []string{"Implement Part B in pkg/b.", "Implement Part C in pkg/c."},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	for _, hint := range []string{"Implement Part B in pkg/b.", "Implement Part C in pkg/c."} {
+		if !strings.Contains(got, hint) {
+			t.Errorf("prompt missing sibling hint %q\n---\n%s", hint, got)
+		}
+	}
+	if !strings.Contains(got, "do NOT modify code in sibling scope") {
+		t.Errorf("prompt missing sibling prohibition notice\n---\n%s", got)
+	}
+}
+
+func TestBuild_Implement_ScopeConstraint_Nil_SectionAbsent(t *testing.T) {
+	got, err := Build("implement", Trigger{
+		Repo:         "o/r",
+		ApprovedPlan: fixturePlan(),
+		// ScopeConstraint deliberately nil.
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if strings.Contains(got, "SCOPE CONSTRAINT") {
+		t.Errorf("SCOPE CONSTRAINT section should not appear when ScopeConstraint is nil:\n%s", got)
+	}
+}
+
+func TestBuild_Implement_ScopeConstraint_AppearsBeforePlan(t *testing.T) {
+	got, err := Build("implement", Trigger{
+		Repo:         "o/r",
+		ApprovedPlan: fixturePlan(),
+		ScopeConstraint: &ScopeConstraint{
+			ScopeHint:   "Implement the foo helper in pkg/bar.",
+			ParentRunID: "00000000-0000-0000-0000-000000000003",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	constraintIdx := strings.Index(got, "SCOPE CONSTRAINT")
+	planIdx := strings.Index(got, "Approved plan (binding instruction)")
+	if constraintIdx < 0 {
+		t.Fatalf("SCOPE CONSTRAINT not found in prompt:\n%s", got)
+	}
+	if planIdx < 0 {
+		t.Fatalf("Approved plan section not found in prompt:\n%s", got)
+	}
+	if constraintIdx > planIdx {
+		t.Errorf("SCOPE CONSTRAINT should appear before the approved plan (constraintIdx=%d planIdx=%d):\n%s",
+			constraintIdx, planIdx, got)
+	}
+}
+
 func TestBuild_Implement_WithSparsePlan_OmitsEmptySections(t *testing.T) {
 	// A plan that fails optional sections (no scope.files, no
 	// risks) should still render cleanly — empty sections drop

--- a/backend/internal/server/prompt.go
+++ b/backend/internal/server/prompt.go
@@ -168,6 +168,7 @@ func (s *Server) handleGetStagePrompt(w http.ResponseWriter, r *http.Request) {
 				StageBudgetMinutes:  budgetSecs / 60,
 			}
 		}
+		trigger.ScopeConstraint = s.resolveDecomposedScopeConstraint(r.Context(), runRow)
 	}
 
 	// Decompose-required hint: when the run's last plan approval was
@@ -314,6 +315,7 @@ func (s *Server) handleGetStagePromptRender(w http.ResponseWriter, r *http.Reque
 				StageBudgetMinutes:  budgetSecs / 60,
 			}
 		}
+		trigger.ScopeConstraint = s.resolveDecomposedScopeConstraint(r.Context(), runRow)
 	}
 
 	// Decompose-required hint: when the run's last plan approval was
@@ -900,6 +902,67 @@ func (s *Server) loadPriorRejectionFeedback(ctx context.Context, repo, triggerRe
 		}
 	}
 	return nil
+}
+
+// resolveDecomposedScopeConstraint builds a *prompt.ScopeConstraint for
+// child runs of a decomposed plan. Returns nil when:
+//   - the run is not decomposed (DecomposedFrom == nil)
+//   - the run has no cached IssueContext (can't match a sub-plan without it)
+//   - ArtifactRepo is unconfigured (nil-guard: avoids a panic in tryLoadPlanForRun)
+//   - the parent plan can't be loaded (degrade gracefully — agent gets an unconstrained prompt)
+//   - no sub-plan title matches the child's IssueContext.Body prefix (defensive — wrong constraint is worse than none)
+//
+// Matching uses strings.HasPrefix(body, "## "+title+"\n\n"), which is the
+// invariant enforced by childIssueContextFromSubPlan in orchestrator.go.
+func (s *Server) resolveDecomposedScopeConstraint(ctx context.Context, runRow *run.Run) *prompt.ScopeConstraint {
+	if runRow.DecomposedFrom == nil || runRow.IssueContext == nil {
+		return nil
+	}
+	if s.cfg.ArtifactRepo == nil {
+		return nil
+	}
+	parentPlan, found, err := s.tryLoadPlanForRun(ctx, *runRow.DecomposedFrom)
+	if err != nil {
+		s.cfg.Logger.LogAttrs(ctx, slog.LevelWarn, "prompt: resolve scope constraint: load parent plan failed",
+			slog.String("parent_run_id", runRow.DecomposedFrom.String()),
+			slog.String("error", err.Error()),
+		)
+		return nil
+	}
+	if !found || parentPlan == nil || parentPlan.Decomposition == nil {
+		return nil
+	}
+
+	body := runRow.IssueContext.Body
+	matchIdx := -1
+	for i, sub := range parentPlan.Decomposition.SubPlans {
+		if strings.HasPrefix(body, "## "+sub.Title+"\n\n") {
+			matchIdx = i
+			break
+		}
+	}
+	if matchIdx < 0 {
+		return nil
+	}
+
+	matched := parentPlan.Decomposition.SubPlans[matchIdx]
+	var siblingHints []string
+	for i, sub := range parentPlan.Decomposition.SubPlans {
+		if i != matchIdx {
+			siblingHints = append(siblingHints, sub.ScopeHint)
+		}
+	}
+	s.cfg.Logger.LogAttrs(ctx, slog.LevelInfo,
+		"prompt: injected scope constraint for decomposed child",
+		slog.String("child_run_id", runRow.ID.String()),
+		slog.String("parent_run_id", runRow.DecomposedFrom.String()),
+		slog.Int("sibling_count", len(siblingHints)),
+	)
+	return &prompt.ScopeConstraint{
+		ScopeHint:    matched.ScopeHint,
+		ParentRunID:  runRow.DecomposedFrom.String(),
+		SiblingHints: siblingHints,
+	}
 }
 
 // loadLastDecomposeRejectionReason scans the run's approval_submitted

--- a/backend/internal/server/prompt_test.go
+++ b/backend/internal/server/prompt_test.go
@@ -14,8 +14,10 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/kuhlman-labs/fishhawk/backend/internal/artifact"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/audit"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/githubclient"
+	"github.com/kuhlman-labs/fishhawk/backend/internal/plan"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/run"
 )
 
@@ -30,6 +32,10 @@ type promptRunRepo struct {
 	getRuns              map[uuid.UUID]*run.Run
 	setPRURLCalls        []promptSetPRURLCall
 	transitionStageCalls []promptTransitionStageCall
+	// stagesByRunID backs ListStagesForRun. When non-nil, the map is
+	// consulted; when nil the method returns an error so accidental
+	// calls in tests that don't seed it stay loud.
+	stagesByRunID map[uuid.UUID][]*run.Stage
 }
 
 type promptTransitionStageCall struct {
@@ -107,8 +113,11 @@ func (r *promptRunRepo) SetRunPullRequestURL(_ context.Context, id uuid.UUID, ur
 func (r *promptRunRepo) CreateStage(context.Context, run.CreateStageParams) (*run.Stage, error) {
 	return nil, errors.New("not used")
 }
-func (r *promptRunRepo) ListStagesForRun(context.Context, uuid.UUID) ([]*run.Stage, error) {
-	return nil, errors.New("not used")
+func (r *promptRunRepo) ListStagesForRun(_ context.Context, runID uuid.UUID) ([]*run.Stage, error) {
+	if r.stagesByRunID == nil {
+		return nil, errors.New("not used")
+	}
+	return r.stagesByRunID[runID], nil
 }
 func (r *promptRunRepo) ListStagesAwaitingApproval(context.Context) ([]*run.Stage, error) {
 	return nil, errors.New("not used")
@@ -1294,5 +1303,110 @@ func TestLoadPriorRejectionFeedback_CurrentRunIDExcluded(t *testing.T) {
 	got := s.loadPriorRejectionFeedback(context.Background(), "x/y", "issue:42", currentID)
 	if got != nil {
 		t.Errorf("got %q, want nil (current run should be excluded)", *got)
+	}
+}
+
+// TestGetStagePrompt_DecomposedChild_ScopeConstraintInjected verifies that
+// when a child run has DecomposedFrom set and a matching IssueContext, the
+// implement-stage prompt contains a SCOPE CONSTRAINT block with this child's
+// scope_hint and the sibling's scope_hint (#541).
+func TestGetStagePrompt_DecomposedChild_ScopeConstraintInjected(t *testing.T) {
+	rr := newPromptRunRepo()
+	sf := newSigningFake()
+	art := newFakeArtifactRepo()
+
+	parentRunID := uuid.New()
+	childRunID := uuid.New()
+	parentPlanStageID := uuid.New()
+	childStageID := uuid.New()
+
+	// Build a standard_v1 plan artifact with a two-sub-plan decomposition.
+	parentPlan := &plan.Plan{
+		PlanVersion: "standard_v1",
+		Summary:     "parent plan",
+		Verification: plan.Verification{
+			TestStrategy: "ts",
+			RollbackPlan: "rb",
+		},
+		Decomposition: &plan.Decomposition{
+			Rationale: "scope split",
+			SubPlans: []plan.SubPlanSummary{
+				{Title: "Part A title", ScopeHint: "Implement Part A in pkg/a."},
+				{Title: "Part B title", ScopeHint: "Implement Part B in pkg/b."},
+			},
+		},
+	}
+	planBytes, err := json.Marshal(parentPlan)
+	if err != nil {
+		t.Fatalf("marshal parent plan: %v", err)
+	}
+	sv := "standard_v1"
+	if _, err := art.Create(context.Background(), artifact.CreateParams{
+		StageID:       parentPlanStageID,
+		Kind:          artifact.KindPlan,
+		SchemaVersion: &sv,
+		Content:       planBytes,
+	}); err != nil {
+		t.Fatalf("seed plan artifact: %v", err)
+	}
+
+	// Seed parent run with a plan stage.
+	rr.stagesByRunID = map[uuid.UUID][]*run.Stage{
+		parentRunID: {
+			{ID: parentPlanStageID, RunID: parentRunID, Type: run.StageTypePlan},
+		},
+	}
+	rr.getRuns[parentRunID] = &run.Run{
+		ID:   parentRunID,
+		Repo: "o/r",
+	}
+
+	// Child run: DecomposedFrom=parentRunID, IssueContext.Body matches Part A.
+	childBody := "## Part A title\n\nImplement Part A in pkg/a.\n\n---\n*Decomposed sub-plan.*"
+	rr.getRuns[childRunID] = &run.Run{
+		ID:             childRunID,
+		Repo:           "o/r",
+		WorkflowID:     "feature_change",
+		TriggerSource:  run.TriggerCLI,
+		DecomposedFrom: &parentRunID,
+		IssueContext: &run.IssueContext{
+			Title: "Part A title",
+			Body:  childBody,
+		},
+	}
+	rr.getStages[childStageID] = &run.Stage{
+		ID:    childStageID,
+		RunID: childRunID,
+		Type:  run.StageTypeImplement,
+	}
+
+	priv, _ := sf.issue(t, childRunID)
+
+	s := New(Config{
+		Addr:         "127.0.0.1:0",
+		RunRepo:      rr,
+		SigningRepo:  sf,
+		ArtifactRepo: art,
+	})
+	s.promptIssueGetterOverride = &stubIssueGetter{}
+
+	w := promptRequest(t, s, childRunID, childStageID, priv, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200:\n%s", w.Code, w.Body.String())
+	}
+	var resp promptResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	for _, want := range []string{
+		"SCOPE CONSTRAINT",
+		"Implement Part A in pkg/a.",
+		"Implement Part B in pkg/b.",
+		"do NOT modify code in sibling scope",
+	} {
+		if !strings.Contains(resp.Prompt, want) {
+			t.Errorf("prompt missing %q\n---\n%s", want, resp.Prompt)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Implements Option A from the issue: promote D4 sub-plan `scope_hint` from background context to a binding `SCOPE CONSTRAINT` section at the top of the implement-stage prompt. The Part A child's "did the work for both sub-plans" failure mode from yesterday's first-PR D4 fanout (#534 → `2896d254`) should no longer be the default.

- **`ScopeConstraint` struct** in `prompt.Trigger`. Nil-able — preserves existing behavior for non-decomposed runs.
- **`buildImplement` renders the constraint at top-of-prompt**, before plan/issue sections. Includes this child's `scope_hint`, sibling scope_hints under "do NOT modify code in sibling scope", and a step-zero "declare your file set first" directive.
- **Server `resolveDecomposedScopeConstraint`** detects decomposed children via `runRow.DecomposedFrom != nil`, matches them to a sub-plan via the `## <title>\n\n` prefix from `orchestrator.go:322`'s `childIssueContextFromSubPlan` format, builds the constraint. Returns nil on no-match (wrong constraint is worse than no constraint). Logs `injected scope constraint for decomposed child` when it fires.
- **Wired into both `handleGetStagePrompt` and `handleGetStagePromptRender`** — render endpoint stays consistent with what the runner actually fetches.

## Notes

Driven through the local MCP loop. **Textbook-clean** — 20 min predicted (~8 min calibrated), implement 17.9k tokens, `verify_run=true`. One in-loop patch: agent skipped my approval ask for the `info` log line on successful injection (added it — 6 LoC).

## Known limitation

The title-prefix matching (`## <title>\n\n`) depends on `orchestrator.go:322`'s persistence format staying stable. If a future PR changes how decomposed children's `IssueContext.Body` is built, the matching silently disables constraints (constraint becomes nil → agent gets unconstrained prompt). The end-to-end test is a canary; a stronger contract via an explicit `sub_plan_index` field in `IssueContext` is a future tightening worth filing if drift is observed.

Constraint is **persuasive, not mechanical**. A determined agent can still edit sibling files. Mechanical enforcement (policy-layer diff-vs-`scope.files` check, plus structured `scope.files[]` on sub_plans) is the issue's deferred Option B — not in this PR.

## Test plan

- [x] `go test -race ./backend/internal/prompt/... ./backend/internal/server/...` — pass (new + existing).
- [x] `golangci-lint run ./backend/internal/prompt/... ./backend/internal/server/...` — 0 issues.
- [x] `scripts/test coverage` — aggregate **81.3%** (threshold 80%).
- [x] `fishhawk_verify_run` — `verified=true`, chain_length=13.
- [ ] Meta: next D4 fanout exercises the constraint path. Watch for `injected scope constraint for decomposed child` info logs and observable scope discipline in the child runs' diffs.

## Out of scope (per issue body)

- Mechanical enforcement at policy layer (Option B) — gated on structured `scope.files[]` ADR.
- Re-decomposition mid-run; cross-child synchronization. Sibling concerns.

Closes #541