### PR TITLE
prompt: enumerate decomposition.sub_plans[i] shape in compound-field rule (#568)

### DIFF
--- a/backend/internal/prompt/prompt.go
+++ b/backend/internal/prompt/prompt.go
@@ -391,6 +391,7 @@ func buildPlan(t Trigger) string {
 	b.WriteString("- ticket_reference: {\"type\": \"...\", \"url\": \"...\", \"id\": \"...\"} object\n")
 	b.WriteString("- generated_by: {\"agent\": \"...\", \"model\": \"...\", \"timestamp\": \"...\"} object\n")
 	b.WriteString("- decomposition (when present): {\"rationale\": \"...\", \"sub_plans\": [...]} object\n")
+	b.WriteString("- decomposition.sub_plans[i]: {\"title\": \"...\", \"scope_hint\": \"...\", \"predicted_runtime_minutes\": N, \"predicted_runtime_confidence\": \"low|medium|high\"} object — use the FULL canonical field names; \"confidence\" / \"minutes\" shorthand will be rejected\n")
 	b.WriteString("The validator rejects any plan where these fields contain bare strings instead of their required structured shapes.\n")
 	b.WriteString("\n")
 	b.WriteString("If your plan scope includes any file under docs/spec/, the verification steps must include: " +

--- a/backend/internal/prompt/prompt_test.go
+++ b/backend/internal/prompt/prompt_test.go
@@ -858,6 +858,8 @@ func TestBuild_Plan_CompoundFieldDirective(t *testing.T) {
 		"approach",
 		"verification",
 		"bare string",
+		"decomposition.sub_plans[i]",
+		"shorthand will be rejected",
 	}
 	for _, w := range wants {
 		if !strings.Contains(got, w) {


### PR DESCRIPTION
## Summary

- Adds a `decomposition.sub_plans[i]` entry to the plan-stage compound-field rule, naming all four required fields with their full canonical names (`title`, `scope_hint`, `predicted_runtime_minutes`, `predicted_runtime_confidence`) plus an explicit anti-shorthand note.
- Inserted immediately after the existing `decomposition` outer-shape line, matching the `scope.files[i]:` outer→inner pattern established two lines above.

Surfaced during the 2026-05-28 loop on #560 (XL ticket, agent decomposed into 5 sub_plans, every one emitted `confidence` instead of `predicted_runtime_confidence` → 11 schema violations, plan-stage failed). The compound-field rule from #556 covered the outer decomposition shape; this PR plugs the inner gap so the failure class can't recur on any future XL plan.

## Test plan

- [x] `TestBuild_Plan_CompoundFieldDirective` extended with two new want strings (`decomposition.sub_plans[i]` and `shorthand will be rejected`) — fails if the new line is absent or its key wording drifts.
- [x] `go test -race ./internal/prompt/...` clean.
- [x] `golangci-lint run ./internal/prompt/...` clean.

## Notes

- Acceptance criteria from #568:
  - [x] `decomposition.sub_plans[i]` entry added with all four required fields named verbatim.
  - [x] Anti-shorthand note explicit.
  - [x] Prompt test asserts the new line renders.
  - [x] Prompt-only — no schema or validator changes.
- Out of scope (per #568): refactoring the compound-field rule to a single source-of-truth (would touch the schema; tracked elsewhere); server-side coercion of `confidence` → `predicted_runtime_confidence` (lossy at this level; the prompt should be explicit).
- Unblocks #560 (ADR-027 plan-review-agent impl 1/2) — the run that surfaced this. Next loop on #560 will use the corrected prompt.

Closes #568

🤖 Generated with [Claude Code](https://claude.com/claude-code)