### PR TITLE
prompt: inject plan-approval conditions into the implement-stage prompt (#557)

### DIFF
--- a/backend/internal/prompt/prompt.go
+++ b/backend/internal/prompt/prompt.go
@@ -165,6 +165,12 @@ type Trigger struct {
 	// prepends a binding SCOPE CONSTRAINT block before the plan and
 	// issue sections. Nil for standalone runs (#541).
 	ScopeConstraint *ScopeConstraint
+	// ApprovalConditions carries the operator's approve-with-notes text for
+	// the current run's plan stage. When non-nil, buildImplement injects a
+	// binding section after the SCOPE CONSTRAINT block (if any) and before
+	// the approved-plan section. Nil means no conditions were given (section
+	// omitted).
+	ApprovalConditions *string
 }
 
 // Build returns the constructed prompt for the given stage type
@@ -218,6 +224,21 @@ func buildImplement(t Trigger) string {
 			"If any file falls outside your scope above, STOP and surface that the boundary is wrong " +
 			"rather than expanding scope. If you find yourself wanting to work in a sibling's area, " +
 			"STOP and signal completion instead.\n\n")
+	}
+
+	// Approval conditions (#557): when the operator approved the plan with
+	// notes, inject a binding section so the agent sees them before reading
+	// the plan. Conditions AMEND the plan, are MANDATORY, and win on conflict.
+	if t.ApprovalConditions != nil {
+		ac := *t.ApprovalConditions
+		const maxConditionBytes = 4000
+		if len(ac) > maxConditionBytes {
+			ac = ac[:maxConditionBytes] + "...[truncated]"
+		}
+		b.WriteString("### Approval conditions\n\n")
+		b.WriteString("The operator approved this plan with the following conditions. These conditions AMEND the plan, are MANDATORY, and win on conflict with plan steps:\n\n")
+		b.WriteString(ac)
+		b.WriteString("\n\n")
 	}
 
 	// Plan-as-contract (#223): when the plan stage produced a

--- a/backend/internal/prompt/prompt_test.go
+++ b/backend/internal/prompt/prompt_test.go
@@ -781,6 +781,52 @@ func TestBuild_Plan_CompoundFieldDirective(t *testing.T) {
 	}
 }
 
+func TestBuild_Implement_ApprovalConditions_Rendered(t *testing.T) {
+	cond := "add the cross-branch rejection test"
+	got, err := Build("implement", Trigger{
+		Repo:               "o/r",
+		ApprovedPlan:       fixturePlan(),
+		ApprovalConditions: &cond,
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	wants := []string{
+		"### Approval conditions",
+		"AMEND the plan",
+		"MANDATORY",
+		"win on conflict",
+		cond,
+	}
+	for _, w := range wants {
+		if !strings.Contains(got, w) {
+			t.Errorf("prompt missing %q\n---\n%s", w, got)
+		}
+	}
+	// Conditions must appear before the approved plan so the agent
+	// sees them before reading the plan steps.
+	condIdx := strings.Index(got, "### Approval conditions")
+	planIdx := strings.Index(got, "Approved plan (binding instruction)")
+	if condIdx < 0 || planIdx < 0 || condIdx > planIdx {
+		t.Errorf("approval conditions should appear before approved plan (condIdx=%d planIdx=%d):\n%s",
+			condIdx, planIdx, got)
+	}
+}
+
+func TestBuild_Implement_ApprovalConditions_Nil_Absent(t *testing.T) {
+	got, err := Build("implement", Trigger{
+		Repo:         "o/r",
+		ApprovedPlan: fixturePlan(),
+		// ApprovalConditions deliberately nil.
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if strings.Contains(got, "### Approval conditions") {
+		t.Errorf("Approval conditions section should not appear when ApprovalConditions is nil:\n%s", got)
+	}
+}
+
 func TestBuild_Implement_WithSparsePlan_OmitsEmptySections(t *testing.T) {
 	// A plan that fails optional sections (no scope.files, no
 	// risks) should still render cleanly — empty sections drop

--- a/backend/internal/server/approvals.go
+++ b/backend/internal/server/approvals.go
@@ -413,6 +413,9 @@ func (s *Server) writeApprovalAudit(r *http.Request, stage *run.Stage, app *appr
 	if app.Decision == approval.DecisionReject && comment != "" {
 		auditPayload["rejection_comment"] = comment
 	}
+	if app.Decision == approval.DecisionApprove && comment != "" {
+		auditPayload["comment"] = comment
+	}
 	payload, _ := json.Marshal(auditPayload)
 
 	approver := app.ApproverSubject

--- a/backend/internal/server/issue_approval.go
+++ b/backend/internal/server/issue_approval.go
@@ -322,6 +322,9 @@ func (s *Server) writeSlashApprovalAudit(ctx context.Context, stage *run.Stage, 
 	if app.Decision == approval.DecisionReject && comment != "" {
 		auditPayload["rejection_comment"] = comment
 	}
+	if app.Decision == approval.DecisionApprove && comment != "" {
+		auditPayload["comment"] = comment
+	}
 	payload, _ := json.Marshal(auditPayload)
 	if _, err := s.cfg.AuditRepo.AppendChained(ctx, audit.ChainAppendParams{
 		RunID:        stage.RunID,

--- a/backend/internal/server/prompt.go
+++ b/backend/internal/server/prompt.go
@@ -169,6 +169,7 @@ func (s *Server) handleGetStagePrompt(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		trigger.ScopeConstraint = s.resolveDecomposedScopeConstraint(r.Context(), runRow)
+		trigger.ApprovalConditions = s.loadApprovalConditions(r.Context(), runRow.ID)
 	}
 
 	// Decompose-required hint: when the run's last plan approval was
@@ -316,6 +317,7 @@ func (s *Server) handleGetStagePromptRender(w http.ResponseWriter, r *http.Reque
 			}
 		}
 		trigger.ScopeConstraint = s.resolveDecomposedScopeConstraint(r.Context(), runRow)
+		trigger.ApprovalConditions = s.loadApprovalConditions(r.Context(), runRow.ID)
 	}
 
 	// Decompose-required hint: when the run's last plan approval was
@@ -995,4 +997,46 @@ func (s *Server) loadLastDecomposeRejectionReason(ctx context.Context, runID uui
 		}
 	}
 	return false
+}
+
+// loadApprovalConditions scans the run's approval_submitted audit entries
+// (newest-first) for the first entry where decision=="approve" and the
+// comment payload key is non-empty. Returns the comment string (capped at
+// 4000 bytes) or nil when none is found. Best-effort: WARN-logs and returns
+// nil on any error.
+func (s *Server) loadApprovalConditions(ctx context.Context, runID uuid.UUID) *string {
+	if s.cfg.AuditRepo == nil {
+		return nil
+	}
+	entries, err := s.cfg.AuditRepo.ListForRunByCategory(ctx, runID, "approval_submitted")
+	if err != nil {
+		s.cfg.Logger.LogAttrs(ctx, slog.LevelWarn, "prompt: list approval_submitted for conditions failed",
+			slog.String("run_id", runID.String()),
+			slog.String("error", err.Error()),
+		)
+		return nil
+	}
+	for i := len(entries) - 1; i >= 0; i-- {
+		var payload struct {
+			Decision string `json:"decision"`
+			Comment  string `json:"comment"`
+		}
+		if err := json.Unmarshal(entries[i].Payload, &payload); err != nil {
+			continue
+		}
+		if payload.Decision == "approve" && payload.Comment != "" {
+			c := payload.Comment
+			const maxConditionBytes = 4000
+			if len(c) > maxConditionBytes {
+				c = c[:maxConditionBytes] + "...[truncated]"
+			}
+			s.cfg.Logger.LogAttrs(ctx, slog.LevelInfo,
+				"prompt: loaded approval conditions into implement prompt",
+				slog.String("run_id", runID.String()),
+				slog.Int("comment_bytes", len(payload.Comment)),
+			)
+			return &c
+		}
+	}
+	return nil
 }

--- a/backend/internal/server/prompt_plan_test.go
+++ b/backend/internal/server/prompt_plan_test.go
@@ -146,9 +146,19 @@ func (r *planArtifactRepo) Create(_ context.Context, _ artifact.CreateParams) (*
 
 // planAuditRepo records appended entries; the implement-prompt
 // handler emits `plan_missing_for_implement` when the plan isn't
-// found, and the test asserts that.
+// found, and the test asserts that. byRunCategory supports seeding
+// canned entries for ListForRunByCategory.
 type planAuditRepo struct {
-	appended []audit.ChainAppendParams
+	appended      []audit.ChainAppendParams
+	byRunCategory map[string][]*audit.Entry
+}
+
+func (a *planAuditRepo) seedByCategory(runID uuid.UUID, category string, entries ...*audit.Entry) {
+	if a.byRunCategory == nil {
+		a.byRunCategory = map[string][]*audit.Entry{}
+	}
+	key := runID.String() + ":" + category
+	a.byRunCategory[key] = append(a.byRunCategory[key], entries...)
 }
 
 func (a *planAuditRepo) Append(context.Context, audit.AppendParams) (*audit.Entry, error) {
@@ -178,7 +188,13 @@ func (a *planAuditRepo) Get(context.Context, uuid.UUID) (*audit.Entry, error) {
 func (a *planAuditRepo) ListForRun(context.Context, uuid.UUID) ([]*audit.Entry, error) {
 	return nil, nil
 }
-func (a *planAuditRepo) ListForRunByCategory(context.Context, uuid.UUID, string) ([]*audit.Entry, error) {
+func (a *planAuditRepo) ListForRunByCategory(_ context.Context, runID uuid.UUID, category string) ([]*audit.Entry, error) {
+	if a.byRunCategory != nil {
+		key := runID.String() + ":" + category
+		if entries, ok := a.byRunCategory[key]; ok {
+			return entries, nil
+		}
+	}
 	return nil, nil
 }
 func (a *planAuditRepo) LastForRun(context.Context, uuid.UUID) (*audit.Entry, error) {
@@ -570,6 +586,84 @@ func TestHandleGetStagePromptRender_BudgetContext(t *testing.T) {
 	}
 	if strings.Contains(planResp.Prompt, "### Budget context") {
 		t.Errorf("plan-stage prompt should not contain Budget context section:\n%s", planResp.Prompt)
+	}
+}
+
+func TestImplementPrompt_ApprovalConditions_Rendered(t *testing.T) {
+	// Seed a run with an approval_submitted entry carrying decision=approve
+	// and a non-empty comment. The implement-stage prompt must contain the
+	// "Approval conditions" section with the comment verbatim.
+	s, rr, ar, au, sf, gh := newImplementPromptServer(t)
+	runID, planStageID, implStageID, _ := seedRunWithStages(rr)
+
+	v := "standard_v1"
+	ar.seed(planStageID, &artifact.Artifact{
+		ID:            uuid.New(),
+		StageID:       planStageID,
+		Kind:          artifact.KindPlan,
+		SchemaVersion: &v,
+		Content:       fixturePlanJSON(t),
+		ContentHash:   "conditions-test",
+		CreatedAt:     time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC),
+	})
+	gh.issue = &githubclient.Issue{Number: 42, Title: "Add foo", Body: "ctx"}
+
+	approveComment := "add the cross-branch rejection test"
+	payload, _ := json.Marshal(map[string]any{
+		"decision": "approve",
+		"comment":  approveComment,
+	})
+	au.seedByCategory(runID, "approval_submitted", &audit.Entry{
+		ID:       uuid.New(),
+		Payload:  payload,
+		Category: "approval_submitted",
+	})
+
+	priv, _ := sf.issue(t, runID)
+	w := promptRequestForStage(t, s, runID, implStageID, priv)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d:\n%s", w.Code, w.Body.String())
+	}
+	var resp promptResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"Approval conditions", approveComment} {
+		if !strings.Contains(resp.Prompt, want) {
+			t.Errorf("prompt missing %q\n---\n%s", want, resp.Prompt)
+		}
+	}
+}
+
+func TestImplementPrompt_ApprovalConditions_AbsentWhenNoComment(t *testing.T) {
+	// No approval_submitted entry with a comment → "Approval conditions"
+	// section must not appear.
+	s, rr, ar, _, sf, gh := newImplementPromptServer(t)
+	runID, planStageID, implStageID, _ := seedRunWithStages(rr)
+
+	v := "standard_v1"
+	ar.seed(planStageID, &artifact.Artifact{
+		ID:            uuid.New(),
+		StageID:       planStageID,
+		Kind:          artifact.KindPlan,
+		SchemaVersion: &v,
+		Content:       fixturePlanJSON(t),
+		ContentHash:   "no-conditions-test",
+		CreatedAt:     time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC),
+	})
+	gh.issue = &githubclient.Issue{Number: 42, Title: "Add foo", Body: "ctx"}
+
+	priv, _ := sf.issue(t, runID)
+	w := promptRequestForStage(t, s, runID, implStageID, priv)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d:\n%s", w.Code, w.Body.String())
+	}
+	var resp promptResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(resp.Prompt, "Approval conditions") {
+		t.Errorf("Approval conditions section should not appear when no approve comment exists:\n%s", resp.Prompt)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes the missing wire behind the "agent ignores approval notes" pattern this session hit ~6 times. The operator's approve-with-notes text was persisted on the approval row but never loaded into the implement-stage prompt — the agent worked purely off the plan artifact. This delivers the notes with plan-level authority, mirroring #539 (rejection feedback → plan prompt).

- **Persistence**: the approve path now writes a `comment` key into the `approval_submitted` audit payload (previously only #539's `rejection_comment` existed, reject-only). Both API (`writeApprovalAudit`) and slash-command (`writeSlashApprovalAudit`) surfaces updated symmetrically.
- **Load**: `loadApprovalConditions` mirrors `loadPriorRejectionFeedback` — newest-first scan of `approval_submitted` for the latest approve-decision comment, 4000-byte cap, info-log on injection. Wired into **both** `handleGetStagePrompt` and `handleGetStagePromptRender`.
- **Render**: `buildImplement` adds a binding `### Approval conditions` section (after SCOPE CONSTRAINT, before the plan) — conditions AMEND the plan, are MANDATORY, win on conflict.

## Notes

Driven through the local MCP loop. **Textbook-clean** — plan first try (9k tokens), implement 14.3k, `verify_run=true`.

Both my approval-note asks landed this time: the agent wired both prompt endpoints (not just the one in the plan's step 6) and the audit-comment key onto both surfaces. (Fitting, given this is the PR that fixes note-delivery — though it won't be live until merged.)

One transient: first `scripts/test coverage` run hit the recurring `runner/internal/gitops` 1Password signing flake (#524, still open); re-run clean at **81.2%**.

## Verification of the fix itself

The end-to-end test (`prompt_plan_test.go`) is the proof: a run whose plan stage was approved with comment `"add the cross-branch rejection test"` now produces an implement prompt containing that text under "Approval conditions". The negative case confirms no section when there's no approve comment.

## Test plan

- [x] `go test -race ./backend/internal/server/... ./backend/internal/prompt/...` — pass (new + existing).
- [x] `golangci-lint run` on both packages — 0 issues.
- [x] `scripts/test coverage` — aggregate **81.2%** (threshold 80%; one transient gitops/1Password flake re-run clean).
- [x] `fishhawk_verify_run` — `verified=true`, chain_length=13.
- [ ] Meta: the next approval-with-notes loop is the real test — the agent should now act on conditions without in-loop patching.

## Out of scope (per issue)

- Option B (require plan artifact update / re-plan on notes) — heavier; A delivers notes with plan authority without mutating the artifact.
- Structured approval-condition shape — that's ADR-027's review-verdict direction.

Closes #557