### PR TITLE
Pass --check-base-ref on implement stages so the local loop emits a git_diff event (#589)

### DIFF
--- a/backend/cmd/fishhawk-mcp/run_stage.go
+++ b/backend/cmd/fishhawk-mcp/run_stage.go
@@ -310,6 +310,16 @@ func (r *runResolver) runStage(ctx context.Context, req *mcp.CallToolRequest, in
 		baseBranch = "main"
 	}
 	argv = append(argv, "--base-branch", baseBranch)
+	// Only implement stages produce a diff to enforce. Passing
+	// --check-base-ref makes the runner run computeAndEmitDiff, which
+	// emits the git_diff event the backend needs to re-evaluate policy
+	// (policy_evaluated) and run implement-review (#561/#585). Plan and
+	// review stages legitimately produce no diff, so they omit it.
+	// Mirrors the runner's own gate (computeAndEmitDiff runs iff
+	// cfg.checkBaseRef != "").
+	if in.Stage == "implement" {
+		argv = append(argv, "--check-base-ref", baseBranch)
+	}
 	if !in.PushAndOpenPR {
 		argv = append(argv, "--no-pr")
 	}

--- a/backend/cmd/fishhawk-mcp/run_stage_test.go
+++ b/backend/cmd/fishhawk-mcp/run_stage_test.go
@@ -366,6 +366,10 @@ func TestRunStage_ArgvComposition_PlanStage(t *testing.T) {
 			t.Errorf("argv missing %q\nfull: %s", want, joined)
 		}
 	}
+	// Plan stages produce no diff, so --check-base-ref must be omitted.
+	if strings.Contains(joined, "--check-base-ref") {
+		t.Errorf("plan stage should not include --check-base-ref\nfull: %s", joined)
+	}
 }
 
 func TestRunStage_ArgvComposition_ImplementStageNoPlanOut(t *testing.T) {
@@ -398,8 +402,14 @@ func TestRunStage_ArgvComposition_ImplementStageNoPlanOut(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runStage: %v", err)
 	}
-	if strings.Contains(strings.Join(capturedArgs, " "), "--plan-out") {
+	joined := strings.Join(capturedArgs, " ")
+	if strings.Contains(joined, "--plan-out") {
 		t.Errorf("implement stage should not include --plan-out: %v", capturedArgs)
+	}
+	// Implement stages must carry --check-base-ref so the runner emits
+	// the git_diff event (backend policy_evaluated + implement-review).
+	if !strings.Contains(joined, "--check-base-ref main") {
+		t.Errorf("implement stage missing --check-base-ref main\nfull: %s", joined)
 	}
 }
 

--- a/cli/cmd/fishhawk/runner.go
+++ b/cli/cmd/fishhawk/runner.go
@@ -167,6 +167,14 @@ func runRunnerStart(args []string, stdout, stderr io.Writer) int {
 	if *baseBranch != "" {
 		argv = append(argv, "--base-branch", *baseBranch)
 	}
+	// Only implement stages produce a diff to enforce. Passing
+	// --check-base-ref makes the runner emit the git_diff event the
+	// backend needs to re-evaluate policy (policy_evaluated) and run
+	// implement-review (#561/#585). Plan/review stages omit it. Mirrors
+	// backend/cmd/fishhawk-mcp/run_stage.go — keep in sync.
+	if *stage == "implement" {
+		argv = append(argv, "--check-base-ref", *baseBranch)
+	}
 	if *noPR {
 		argv = append(argv, "--no-pr")
 	}

--- a/cli/cmd/fishhawk/runner_test.go
+++ b/cli/cmd/fishhawk/runner_test.go
@@ -138,6 +138,12 @@ func TestRunnerStart_HappyPath_BuildsExpectedArgv(t *testing.T) {
 			t.Errorf("argv missing %q: %v", want, cap.args)
 		}
 	}
+	// Implement stages carry --check-base-ref <baseBranch> so the runner
+	// emits the git_diff event (backend policy_evaluated +
+	// implement-review). Assert both the flag and its value follow.
+	if i := indexOf(cap.args, "--check-base-ref"); i < 0 || i+1 >= len(cap.args) || cap.args[i+1] != "main" {
+		t.Errorf("implement argv missing --check-base-ref main: %v", cap.args)
+	}
 	if contains(cap.args, "--no-pr") {
 		t.Errorf("argv should NOT include --no-pr when flag is not passed (default=false): %v", cap.args)
 	}
@@ -170,6 +176,10 @@ func TestRunnerStart_PlanStage_PassesPlanOut(t *testing.T) {
 	}
 	if !contains(cap.args, "/tmp/fishhawk-plan.json") {
 		t.Errorf("plan-stage argv missing /tmp/fishhawk-plan.json: %v", cap.args)
+	}
+	// Plan stages produce no diff, so --check-base-ref is omitted.
+	if contains(cap.args, "--check-base-ref") {
+		t.Errorf("plan-stage argv should NOT include --check-base-ref: %v", cap.args)
 	}
 }
 
@@ -495,10 +505,14 @@ func TestRunnerStart_StageCompleteComment(t *testing.T) {
 
 // contains reports whether s appears anywhere in xs.
 func contains(xs []string, s string) bool {
-	for _, x := range xs {
+	return indexOf(xs, s) >= 0
+}
+
+func indexOf(xs []string, s string) int {
+	for i, x := range xs {
 		if x == s {
-			return true
+			return i
 		}
 	}
-	return false
+	return -1
 }


### PR DESCRIPTION
## Summary

`fishhawk_run_stage` and the CLI `fishhawk runner start` built the runner argv with `--base-branch` but **never `--check-base-ref`**. The runner only runs `computeAndEmitDiff` (which emits the `git_diff` event) when `cfg.checkBaseRef != ""` (`runner/cmd/fishhawk-runner/main.go:389`), so the local loop produced **no diff event**. Two silent consequences on every local-loop implement stage:

- **implement-review (#561/#585) skipped** — `advanceStageAfterTrace` guards on `bundle.ExtractDiff` succeeding, impossible without the event.
- **policy constraints never enforced** — `max_files_changed`, `forbidden_paths`, `required_outcomes` skipped via `policy_evaluated{skip_reason: no_diff_in_bundle}`.

Fix: pass `--check-base-ref <baseBranch>` on **implement** stages (gated on stage type, mirroring the runner's existing implement/review special-casing) from **both** argv builders, kept in sync. Plan/review stages legitimately produce no diff and omit it.

Deliberately does **not** add `--constraints-file`: the backend re-evaluates policy from the cached spec once the `git_diff` event exists, so emitting the event alone restores backend-side `policy_evaluated` + implement-review. In-runner enforcement (`--constraints-file`) is a separate concern.

## Test plan

- `go test` + `golangci-lint` clean on both `backend/cmd/fishhawk-mcp` and `cli/cmd/fishhawk`. New assertions in both packages: implement-stage argv includes `--check-base-ref <baseBranch>`; plan-stage argv omits it.
- Driven through the local dogfood loop (run `6df2ba76`); plan-review verdict landed `approve` (0 concerns).

## Notes

- The **behavioral proof** (a local implement stage emits a `git_diff` event, `policy_evaluated` shows changed files instead of `no_diff_in_bundle`, and an `implement_reviewed` verdict lands with reviewers configured) needs a live runner subprocess — it's operator-verified via the dogfood loop after merge + `scripts/dev up --all`, not by unit tests. I'll run that verification post-merge; it's the same protocol that proved out #584.
- This unblocks local dogfooding of the #561/#585/#584 implement-review stack and restores implement-stage policy enforcement that had been silently off.

Closes #589