### PR TITLE
Add scripts/dev reload + one-step MCP-reconnect signal (#601)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,16 @@ Cross-reference: this checklist codifies the rollout discipline introduced by #5
 | `cli/cmd/fishhawk/` or `cli/internal/...` | `fishhawk` CLI |
 | `backend/internal/plan/` or `backend/internal/spec/` (shared libs) | all four binaries |
 
+**Rebuilt-on-disk is not the same as live.** What it takes for a rebuilt binary to actually take effect differs per binary:
+
+| Binary | Activation after a rebuild |
+|---|---|
+| `fishhawkd` | rebuilt **and restarted** by `scripts/dev up`/`reload` |
+| `fishhawk-runner` | picked up automatically — spawned fresh from `bin/` on each `fishhawk_run_stage` |
+| `fishhawk-mcp` | rebuilt on disk but **needs a manual `/mcp` reconnect** — the Claude Code harness owns the MCP server process, so `scripts/dev` cannot restart it; it only signals the operator |
+
+`scripts/dev reload` (down-then-up) is the one-step post-merge command: plain `scripts/dev up` no-ops when fishhawkd is already running and so never rebuilds. Both `up` and `reload` print, as their last line(s), whether a `/mcp` reconnect is required (and why) based on whether `bin/fishhawk-mcp` was rebuilt. This supersedes the older "MCP server stale after rebuild" gotcha by making the reconnect-vs-rebuild distinction first-class.
+
 ## Adding a Go module
 
 1. `mkdir <name> && cd <name> && go mod init github.com/kuhlman-labs/fishhawk/<name>`

--- a/scripts/dev
+++ b/scripts/dev
@@ -120,6 +120,27 @@ _build_binary() {
   esac
 }
 
+# Emits the MCP reconnect signal — must be the LAST thing printed by up/reload
+# so it is unmissable. Arg 1: 1 if bin/fishhawk-mcp was rebuilt this run, else 0.
+# scripts/dev cannot restart the MCP server (the Claude Code harness owns that
+# process), so on a rebuild the only lever is to tell the operator, unmissably,
+# that a manual /mcp reconnect is required or the new binary stays inert.
+_signal_mcp_activation() {
+  local rebuilt="${1:-0}"
+  if (( rebuilt )); then
+    print ""
+    print "================================================================"
+    print "  ACTION REQUIRED: bin/fishhawk-mcp was rebuilt this run."
+    print ""
+    print "  scripts/dev cannot restart the MCP server — the Claude Code"
+    print "  harness owns that process. Run /mcp to reconnect, or the"
+    print "  rebuilt fishhawk-mcp binary stays inert in this session."
+    print "================================================================"
+  else
+    print "no MCP reconnect needed (bin/fishhawk-mcp unchanged)"
+  fi
+}
+
 cmd_up() {
   local force_all=0
   local start_deps=0
@@ -225,6 +246,14 @@ cmd_up() {
     print "rebuilt 0 of 4 binaries (nothing changed)"
   fi
 
+  # Detect whether fishhawk-mcp was rebuilt off the existing rebuilt_list — no
+  # second detection mechanism. The (Ie) subscript flags return the matching
+  # index (>0) or 0 when absent. The signal itself is emitted last (below).
+  local mcp_rebuilt=0
+  if (( ${rebuilt_list[(Ie)fishhawk-mcp]} )); then
+    mcp_rebuilt=1
+  fi
+
   # Migrate
   print "applying migrations..."
   "$BIN" migrate up
@@ -235,6 +264,9 @@ cmd_up() {
   local pid=$!
   print "$pid" > "$PID_FILE"
   print "fishhawkd started (pid ${pid}) — logs: ${LOG_FILE}"
+
+  # Last line(s): tell the operator whether a /mcp reconnect is required.
+  _signal_mcp_activation "$mcp_rebuilt"
 }
 
 cmd_down() {
@@ -270,8 +302,37 @@ cmd_down() {
   rm -f "$PID_FILE"
 }
 
-case "$cmd" in
-  up)   cmd_up "${@:2}" ;;
-  down) cmd_down ;;
-  *)    print -u2 "usage: scripts/dev <up [--all] [--start-deps]|down>"; exit 1 ;;
-esac
+# One-step post-merge command: stop fishhawkd (if running), rebuild changed
+# binaries, restart fishhawkd, and emit the MCP reconnect signal. Plain `up`
+# no-ops when fishhawkd is already running, so it never rebuilds after a merge;
+# reload (down-then-up) closes that gap. Flags (--all/--start-deps) forward to
+# cmd_up.
+cmd_reload() {
+  if [[ -f "$PID_FILE" ]]; then
+    cmd_down
+  fi
+  cmd_up "$@"
+}
+
+_usage() {
+  print -u2 "usage: scripts/dev <up [--all] [--start-deps]|reload [--all] [--start-deps]|down>"
+  print -u2 ""
+  print -u2 "  reload is the one-step post-merge command (down-then-up); plain up no-ops"
+  print -u2 "  when fishhawkd is already running and so never rebuilds."
+  print -u2 ""
+  print -u2 "binary activation after a rebuild:"
+  print -u2 "  fishhawkd        rebuilt + restarted by up/reload"
+  print -u2 "  fishhawk-runner  picked up automatically (spawned fresh from bin/ per stage)"
+  print -u2 "  fishhawk-mcp     rebuilt on disk but requires a manual /mcp reconnect"
+}
+
+# DEV_LIB_ONLY lets scripts/test-dev source this file to unit-test the helpers
+# without triggering the dispatch (and thus the stack).
+if [[ -z "${DEV_LIB_ONLY:-}" ]]; then
+  case "$cmd" in
+    up)     cmd_up "${@:2}" ;;
+    reload) cmd_reload "${@:2}" ;;
+    down)   cmd_down ;;
+    *)      _usage; exit 1 ;;
+  esac
+fi

--- a/scripts/test-dev
+++ b/scripts/test-dev
@@ -1,0 +1,69 @@
+#!/usr/bin/env zsh
+# Hermetic unit test for scripts/dev library helpers.
+# Sources scripts/dev with DEV_LIB_ONLY=1 (dispatch suppressed) and asserts the
+# MCP-activation signalling and cmd_reload wiring without starting the stack.
+# Must be zsh: scripts/dev uses zsh-only features (typeset -A, subscript flags).
+# Standalone like scripts/test-cleanup-merged — not wired into scripts/test or CI.
+set -uo pipefail
+
+REPO_ROOT="${0:A:h:h}"
+PASS=0
+FAIL=0
+
+pass() { print "PASS: $1"; PASS=$(( PASS + 1 )) }
+fail() { print "FAIL: $1"; FAIL=$(( FAIL + 1 )) }
+
+# Source the library. scripts/dev enables `set -e`; turn it back off so the
+# assertions below (which run commands expected to fail) don't abort the test.
+DEV_LIB_ONLY=1 source "${REPO_ROOT}/scripts/dev"
+set +e
+
+# 1. Rebuilt path: prominent, names the binary, and tells the operator to reconnect.
+out="$(_signal_mcp_activation 1)"
+if [[ "$out" == *fishhawk-mcp* ]]; then
+  pass "rebuilt signal mentions fishhawk-mcp"
+else
+  fail "rebuilt signal should mention fishhawk-mcp (got: $out)"
+fi
+if print -r -- "$out" | grep -qi reconnect; then
+  pass "rebuilt signal matches /reconnect/i"
+else
+  fail "rebuilt signal should match /reconnect/i (got: $out)"
+fi
+
+# 2. Unchanged path: single explicit no-op line.
+out="$(_signal_mcp_activation 0)"
+if [[ "$out" == *"no MCP reconnect needed"* ]]; then
+  pass "unchanged signal says 'no MCP reconnect needed'"
+else
+  fail "unchanged signal should say 'no MCP reconnect needed' (got: $out)"
+fi
+
+# 3. cmd_reload core behavior: invokes cmd_down then cmd_up, forwarding flags.
+reload_body="$(typeset -f cmd_reload)"
+if print -r -- "$reload_body" | grep -q cmd_down; then
+  pass "cmd_reload invokes cmd_down"
+else
+  fail "cmd_reload should invoke cmd_down"
+fi
+if print -r -- "$reload_body" | grep -q cmd_up; then
+  pass "cmd_reload invokes cmd_up"
+else
+  fail "cmd_reload should invoke cmd_up"
+fi
+if print -r -- "$reload_body" | grep -q '"\$@"'; then
+  pass "cmd_reload forwards flags (\"\$@\") to cmd_up"
+else
+  fail "cmd_reload should forward \"\$@\" to cmd_up"
+fi
+
+# 4. Parse check: scripts/dev is valid zsh.
+if zsh -n "${REPO_ROOT}/scripts/dev"; then
+  pass "scripts/dev parses clean (zsh -n)"
+else
+  fail "scripts/dev failed zsh -n parse check"
+fi
+
+print ""
+print "Results: ${PASS} passed, ${FAIL} failed"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

After each merge the operator had to track per-binary activation rules by hand (fishhawkd=restart, runner=auto-respawn, fishhawk-mcp=needs `/mcp` reconnect) — which bit hard when #589's `fishhawk-mcp` change stayed inert behind a stale MCP server.

- **`scripts/dev reload`** (down-then-up): the one-step post-merge command. Plain `up` no-ops when fishhawkd is already running and so never rebuilds; `reload` stops, rebuilds changed binaries, restarts fishhawkd.
- **Both `up` and `reload`** emit, as their **last** line(s), whether a `/mcp` reconnect is required — a prominent banner when `bin/fishhawk-mcp` was rebuilt (driven off the existing rebuilt-set detection via the zsh `(Ie)` membership idiom), else an explicit "no MCP reconnect needed". Printed **after** the "fishhawkd started" line so it's genuinely unmissable. The script can't restart the harness-owned MCP server — it only signals.
- **`scripts/test-dev`**: hermetic zsh test (no docker/go) covering the signal branches AND that `cmd_reload` invokes `cmd_down`+`cmd_up` and forwards flags; guarded behind `DEV_LIB_ONLY` so the script can be sourced for unit testing.
- **CLAUDE.md** Rebuild matrix documents the binary→activation matrix.

Both plan-review concerns folded in: the signal is emitted after the spawn line (now unmissable), and `test-dev` asserts `cmd_reload`'s core behavior.

## Test plan

- `zsh -n scripts/dev` clean; `zsh scripts/test-dev` → **7/7 passed**. No Go files change, so the go test/coverage gates are N/A.

## Notes

- **The implement stage failed-B on a policy false-positive** (`required_outcomes: tests_added_or_updated` → "no test files added or updated") — the check only recognizes Go `*_test.go` files and doesn't count the added shell test `scripts/test-dev`. This is the first non-Go-only change to hit the check now that **#589 enabled git_diff-event policy enforcement in the local loop** (previously skipped as `no_diff_in_bundle`). Shipped after human-verifying the shell test exists and passes 7/7; the check bug is filed as a follow-up.
- Driven via the loop (run `679b042c`); `await_review` (just-merged #600) returned the plan-review verdict in one call — first live use.

Closes #601