### PR TITLE
Emit mid-stage progress heartbeats so the run_stage relay shows liveness (#580)

### DIFF
--- a/backend/cmd/fishhawk-mcp/README.md
+++ b/backend/cmd/fishhawk-mcp/README.md
@@ -75,6 +75,16 @@ cosign verify-blob \
   SHA256SUMS
 ```
 
+## Progress notifications (`fishhawk_run_stage`)
+
+`fishhawk_run_stage` spawns the runner and relays its stderr JSONL lines as MCP `notifications/progress` updates — but **only when the client supplied a `progressToken`** on the call (the MCP opt-in progress model; without a token the runner's events are still returned post-hoc in the final result's `events` list).
+
+While the agent runs, the runner emits a `stage_progress` heartbeat (~every 15s, see [runner/README.md](../../../runner/README.md#progress-heartbeats-580)). The relay renders it into the notification's message:
+
+    stage_progress turns=7 tokens=13402 elapsed=42s last=assistant
+
+Because the cadence is time-driven, a stalled stage keeps producing heartbeats with non-advancing `turns`/`tokens`, so a watching operator/client can tell a progressing stage from a stuck one. Note this is a signal for the **operator/client watching the run**, not a live early-cancel channel for the synchronously-blocked driving agent — that agent sees the heartbeats only after `fishhawk_run_stage` returns (and as groundwork for a future async run_stage).
+
 ## Runner integration
 
 E19.8 / future wires `fishhawk-mcp` into the runner's container image. Until then the MCP surface is interactive-Claude-Code-only.

--- a/backend/cmd/fishhawk-mcp/run_stage.go
+++ b/backend/cmd/fishhawk-mcp/run_stage.go
@@ -181,9 +181,22 @@ agent-driven local-runner loop:
   3. fishhawk_approve_plan ...
   4. fishhawk_run_stage --stage implement ...
 
-Runner output streams as MCP progress notifications when the
-client provides a progress token; the final tool result carries
-the full event list plus the post-run stage state.
+Runner output streams as MCP progress notifications ONLY when the
+client supplies a progressToken on the call (opt-in per the MCP
+spec); the final tool result always carries the full event list
+plus the post-run stage state.
+
+During execution the runner emits periodic stage_progress
+heartbeats (~every 15s) carrying the turn count, elapsed time,
+tokens-so-far, and last event kind, so the driver can distinguish a
+progressing stage from a stalled one (the counters keep ticking on
+elapsed even when turns/tokens stall). With a progressToken these
+arrive live as progress notifications for the operator/client
+watching the run; without one they still appear post-hoc in the
+final result's events list. This is NOT a live mid-call early-cancel
+signal for the synchronously-blocked driving agent — the agent sees
+the heartbeats only after the call returns (and as groundwork for a
+future async run_stage).
 
 Output fields (three additional best-effort fields, omitted when
 unavailable):
@@ -566,8 +579,24 @@ func runStageParseEvents(
 // for the progress notification's human-readable summary. Looks for
 // a top-level `kind` or `type` field (the runner's event shape uses
 // `kind`); falls back to the JSON-encoded payload truncated.
+//
+// A stage_progress heartbeat (#580) is special-cased: its Message
+// carries the coarse counters (turns / tokens-so-far / elapsed /
+// last event kind) so the driver can tell a progressing stage from a
+// stalled one. This Message is the only per-event field the relay
+// populates, so it is where the liveness signal must land.
 func runStageEventMessage(payload any) string {
 	if m, ok := payload.(map[string]any); ok {
+		if ev, _ := m["event"].(string); ev == "stage_progress" {
+			// JSON numbers decode as float64; format as integers.
+			num := func(k string) float64 {
+				f, _ := m[k].(float64)
+				return f
+			}
+			last, _ := m["last_event_kind"].(string)
+			return fmt.Sprintf("stage_progress turns=%.0f tokens=%.0f elapsed=%.0fs last=%s",
+				num("turns"), num("tokens_so_far"), num("elapsed_seconds"), last)
+		}
 		for _, key := range []string{"kind", "type", "event"} {
 			if v, ok := m[key].(string); ok && v != "" {
 				return v

--- a/backend/cmd/fishhawk-mcp/run_stage_test.go
+++ b/backend/cmd/fishhawk-mcp/run_stage_test.go
@@ -728,6 +728,35 @@ func TestRunStageEventMessage_FallsBackToJSON(t *testing.T) {
 	}
 }
 
+// TestRunStageEventMessage_StageProgress verifies a stage_progress
+// heartbeat (#580) renders its coarse counters into the progress
+// message (turns / tokens / elapsed / last), while a normal event
+// still falls through to its kind.
+func TestRunStageEventMessage_StageProgress(t *testing.T) {
+	// JSON numbers decode as float64, mirroring the relay's
+	// json.Unmarshal-into-any path.
+	progress := map[string]any{
+		"event":           "stage_progress",
+		"elapsed_seconds": float64(42),
+		"turns":           float64(7),
+		"tokens_so_far":   float64(13402),
+		"last_event_kind": "assistant",
+	}
+	got := runStageEventMessage(progress)
+	for _, want := range []string{"turns=7", "tokens=13402", "elapsed=42s", "last=assistant"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("message = %q, want it to contain %q", got, want)
+		}
+	}
+
+	// A normal event still returns its kind, unaffected by the
+	// stage_progress special-case.
+	normal := map[string]any{"kind": "runner_started"}
+	if msg := runStageEventMessage(normal); msg != "runner_started" {
+		t.Errorf("normal event message = %q, want runner_started", msg)
+	}
+}
+
 // --- DiffSummary, AuditPointer, RunURL enrichment (#442) ---
 
 // TestRunStage_DiffSummary_NilWhenNoGitDiffEvent verifies acceptance

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -212,6 +212,8 @@ Connection pool: `pgxpool.Pool` per service instance.
 | `agent_retry` | Middle | Boundary marker the runner's Claude Code driver emits between attempts when it re-spawns the agent after a transient thinking-block API 400 (payload: `attempt`, `reason`, `tokens_so_far`). See the bounded in-driver retry row in §10. |
 | `trailer` | Last line | `event_count`, content hash of preceding lines |
 
+**Not a bundle event — `stage_progress` liveness heartbeat (#580)**: during agent invocation the Claude Code driver writes a single-line `{"event":"stage_progress","elapsed_seconds":N,"turns":N,"tokens_so_far":N,"last_event_kind":"…"}` to the runner's **logSink (stderr) only**, every ~15s (`claudecode.Invoker.HeartbeatInterval`, default 15s). It carries coarse structural counters — never agent payload text — so a long stage is visibly progressing. It is **never** appended to `Result.Events`, so the signed trace bundle is unchanged (same treatment as the logSink-only `runner_cancelled` / `stage_self_retry` lines). The `fishhawk-mcp` `fishhawk_run_stage` relay forwards it as a `notifications/progress` update whose message renders the counters; because it's time-driven, a stalled stage still emits heartbeats with non-advancing `turns`/`tokens_so_far`, letting the driver tell "alive and progressing" from "stuck".
+
 ## 6. Invariants
 
 These are load-bearing. Do not break them without explicit ADR.

--- a/runner/README.md
+++ b/runner/README.md
@@ -92,6 +92,14 @@ The same binary the action runs can be invoked locally for development:
 
 When `--prompt-file` is set the runner invokes Claude Code; the structured runner log lines (`runner_started`, `runner_completed`) go to stderr. With `--bundle-out`, captured events are packed into `*.jsonl.gz` per ADR-007. Without it, events fall back to JSONL on stdout.
 
+### Progress heartbeats (#580)
+
+While the agent runs, the runner writes a `stage_progress` liveness line to stderr every ~15 seconds:
+
+    {"event":"stage_progress","elapsed_seconds":42,"turns":7,"tokens_so_far":13402,"last_event_kind":"assistant"}
+
+The counters are coarse and structural — elapsed seconds, parsed-event count, cumulative tokens, and the last event kind — never agent payload text. The cadence is time-driven, so a stalled stage keeps emitting heartbeats with non-advancing `turns`/`tokens_so_far`, distinguishing "alive and progressing" from "stuck". These lines go to stderr **only**: they never enter the signed trace bundle. The `fishhawk-mcp` `fishhawk_run_stage` tool forwards them as MCP progress notifications. There is no flag to disable them in normal operation; they are suppressed only when the runner is driven without a progress sink (not reachable from the CLI).
+
 ## Releases
 
 The release workflow at `.github/workflows/runner-release.yml` triggers on tags matching `runner/v*`. To cut a release:

--- a/runner/cmd/fishhawk-runner/main.go
+++ b/runner/cmd/fishhawk-runner/main.go
@@ -310,6 +310,15 @@ func run(args []string, logSink io.Writer) (exitCode int) {
 			Timeout:   cfg.timeout,
 		},
 		Env: map[string]string{},
+		// Wire mid-stage progress heartbeats to logSink (the runner's
+		// structured stderr stream, which the fishhawk-mcp run_stage
+		// relay forwards as progress notifications). The agent adapter
+		// emits a single-line stage_progress JSON heartbeat here every
+		// ~15s during the agent invocation so a long stage is visibly
+		// progressing rather than silent (#580). These never enter the
+		// signed trace bundle. Reverting this one line fully disables
+		// emission.
+		ProgressSink: logSink,
 	}
 
 	// E19.8 / #348: mint a short-lived MCP token for the agent and

--- a/runner/cmd/fishhawk-runner/main_test.go
+++ b/runner/cmd/fishhawk-runner/main_test.go
@@ -1458,6 +1458,41 @@ func TestRun_FetchPrompt_MCPTokenFetchFailure_StillProceeds(t *testing.T) {
 	}
 }
 
+// TestRun_WiresProgressSinkToLogSink confirms run() sets the
+// Invocation's ProgressSink to the same logSink it writes lifecycle
+// lines to, so the agent adapter's stage_progress heartbeats land on
+// the stream the fishhawk-mcp relay forwards (#580).
+func TestRun_WiresProgressSinkToLogSink(t *testing.T) {
+	invoker := &fakeInvoker{canned: agent.Result{OK: true}}
+	withFakeInvoker(t, invoker)
+	fu := newFakeUploader(t)
+	fu.promptResp = &upload.FetchedPrompt{
+		StageID:    "22222222-3333-4444-5555-666666666666",
+		StageType:  "implement",
+		Prompt:     "Hello agent.",
+		PromptHash: "deadbeef",
+	}
+	withFakeUploader(t, fu)
+
+	var stderr strings.Builder
+	got := run([]string{
+		"--run-id", "11111111-2222-3333-4444-555555555555",
+		"--backend-url", "https://api.fishhawk.test",
+		"--workflow", "feature_change", "--stage", "implement",
+		"--stage-id", "22222222-3333-4444-5555-666666666666",
+		"--fetch-prompt",
+	}, &stderr)
+	if got != exitOK {
+		t.Fatalf("run = %d, want exitOK:\n%s", got, stderr.String())
+	}
+	if invoker.gotInv == nil {
+		t.Fatal("invoker.gotInv nil — invocation not captured")
+	}
+	if invoker.gotInv.ProgressSink != io.Writer(&stderr) {
+		t.Errorf("ProgressSink = %v, want the logSink passed to run()", invoker.gotInv.ProgressSink)
+	}
+}
+
 func TestRun_FetchPrompt_PromptFileWins(t *testing.T) {
 	dir := t.TempDir()
 	promptPath := filepath.Join(dir, "prompt.txt")

--- a/runner/internal/agent/agent.go
+++ b/runner/internal/agent/agent.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"time"
 )
 
@@ -54,6 +55,20 @@ type Invocation struct {
 	// mid-execution. Empty / nil is fine — the child inherits the
 	// parent env unchanged.
 	Env map[string]string
+
+	// ProgressSink receives single-line JSON stage_progress
+	// heartbeats emitted at a fixed cadence during the invocation
+	// (#580). Each line is a complete `{"event":"stage_progress",...}`
+	// JSON object terminated by '\n' carrying coarse, structural
+	// liveness metadata (elapsed seconds, turn count, tokens-so-far,
+	// last event kind) — never agent payload text, so it has no
+	// redaction exposure. The runner wires this to its logSink (the
+	// structured stderr stream the fishhawk-mcp relay forwards as
+	// progress notifications). Heartbeats are written ONLY here, never
+	// appended to Result.Events, so the signed trace bundle is
+	// unchanged. A nil ProgressSink disables heartbeats entirely
+	// (zero writes), preserving the pre-#580 behavior and tests.
+	ProgressSink io.Writer
 }
 
 // Budget caps an agent invocation. Per MVP_SPEC §4.2 (`budget`

--- a/runner/internal/agent/claudecode/claudecode.go
+++ b/runner/internal/agent/claudecode/claudecode.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/kuhlman-labs/fishhawk/runner/internal/agent"
@@ -34,6 +35,11 @@ import (
 // DefaultBinary is the executable name resolved against PATH when
 // Invoker.Binary is empty.
 const DefaultBinary = "claude"
+
+// defaultHeartbeatInterval is the cadence of stage_progress liveness
+// heartbeats written to Invocation.ProgressSink during an invocation
+// (#580). Used when Invoker.HeartbeatInterval is zero.
+const defaultHeartbeatInterval = 15 * time.Second
 
 // Invoker is the agent.Invoker implementation for Claude Code.
 type Invoker struct {
@@ -62,6 +68,13 @@ type Invoker struct {
 	// default (1) is set at construction in New(); a zero value means
 	// "no retry" so tests and operators can disable it deterministically.
 	MaxThinkingBlockRetries int
+
+	// HeartbeatInterval is the cadence of stage_progress liveness
+	// heartbeats written to Invocation.ProgressSink during an
+	// invocation (#580). Zero means defaultHeartbeatInterval (15s).
+	// A per-Invoker field rather than a package-level global so
+	// parallel tests can shorten it without racing on shared state.
+	HeartbeatInterval time.Duration
 }
 
 // New returns an Invoker configured to use the system `claude`
@@ -259,6 +272,71 @@ func (i *Invoker) invokeOnce(ctx context.Context, inv agent.Invocation) (agent.R
 	// thinking-block detection (see isThinkingBlock400).
 	var resultPayload []byte
 
+	// Progress heartbeat state (#580). The scan loop below writes
+	// turns / tokensUsed / lastKind; the heartbeat goroutine reads
+	// them on each tick. Both accesses go through progMu so the race
+	// detector stays quiet (Go memory model: concurrent access from
+	// multiple goroutines needs explicit synchronization).
+	var (
+		progMu   sync.Mutex
+		turns    int
+		lastKind string
+	)
+	start := now()
+
+	// Heartbeat goroutine. It is the SOLE writer to inv.ProgressSink
+	// during Invoke, so single whole-line Fprintf writes never
+	// interleave with another writer's partial line. Proof by
+	// inspection of every ProgressSink (== runner logSink) writer:
+	//   - This goroutine — the only writer inside invokeOnce.
+	//   - The scan loop (same invokeOnce) — touches res.Events and the
+	//     progMu-guarded counters only; never writes ProgressSink.
+	//   - main.go run() lifecycle lines (runner_started, prompt_fetched,
+	//     mcp_token_issued, etc.) — all on run()'s main goroutine, which
+	//     is blocked inside invoker.Invoke for the whole invocation, so
+	//     they are strictly before/after, never concurrent.
+	//   - main.go's deferred runner_cancelled line — runs only when
+	//     run() returns, i.e. after Invoke has already returned; a
+	//     SIGTERM/cancel during Invoke propagates via ctx (cooperative
+	//     shutdown) and the line is emitted post-Invoke, not concurrently.
+	// Hence no second goroutine ever writes ProgressSink while this one
+	// is running, and JSONL line integrity is guaranteed. A nil
+	// ProgressSink starts no goroutine and emits zero heartbeats.
+	var (
+		hbDone    chan struct{}
+		hbStopped chan struct{}
+	)
+	if inv.ProgressSink != nil {
+		interval := i.HeartbeatInterval
+		if interval <= 0 {
+			interval = defaultHeartbeatInterval
+		}
+		hbDone = make(chan struct{})
+		hbStopped = make(chan struct{})
+		go func() {
+			defer close(hbStopped)
+			ticker := time.NewTicker(interval)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-hbDone:
+					return
+				case <-ticker.C:
+					// Time-driven, not event-driven: a stalled stage
+					// still emits heartbeats with non-advancing counters,
+					// which is exactly how the driver tells "alive and
+					// progressing" from "stuck".
+					progMu.Lock()
+					t, tok, lk := turns, tokensUsed, lastKind
+					progMu.Unlock()
+					_, _ = fmt.Fprintf(inv.ProgressSink,
+						`{"event":"stage_progress","elapsed_seconds":%d,"turns":%d,"tokens_so_far":%d,"last_event_kind":%q}`+"\n",
+						int(now().Sub(start).Seconds()), t, tok, lk)
+				}
+			}
+		}()
+	}
+
 	scanner := bufio.NewScanner(stdout)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	for scanner.Scan() {
@@ -268,8 +346,14 @@ func (i *Invoker) invokeOnce(ctx context.Context, inv agent.Invocation) (agent.R
 		if ev.Kind == "result" || strings.HasPrefix(ev.Kind, "result.") {
 			resultPayload = append([]byte(nil), ev.Payload...)
 		}
+		progMu.Lock()
+		turns++
+		lastKind = ev.Kind
 		if ok && used > 0 {
 			tokensUsed = used
+		}
+		progMu.Unlock()
+		if ok && used > 0 {
 			if inv.Budget.MaxTokens > 0 && tokensUsed > inv.Budget.MaxTokens {
 				budgetHit = true
 				_ = cmd.Process.Kill()
@@ -278,6 +362,14 @@ func (i *Invoker) invokeOnce(ctx context.Context, inv agent.Invocation) (agent.R
 		}
 	}
 	scanErr := scanner.Err()
+
+	// Stop the heartbeat goroutine now the scan loop has finished —
+	// covers both the EOF path and the budget-hit early break, so the
+	// goroutine never outlives the invocation (no ticker/timer leak).
+	if hbDone != nil {
+		close(hbDone)
+		<-hbStopped
+	}
 
 	// Drain remaining stdout if we killed mid-stream.
 	_, _ = io.Copy(io.Discard, stdout)

--- a/runner/internal/agent/claudecode/claudecode_test.go
+++ b/runner/internal/agent/claudecode/claudecode_test.go
@@ -1,7 +1,10 @@
 package claudecode
 
 import (
+	"bufio"
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -78,6 +81,20 @@ func TestHelperProcess(t *testing.T) {
 		fmt.Println(`{"type":"system","subtype":"init"}`)
 		fmt.Println(`{"type":"assistant","content":"recovered"}`)
 		fmt.Println(`{"type":"result","usage":{"input_tokens":10,"output_tokens":20}}`)
+	case "spaced":
+		// Emit several events spaced apart so a shortened heartbeat
+		// interval fires multiple times across the invocation, with
+		// usage advancing so the heartbeat counters move (#580).
+		fmt.Println(`{"type":"system","subtype":"init"}`)
+		os.Stdout.Sync()
+		time.Sleep(60 * time.Millisecond)
+		fmt.Println(`{"type":"assistant","usage":{"input_tokens":10,"output_tokens":5}}`)
+		os.Stdout.Sync()
+		time.Sleep(60 * time.Millisecond)
+		fmt.Println(`{"type":"assistant","usage":{"input_tokens":30,"output_tokens":10}}`)
+		os.Stdout.Sync()
+		time.Sleep(60 * time.Millisecond)
+		fmt.Println(`{"type":"result","usage":{"input_tokens":50,"output_tokens":20}}`)
 	case "echo_env":
 		// Echo a single env var so we can assert the harness
 		// wired API key forwarding correctly.
@@ -531,5 +548,155 @@ func TestInvoke_GenericExitNoRetry(t *testing.T) {
 	}
 	if starts != 1 {
 		t.Errorf("invocation_start count = %d, want 1 (no retry on generic failure)", starts)
+	}
+}
+
+// progressHeartbeats parses every stage_progress JSONL line written to
+// a ProgressSink buffer, asserting each carries the four expected
+// fields. Returns the decoded heartbeats in arrival order.
+type heartbeat struct {
+	Event         string  `json:"event"`
+	ElapsedSecs   *int    `json:"elapsed_seconds"`
+	Turns         *int    `json:"turns"`
+	TokensSoFar   *int    `json:"tokens_so_far"`
+	LastEventKind *string `json:"last_event_kind"`
+}
+
+func parseHeartbeats(t *testing.T, raw []byte) []heartbeat {
+	t.Helper()
+	var hbs []heartbeat
+	sc := bufio.NewScanner(bytes.NewReader(raw))
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		var hb heartbeat
+		if err := json.Unmarshal([]byte(line), &hb); err != nil {
+			t.Fatalf("ProgressSink line is not valid JSON: %q: %v", line, err)
+		}
+		if hb.Event != "stage_progress" {
+			t.Fatalf("ProgressSink line has event=%q, want stage_progress: %q", hb.Event, line)
+		}
+		if hb.ElapsedSecs == nil || hb.Turns == nil || hb.TokensSoFar == nil || hb.LastEventKind == nil {
+			t.Fatalf("stage_progress line missing one of the four fields: %q", line)
+		}
+		hbs = append(hbs, hb)
+	}
+	return hbs
+}
+
+// TestInvokeOnce_ProgressHeartbeats drives invokeOnce against a binary
+// that emits several spaced events under a shortened heartbeat
+// interval, and asserts heartbeats were written, each is a complete
+// well-formed JSON line, and the counters advance across them (#580).
+func TestInvokeOnce_ProgressHeartbeats(t *testing.T) {
+	var sink bytes.Buffer
+	inv := &Invoker{
+		Cmd:               helperCommand("spaced"),
+		HeartbeatInterval: 20 * time.Millisecond,
+		// Note: real Now (default) — frozenNow mutates shared state
+		// unsynchronized and would race the heartbeat goroutine under -race.
+	}
+	res, _, err := inv.invokeOnce(context.Background(), agent.Invocation{
+		ProgressSink: &sink,
+	})
+	if err != nil {
+		t.Fatalf("invokeOnce: %v", err)
+	}
+	if !res.OK {
+		t.Fatalf("OK = false; FailureReason = %q", res.FailureReason)
+	}
+
+	hbs := parseHeartbeats(t, sink.Bytes())
+	if len(hbs) == 0 {
+		t.Fatal("no stage_progress heartbeats written to ProgressSink")
+	}
+	// Counters must be monotonic non-decreasing and the last one must
+	// reflect progress past the first event.
+	last := hbs[len(hbs)-1]
+	if *last.Turns < 1 {
+		t.Errorf("final heartbeat turns = %d, want >= 1", *last.Turns)
+	}
+	for i := 1; i < len(hbs); i++ {
+		if *hbs[i].Turns < *hbs[i-1].Turns {
+			t.Errorf("turns went backwards: %d then %d", *hbs[i-1].Turns, *hbs[i].Turns)
+		}
+		if *hbs[i].TokensSoFar < *hbs[i-1].TokensSoFar {
+			t.Errorf("tokens_so_far went backwards: %d then %d", *hbs[i-1].TokensSoFar, *hbs[i].TokensSoFar)
+		}
+	}
+	// Heartbeats are ProgressSink-only: they must never enter res.Events.
+	for _, ev := range res.Events {
+		if ev.Kind == "stage_progress" {
+			t.Error("stage_progress leaked into res.Events; must be ProgressSink-only")
+		}
+	}
+}
+
+// TestInvokeOnce_NilProgressSinkNoHeartbeats confirms a nil
+// ProgressSink emits zero heartbeats and leaves res.Events as the
+// pre-#580 happy path produced it.
+func TestInvokeOnce_NilProgressSinkNoHeartbeats(t *testing.T) {
+	inv := &Invoker{
+		Cmd:               helperCommand("happy"),
+		Now:               frozenNow(),
+		HeartbeatInterval: time.Millisecond, // would fire constantly if a sink existed
+	}
+	res, _, err := inv.invokeOnce(context.Background(), agent.Invocation{
+		// ProgressSink nil on purpose.
+	})
+	if err != nil {
+		t.Fatalf("invokeOnce: %v", err)
+	}
+	if !res.OK {
+		t.Fatalf("OK = false; FailureReason = %q", res.FailureReason)
+	}
+	// invocation_start, system.init, assistant, result, invocation_end → 5
+	if got, want := len(res.Events), 5; got != want {
+		t.Fatalf("Events = %d, want %d (nil sink must not alter event stream)", got, want)
+	}
+	for _, ev := range res.Events {
+		if ev.Kind == "stage_progress" {
+			t.Error("stage_progress event present with nil ProgressSink")
+		}
+	}
+}
+
+// TestInvokeOnce_ProgressSinkReturnsPromptly asserts invokeOnce with a
+// ProgressSink returns without hanging (no goroutine leak / ticker
+// leak) on both the normal-completion and budget-hit early-break paths
+// (#580 condition 3).
+func TestInvokeOnce_ProgressSinkReturnsPromptly(t *testing.T) {
+	cases := []struct {
+		name   string
+		mode   string
+		budget agent.Budget
+	}{
+		{"normal_completion", "happy", agent.Budget{}},
+		{"budget_hit_break", "budget", agent.Budget{MaxTokens: 100}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var sink bytes.Buffer
+			inv := &Invoker{
+				Cmd:               helperCommand(tc.mode),
+				HeartbeatInterval: 10 * time.Millisecond,
+			}
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				_, _, _ = inv.invokeOnce(context.Background(), agent.Invocation{
+					Budget:       tc.budget,
+					ProgressSink: &sink,
+				})
+			}()
+			select {
+			case <-done:
+				// Returned — the heartbeat goroutine was joined, no hang.
+			case <-time.After(5 * time.Second):
+				t.Fatal("invokeOnce did not return within 5s — goroutine leak / hang")
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Driving the loop over MCP, the agent (and its operator) was blind for a stage's whole duration — `run_stage` returned its event list only at completion. **Root cause is (a), not the relay:** `fishhawk-mcp` already forwards every runner stderr JSONL line as a `notifications/progress` update (`run_stage.go`), but the claudecode adapter buffered per-turn events in `res.Events` and emitted nothing to stderr until `Invoke` returned.

Fix: a **time-driven** heartbeat in `claudecode.invokeOnce` writes a single-line `stage_progress` event `{elapsed_seconds, turns, tokens_so_far, last_event_kind}` to a new `agent.Invocation.ProgressSink` (wired to `logSink`) every `HeartbeatInterval` (default 15s). Time-driven so a **stalled** stage still emits heartbeats with non-advancing counters — distinguishing "progressing" from "stuck". `fishhawk-mcp`'s `runStageEventMessage` formats the counters into the progress-notification message.

- Counters guarded by `sync.Mutex` (scan loop writes, ticker reads); `ticker.Stop` + done channel cover the EOF and budget-break paths.
- The heartbeat goroutine is the **sole `ProgressSink` writer during Invoke** — every `logSink` writer is enumerated in a comment to prove no concurrent line interleaving (plan-review's medium concern). Heartbeats go **only** to `ProgressSink`, never `res.Events`, so the signed trace bundle is unchanged (no redaction exposure).
- `HeartbeatInterval` is a per-Invoker field (no shared-global test race); nil `ProgressSink` → zero heartbeats, `res.Events` unchanged.

## Test plan

- `go test -race -count=1 ./internal/agent/...` green (claudecode ran ~11s under `-race` exercising the heartbeat concurrency — no race). Per-module `go test` + `golangci-lint` clean on runner + `fishhawk-mcp`. Coverage **80.9%**.
- New tests: heartbeats emitted with the four fields + advancing counters; nil-sink → zero heartbeats; ticker no-leak/return-promptly; `runStageEventMessage` formats a `stage_progress` payload.

## Notes

- **Honesty on scope:** progress notifications surface only when the client supplies a `progressToken` (MCP opt-in — documented in the tool description); a token-less client still gets the heartbeats **post-hoc** in `RunStageOutput.Events`. This delivers operator/client liveness + a post-hoc timeline. Mid-call early-cancel by the synchronously-blocked driving agent is **out of scope** (needs an async `run_stage`).
- `fishhawk-mcp` change → needs an **MCP reconnect** after merge to go live (per the stale-server behavior).
- Verified through the dogfood loop (run `f35a25d4`). This run was also the first to confirm the full implement-review stack end-to-end: `policy_evaluated` showed `#changed=10, passed=True` (no more `no_diff_in_bundle`), and an `implement_reviewed` verdict (`approve`) landed on this PR's own diff — the agent reviewer independently validated the heartbeat concurrency the plan-reviewer had flagged.

Closes #580