### PR TITLE
Coerce null-valued optional plan fields to absent (#612)

### DIFF
--- a/backend/internal/plan/coerce.go
+++ b/backend/internal/plan/coerce.go
@@ -33,8 +33,51 @@ type coercionAnnotation struct {
 // built once at package init by parsing the embedded schema.
 var coercionRegistry map[string]coercionEntry
 
+// optionalTopLevelFields is the schema-derived set of top-level properties that
+// are NOT in the schema's `required` array (properties \ required), built once
+// at package init. TryCoerce drops any of these whose value is JSON null,
+// treating null-as-absent. Required fields are intentionally excluded so a null
+// required field still fails Validate with a precise message.
+var optionalTopLevelFields map[string]struct{}
+
 func init() {
 	coercionRegistry = buildCoercionRegistry()
+	optionalTopLevelFields = buildOptionalTopLevelFields()
+}
+
+// buildOptionalTopLevelFields parses the embedded schema and returns the set of
+// top-level property names that are not listed in the schema's `required`
+// array. Schema-derived so it auto-adapts as the schema evolves (today:
+// decomposition, risks_and_assumptions).
+func buildOptionalTopLevelFields() map[string]struct{} {
+	const schemaPath = "schemas/plan-standard-v1.schema.json"
+	data, err := schemaFS.ReadFile(schemaPath)
+	if err != nil {
+		panic(fmt.Sprintf("plan: coerce: read schema %s: %v", schemaPath, err))
+	}
+	var schema map[string]any
+	if err := json.Unmarshal(data, &schema); err != nil {
+		panic(fmt.Sprintf("plan: coerce: parse schema %s: %v", schemaPath, err))
+	}
+
+	required := make(map[string]struct{})
+	if reqRaw, ok := schema["required"].([]any); ok {
+		for _, r := range reqRaw {
+			if s, ok := r.(string); ok {
+				required[s] = struct{}{}
+			}
+		}
+	}
+
+	optional := make(map[string]struct{})
+	if props, ok := schema["properties"].(map[string]any); ok {
+		for name := range props {
+			if _, isRequired := required[name]; !isRequired {
+				optional[name] = struct{}{}
+			}
+		}
+	}
+	return optional
 }
 
 func buildCoercionRegistry() map[string]coercionEntry {
@@ -179,9 +222,12 @@ func CoercionRegistrySummary() string {
 	return fmt.Sprintf("%d paths: %s", len(paths), strings.Join(paths, ", "))
 }
 
-// TryCoerce attempts to fix the known string-elision class of plan schema
-// violations: cases where an agent emits a bare string where the schema
-// expects an object. The set of coercible paths is derived at init time from
+// TryCoerce attempts to fix two known classes of plan schema violations:
+// (1) the string-elision class — an agent emits a bare string where the schema
+// expects an object; and (2) the null-optional class — an agent sets an
+// optional top-level field to JSON null, which TryCoerce drops (treating
+// null-as-absent). A null in a REQUIRED field is left in place so Validate
+// still fails with a precise message. The set of coercible paths is derived at init time from
 // the x-coerce-principal / x-coerce-defaults annotations in the embedded
 // schema — no per-field code changes are required when the schema gains a new
 // annotated $defs entry.
@@ -201,6 +247,24 @@ func TryCoerce(data []byte, now time.Time) ([]byte, []Coercion, error) {
 	}
 
 	var coercions []Coercion
+
+	// Drop top-level optional fields whose value is JSON null. encoding/json
+	// stores a JSON null as a present key with a nil value, so an agent that
+	// emits e.g. "decomposition": null lands here as (present, nil) and would
+	// otherwise fail schema validation. Treat null-as-absent for optional fields
+	// only; a null in a REQUIRED field is left in place so Validate still fails
+	// with a precise message.
+	for key := range optionalTopLevelFields {
+		if v, ok := m[key]; ok && v == nil {
+			delete(m, key)
+			coercions = append(coercions, Coercion{
+				FieldPath:     "/" + key,
+				OriginalType:  "null",
+				OriginalValue: nil,
+				CoercedTo:     nil,
+			})
+		}
+	}
 
 	for path, entry := range coercionRegistry {
 		parts := strings.Split(strings.TrimPrefix(path, "/"), "/")

--- a/backend/internal/plan/coerce_test.go
+++ b/backend/internal/plan/coerce_test.go
@@ -263,3 +263,58 @@ func TestTryCoerce_AlreadyValid(t *testing.T) {
 		t.Errorf("err = %v, want nil", err)
 	}
 }
+
+// TestTryCoerce_NullDecompositionDropped verifies that an optional top-level
+// field set to JSON null (decomposition) is dropped and treated as absent so
+// the plan validates, rather than deterministically failing schema validation.
+func TestTryCoerce_NullDecompositionDropped(t *testing.T) {
+	m := planfixture.Valid()
+	m["decomposition"] = nil
+	data := marshal(t, m)
+
+	coercedBytes, coercions, err := plan.TryCoerce(data, testNow)
+	if err != nil {
+		t.Fatalf("TryCoerce: unexpected error: %v", err)
+	}
+	if len(coercions) != 1 {
+		t.Fatalf("coercions = %d, want 1", len(coercions))
+	}
+	if got := coercions[0].FieldPath; got != "/decomposition" {
+		t.Errorf("FieldPath = %q, want /decomposition", got)
+	}
+	if got := coercions[0].OriginalType; got != "null" {
+		t.Errorf("OriginalType = %q, want null", got)
+	}
+	if coercedBytes == nil {
+		t.Fatal("coercedBytes is nil")
+	}
+	if err := plan.Validate(coercedBytes); err != nil {
+		t.Errorf("coerced plan does not validate: %v", err)
+	}
+	var result map[string]any
+	if err := json.Unmarshal(coercedBytes, &result); err != nil {
+		t.Fatalf("unmarshal coerced: %v", err)
+	}
+	if _, present := result["decomposition"]; present {
+		t.Error("decomposition key still present after coercion; want dropped")
+	}
+}
+
+// TestTryCoerce_NullRequiredFieldNotDropped verifies that a JSON null in a
+// REQUIRED field (summary) is NOT dropped — it must still fail Validate with a
+// precise message rather than being silently removed.
+func TestTryCoerce_NullRequiredFieldNotDropped(t *testing.T) {
+	m := planfixture.Valid()
+	m["summary"] = nil
+	data := marshal(t, m)
+
+	_, coercions, err := plan.TryCoerce(data, testNow)
+	if err == nil {
+		t.Fatal("err = nil, want non-nil: null required field must fail validation")
+	}
+	for _, c := range coercions {
+		if c.FieldPath == "/summary" {
+			t.Errorf("required field /summary was coerced/dropped; want left in place")
+		}
+	}
+}

--- a/backend/internal/prompt/prompt.go
+++ b/backend/internal/prompt/prompt.go
@@ -422,7 +422,7 @@ func buildPlan(t Trigger) string {
 	b.WriteString("- scope.files[i]: {\"path\": \"...\", \"operation\": \"...\"} object\n")
 	b.WriteString("- ticket_reference: {\"type\": \"...\", \"url\": \"...\", \"id\": \"...\"} object\n")
 	b.WriteString("- generated_by: {\"agent\": \"...\", \"model\": \"...\", \"timestamp\": \"...\"} object\n")
-	b.WriteString("- decomposition (when present): {\"rationale\": \"...\", \"sub_plans\": [...]} object\n")
+	b.WriteString("- decomposition (when present): {\"rationale\": \"...\", \"sub_plans\": [...]} object — when you are NOT decomposing, OMIT this field entirely; do NOT set it to null\n")
 	b.WriteString("- decomposition.sub_plans[i]: {\"title\": \"...\", \"scope_hint\": \"...\", \"predicted_runtime_minutes\": N, \"predicted_runtime_confidence\": \"low|medium|high\"} object — use the FULL canonical field names; \"confidence\" / \"minutes\" shorthand will be rejected\n")
 	b.WriteString("The validator rejects any plan where these fields contain bare strings instead of their required structured shapes.\n")
 	b.WriteString("\n")

--- a/backend/internal/prompt/prompt_test.go
+++ b/backend/internal/prompt/prompt_test.go
@@ -860,6 +860,7 @@ func TestBuild_Plan_CompoundFieldDirective(t *testing.T) {
 		"bare string",
 		"decomposition.sub_plans[i]",
 		"shorthand will be rejected",
+		"do NOT set it to null",
 	}
 	for _, w := range wants {
 		if !strings.Contains(got, w) {

--- a/runner/internal/plan/coerce.go
+++ b/runner/internal/plan/coerce.go
@@ -44,8 +44,53 @@ type coercionAnnotation struct {
 // nothing to fix).
 var coercionRegistry map[string]coercionEntry
 
+// optionalTopLevelFields is the schema-derived set of top-level properties that
+// are NOT in the schema's `required` array (properties \\ required), built once
+// at package init. TryCoerce drops any of these whose value is JSON null,
+// treating null-as-absent. Required fields are intentionally excluded so a null
+// required field still fails Validate with a precise message.
+//
+// Mirror of backend/internal/plan.optionalTopLevelFields.
+var optionalTopLevelFields map[string]struct{}
+
 func init() {
 	coercionRegistry = buildCoercionRegistry()
+	optionalTopLevelFields = buildOptionalTopLevelFields()
+}
+
+// buildOptionalTopLevelFields parses the embedded schema and returns the set of
+// top-level property names that are not listed in the schema's `required`
+// array. Schema-derived so it auto-adapts as the schema evolves (today:
+// decomposition, risks_and_assumptions).
+func buildOptionalTopLevelFields() map[string]struct{} {
+	const schemaPath = "schemas/plan-standard-v1.schema.json"
+	data, err := schemaFS.ReadFile(schemaPath)
+	if err != nil {
+		panic(fmt.Sprintf("plan: coerce: read schema %s: %v", schemaPath, err))
+	}
+	var schema map[string]any
+	if err := json.Unmarshal(data, &schema); err != nil {
+		panic(fmt.Sprintf("plan: coerce: parse schema %s: %v", schemaPath, err))
+	}
+
+	required := make(map[string]struct{})
+	if reqRaw, ok := schema["required"].([]any); ok {
+		for _, r := range reqRaw {
+			if s, ok := r.(string); ok {
+				required[s] = struct{}{}
+			}
+		}
+	}
+
+	optional := make(map[string]struct{})
+	if props, ok := schema["properties"].(map[string]any); ok {
+		for name := range props {
+			if _, isRequired := required[name]; !isRequired {
+				optional[name] = struct{}{}
+			}
+		}
+	}
+	return optional
 }
 
 func buildCoercionRegistry() map[string]coercionEntry {
@@ -190,9 +235,12 @@ func CoercionRegistrySummary() string {
 	return fmt.Sprintf("%d paths: %s", len(paths), strings.Join(paths, ", "))
 }
 
-// TryCoerce attempts to fix the known string-elision class of plan schema
-// violations: cases where an agent emits a bare string where the schema
-// expects an object. The set of coercible paths is derived at init time from
+// TryCoerce attempts to fix two known classes of plan schema violations:
+// (1) the string-elision class — an agent emits a bare string where the schema
+// expects an object; and (2) the null-optional class — an agent sets an
+// optional top-level field to JSON null, which TryCoerce drops (treating
+// null-as-absent). A null in a REQUIRED field is left in place so Validate
+// still fails with a precise message. The set of coercible paths is derived at init time from
 // the x-coerce-principal / x-coerce-defaults annotations in the embedded
 // schema — no per-field code changes are required when the schema gains a new
 // annotated $defs entry.
@@ -217,6 +265,24 @@ func TryCoerce(data []byte, now time.Time) ([]byte, []Coercion, error) {
 	}
 
 	var coercions []Coercion
+
+	// Drop top-level optional fields whose value is JSON null. encoding/json
+	// stores a JSON null as a present key with a nil value, so an agent that
+	// emits e.g. "decomposition": null lands here as (present, nil) and would
+	// otherwise fail schema validation. Treat null-as-absent for optional fields
+	// only; a null in a REQUIRED field is left in place so Validate still fails
+	// with a precise message.
+	for key := range optionalTopLevelFields {
+		if v, ok := m[key]; ok && v == nil {
+			delete(m, key)
+			coercions = append(coercions, Coercion{
+				FieldPath:     "/" + key,
+				OriginalType:  "null",
+				OriginalValue: nil,
+				CoercedTo:     nil,
+			})
+		}
+	}
 
 	for path, entry := range coercionRegistry {
 		parts := strings.Split(strings.TrimPrefix(path, "/"), "/")

--- a/runner/internal/plan/coerce_test.go
+++ b/runner/internal/plan/coerce_test.go
@@ -262,3 +262,58 @@ func TestTryCoerce_AlreadyValid(t *testing.T) {
 		t.Errorf("err = %v, want nil", err)
 	}
 }
+
+// TestTryCoerce_NullDecompositionDropped verifies that an optional top-level
+// field set to JSON null (decomposition) is dropped and treated as absent so
+// the plan validates, rather than deterministically failing schema validation.
+func TestTryCoerce_NullDecompositionDropped(t *testing.T) {
+	m := planfixture.Valid()
+	m["decomposition"] = nil
+	data := marshal(t, m)
+
+	coercedBytes, coercions, err := plan.TryCoerce(data, testNow)
+	if err != nil {
+		t.Fatalf("TryCoerce: unexpected error: %v", err)
+	}
+	if len(coercions) != 1 {
+		t.Fatalf("coercions = %d, want 1", len(coercions))
+	}
+	if got := coercions[0].FieldPath; got != "/decomposition" {
+		t.Errorf("FieldPath = %q, want /decomposition", got)
+	}
+	if got := coercions[0].OriginalType; got != "null" {
+		t.Errorf("OriginalType = %q, want null", got)
+	}
+	if coercedBytes == nil {
+		t.Fatal("coercedBytes is nil")
+	}
+	if err := plan.Validate(coercedBytes); err != nil {
+		t.Errorf("coerced plan does not validate: %v", err)
+	}
+	var result map[string]any
+	if err := json.Unmarshal(coercedBytes, &result); err != nil {
+		t.Fatalf("unmarshal coerced: %v", err)
+	}
+	if _, present := result["decomposition"]; present {
+		t.Error("decomposition key still present after coercion; want dropped")
+	}
+}
+
+// TestTryCoerce_NullRequiredFieldNotDropped verifies that a JSON null in a
+// REQUIRED field (summary) is NOT dropped — it must still fail Validate with a
+// precise message rather than being silently removed.
+func TestTryCoerce_NullRequiredFieldNotDropped(t *testing.T) {
+	m := planfixture.Valid()
+	m["summary"] = nil
+	data := marshal(t, m)
+
+	_, coercions, err := plan.TryCoerce(data, testNow)
+	if err == nil {
+		t.Fatal("err = nil, want non-nil: null required field must fail validation")
+	}
+	for _, c := range coercions {
+		if c.FieldPath == "/summary" {
+			t.Errorf("required field /summary was coerced/dropped; want left in place")
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a deterministic plan-stage failure: an agent that emits `"decomposition": null` (rather than omitting the field) failed schema validation every time. standard_v1 wants `/decomposition` to be **object-or-absent**, and the existing coercion registry only handled the bare-string-where-object class — so the null slipped through and the runner failed the plan locally (category B) before upload. This stranded #610 across two identical attempts.

`TryCoerce` now drops any **top-level optional field whose value is JSON null** before the string-elision pass, treating null-as-absent. The optional set is **schema-derived** (`properties \ required`) at package init, so it auto-adapts as the schema evolves (today: `decomposition`, `risks_and_assumptions`) with no per-field code. A null in a **required** field is deliberately left in place so `Validate` still fails with a precise message.

The change is mirrored in both `backend/internal/plan/coerce.go` and `runner/internal/plan/coerce.go` (deliberate mirrors). A secondary prompt backstop instructs the plan agent to OMIT `decomposition` rather than set it to null.

Built and verified end-to-end through the Fishhawk local loop (run `f43b0757`): plan stage validated cleanly, advisory plan-review `approve`, advisory implement-review `approve`.

## Test plan

- `TestTryCoerce_NullDecompositionDropped` (both backend + runner): `decomposition: null` → coerced-absent (one `Coercion{FieldPath:"/decomposition", OriginalType:"null"}`) → `Validate` passes → key no longer present.
- `TestTryCoerce_NullRequiredFieldNotDropped` (both): `summary: null` (required) is NOT dropped and still fails `Validate`.
- `prompt_test.go`: pins the new "do NOT set it to null" instruction.
- `scripts/test coverage` — full `-race` suite across all modules, aggregate **81.4% ≥ 80%**. `golangci-lint` clean on touched packages.

## Notes

- **Schema unchanged.** No file under `docs/spec/` is touched — `decomposition` was already object-or-absent — so the schema-sync gate is not triggered.
- **Deferred follow-up: #613.** When the runner fails plan-validation *locally*, it never POSTs the plan, so the backend's #603 plan-ship-invalid path (`FailStage(FailureB)` + `advanceAfterFailure`) never fires — the stage is left `running` until the SLA watchdog reaps it. That propagation gap is out of scope here and filed as #613.
- Unblocks #610.

Closes #612