### PR TITLE
run: document + test TransitionStage same-state no-op contract (#553)

### DIFF
--- a/backend/internal/run/postgres_test.go
+++ b/backend/internal/run/postgres_test.go
@@ -708,6 +708,42 @@ func TestPostgres_StageGate_NilWhenSpecHasNoGate(t *testing.T) {
 	}
 }
 
+func TestPostgres_TransitionStage_SameState_NoOp(t *testing.T) {
+	// Pins the same-state no-op contract documented on
+	// Repository.TransitionStage: when the stage is already in the
+	// target state, the call must return the unchanged stage (nil
+	// error) without bumping updated_at.
+	pool := startPostgres(t)
+	repo := run.NewPostgresRepository(pool)
+
+	r := makeRun(t, repo)
+	s := makeStage(t, repo, r.ID, 0)
+
+	// Walk to succeeded via the normal lifecycle.
+	if _, err := repo.TransitionStage(context.Background(), s.ID, run.StageStateDispatched, nil); err != nil {
+		t.Fatalf("→dispatched: %v", err)
+	}
+	if _, err := repo.TransitionStage(context.Background(), s.ID, run.StageStateRunning, nil); err != nil {
+		t.Fatalf("→running: %v", err)
+	}
+	first, err := repo.TransitionStage(context.Background(), s.ID, run.StageStateSucceeded, nil)
+	if err != nil {
+		t.Fatalf("→succeeded: %v", err)
+	}
+
+	// Call again with the same target state.
+	second, err := repo.TransitionStage(context.Background(), s.ID, run.StageStateSucceeded, nil)
+	if err != nil {
+		t.Fatalf("same-state re-apply returned error: %v", err)
+	}
+	if second.State != run.StageStateSucceeded {
+		t.Errorf("state = %q, want succeeded", second.State)
+	}
+	if first.UpdatedAt.UnixNano() != second.UpdatedAt.UnixNano() {
+		t.Errorf("same-state re-apply mutated row (updated_at changed)")
+	}
+}
+
 func TestPostgres_StageGate_CheckGateHasNoApprovers(t *testing.T) {
 	// routine_change.workflows.yaml's review stage uses a check-only
 	// gate (no approvers; just blocking_checks). The persisted Gate

--- a/backend/internal/run/repository.go
+++ b/backend/internal/run/repository.go
@@ -200,6 +200,14 @@ type Repository interface {
 	// TransitionStage moves a stage to the target state. completion
 	// must be non-nil and populated when transitioning to
 	// StageStateFailed; nil otherwise.
+	//
+	// Same-state (idempotent) calls return the unchanged stage and a
+	// nil error — the row is not mutated and UpdatedAt is not bumped.
+	// Racing callers (e.g. maybeAdvanceDecomposedParent from
+	// concurrent child completions) rely on this: when the parent
+	// stage was already advanced by the first caller, subsequent
+	// callers silently no-op rather than returning an error. "No
+	// change" is not surfaced as a distinct outcome.
 	TransitionStage(ctx context.Context, id uuid.UUID, to StageState, completion *StageCompletion) (*Stage, error)
 
 	// RetryStage is the explicit override path off a terminal state —


### PR DESCRIPTION
## Summary

Codifies the same-state no-op contract that PR #551's `maybeAdvanceDecomposedParent` race-tolerance depends on. The behavior existed (postgres early-returns the unchanged stage when `from == to`) but was undocumented and untested.

- **`repository.go`** — `TransitionStage` godoc now states: already-in-target returns the unchanged stage + nil error; "no change" isn't a distinct outcome. Cross-references the #551 caller so the next reader sees *why* it matters.
- **`postgres_test.go`** — `TestPostgres_TransitionStage_SameState_NoOp`: walk a stage to `succeeded`, call `TransitionStage(succeeded)` again, assert nil error + state unchanged + `UpdatedAt` unchanged (proves the row wasn't mutated). Mirrors `TestPostgres_TransitionRun_Idempotent`.

Option A from the issue (document + test). Option B (caller-level guards) correctly deferred — the contract is now explicit, so callers can rely on it.

## Notes

Driven through the local MCP loop — **first loop after the macOS TCC / Docker-daemon recovery** (Documents-folder access was revoked during a Claude Code restart; restored after re-granting + restart; Docker Desktop + postgres/minio also had to be brought back up). The full stack recovered cleanly.

One non-happy-path moment: first plan-stage attempt failed with `/approach: got string, want array` — a **string-where-array** schema violation. This is the case #547 explicitly deferred (coercion handles string-where-object only). **First observed occurrence** — strengthens the case for extending coercion to array-typed fields (relevant to #552's investigation). Retried; second attempt clean (5.5k tokens). Implement 2.9k tokens. `verify_run=true`.

## Test plan

- [x] `go test -race ./backend/internal/run/...` — pass (new test + existing; ~22s with testcontainers).
- [x] `golangci-lint run ./backend/internal/run/...` — 0 issues.
- [x] `scripts/test coverage` — aggregate **81.2%** (threshold 80%).
- [x] `fishhawk_verify_run` — `verified=true`, chain_length=13.

## Follow-up signal

`/approach: got string, want array` is a new data point for the coercion-gap work. The string-where-array class is now observed in the wild (not just hypothesized in #547's out-of-scope). Worth folding into #552's investigation or a dedicated array-coercion extension.

Closes #553