### PR TITLE
Ground review-agent rule citations so reviewers stop fabricating project rules (#595)

### DIFF
--- a/backend/internal/prompt/prompt.go
+++ b/backend/internal/prompt/prompt.go
@@ -555,7 +555,12 @@ func buildPlanReview(t Trigger) string {
 		"Is the rollback plan realistic?\n")
 	b.WriteString("4. **Risk coverage**: Are meaningful risks identified? Are assumptions cited or testable?\n")
 	b.WriteString("5. **Schema compliance**: Does the plan conform to the standard_v1 shape? " +
-		"(docs/spec/plan-standard-v1.md)\n\n")
+		"(docs/spec/plan-standard-v1.md)\n")
+	b.WriteString("6. **Grounded citations**: Any rule you cite — from CLAUDE.md, a style guide, or a project " +
+		"convention — MUST be one you can quote verbatim from the context provided in this prompt or from a " +
+		"repository file you actually read during this review. Do NOT assert rules from memory. If you cannot " +
+		"verify the rule exists, do NOT raise the concern. Ground every concern in the plan, issue, and context " +
+		"actually provided.\n\n")
 
 	// Verdict decision rule.
 	b.WriteString("### Verdict decision rule\n\n")
@@ -695,7 +700,15 @@ func buildImplementReview(t Trigger) string {
 	b.WriteString("3. **Verification satisfiability**: Are the plan's verification steps (test strategy, rollback) " +
 		"satisfiable against this diff?\n")
 	b.WriteString("4. **Obvious regressions**: Does the diff introduce obvious correctness regressions, " +
-		"broken references, or removed behaviour the issue didn't ask for?\n\n")
+		"broken references, or removed behaviour the issue didn't ask for?\n")
+	b.WriteString("5. **Grounded citations**: Any rule you cite — from CLAUDE.md, a style guide, or a project " +
+		"convention — MUST be one you can quote verbatim from the context provided in this prompt or from a " +
+		"repository file you actually read during this review. Do NOT assert rules from memory. If you cannot " +
+		"verify the rule exists, do NOT raise the concern. Ground every concern in the plan, issue, and diff " +
+		"actually provided.\n")
+	b.WriteString("6. **Style is out of scope**: Subjective style judgments (comment length, naming aesthetics, " +
+		"formatting) are out of scope for review — that is lint's job. Focus on plan adherence, scope " +
+		"(flag-only), verification satisfiability, and obvious regressions.\n\n")
 
 	// Verdict decision rule.
 	b.WriteString("### Verdict decision rule\n\n")

--- a/backend/internal/prompt/prompt_test.go
+++ b/backend/internal/prompt/prompt_test.go
@@ -1092,6 +1092,31 @@ func TestBuild_PlanReview_ReviewCriteriaPresent(t *testing.T) {
 	}
 }
 
+func TestBuild_PlanReview_GroundsRuleCitations(t *testing.T) {
+	// #595: review agents fabricated a CLAUDE.md comment-length rule that
+	// does not exist. The grounding constraint must instruct the reviewer to
+	// only cite rules it can quote verbatim from provided context, never from
+	// memory. Pin the load-bearing substrings.
+	got, err := Build("plan_review", Trigger{
+		Repo:         "x/y",
+		ApprovedPlan: fixturePlan(),
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	wants := []string{
+		"Grounded citations",
+		"quote verbatim",
+		"CLAUDE.md",
+		"Do NOT assert rules from memory",
+	}
+	for _, w := range wants {
+		if !strings.Contains(got, w) {
+			t.Errorf("plan_review prompt missing grounding-constraint substring %q:\n%s", w, got)
+		}
+	}
+}
+
 func TestBuild_PlanReview_ProducesNoPRDescriptionGuidance(t *testing.T) {
 	got, err := Build("plan_review", Trigger{
 		Repo:         "x/y",
@@ -1200,6 +1225,37 @@ func TestBuild_ImplementReview_FullContext(t *testing.T) {
 	for _, w := range wants {
 		if !strings.Contains(got, w) {
 			t.Errorf("implement_review prompt missing %q:\n%s", w, got)
+		}
+	}
+}
+
+func TestBuild_ImplementReview_GroundsRuleCitationsAndScopesStyle(t *testing.T) {
+	// #595: on run 112743b1 the implement-review raised {category:scope}
+	// concerns asserting a CLAUDE.md comment-length rule that does not exist
+	// and flagged compliant multi-line WHY comments. The grounding constraint
+	// and the style-is-lint scoping line must both be present.
+	got, err := Build("implement_review", Trigger{
+		Repo:         "kuhlman-labs/example",
+		ApprovedPlan: fixturePlan(),
+		Diff:         "- M pkg/bar/bar.go\n",
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	wants := []string{
+		// Grounding constraint.
+		"Grounded citations",
+		"quote verbatim",
+		"CLAUDE.md",
+		"Do NOT assert rules from memory",
+		// Style-is-lint scoping.
+		"Style is out of scope",
+		"comment length, naming aesthetics, formatting",
+		"that is lint's job",
+	}
+	for _, w := range wants {
+		if !strings.Contains(got, w) {
+			t.Errorf("implement_review prompt missing substring %q:\n%s", w, got)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

On run `112743b1` (#593's implement-review) the reviewer raised two `{category:scope}` concerns asserting a CLAUDE.md comment-length rule ("one short line max", "never multi-line comment blocks") that **does not exist** in CLAUDE.md, flagging comments that match the codebase's dense multi-line WHY norm. A review layer that invents project rules erodes trust in its verdicts and — under gating authority (`human==0`) — could block legitimate work on a fabricated basis.

Prompt-text-only fix to both review builders (`backend/internal/prompt/prompt.go`):

- **`buildPlanReview` + `buildImplementReview`** gain a "Grounded citations" criterion: any cited rule (CLAUDE.md / style guide / convention) MUST be quotable from the prompt context or a repo file the reviewer actually read this review — never asserted from memory; if it can't verify the rule, it must not raise the concern, and should ground concerns in the plan/issue/diff provided.
- **`buildImplementReview`** additionally scopes subjective style (comment length, naming aesthetics, formatting) out of review as lint's job, keeping the reviewer on plan-adherence / scope-flag / verification / regressions.

Appended after existing criteria so determinism and the cache split-marker position are unaffected.

## Test plan

- `go test -race ./internal/prompt/...` + `golangci-lint` clean. New tests pin the grounding-constraint substring in the plan-review prompt and both the grounding + style-scoping substrings in the implement-review prompt; existing determinism / split-marker / criteria tests guard against regression.
- Driven through the dogfood loop (run `47b9cdc3`); plan-review and implement-review both returned `approve` (0 concerns), and #580 heartbeats streamed live.

## Notes

- Prompt-text-only — no CLAUDE.md plumbing into the prompt (kept it lean; the builder doesn't load CLAUDE.md and bloating the prompt with it wasn't warranted). If we later want the reviewer to actively *enforce* CLAUDE.md, feeding the relevant excerpt is a separate, larger choice.
- This sharpens the review layer the loop now depends on — verdicts should stop wasting attention on (and, worse, fabricating) style rules.

Closes #595