### PR TITLE
plan: fix coercion misfire on combined violations + registry observability (#552)

### DIFF
--- a/backend/cmd/fishhawkd/serve.go
+++ b/backend/cmd/fishhawkd/serve.go
@@ -30,6 +30,7 @@ import (
 	"github.com/kuhlman-labs/fishhawk/backend/internal/issuecomment"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/mcptoken"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/orchestrator"
+	"github.com/kuhlman-labs/fishhawk/backend/internal/plan"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/reactionpoller"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/role"
 	runpkg "github.com/kuhlman-labs/fishhawk/backend/internal/run"
@@ -126,6 +127,7 @@ func runServe(args []string, logSink io.Writer) int {
 	}
 
 	logger := newLogger(logSink)
+	logger.Info("plan coercion registry", slog.String("summary", plan.CoercionRegistrySummary()))
 
 	cfg := server.Config{Addr: *addr, Logger: logger, ExternalURL: *externalURL}
 

--- a/backend/internal/plan/coerce.go
+++ b/backend/internal/plan/coerce.go
@@ -3,6 +3,7 @@ package plan
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 )
@@ -166,6 +167,18 @@ func navigateTo(m map[string]any, parts []string) (map[string]any, string, bool)
 	return parent, parts[len(parts)-1], true
 }
 
+// CoercionRegistrySummary returns a human-readable description of the paths
+// registered for coercion. Call at startup with the binary's configured logger
+// to confirm the registry is populated without waiting for a misfire.
+func CoercionRegistrySummary() string {
+	paths := make([]string, 0, len(coercionRegistry))
+	for path := range coercionRegistry {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	return fmt.Sprintf("%d paths: %s", len(paths), strings.Join(paths, ", "))
+}
+
 // TryCoerce attempts to fix the known string-elision class of plan schema
 // violations: cases where an agent emits a bare string where the schema
 // expects an object. The set of coercible paths is derived at init time from
@@ -176,9 +189,11 @@ func navigateTo(m map[string]any, parts []string) (map[string]any, string, bool)
 // Returns (coercedBytes, coercions, nil) when coercion produces a valid plan.
 // Returns (nil, nil, nil) when no string-valued nested-object fields are
 // detected AND the original data already validates — caller keeps original
-// bytes. Returns (nil, nil, err) when coercions were applied but re-validation
-// still fails, or when no coercions apply and the original data is invalid —
-// either way the caller should fall through to the 400 path.
+// bytes. Returns (coercedBytes, coercions, err) when coercions were applied
+// but re-validation still fails — callers use coercedBytes to report the
+// post-coercion violation rather than the original error (which may name a
+// field already fixed by coercion). Returns (nil, nil, err) when no coercions
+// apply and the original data is invalid — caller falls through to the 400 path.
 func TryCoerce(data []byte, now time.Time) ([]byte, []Coercion, error) {
 	var m map[string]any
 	if err := json.Unmarshal(data, &m); err != nil {
@@ -254,7 +269,7 @@ func TryCoerce(data []byte, now time.Time) ([]byte, []Coercion, error) {
 	}
 
 	if err := Validate(coercedBytes); err != nil {
-		return nil, nil, err
+		return coercedBytes, coercions, err
 	}
 
 	return coercedBytes, coercions, nil

--- a/backend/internal/plan/coerce_test.go
+++ b/backend/internal/plan/coerce_test.go
@@ -2,6 +2,7 @@ package plan_test
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -209,6 +210,39 @@ func TestTryCoerce_IntegerTicketReference(t *testing.T) {
 	}
 	if err == nil {
 		t.Error("err = nil, want non-nil: integer is not coercible and original schema error should propagate")
+	}
+}
+
+// TestTryCoerce_PartialCoercionWithRemainingViolation exercises the production
+// failure shape: agent emits a coercible field (generated_by as bare string)
+// AND a non-coercible field (approach as bare string — expects array). Coercion
+// fires on generated_by but the plan is still invalid after. The fix: TryCoerce
+// returns (coercedBytes, coercions, err) so callers report the post-coercion
+// violation (/approach) rather than the original /generated_by error.
+func TestTryCoerce_PartialCoercionWithRemainingViolation(t *testing.T) {
+	m := planfixture.Valid()
+	m["generated_by"] = "my-agent" // coercible: bare string → object
+	m["approach"] = "do the thing" // non-coercible: string where array required
+	data := marshal(t, m)
+
+	coercedBytes, coercions, err := plan.TryCoerce(data, testNow)
+
+	if err == nil {
+		t.Fatal("err = nil, want non-nil: approach is not coercible so plan remains invalid")
+	}
+	if len(coercions) != 1 {
+		t.Fatalf("coercions = %d, want 1 (generated_by coerced; approach not coercible)", len(coercions))
+	}
+	if got := coercions[0].FieldPath; got != "/generated_by" {
+		t.Errorf("coercions[0].FieldPath = %q, want /generated_by", got)
+	}
+	if coercedBytes == nil {
+		t.Fatal("coercedBytes = nil, want non-nil: partial fix bytes must be returned so caller reports post-coercion error")
+	}
+	// The returned error must name the remaining violation, not generated_by.
+	errStr := err.Error()
+	if strings.Contains(errStr, "generated_by") {
+		t.Errorf("err mentions generated_by (already coerced); want error naming remaining violation: %v", err)
 	}
 }
 

--- a/backend/internal/server/plan.go
+++ b/backend/internal/server/plan.go
@@ -135,6 +135,7 @@ func (s *Server) handleShipPlan(w http.ResponseWriter, r *http.Request) {
 	// doesn't retry — the agent's output is bad and re-shipping won't help.
 	if err := plan.Validate(body); err != nil {
 		coercionOK := false
+		reportErr := err // updated to post-coercion error on partial coercion
 		var schemaErr *plan.SchemaError
 		if errors.As(err, &schemaErr) {
 			coercedBytes, coercions, coerceErr := plan.TryCoerce(body, time.Now().UTC())
@@ -162,6 +163,12 @@ func (s *Server) handleShipPlan(w http.ResponseWriter, r *http.Request) {
 				}
 				body = coercedBytes
 				coercionOK = true
+			} else if coerceErr != nil && len(coercions) > 0 {
+				// Partial coercion: some fields were fixed but the plan is
+				// still invalid. Report the post-coercion error so the 400
+				// names the remaining violation rather than a field that
+				// coercion already fixed.
+				reportErr = coerceErr
 			}
 		}
 		if !coercionOK {
@@ -171,7 +178,7 @@ func (s *Server) handleShipPlan(w http.ResponseWriter, r *http.Request) {
 			// `running` (#527). Best-effort: a TransitionStage error
 			// logs but doesn't change the upload response.
 			cat := run.FailureB
-			reason := "plan_invalid: " + err.Error()
+			reason := "plan_invalid: " + reportErr.Error()
 			if _, terr := s.cfg.RunRepo.TransitionStage(r.Context(), stageID,
 				run.StageStateFailed, &run.StageCompletion{
 					FailureCategory: &cat,
@@ -185,7 +192,7 @@ func (s *Server) handleShipPlan(w http.ResponseWriter, r *http.Request) {
 			}
 			s.writeError(w, r, http.StatusBadRequest, "plan_invalid",
 				"plan does not validate against standard_v1",
-				map[string]any{"error": err.Error()})
+				map[string]any{"error": reportErr.Error()})
 			return
 		}
 	}

--- a/runner/cmd/fishhawk-runner/main.go
+++ b/runner/cmd/fishhawk-runner/main.go
@@ -181,6 +181,7 @@ func run(args []string, logSink io.Writer) (exitCode int) {
 	}
 
 	logStartup(logSink, cfg)
+	_, _ = fmt.Fprintf(logSink, `{"event":"coercion_registry","summary":%q}`+"\n", plan.CoercionRegistrySummary())
 
 	ctx, stop := newRunnerContext()
 	defer stop()
@@ -1075,12 +1076,28 @@ func validatePlan(path string) (agent.Event, error) {
 			}, fmt.Errorf("plan: write coerced %s: %w", path, err)
 		}
 		data = coercedBytes
+	} else if coerceErr != nil && len(coercions) > 0 {
+		// Partial coercion: some fields were fixed but the plan is still
+		// invalid. Rewrite the file with the partially-fixed bytes so the
+		// subsequent Validate reports the remaining violation rather than
+		// the original error (which may name a field already coerced).
+		if err := os.WriteFile(path, coercedBytes, 0o600); err != nil {
+			return agent.Event{
+				Kind:    "policy_event",
+				Payload: agent.MakePayload(map[string]string{"check": "plan_validation", "outcome": "coerce_write_failed", "path": path, "error": err.Error()}),
+			}, fmt.Errorf("plan: write coerced %s: %w", path, err)
+		}
+		data = coercedBytes
 	}
 
 	if vErr := plan.Validate(data); vErr != nil {
+		invalidPayload := map[string]string{"check": "plan_validation", "outcome": "invalid", "path": path, "error": vErr.Error()}
+		if len(coercions) > 0 {
+			invalidPayload["coerced"] = fmt.Sprintf("%d field(s)", len(coercions))
+		}
 		return agent.Event{
 			Kind:    "policy_event",
-			Payload: agent.MakePayload(map[string]string{"check": "plan_validation", "outcome": "invalid", "path": path, "error": vErr.Error()}),
+			Payload: agent.MakePayload(invalidPayload),
 		}, vErr
 	}
 

--- a/runner/internal/plan/coerce.go
+++ b/runner/internal/plan/coerce.go
@@ -3,6 +3,7 @@ package plan
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 )
@@ -177,6 +178,18 @@ func navigateTo(m map[string]any, parts []string) (map[string]any, string, bool)
 	return parent, parts[len(parts)-1], true
 }
 
+// CoercionRegistrySummary returns a human-readable description of the paths
+// registered for coercion. Call at startup with the binary's configured logger
+// to confirm the registry is populated without waiting for a misfire.
+func CoercionRegistrySummary() string {
+	paths := make([]string, 0, len(coercionRegistry))
+	for path := range coercionRegistry {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	return fmt.Sprintf("%d paths: %s", len(paths), strings.Join(paths, ", "))
+}
+
 // TryCoerce attempts to fix the known string-elision class of plan schema
 // violations: cases where an agent emits a bare string where the schema
 // expects an object. The set of coercible paths is derived at init time from
@@ -187,10 +200,12 @@ func navigateTo(m map[string]any, parts []string) (map[string]any, string, bool)
 // Returns (coercedBytes, coercions, nil) when coercion produces a valid plan.
 // Returns (nil, nil, nil) when no string-valued nested-object fields are
 // detected AND the original data already validates — caller keeps original
-// bytes (content_hash stability for the signed upload). Returns (nil, nil, err)
-// when coercions were applied but re-validation still fails, or when no
-// coercions apply and the original data is invalid — either way the caller
-// should fall through to the existing rejection path.
+// bytes (content_hash stability for the signed upload). Returns
+// (coercedBytes, coercions, err) when coercions were applied but re-validation
+// still fails — callers use coercedBytes to report the post-coercion
+// violation rather than the original error (which may name a field already
+// fixed by coercion). Returns (nil, nil, err) when no coercions apply and the
+// original data is invalid.
 //
 // Mirror of backend/internal/plan.TryCoerce. Both packages must apply the same
 // defaults so the runner-coerced bytes pass the backend's Validate cleanly
@@ -269,7 +284,7 @@ func TryCoerce(data []byte, now time.Time) ([]byte, []Coercion, error) {
 	}
 
 	if err := Validate(coercedBytes); err != nil {
-		return nil, nil, err
+		return coercedBytes, coercions, err
 	}
 
 	return coercedBytes, coercions, nil

--- a/runner/internal/plan/coerce_test.go
+++ b/runner/internal/plan/coerce_test.go
@@ -2,6 +2,7 @@ package plan_test
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -208,6 +209,39 @@ func TestTryCoerce_IntegerTicketReference(t *testing.T) {
 	}
 	if err == nil {
 		t.Error("err = nil, want non-nil: integer is not coercible and original schema error should propagate")
+	}
+}
+
+// TestTryCoerce_PartialCoercionWithRemainingViolation exercises the production
+// failure shape: agent emits a coercible field (generated_by as bare string)
+// AND a non-coercible field (approach as bare string — expects array). Coercion
+// fires on generated_by but the plan is still invalid after. The fix: TryCoerce
+// returns (coercedBytes, coercions, err) so callers report the post-coercion
+// violation (/approach) rather than the original /generated_by error.
+func TestTryCoerce_PartialCoercionWithRemainingViolation(t *testing.T) {
+	m := planfixture.Valid()
+	m["generated_by"] = "my-agent" // coercible: bare string → object
+	m["approach"] = "do the thing" // non-coercible: string where array required
+	data := marshal(t, m)
+
+	coercedBytes, coercions, err := plan.TryCoerce(data, testNow)
+
+	if err == nil {
+		t.Fatal("err = nil, want non-nil: approach is not coercible so plan remains invalid")
+	}
+	if len(coercions) != 1 {
+		t.Fatalf("coercions = %d, want 1 (generated_by coerced; approach not coercible)", len(coercions))
+	}
+	if got := coercions[0].FieldPath; got != "/generated_by" {
+		t.Errorf("coercions[0].FieldPath = %q, want /generated_by", got)
+	}
+	if coercedBytes == nil {
+		t.Fatal("coercedBytes = nil, want non-nil: partial fix bytes must be returned so caller reports post-coercion error")
+	}
+	// The returned error must name the remaining violation, not generated_by.
+	errStr := err.Error()
+	if strings.Contains(errStr, "generated_by") {
+		t.Errorf("err mentions generated_by (already coerced); want error naming remaining violation: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Root-causes and fixes the #542 "coercion didn't fire despite coverage" mystery. It wasn't a misfire — it was a **stale error report**.

**The bug:** when a plan has a coercible violation (`generated_by` as string) AND a non-coercible one (`approach` as string) together, `TryCoerce` coerces `generated_by`, re-validates, fails on `/approach`, and returned `(nil, nil, err)` — *discarding the coercions*. The caller then validated the **original** uncoerced bytes, whose first violation is `/generated_by` — the field coercion already fixed. So production reported a coercible field as broken even though coercion ran.

This explains everything: single-violation tests passed, production reported `/generated_by`, the 3rd #542 attempt succeeded (only-coercible or zero violations that time).

**Fix (both plan packages, mirrored):**
- `TryCoerce` returns `(coercedBytes, coercions, err)` on partial-coercion-failure instead of `(nil, nil, err)`. Callers validate the *coerced* bytes and report the *remaining* violation.
- Runner + backend call sites use the coerced bytes on that path, so the failure reason names the real un-coercible problem (`/approach`), not the already-fixed `/generated_by`. Composes cleanly with #555's enumerate-all.

**Observability:** `CoercionRegistrySummary()` logged at startup by both binaries (fishhawkd via configured slog, runner via JSONL) so operators can confirm the registry is populated without waiting for a misfire.

## Notes — first loop with #557 live

This was the first loop after #558 (approval-conditions delivery) deployed, and it **validated #557 end-to-end**. All three of my approval-stage notes reached the implement agent and were acted on:

1. "Use a `CoercionRegistrySummary()` function + configured logger, not package-init slog" → done exactly (serve.go:130, main.go:184), avoiding the init-time global-logger anti-pattern.
2. "Note the synergy with #555 in the PR body" → reflected.
3. "Verify there's no third TryCoerce call site" → confirmed two sites, both updated.

Before today the implement agent never received approval notes (the #557 missing wire); this PR is the proof the wire works. No in-loop patching needed this time.

Plan 24k tokens, implement 24.5k, `verify_run=true`, chain_length=13.

## Test plan

- [x] `go test -race ./backend/internal/plan/... ./backend/internal/server/... ./runner/internal/plan/... ./runner/cmd/fishhawk-runner/...` — pass (incl. new `TestTryCoerce_PartialCoercionWithRemainingViolation` in both plan packages).
- [x] `golangci-lint run` on all touched packages — 0 issues.
- [x] `scripts/test coverage` — aggregate **81.1%** (threshold 80%).
- [x] `fishhawk_verify_run` — `verified=true`, chain_length=13.

## Out of scope (per issue)

- Re-architecting coercion (the x-coerce-principal design is correct; this was a control-flow bug).
- The MCP-server-caching / stale-runner hypotheses from the original issue body — superseded by this root cause. (The stale-runner concern is real for the rebuild matrix but separate; the actual #542 failures were this combined-violation bug.)

Closes #552