### PR TITLE
ci: pin golangci-lint install.sh to the v2.8.0 tag, not master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,12 @@ jobs:
           # v2.8.0 binaries are built with go1.25.x, so they can typecheck
           # packages whose deps require go 1.25. Older v2 releases (v2.0.x)
           # were built with go1.24 and reject go 1.25 packages.
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
+          #
+          # Pin install.sh to the v2.8.0 tag, NOT master: the master script
+          # is unpinned and an upstream change to it broke CI (exit 1 right
+          # after resolving v2.8.0) with no change on our side. The tagged
+          # script matches the version it installs and is reproducible.
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v2.8.0/install.sh \
             | sh -s -- -b "$(go env GOPATH)/bin" v2.8.0
 
       - name: Lint, build, and test each module


### PR DESCRIPTION
## Summary

The CI Go job installs golangci-lint via the **unpinned `master`** install script:

```
curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)/bin" v2.8.0
```

An upstream change to that script broke it: it resolves `v2.8.0` then **exits 1** during install. This reddened **every PR and main** with no change on our side — main's CI was green a day ago and is now failing at this exact step (caught while checking #605's CI; #605's code passed `go build` / full `go test -race ./...` / lint / coverage locally).

Fix: pin `install.sh` to the **`v2.8.0` tag** (matching the version it installs) instead of `master`. Verified end-to-end locally — the v2.8.0-tagged script installs golangci-lint v2.8.0 cleanly where `master` fails.

## Test plan

- **This PR's own CI is the test** — the Go job now runs the pinned installer; a green "Go (lint + build + test)" here confirms the fix.
- Local verification: `curl … /golangci-lint/v2.8.0/install.sh | sh -s -- -b /tmp/bin v2.8.0` → `golangci-lint has version 2.8.0`.

## Notes

- Root cause is fetching tooling from an unpinned `master` ref; pinning makes the install reproducible and immune to upstream install-script changes. Tracking the broader "don't fetch tooling from master" lesson in a follow-up issue.
- Unblocks #605 (and all open PRs) once merged.