### PR TITLE
prompt: surface p50/p95 + high-band advisory in plan-stage calibration hint (#564)

### DIFF
--- a/backend/internal/prompt/prompt.go
+++ b/backend/internal/prompt/prompt.go
@@ -63,6 +63,8 @@ type CalibrationBand struct {
 type CalibrationHint struct {
 	Samples          int
 	CalibrationRatio float64
+	ActualP50Minutes float64
+	ActualP95Minutes float64
 	ConfidenceBands  map[string]CalibrationBand
 }
 
@@ -411,8 +413,8 @@ func buildPlan(t Trigger) string {
 		"If your plan commits to an expensive step, allocate explicit minutes for it in predicted_runtime_minutes.\n")
 	if t.CalibrationHint != nil {
 		b.WriteString("\n### Calibration hint\n\n")
-		fmt.Fprintf(&b, "Your last %d implement-stage predictions on this workflow: actual runtime was %.2fx of predicted (actual / predicted).\n",
-			t.CalibrationHint.Samples, t.CalibrationHint.CalibrationRatio)
+		fmt.Fprintf(&b, "Your last %d implement-stage predictions on this workflow: actual p50 = %.1f min, p95 = %.1f min, ratio = %.2f.\n",
+			t.CalibrationHint.Samples, t.CalibrationHint.ActualP50Minutes, t.CalibrationHint.ActualP95Minutes, t.CalibrationHint.CalibrationRatio)
 		b.WriteString("Confidence-band accuracy:\n")
 		for _, level := range []string{"high", "medium", "low"} {
 			band, ok := t.CalibrationHint.ConfidenceBands[level]
@@ -423,6 +425,14 @@ func buildPlan(t Trigger) string {
 				level, band.Samples, band.WithinScale)
 		}
 		fmt.Fprintf(&b, "Multiply your raw estimate by %.2f to get a calibrated value.\n", t.CalibrationHint.CalibrationRatio)
+		if highBand, ok := t.CalibrationHint.ConfidenceBands["high"]; ok && highBand.Samples >= 5 {
+			if float64(highBand.WithinScale)/float64(highBand.Samples) <= 0.25 {
+				fmt.Fprintf(&b, "→ \"high\" has been the LEAST accurate band historically (%d/%d within 1.5x). "+
+					"Reserve \"high\" for genuinely mechanical changes (rename, doc edit). "+
+					"Default to \"medium\" when there's any logic, multi-file, or new-code uncertainty.\n",
+					highBand.WithinScale, highBand.Samples)
+			}
+		}
 	}
 	return b.String()
 }

--- a/backend/internal/prompt/prompt_test.go
+++ b/backend/internal/prompt/prompt_test.go
@@ -416,6 +416,8 @@ func TestBuild_Plan_CalibrationHintRendered(t *testing.T) {
 		CalibrationHint: &CalibrationHint{
 			Samples:          10,
 			CalibrationRatio: 1.18,
+			ActualP50Minutes: 12.5,
+			ActualP95Minutes: 18.0,
 			ConfidenceBands: map[string]CalibrationBand{
 				"high":   {Samples: 4, WithinScale: 3},
 				"medium": {Samples: 6, WithinScale: 4},
@@ -428,8 +430,10 @@ func TestBuild_Plan_CalibrationHintRendered(t *testing.T) {
 	}
 	wants := []string{
 		"### Calibration hint",
-		"actual runtime was 1.18x of predicted",
 		"10 implement-stage",
+		"actual p50 = 12.5 min",
+		"p95 = 18.0 min",
+		"ratio = 1.18",
 		"high: 4 samples, 3 within 1.5x of prediction",
 		"medium: 6 samples, 4 within 1.5x of prediction",
 		"low: 2 samples, 2 within 1.5x of prediction",
@@ -510,6 +514,87 @@ func TestBuild_Plan_CalibrationHint_Deterministic(t *testing.T) {
 	b, _ := Build("plan", tr)
 	if a != b {
 		t.Errorf("Build with CalibrationHint is non-deterministic across calls:\nA: %s\nB: %s", a, b)
+	}
+}
+
+func TestBuild_Plan_CalibrationHint_HighBandAdvisory(t *testing.T) {
+	// High band at 1/10 within 1.5x (10% ≤ 25%) → advisory fires naming "high".
+	got, err := Build("plan", Trigger{
+		IssueNumber: 7,
+		Repo:        "x/y",
+		CalibrationHint: &CalibrationHint{
+			Samples:          10,
+			CalibrationRatio: 2.50,
+			ActualP50Minutes: 25.0,
+			ActualP95Minutes: 45.0,
+			ConfidenceBands: map[string]CalibrationBand{
+				"high": {Samples: 10, WithinScale: 1},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	wants := []string{
+		"\"high\" has been the LEAST accurate band historically",
+		"1/10 within 1.5x",
+		"Reserve \"high\" for genuinely mechanical changes",
+		"Default to \"medium\"",
+	}
+	for _, w := range wants {
+		if !strings.Contains(got, w) {
+			t.Errorf("plan prompt missing advisory string %q:\n%s", w, got)
+		}
+	}
+}
+
+func TestBuild_Plan_CalibrationHint_NoAdvisoryWhenHighAccurate(t *testing.T) {
+	// Coverage: medium is the worst band (1/10) but high is accurate (8/10).
+	// The advisory is gated on high specifically, so it must NOT fire here.
+	got, err := Build("plan", Trigger{
+		IssueNumber: 7,
+		Repo:        "x/y",
+		CalibrationHint: &CalibrationHint{
+			Samples:          20,
+			CalibrationRatio: 1.00,
+			ActualP50Minutes: 10.0,
+			ActualP95Minutes: 15.0,
+			ConfidenceBands: map[string]CalibrationBand{
+				"medium": {Samples: 10, WithinScale: 1},
+				"high":   {Samples: 10, WithinScale: 8},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if strings.Contains(got, "LEAST accurate band historically") {
+		t.Errorf("high-band advisory must not fire when high band is accurate (8/10):\n%s", got)
+	}
+}
+
+func TestBuild_Plan_CalibrationHint_NoAdvisoryAboveThreshold(t *testing.T) {
+	// All bands above 25% accuracy → no advisory.
+	got, err := Build("plan", Trigger{
+		IssueNumber: 7,
+		Repo:        "x/y",
+		CalibrationHint: &CalibrationHint{
+			Samples:          30,
+			CalibrationRatio: 1.00,
+			ActualP50Minutes: 10.0,
+			ActualP95Minutes: 15.0,
+			ConfidenceBands: map[string]CalibrationBand{
+				"high":   {Samples: 10, WithinScale: 4}, // 40% > 25%
+				"medium": {Samples: 10, WithinScale: 4},
+				"low":    {Samples: 10, WithinScale: 4},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if strings.Contains(got, "LEAST accurate band historically") {
+		t.Errorf("advisory must not fire when all bands exceed 25%% accuracy:\n%s", got)
 	}
 }
 

--- a/backend/internal/server/calibration_hint_test.go
+++ b/backend/internal/server/calibration_hint_test.go
@@ -35,10 +35,14 @@ func (a *hintAuditRepo) ListAll(_ context.Context, p audit.ListAllParams) ([]*au
 }
 
 func (a *hintAuditRepo) seedRuntimeObserved(runID uuid.UUID, predicted, actual float64) {
+	a.seedRuntimeObservedConf(runID, predicted, actual, "medium")
+}
+
+func (a *hintAuditRepo) seedRuntimeObservedConf(runID uuid.UUID, predicted, actual float64, confidence string) {
 	payload, _ := json.Marshal(runtimeObservedPayload{
 		StageType:        "implement",
 		PredictedMinutes: predicted,
-		Confidence:       "medium",
+		Confidence:       confidence,
 		ActualMinutes:    actual,
 		Outcome:          "success",
 	})
@@ -96,6 +100,37 @@ func TestPlanPrompt_CalibrationHint_BelowThreshold(t *testing.T) {
 	}
 }
 
+func TestPlanPrompt_CalibrationHint_BandAdvisoryRendered(t *testing.T) {
+	s, rr, hintRepo, sf := newCalibrationHintPromptServer(t)
+	runID, planStageID, _, _ := seedRunWithStages(rr)
+
+	// Seed 9 high-confidence entries outside 1.5x (actual=20, predicted=10 → ratio=2x)
+	// and 1 high-confidence entry inside 1.5x → 1/10 = 10% ≤ 25% threshold.
+	for range 9 {
+		hintRepo.seedRuntimeObservedConf(runID, 10.0, 20.0, "high")
+	}
+	hintRepo.seedRuntimeObservedConf(runID, 10.0, 12.0, "high")
+
+	priv, _ := sf.issue(t, runID)
+	w := promptRequestForStage(t, s, runID, planStageID, priv)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d:\n%s", w.Code, w.Body.String())
+	}
+	var resp promptResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(resp.Prompt, "### Calibration hint") {
+		t.Errorf("plan prompt missing calibration hint section:\n%s", resp.Prompt)
+	}
+	if !strings.Contains(resp.Prompt, "LEAST accurate band historically") {
+		t.Errorf("plan prompt missing high-band advisory:\n%s", resp.Prompt)
+	}
+	if !strings.Contains(resp.Prompt, "1/10 within 1.5x") {
+		t.Errorf("plan prompt missing advisory X/Y count (1/10):\n%s", resp.Prompt)
+	}
+}
+
 func TestPlanPrompt_CalibrationHint_AboveThreshold(t *testing.T) {
 	s, rr, hintRepo, sf := newCalibrationHintPromptServer(t)
 	runID, planStageID, _, _ := seedRunWithStages(rr)
@@ -117,7 +152,7 @@ func TestPlanPrompt_CalibrationHint_AboveThreshold(t *testing.T) {
 	if !strings.Contains(resp.Prompt, "### Calibration hint") {
 		t.Errorf("plan prompt missing calibration hint section:\n%s", resp.Prompt)
 	}
-	if !strings.Contains(resp.Prompt, "1.20x") {
-		t.Errorf("plan prompt missing calibration ratio 1.20x:\n%s", resp.Prompt)
+	if !strings.Contains(resp.Prompt, "ratio = 1.20") {
+		t.Errorf("plan prompt missing calibration ratio 1.20:\n%s", resp.Prompt)
 	}
 }

--- a/backend/internal/server/prompt.go
+++ b/backend/internal/server/prompt.go
@@ -523,6 +523,8 @@ func (s *Server) resolveCalibrationHint(ctx context.Context, workflowID string) 
 	return &prompt.CalibrationHint{
 		Samples:          result.Samples,
 		CalibrationRatio: result.CalibrationRatio,
+		ActualP50Minutes: result.ActualP50Minutes,
+		ActualP95Minutes: result.ActualP95Minutes,
 		ConfidenceBands:  bands,
 	}, nil
 }


### PR DESCRIPTION
## Summary

- Plan-stage calibration hint now surfaces actual **p50 + p95** alongside the ratio (`actual p50 = X.X min, p95 = Y.Y min, ratio = Z.ZZ`). The p95 tail is the budget-blowing case; surfacing it nudges the agent to think "what if I'm in the tail" at planning time.
- When the **high band has ≥5 samples AND its within-1.5x hit rate is ≤25%**, the hint emits an advisory naming high as the LEAST accurate band historically (with raw X/Y numbers) and steering the agent toward "medium" as the default.
- Advisory is **gated on the high band specifically**, not on a generalized worst-band computation. The advisory copy discourages "high" by design — generalizing the leading sentence while keeping the body specific to "high" would create label/message inconsistency if "medium" ever became empirically worst. A different worst-band scenario would need its own copy, which is out of scope here.
- Wires through two fields (`ActualP50Minutes`, `ActualP95Minutes`) that `computeCalibration` was already producing but dropping before the hint struct.

## Test plan

- [x] `TestBuild_Plan_CalibrationHintRendered` extended to assert p50 + p95 + ratio strings render.
- [x] `TestBuild_Plan_CalibrationHint_HighBandAdvisory` — seeds high band at 1/10 → advisory present, includes `1/10 within 1.5x`.
- [x] `TestBuild_Plan_CalibrationHint_NoAdvisoryWhenHighAccurate` — coverage test: medium worst at 1/10 but high accurate at 8/10 → advisory ABSENT. Guards the gating logic against drift into "name whichever is worst."
- [x] `TestBuild_Plan_CalibrationHint_NoAdvisoryAboveThreshold` — all bands at 40% → no advisory.
- [x] `TestPlanPrompt_CalibrationHint_BandAdvisoryRendered` — server-rendered prompt end-to-end (9× high at 2x predicted + 1× within 1.5x → 1/10 → advisory present).
- [x] `go test -race ./internal/prompt/... ./internal/server/...` clean.
- [x] `golangci-lint run` clean on touched packages.

## Notes

- Acceptance criteria from #564:
  - [x] Plan-stage calibration hint includes per-confidence-band within-1.5x accuracy (already shipped; unchanged).
  - [x] Hint includes p95 alongside p50.
  - [x] Hint copy explicitly discourages "high" given the historical band accuracy, reserving it for mechanical changes.
  - [x] Prompt test asserts the advisory line renders when calibration data is present; the zero-samples case continues to omit the hint entirely (inherited from existing `resolveCalibrationHint` behavior).
- **Why high-band-gated rather than worst-band-gated:** the advisory's purpose is to discourage over-use of "high." Today's empirical state is `high=10%, medium=50%` — exactly what this catches. If medium ever degrades to "worst," that's a different problem ("model your tasks more conservatively") deserving different copy, not this one repurposed.
- Out of scope (per #564): rejecting/auto-downgrading "high" server-side, re-weighting the calibration ratio.
- Third of the three retro-surfaced operability warm-ups (after #562 and #563) before the ADR-027 impl headline #560.

Closes #564

🤖 Generated with [Claude Code](https://claude.com/claude-code)