### PR TITLE
Drive plan-stage advancement from the plan artifact, not trace upload (#603)

### DIFF
--- a/backend/internal/server/plan.go
+++ b/backend/internal/server/plan.go
@@ -186,23 +186,26 @@ func (s *Server) handleShipPlan(w http.ResponseWriter, r *http.Request) {
 		}
 		if !coercionOK {
 			// Coercion could not help (non-string type or re-validation
-			// still fails). Transition the stage to failed-B so the run
-			// reflects the bad output rather than getting stuck in
-			// `running` (#527). Best-effort: a TransitionStage error
-			// logs but doesn't change the upload response.
+			// still fails). Fail the stage as category-B and walk the run
+			// to terminal failed (#527 / #603). The trace handler now
+			// leaves a plan stage in running (it no longer advances plan
+			// stages without a plan artifact), so FailStage walks
+			// running → failed; under a future plan-first reordering it
+			// walks from whatever non-terminal state the stage is in.
+			// advanceAfterFailure then drives the orchestrator so the run
+			// doesn't strand with a failed stage but a pending/running run.
+			// Best-effort: a transition / advance error logs but doesn't
+			// change the upload response.
 			cat := run.FailureB
 			reason := "plan_invalid: " + reportErr.Error()
-			if _, terr := s.cfg.RunRepo.TransitionStage(r.Context(), stageID,
-				run.StageStateFailed, &run.StageCompletion{
-					FailureCategory: &cat,
-					FailureReason:   &reason,
-				}); terr != nil {
+			if _, ferr := run.FailStage(r.Context(), s.cfg.RunRepo, stageID, cat, reason); ferr != nil {
 				s.cfg.Logger.LogAttrs(r.Context(), slog.LevelWarn,
 					"plan upload: transition to failed-B after validation error failed",
 					slog.String("run_id", runID.String()),
 					slog.String("stage_id", stageID.String()),
-					slog.String("error", terr.Error()))
+					slog.String("error", ferr.Error()))
 			}
+			s.advanceAfterFailure(r, runID, stageID)
 			s.writeError(w, r, http.StatusBadRequest, "plan_invalid",
 				"plan does not validate against standard_v1",
 				map[string]any{"error": reportErr.Error()})
@@ -286,14 +289,22 @@ func (s *Server) handleShipPlan(w http.ResponseWriter, r *http.Request) {
 	// stage advancement is blocked.
 	gatingRejected := s.runPlanReviews(r.Context(), runID, stageID, body)
 
-	// Plan-ready comment-back hook (#245). Fires here so the
-	// notifier sees the just-landed artifact even when the runner's
-	// trace-then-plan upload order beats the trace-handler's
-	// notifyPlanReady to running. Best-effort + dedup'd via the
-	// audit log; safe to call alongside the trace-handler hook.
-	// Suppressed on gating-reject: the stage has been failed, not
-	// awaiting approval, so a plan-ready comment would be misleading.
+	// Plan-stage terminal advancement (#603). With a valid plan artifact
+	// now stored, this handler is the authoritative driver of the plan
+	// stage's terminal transition: the trace handler leaves plan stages in
+	// running until a plan exists. Advance running → awaiting_approval (or
+	// → succeeded + orchestrator Advance for a gateless plan stage).
+	// Suppressed on gating-reject: runPlanReviews has already failed the
+	// stage, so advancing it would be a no-op-or-fault either way.
+	//
+	// notifyPlanReadyIfReady must run AFTER the advance — its guard
+	// requires the stage to be terminal/awaiting_approval. The
+	// just-landed artifact is now visible to the notifier even when the
+	// runner's trace-then-plan order beat the trace-handler hook to
+	// running. Best-effort + dedup'd via the audit log; safe alongside
+	// the trace-handler hook.
 	if !gatingRejected {
+		stage = s.advancePlanStageTerminal(r, runID, stage)
 		s.notifyPlanReadyIfReady(r, runID, stage)
 	}
 
@@ -321,6 +332,56 @@ func (s *Server) notifyPlanReadyIfReady(r *http.Request, runID uuid.UUID, stage 
 		return
 	}
 	s.notifyPlanReady(r.Context(), runID, stage)
+}
+
+// advancePlanStageTerminal drives the plan stage's terminal transition
+// once a valid plan artifact has landed (#603). The trace handler leaves
+// plan stages in running until a plan exists, so this handler owns the
+// running → awaiting_approval (gated) or running → succeeded (gateless)
+// transition.
+//
+// Idempotent: the state machine treats same-state re-application as a
+// no-op, so a future runner reordering where the trace handler already
+// advanced the stage (plan-first ordering) does not double-fault. On the
+// gateless path it fires the orchestrator's Advance so the next stage is
+// picked up, mirroring advanceStageAfterTrace.
+//
+// Best-effort: transition / advance / notify errors are WARN-logged and
+// never unwind the upload response. Returns the post-transition stage
+// (or the pre-transition stage on error) so the caller can pass the
+// settled state to notifyPlanReadyIfReady.
+func (s *Server) advancePlanStageTerminal(r *http.Request, runID uuid.UUID, stage *run.Stage) *run.Stage {
+	terminal := run.StageStateAwaitingApproval
+	if !stage.RequiresApproval {
+		terminal = run.StageStateSucceeded
+	}
+	updated, err := s.cfg.RunRepo.TransitionStage(r.Context(), stage.ID, terminal, nil)
+	if err != nil {
+		s.cfg.Logger.LogAttrs(r.Context(), slog.LevelWarn,
+			"plan upload: transition to terminal failed",
+			slog.String("run_id", runID.String()),
+			slog.String("stage_id", stage.ID.String()),
+			slog.String("target", string(terminal)),
+			slog.String("error", err.Error()))
+		return stage
+	}
+
+	// Sticky status comment (E20.4 / #330): the plan stage just settled.
+	s.notifyStatusUpdate(r.Context(), runID, "plan_handler")
+
+	// Gateless plan stages get no approval submission to drive the next
+	// dispatch — fire the orchestrator ourselves so the next stage gets
+	// picked up. Best-effort: a failure here logs but doesn't unwind.
+	if terminal == run.StageStateSucceeded && s.cfg.Orchestrator != nil {
+		if _, err := s.cfg.Orchestrator.Advance(r.Context(), runID); err != nil {
+			s.cfg.Logger.LogAttrs(r.Context(), slog.LevelWarn,
+				"plan upload: orchestrator advance after gateless plan stage failed",
+				slog.String("run_id", runID.String()),
+				slog.String("stage_id", stage.ID.String()),
+				slog.String("error", err.Error()))
+		}
+	}
+	return updated
 }
 
 // planResponse is the JSON returned to the runner on plan upload.

--- a/backend/internal/server/plan_test.go
+++ b/backend/internal/server/plan_test.go
@@ -15,11 +15,133 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/kuhlman-labs/fishhawk/backend/internal/orchestrator"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/plan/planfixture"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/planreview"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/run"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/signing"
 )
+
+// recordingOrchestratorRepo wraps orchestratorRepo to record every
+// successful TransitionStage target, so a sequence test can assert that a
+// plan stage never passed through awaiting_approval. The embedded repo
+// validates the stage/run transition tables and mutates state, and a real
+// orchestrator.Orchestrator can drive it, so the run advances exactly as
+// in production. (#603)
+type recordingOrchestratorRepo struct {
+	*orchestratorRepo
+	stageTransitions []run.StageState
+}
+
+func (r *recordingOrchestratorRepo) TransitionStage(ctx context.Context, id uuid.UUID, to run.StageState, c *run.StageCompletion) (*run.Stage, error) {
+	st, err := r.orchestratorRepo.TransitionStage(ctx, id, to, c)
+	if err == nil {
+		r.stageTransitions = append(r.stageTransitions, to)
+	}
+	return st, err
+}
+
+func (r *recordingOrchestratorRepo) sawTransitionTo(to run.StageState) bool {
+	for _, s := range r.stageTransitions {
+		if s == to {
+			return true
+		}
+	}
+	return false
+}
+
+// newPlanSequenceServer wires the full plan-stage path — signing, trace
+// store, audit, artifacts, a transition-recording run repo, and a real
+// orchestrator — so a test can drive the runner's true trace-then-plan
+// upload order and observe the resulting stage + run states. (#603)
+func newPlanSequenceServer(t *testing.T) (*Server, *recordingOrchestratorRepo, *fakeArtifactRepo, *signingFake) {
+	t.Helper()
+	rr := &recordingOrchestratorRepo{orchestratorRepo: newOrchestratorRepo()}
+	art := newFakeArtifactRepo()
+	sf := newSigningFake()
+	s := New(Config{
+		Addr:         "127.0.0.1:0",
+		SigningRepo:  sf,
+		TraceStore:   newTraceStoreFake(),
+		AuditRepo:    newAuditFake(),
+		RunRepo:      rr,
+		ArtifactRepo: art,
+		Orchestrator: &orchestrator.Orchestrator{Runs: rr},
+	})
+	return s, rr, art, sf
+}
+
+// TestPlanStage_TraceThenInvalidPlan_EndsFailed reproduces the #603
+// sequence: the runner ships the trace (which no longer advances a plan
+// stage past running) and then an invalid plan. The stage must end in
+// failed — never awaiting_approval — and the run must be advanced to
+// terminal failed rather than stranded.
+func TestPlanStage_TraceThenInvalidPlan_EndsFailed(t *testing.T) {
+	s, rr, _, sf := newPlanSequenceServer(t)
+	runRow := rr.seedRun()
+	planStage := rr.seedStage(runRow.ID, 0, run.StageStateDispatched)
+	planStage.RequiresApproval = true // gated plan stage — the #603 shape
+	priv, _ := sf.issue(t, runRow.ID)
+
+	// 1. Trace upload (raw). With no plan artifact yet, the trace handler
+	//    must leave the plan stage in running.
+	wt := shipRequest(t, s, runRow.ID, planStage.ID, "raw", priv, []byte("b"), "")
+	if wt.Code != http.StatusAccepted {
+		t.Fatalf("trace status = %d, want 202:\n%s", wt.Code, wt.Body.String())
+	}
+	if got := rr.stagesByID[planStage.ID].State; got != run.StageStateRunning {
+		t.Fatalf("after trace: stage state = %q, want running (plan stage must not advance without a plan artifact)", got)
+	}
+
+	// 2. Plan upload with an invalid body.
+	wp := shipPlanRequest(t, s, runRow.ID, planStage.ID, priv,
+		[]byte(`{"plan_version":"standard_v1"}`), "")
+	if wp.Code != http.StatusBadRequest {
+		t.Fatalf("plan status = %d, want 400:\n%s", wp.Code, wp.Body.String())
+	}
+
+	// The plan stage never reached a human gate with no plan to review.
+	if rr.sawTransitionTo(run.StageStateAwaitingApproval) {
+		t.Errorf("stage transitioned to awaiting_approval; #603 requires it stay out of the gate with no valid plan\ntransitions: %+v", rr.stageTransitions)
+	}
+	// The stage ends failed.
+	if got := rr.stagesByID[planStage.ID].State; got != run.StageStateFailed {
+		t.Errorf("final stage state = %q, want failed", got)
+	}
+	// The run is advanced to terminal failed (the stranded-run half).
+	if got := rr.runs[runRow.ID].State; got != run.StateFailed {
+		t.Errorf("final run state = %q, want failed (run must not strand once the stage fails)", got)
+	}
+}
+
+// TestPlanStage_TraceThenValidPlan_AdvancesToAwaitingApproval is the happy
+// path of the #603 reordering: the trace leaves the gated plan stage in
+// running, and the plan-upload handler drives it to awaiting_approval once
+// the valid plan lands.
+func TestPlanStage_TraceThenValidPlan_AdvancesToAwaitingApproval(t *testing.T) {
+	s, rr, _, sf := newPlanSequenceServer(t)
+	runRow := rr.seedRun()
+	planStage := rr.seedStage(runRow.ID, 0, run.StageStateDispatched)
+	planStage.RequiresApproval = true
+	priv, _ := sf.issue(t, runRow.ID)
+
+	wt := shipRequest(t, s, runRow.ID, planStage.ID, "raw", priv, []byte("b"), "")
+	if wt.Code != http.StatusAccepted {
+		t.Fatalf("trace status = %d, want 202:\n%s", wt.Code, wt.Body.String())
+	}
+	if got := rr.stagesByID[planStage.ID].State; got != run.StageStateRunning {
+		t.Fatalf("after trace: stage state = %q, want running", got)
+	}
+
+	wp := shipPlanRequest(t, s, runRow.ID, planStage.ID, priv, validPlanBytes(t), "")
+	if wp.Code != http.StatusCreated {
+		t.Fatalf("plan status = %d, want 201:\n%s", wp.Code, wp.Body.String())
+	}
+
+	if got := rr.stagesByID[planStage.ID].State; got != run.StageStateAwaitingApproval {
+		t.Errorf("final stage state = %q, want awaiting_approval (plan handler must drive the terminal advance)", got)
+	}
+}
 
 // fakePlanReviewer records each Review invocation and returns a canned verdict.
 type fakePlanReviewer struct {
@@ -318,9 +440,13 @@ func TestShipPlan_CoercibleSchemaError_Returns201(t *testing.T) {
 		t.Errorf("audit[1].category = %q, want plan_generated", got)
 	}
 
-	// Coerced plans must NOT transition to failed-B.
-	if len(rr.transitionStageCalls) != 0 {
-		t.Errorf("transitionStage calls = %d, want 0 (coercion succeeded)", len(rr.transitionStageCalls))
+	// Coerced plans must NOT transition to failed-B. (#603: the success
+	// path now drives the plan stage's terminal advance, so a transition
+	// to a terminal *success* state is expected — only failed is wrong.)
+	for _, call := range rr.transitionStageCalls {
+		if call.StageID == stageID && call.To == run.StageStateFailed {
+			t.Errorf("coerced plan should not transition the stage to failed; got %+v", call)
+		}
 	}
 }
 
@@ -360,6 +486,10 @@ func TestShipPlan_NonCoercibleSchemaError_400(t *testing.T) {
 func TestShipPlan_SchemaInvalid_400(t *testing.T) {
 	runID, stageID := uuid.New(), uuid.New()
 	s, sf, ar, _, rr := newPlanServer(t, runID, stageID)
+	// #603: the trace handler no longer advances a plan stage past
+	// running until a plan artifact exists, so at plan-ship time the
+	// stage is in running. FailStage walks running → failed.
+	rr.getStages[stageID] = &run.Stage{ID: stageID, RunID: runID, State: run.StageStateRunning}
 	priv, _ := sf.issue(t, runID)
 	body := []byte(`{"plan_version":"standard_v1"}`) // missing required fields
 
@@ -374,12 +504,13 @@ func TestShipPlan_SchemaInvalid_400(t *testing.T) {
 		t.Errorf("artifacts = %d, want 0 on schema fail", len(ar.all))
 	}
 
-	// #527: when the plan body fails standard_v1 validation, the
-	// plan handler must transition the stage to failed-B so the run
-	// doesn't get stuck in awaiting_approval with no valid plan
-	// attached. The trace handler advances the stage to
-	// awaiting_approval first (trace arrives before plan); this
-	// handler corrects course on the failure path.
+	// #527 / #603: when the plan body fails standard_v1 validation, the
+	// plan handler fails the stage as category-B (running → failed via
+	// run.FailStage) so the run reflects the bad output rather than
+	// stranding at awaiting_approval with no valid plan. The orchestrator
+	// advance that walks the run to terminal failed is asserted in
+	// TestPlanStage_TraceThenInvalidPlan_EndsFailed (this server wires no
+	// orchestrator, so advanceAfterFailure is a no-op here).
 	if len(rr.transitionStageCalls) != 1 {
 		t.Fatalf("transitionStage calls = %d, want 1:\n%+v",
 			len(rr.transitionStageCalls), rr.transitionStageCalls)

--- a/backend/internal/server/trace.go
+++ b/backend/internal/server/trace.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/kuhlman-labs/fishhawk/backend/internal/artifact"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/audit"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/bundle"
 	"github.com/kuhlman-labs/fishhawk/backend/internal/planreview"
@@ -371,6 +372,25 @@ func (s *Server) advanceStageAfterTrace(r *http.Request, runID, stageID uuid.UUI
 		}
 	}
 
+	// Plan-stage advancement gate (#603). A plan stage's terminal
+	// transition (→ awaiting_approval, or → succeeded for a gateless
+	// stage) is driven by a valid standard_v1 plan artifact landing via
+	// the plan-upload handler, not by trace upload alone. The runner
+	// ships both trace variants before the plan, so at trace-upload time
+	// a plan stage has no plan artifact yet — leave it in running and let
+	// handleShipPlan drive the terminal transition once the plan
+	// validates. Without this a gated plan stage would reach
+	// awaiting_approval with nothing to review when the later plan-ship
+	// fails validation, and get_plan would return no_plan_yet.
+	//
+	// Non-plan stages (implement/review) advance unchanged. When
+	// ArtifactRepo is nil (minimal config) planArtifactExists returns
+	// true so this gate is a no-op and the prior trace-driven behavior is
+	// preserved.
+	if stage.Type == run.StageTypePlan && !s.planArtifactExists(r.Context(), stageID) {
+		return
+	}
+
 	terminal := run.StageStateAwaitingApproval
 	if !stage.RequiresApproval {
 		terminal = run.StageStateSucceeded
@@ -422,6 +442,43 @@ func (s *Server) advanceStageAfterTrace(r *http.Request, runID, stageID uuid.UUI
 	// short-circuits for non-issue triggers; for issue triggers it
 	// edits the seeded comment in place.
 	s.notifyStatusUpdate(r.Context(), runID, "trace_handler")
+}
+
+// planArtifactExists reports whether a valid standard_v1 plan artifact
+// has been stored for the stage (#603). It mirrors the Kind == plan +
+// SchemaVersion == standard_v1 filter in prompt.go::tryLoadPlanForRun so
+// the trace handler's plan-stage advancement gate and the prompt builder
+// agree on what counts as a usable plan.
+//
+// When ArtifactRepo is nil (minimal config) it returns true so the gate
+// is a no-op and the prior trace-driven advancement is preserved. On a
+// list error it returns false — leaving the plan stage in running rather
+// than advancing it past a human gate with no plan — because the
+// plan-upload handler is the authoritative driver of the terminal
+// transition and will advance the stage once a valid plan lands.
+func (s *Server) planArtifactExists(ctx context.Context, stageID uuid.UUID) bool {
+	if s.cfg.ArtifactRepo == nil {
+		return true
+	}
+	arts, err := s.cfg.ArtifactRepo.ListForStage(ctx, stageID)
+	if err != nil {
+		s.cfg.Logger.LogAttrs(ctx, slog.LevelWarn,
+			"plan-stage gate: list artifacts failed — leaving stage in running",
+			slog.String("stage_id", stageID.String()),
+			slog.String("error", err.Error()),
+		)
+		return false
+	}
+	for _, a := range arts {
+		if a.Kind != artifact.KindPlan {
+			continue
+		}
+		if a.SchemaVersion == nil || *a.SchemaVersion != "standard_v1" {
+			continue
+		}
+		return true
+	}
+	return false
 }
 
 // notifyPlanReady fires the plan-ready comment-back hook after a

--- a/backend/internal/server/trace_test.go
+++ b/backend/internal/server/trace_test.go
@@ -528,6 +528,71 @@ func TestShipTrace_DispatchedStage_SkipsExtraStep(t *testing.T) {
 	}
 }
 
+// TestAdvanceStageAfterTrace_PlanStage_NoArtifact_StaysRunning pins the
+// #603 gate: a gated plan stage whose ArtifactRepo holds no standard_v1
+// plan artifact is left in running by the trace handler — it must NOT
+// reach awaiting_approval on trace upload alone. The complementary
+// sub-test pre-seeds a valid plan artifact so the trace handler DOES
+// advance (the future plan-first ordering), proving the gate keys on the
+// artifact rather than the stage type.
+func TestAdvanceStageAfterTrace_PlanStage_NoArtifact_StaysRunning(t *testing.T) {
+	t.Run("no artifact stays running", func(t *testing.T) {
+		sf := newSigningFake()
+		rr := newApprovalRunRepo()
+		art := newFakeArtifactRepo()                    // empty: no plan artifact for the stage
+		stage := rr.seedStage(run.StageStateDispatched) // plan-type, gated
+		s := New(Config{
+			Addr:         "127.0.0.1:0",
+			SigningRepo:  sf,
+			TraceStore:   newTraceStoreFake(),
+			AuditRepo:    newAuditFake(),
+			RunRepo:      rr,
+			ArtifactRepo: art,
+		})
+
+		priv, _ := sf.issue(t, stage.RunID)
+		w := shipRequest(t, s, stage.RunID, stage.ID, "raw", priv, []byte("b"), "")
+		if w.Code != http.StatusAccepted {
+			t.Fatalf("status = %d, want 202:\n%s", w.Code, w.Body.String())
+		}
+		if got := rr.stages[stage.ID].State; got != run.StageStateRunning {
+			t.Errorf("stage state = %q, want running (no plan artifact → gate leaves it in running)", got)
+		}
+		for _, tr := range rr.transitions {
+			if tr.To == run.StageStateAwaitingApproval {
+				t.Errorf("stage transitioned to awaiting_approval with no plan artifact:\n%+v", rr.transitions)
+			}
+		}
+	})
+
+	t.Run("pre-seeded plan artifact advances", func(t *testing.T) {
+		sf := newSigningFake()
+		rr := newApprovalRunRepo()
+		art := newFakeArtifactRepo()
+		stage := rr.seedStage(run.StageStateDispatched) // plan-type, gated
+		// Pre-seed a standard_v1 plan artifact for the stage so the gate
+		// passes — modelling the future plan-first upload ordering.
+		seedBudgetPlanArtifact(t, art, stage.ID, &plan.Plan{PlanVersion: "standard_v1"})
+		s := New(Config{
+			Addr:         "127.0.0.1:0",
+			SigningRepo:  sf,
+			TraceStore:   newTraceStoreFake(),
+			AuditRepo:    newAuditFake(),
+			RunRepo:      rr,
+			ArtifactRepo: art,
+		})
+
+		priv, _ := sf.issue(t, stage.RunID)
+		w := shipRequest(t, s, stage.RunID, stage.ID, "raw", priv, []byte("b"), "")
+		if w.Code != http.StatusAccepted {
+			t.Fatalf("status = %d, want 202:\n%s", w.Code, w.Body.String())
+		}
+		if got := rr.stages[stage.ID].State; got != run.StageStateAwaitingApproval {
+			t.Errorf("stage state = %q, want awaiting_approval (plan artifact present → gate passes)", got)
+		}
+	})
+}
+
 func TestShipTrace_GatelessStage_TransitionsStraightToSucceeded(t *testing.T) {
 	// Implement stages have no approval gate per workflows.yaml.
 	// The trace upload handler must walk dispatched → running →

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -86,7 +86,9 @@ When a stage's `reviewers.agent > 0` is configured in the workflow spec, the bac
 4. Self-review guard: if the review agent's model matches `plan.GeneratedBy.Model`, log WARN (ADR-027 §5 — no hard block in v0).
 5. For each review response, decode the `ReviewVerdict` JSON, append a `plan_reviewed` audit entry (category string `"plan_reviewed"`, payload `PlanReviewedPayload` from `backend/internal/planreview/review.go`).
 6. Authority check: if `ResolveAuthority(reviewers) == AuthorityGating` (i.e. `agent>0 && human==0`) and any verdict is `reject`, the stage stays in its current state rather than advancing to `awaiting_approval`.
-7. Otherwise proceed to `awaiting_approval` (or `succeeded` for gateless stages).
+7. Otherwise `handleShipPlan` drives the plan stage's terminal advance (`advancePlanStageTerminal`): `running → awaiting_approval`, or `running → succeeded` + an orchestrator `Advance` for a gateless plan stage.
+
+**Plan-stage advancement invariant** (#603): a plan stage's terminal transition is driven by a valid `standard_v1` plan artifact landing via the plan-upload handler (`handleShipPlan`), **not** by trace upload alone. The runner ships both trace variants before the plan, so `advanceStageAfterTrace` (`backend/internal/server/trace.go`) leaves a plan stage in `running` until `planArtifactExists` confirms a plan is stored — guarding against a gated plan stage reaching `awaiting_approval` with nothing to review when the later plan-ship fails `standard_v1` validation. On an invalid plan, `handleShipPlan` fails the stage category-B (`running → failed`) and calls `advanceAfterFailure` so the run walks to terminal `failed` rather than stranding. The transition is idempotent (same-state re-application is a repo-layer no-op), so a future plan-first upload ordering — where the trace handler finds the artifact and advances first — does not double-fault. When `ArtifactRepo` is unwired (minimal config), `planArtifactExists` returns true so the gate is a no-op and the prior trace-driven advance is preserved.
 
 **Authority resolution** (`backend/internal/planreview/review.go::ResolveAuthority`):
 


### PR DESCRIPTION
## Summary

A gated plan stage could reach `awaiting_approval` with **no plan artifact**. The runner ships trace (raw, then redacted) before the plan, and `advanceStageAfterTrace` advanced the gated plan stage to `awaiting_approval` on trace upload alone. When the later plan-ship failed `standard_v1` validation, the stage was already at a human gate with nothing to review (`get_plan: no_plan_yet`) — and the run stranded (the failed-stage path didn't advance the run). Found on run `54423e70` (the #600 attempt) via a malformed `ticket_reference.type`.

Fix — make the **plan artifact the completion signal** for plan stages:
- **`trace.go`**: skip the terminal transition for a plan stage when no valid `standard_v1` plan artifact exists yet (leave it `running`). Non-plan stages unchanged; nil `ArtifactRepo` → no-op (returns true); list-error → stay running (conservative). `planArtifactExists` reuses the `Kind==plan` + `standard_v1` filter from `prompt.go::tryLoadPlanForRun`.
- **`plan.go` (`handleShipPlan`)** is now the authoritative driver of the plan stage's terminal transition: valid plan → `running→awaiting_approval` (or `→succeeded` + orchestrator `Advance` for a gateless plan stage); invalid → `run.FailStage(FailureB)` + `advanceAfterFailure` so the **run** walks to terminal `failed` (fixes the stranded-run half). Idempotent against a future trace-after-valid-plan ordering. `notifyPlanReadyIfReady` moved after the advance.

A plan stage never reaches a human gate with no plan; `get_plan` and stage state now agree.

## Test plan

- `go build ./...`, **full `go test -race ./...`** in the backend module green (this touches the central stage-advancement path — exercised the orchestrator/approval interactions), `golangci-lint` clean, coverage **PASS (≥80%)**.
- New/updated tests pin: trace-then-**invalid**-plan → stage `failed` (not `awaiting_approval`) + run advanced; trace-then-**valid**-plan → `awaiting_approval`; **no-artifact** → stays `running`; updated `TestShipPlan_SchemaInvalid_400`.
- Driven through the dogfood loop (run `cc1e4d69`); #580 heartbeats made the 11-min implement run observable.

## Notes

- **Out of scope:** the gating-review-reject path (`runPlanReviews`) similarly fails-B without an orchestrator advance — separate follow-up if the stranded-run symptom is observed there.
- **Recurring signal worth a ticket:** this run's plan-review (and #600's) timed out at the 180s reviewer budget — **two consecutive large-plan reviews** that never produced a verdict. #600's `review_status`/`await_review` handle it gracefully as `pending`, but agent plan-review is effectively unavailable for large plans; raising the timeout / a faster review model / smaller plans is the underlying lever. Happy to file if you want it tracked.

Closes #603