### PR TITLE
scripts/dev,doctor: env-recovery preflight + 3 dependency rungs (#563)

### DIFF
--- a/cli/cmd/fishhawk/doctor.go
+++ b/cli/cmd/fishhawk/doctor.go
@@ -55,6 +55,9 @@ func runDoctor(args []string, stdout, stderr io.Writer) int {
 	}
 
 	checks := []checkResult{
+		checkDockerDaemon(),
+		checkPostgresContainer(),
+		checkMinioContainer(),
 		checkBackend(*cf.backendURL),
 		checkToken(*cf.backendURL, *cf.token),
 		checkSpec(*workingDir),
@@ -122,6 +125,62 @@ func isTerminal(w io.Writer) bool {
 		return false
 	}
 	return (fi.Mode() & os.ModeCharDevice) != 0
+}
+
+// checkDockerDaemon verifies the Docker daemon is reachable via `docker info`.
+func checkDockerDaemon() checkResult {
+	label := "docker daemon running"
+	_, err := doctorRunOutput("docker", "info")
+	if err != nil {
+		return checkResult{label: label, detail: "daemon not reachable", status: "fail",
+			remediate: "run: open -a Docker, wait ~20s, then retry"}
+	}
+	return checkResult{label: label, detail: "ok", status: "ok"}
+}
+
+// checkPostgresContainer verifies the fishhawk-postgres container is running
+// and accepting connections.
+func checkPostgresContainer() checkResult {
+	label := "postgres container"
+	out, err := doctorRunOutput("docker", "ps", "--filter", "name=^/fishhawk-postgres$", "--format", "{{.Names}}")
+	if err != nil || strings.TrimSpace(out) == "" {
+		return checkResult{label: label, detail: "not running", status: "fail",
+			remediate: "run: docker compose up -d"}
+	}
+	_, pgErr := doctorRunOutput("pg_isready", "-h", "localhost", "-p", "5432")
+	if pgErr != nil {
+		return checkResult{label: label, detail: "container up, postgres initialising", status: "warn",
+			remediate: "postgres container is up but not yet accepting connections; wait and retry"}
+	}
+	return checkResult{label: label, detail: "accepting connections", status: "ok"}
+}
+
+// checkMinioContainer verifies the fishhawk-minio container is running and
+// its health endpoint returns 200.
+func checkMinioContainer() checkResult {
+	label := "minio container"
+	out, err := doctorRunOutput("docker", "ps", "--filter", "name=^/fishhawk-minio$", "--format", "{{.Names}}")
+	if err != nil || strings.TrimSpace(out) == "" {
+		return checkResult{label: label, detail: "not running", status: "fail",
+			remediate: "run: docker compose up -d"}
+	}
+	// Port 9000 is hardcoded; if .env overrides MINIO_PORT this rung will not read it (v1 limitation).
+	req, reqErr := http.NewRequest(http.MethodGet, "http://localhost:9000/minio/health/live", nil)
+	if reqErr != nil {
+		return checkResult{label: label, detail: reqErr.Error(), status: "warn",
+			remediate: "minio container is up but health probe failed; check logs with docker logs fishhawk-minio"}
+	}
+	resp, doErr := doctorHTTPDo(req)
+	if doErr != nil {
+		return checkResult{label: label, detail: "container up, health probe failed", status: "warn",
+			remediate: "minio container is up but health probe failed; check logs with docker logs fishhawk-minio"}
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return checkResult{label: label, detail: fmt.Sprintf("container up, health probe returned HTTP %d", resp.StatusCode), status: "warn",
+			remediate: "minio container is up but health probe failed; check logs with docker logs fishhawk-minio"}
+	}
+	return checkResult{label: label, detail: "healthy", status: "ok"}
 }
 
 // checkBackend probes GET {backendURL}/healthz and shows the version on success.

--- a/cli/cmd/fishhawk/doctor_test.go
+++ b/cli/cmd/fishhawk/doctor_test.go
@@ -44,6 +44,133 @@ func fakeHTTPResponse(code int, body string) *http.Response {
 	}
 }
 
+// TestDoctorCheck_DockerDaemonDown verifies checkDockerDaemon returns fail
+// when docker info returns an error (daemon not running).
+func TestDoctorCheck_DockerDaemonDown(t *testing.T) {
+	withFakeDoctorRunOutput(t, func(_ string, _ ...string) (string, error) {
+		return "", errors.New("Cannot connect to the Docker daemon")
+	})
+	r := checkDockerDaemon()
+	if r.status != "fail" {
+		t.Errorf("status = %q, want fail", r.status)
+	}
+	if r.remediate == "" {
+		t.Error("remediate should be non-empty on fail")
+	}
+}
+
+// TestDoctorCheck_DockerDaemonUp verifies checkDockerDaemon returns ok
+// when docker info succeeds.
+func TestDoctorCheck_DockerDaemonUp(t *testing.T) {
+	withFakeDoctorRunOutput(t, func(_ string, _ ...string) (string, error) {
+		return "Server Version: 24.0.0", nil
+	})
+	r := checkDockerDaemon()
+	if r.status != "ok" {
+		t.Errorf("status = %q, want ok", r.status)
+	}
+}
+
+// TestDoctorCheck_PostgresContainerAbsent verifies checkPostgresContainer
+// returns fail when docker ps returns empty output (container not running).
+func TestDoctorCheck_PostgresContainerAbsent(t *testing.T) {
+	withFakeDoctorRunOutput(t, func(_ string, _ ...string) (string, error) {
+		return "", nil // docker ps returned empty — no matching container
+	})
+	r := checkPostgresContainer()
+	if r.status != "fail" {
+		t.Errorf("status = %q, want fail", r.status)
+	}
+	if r.remediate == "" {
+		t.Error("remediate should be non-empty on fail")
+	}
+}
+
+// TestDoctorCheck_PostgresContainerUpNotReady verifies checkPostgresContainer
+// returns warn when the container exists but pg_isready reports not-yet-ready.
+func TestDoctorCheck_PostgresContainerUpNotReady(t *testing.T) {
+	withFakeDoctorRunOutput(t, func(name string, arg ...string) (string, error) {
+		if name == "docker" {
+			return "fishhawk-postgres", nil
+		}
+		// pg_isready returns non-zero — postgres initialising
+		return "", errors.New("no response")
+	})
+	r := checkPostgresContainer()
+	if r.status != "warn" {
+		t.Errorf("status = %q, want warn", r.status)
+	}
+	if r.remediate == "" {
+		t.Error("remediate should be non-empty on warn")
+	}
+}
+
+// TestDoctorCheck_PostgresContainerHealthy verifies checkPostgresContainer
+// returns ok when container is running and pg_isready succeeds.
+func TestDoctorCheck_PostgresContainerHealthy(t *testing.T) {
+	withFakeDoctorRunOutput(t, func(name string, _ ...string) (string, error) {
+		if name == "docker" {
+			return "fishhawk-postgres", nil
+		}
+		return "localhost:5432 - accepting connections", nil
+	})
+	r := checkPostgresContainer()
+	if r.status != "ok" {
+		t.Errorf("status = %q, want ok; detail: %s", r.status, r.detail)
+	}
+}
+
+// TestDoctorCheck_MinioContainerAbsent verifies checkMinioContainer returns
+// fail when docker ps returns empty output (container not running).
+func TestDoctorCheck_MinioContainerAbsent(t *testing.T) {
+	withFakeDoctorRunOutput(t, func(_ string, _ ...string) (string, error) {
+		return "", nil // docker ps returned empty — no matching container
+	})
+	r := checkMinioContainer()
+	if r.status != "fail" {
+		t.Errorf("status = %q, want fail", r.status)
+	}
+	if r.remediate == "" {
+		t.Error("remediate should be non-empty on fail")
+	}
+}
+
+// TestDoctorCheck_MinioContainerUpHealthFailed verifies checkMinioContainer
+// returns warn when the container is up but the health HTTP probe fails.
+func TestDoctorCheck_MinioContainerUpHealthFailed(t *testing.T) {
+	withFakeDoctorRunOutput(t, func(_ string, _ ...string) (string, error) {
+		return "fishhawk-minio", nil
+	})
+	withFakeDoctorHTTP(t, func(req *http.Request) (*http.Response, error) {
+		if strings.Contains(req.URL.Path, "/minio/health/live") {
+			return nil, errors.New("connection refused")
+		}
+		return fakeHTTPResponse(http.StatusOK, ""), nil
+	})
+	r := checkMinioContainer()
+	if r.status != "warn" {
+		t.Errorf("status = %q, want warn", r.status)
+	}
+	if r.remediate == "" {
+		t.Error("remediate should be non-empty on warn")
+	}
+}
+
+// TestDoctorCheck_MinioContainerHealthy verifies checkMinioContainer returns
+// ok when the container is up and the health probe returns 200.
+func TestDoctorCheck_MinioContainerHealthy(t *testing.T) {
+	withFakeDoctorRunOutput(t, func(_ string, _ ...string) (string, error) {
+		return "fishhawk-minio", nil
+	})
+	withFakeDoctorHTTP(t, func(req *http.Request) (*http.Response, error) {
+		return fakeHTTPResponse(http.StatusOK, ""), nil
+	})
+	r := checkMinioContainer()
+	if r.status != "ok" {
+		t.Errorf("status = %q, want ok; detail: %s", r.status, r.detail)
+	}
+}
+
 // TestDoctorCheck_BackendDown verifies checkBackend returns fail when the
 // backend is unreachable (doctorHTTPDo returns a connection error).
 func TestDoctorCheck_BackendDown(t *testing.T) {

--- a/scripts/dev
+++ b/scripts/dev
@@ -122,8 +122,10 @@ _build_binary() {
 
 cmd_up() {
   local force_all=0
+  local start_deps=0
   for arg in "$@"; do
     [[ "$arg" == "--all" ]] && force_all=1
+    [[ "$arg" == "--start-deps" ]] && start_deps=1
   done
 
   # Idempotency: bail if already running
@@ -150,17 +152,43 @@ cmd_up() {
     print "warning: .env not found — using current shell environment"
   fi
 
-  # Dependency health checks
-  if _pg_ready; then
-    print "postgres: ready"
-  else
-    print "warning: postgres not reachable — fishhawkd may fail to start"
+  # TCC preflight (macOS Full Disk Access)
+  if ! stat -- "${REPO_ROOT}/README.md" >/dev/null 2>/tmp/_dev_stat_err; then
+    if grep -q 'Operation not permitted' /tmp/_dev_stat_err 2>/dev/null; then
+      _die "no read access to the repo — grant Claude Code Full Disk Access in System Settings > Privacy & Security > Full Disk Access, then restart Claude Code"
+    fi
   fi
 
-  if _minio_ready; then
-    print "minio: ready"
+  # Docker daemon preflight
+  if ! docker info &>/dev/null 2>&1; then
+    _die 'Docker daemon not running — run "open -a Docker" and wait ~20s, then retry'
+  fi
+
+  # Containers preflight — check each independently, but run docker compose up -d at most once.
+  local pg_running=0 minio_running=0
+  [[ -n "$(docker ps --filter 'name=^/fishhawk-postgres$' --format '{{.Names}}')" ]] && pg_running=1
+  [[ -n "$(docker ps --filter 'name=^/fishhawk-minio$' --format '{{.Names}}')" ]] && minio_running=1
+
+  if (( !pg_running || !minio_running )); then
+    if (( start_deps )); then
+      print "starting containers..."
+      docker compose up -d
+      local i=0
+      while (( i < 30 )); do
+        _pg_ready && _minio_ready && break
+        sleep 2
+        (( i++ ))
+      done
+      _pg_ready || _die "postgres did not become ready within 60s — check: docker logs fishhawk-postgres"
+      _minio_ready || _die "minio did not become ready within 60s — check: docker logs fishhawk-minio"
+      print "postgres: ready"
+      print "minio: ready"
+    else
+      _die 'postgres/minio containers not up — run "docker compose up -d", then retry (or pass --start-deps)'
+    fi
   else
-    print "warning: minio not reachable — fishhawkd may fail to start"
+    print "postgres: running"
+    print "minio: running"
   fi
 
   # Build
@@ -245,5 +273,5 @@ cmd_down() {
 case "$cmd" in
   up)   cmd_up "${@:2}" ;;
   down) cmd_down ;;
-  *)    print -u2 "usage: scripts/dev <up [--all]|down>"; exit 1 ;;
+  *)    print -u2 "usage: scripts/dev <up [--all] [--start-deps]|down>"; exit 1 ;;
 esac


### PR DESCRIPTION
## Summary

- `scripts/dev up` adds three preflight checks that distinguish daemon-down / containers-down / TCC-access failures and print the specific recovery step, exiting before the cryptic migrate error.
- `--start-deps` brings the compose stack up once (regardless of which container is missing) and polls both `_pg_ready` and `_minio_ready` within a 60s budget — no duplicate `docker compose up -d`.
- `fishhawk doctor` gains three rungs: docker daemon, postgres container, minio container — inserted before `checkBackend` so infrastructure failures surface ahead of backend-connectivity ones. Each rung carries a `remediate` hint with the recovery command.

This encodes the 2026-05-27 ~30-min recovery scramble (TCC + Docker daemon down + containers down) into a one-line diagnosis the operator (or agent) sees immediately.

## Test plan

- [x] `cli` tests pass: 8 new test cases cover all status states for each rung (daemon-down/up; postgres absent/up-not-ready/healthy; minio absent/up-health-failed/healthy) via the existing `doctorRunOutput` / `doctorHTTPDo` seams. No real Docker, postgres, or MinIO needed.
- [x] `cli` lint clean.
- [x] zsh syntax check on `scripts/dev`.
- [x] Daemon-down preflight exercised live with a fake `docker` shim — confirms `error: Docker daemon not running — run "open -a Docker" and wait ~20s, then retry` and non-zero exit before any build step.
- [x] Happy path exercised live — `postgres: running` / `minio: running` print, then build/migrate proceed.

## Notes

- Acceptance criteria from #563:
  - [x] `scripts/dev up` distinguishes daemon-down / containers-down / TCC-access failures and prints the specific recovery step for each, exiting before the cryptic migrate error.
  - [x] `fishhawk doctor` gains Docker-daemon / postgres / minio rungs with recovery hints.
  - [x] Containers-down case auto-runs `docker compose up -d` (flag-gated as `--start-deps`).
- **In-loop fix (folded into this PR):** live-test of the TCC probe showed `stat` was leaking metadata to stdout on the happy path. Added `>/dev/null` to the probe so only the EPERM/ENOENT decision via stderr matters. Per the `feedback-in-loop-bugs-same-pr` rule.
- **MinIO port hardcoded at 9000** — risk acknowledged in the doctor rung. If `.env` overrides `MINIO_PORT`, this v1 rung will not read it. Documented as a code comment near the literal so a future operator knows why their override isn't reflected.
- **TCC probe pattern:** `stat README.md` + stderr-match for `Operation not permitted`. Distinguishes EPERM from ENOENT (file genuinely absent vs file blocked by macOS TCC), the latter not triggering the preflight error.
- Out of scope (per #563): auto-granting TCC (impossible on macOS), auto-launching Docker Desktop without `--start-deps`, production health-checking.
- Second of the three retro-surfaced operability warm-ups (after #562, before #564) before the ADR-027 impl headline #560.

Closes #563

🤖 Generated with [Claude Code](https://claude.com/claude-code)