### PR TITLE
scripts/dev: reload forces full rebuild + scope MCP banner to merge delta (#616)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,9 @@ Cross-reference: this checklist codifies the rollout discipline introduced by #5
 | `fishhawk-runner` | picked up automatically — spawned fresh from `bin/` on each `fishhawk_run_stage` |
 | `fishhawk-mcp` | rebuilt on disk but **needs a manual `/mcp` reconnect** — the Claude Code harness owns the MCP server process, so `scripts/dev` cannot restart it; it only signals the operator |
 
-`scripts/dev reload` (down-then-up) is the one-step post-merge command: plain `scripts/dev up` no-ops when fishhawkd is already running and so never rebuilds. Both `up` and `reload` print, as their last line(s), whether a `/mcp` reconnect is required (and why) based on whether `bin/fishhawk-mcp` was rebuilt. This supersedes the older "MCP server stale after rebuild" gotcha by making the reconnect-vs-rebuild distinction first-class.
+`scripts/dev reload` (down-then-up) is the one-step post-merge command: plain `scripts/dev up` no-ops when fishhawkd is already running and so never rebuilds. **`reload` always rebuilds all four binaries (it forces `--all`)** — after a merge `HEAD == origin/main`, so the `origin/main...HEAD` diff is empty and the rebuild matrix would match nothing, silently skipping runner/CLI/mcp. Forcing `--all` closes that gap.
+
+Because `--all` always rebuilds `fishhawk-mcp`, the `/mcp` reconnect banner is **decoupled from the rebuild action**: it is keyed to whether the pull's merge-aware diff (`HEAD@{1}..HEAD`) actually touched fishhawk-mcp source — `backend/cmd/fishhawk-mcp/` or the shared libs `backend/internal/plan/` + `backend/internal/spec/` (the same matrix globs that route to mcp). So `reload` no longer false-nags a reconnect when the merge never touched the MCP server. Fresh-clone / no-reflog / detached-HEAD (where `HEAD@{1}` is unresolvable) falls back to firing the banner conservatively — never a false-negative silent-stale mcp. Plain `up` (branch-diff, not `--all`) still keys the banner off whether mcp was rebuilt, since there a rebuild genuinely means mcp source differs from main. This supersedes the older "MCP server stale after rebuild" gotcha by making the reconnect-vs-rebuild distinction first-class.
 
 ## Adding a Go module
 

--- a/scripts/dev
+++ b/scripts/dev
@@ -120,8 +120,64 @@ _build_binary() {
   esac
 }
 
+# Pure path matcher: returns 0 if any line of the newline-delimited changed-file
+# text in $1 matches a rebuild-matrix glob that routes to fishhawk-mcp, else 1.
+# Reuses the exact glob set _detect_rebuild_set uses for fishhawk-mcp — the
+# shared-lib case (backend/internal/plan|spec, line ~71) plus the mcp-cmd case
+# (backend/cmd/fishhawk-mcp, line ~81). If those matrix globs change, this must
+# move with them. Git-free so scripts/test-dev can drive it with crafted input.
+_diff_touches_mcp() {
+  local diff_text="$1"
+  local f
+  while IFS= read -r f; do
+    [[ -z "$f" ]] && continue
+    case "$f" in
+      backend/cmd/fishhawk-mcp/*|backend/internal/plan/*|backend/internal/spec/*)
+        return 0
+        ;;
+    esac
+  done <<< "$diff_text"
+  return 1
+}
+
+# Pure decision helper for the MCP reconnect banner — extracted so the
+# three-branch logic is hermetically testable. The caller runs the git diff and
+# passes the result in. Echoes 1 (fire the banner) or 0 (stay quiet).
+# Args: <mcp_rebuilt 0|1> <force_all 0|1> <reflog_ok 0|1> <merge_diff_text>
+#   - mcp not rebuilt              -> 0
+#   - rebuilt under --all, reflog ok -> consult merge diff (touches mcp ? 1 : 0)
+#   - rebuilt under --all, no reflog -> 1 (safe fallback; never a silent stale mcp)
+#   - rebuilt under a branch-diff up -> 1 (rebuilt_list membership already means
+#                                          mcp source differs from main)
+_decide_mcp_signal() {
+  local mcp_rebuilt="$1"
+  local force_all="$2"
+  local reflog_ok="$3"
+  local merge_diff="$4"
+
+  if (( ! mcp_rebuilt )); then
+    print 0
+    return
+  fi
+
+  if (( force_all )); then
+    if (( reflog_ok )); then
+      if _diff_touches_mcp "$merge_diff"; then
+        print 1
+      else
+        print 0
+      fi
+    else
+      print 1
+    fi
+    return
+  fi
+
+  print 1
+}
+
 # Emits the MCP reconnect signal — must be the LAST thing printed by up/reload
-# so it is unmissable. Arg 1: 1 if bin/fishhawk-mcp was rebuilt this run, else 0.
+# so it is unmissable. Arg 1: 1 if a /mcp reconnect is required this run, else 0.
 # scripts/dev cannot restart the MCP server (the Claude Code harness owns that
 # process), so on a rebuild the only lever is to tell the operator, unmissably,
 # that a manual /mcp reconnect is required or the new binary stays inert.
@@ -248,11 +304,26 @@ cmd_up() {
 
   # Detect whether fishhawk-mcp was rebuilt off the existing rebuilt_list — no
   # second detection mechanism. The (Ie) subscript flags return the matching
-  # index (>0) or 0 when absent. The signal itself is emitted last (below).
+  # index (>0) or 0 when absent.
   local mcp_rebuilt=0
   if (( ${rebuilt_list[(Ie)fishhawk-mcp]} )); then
     mcp_rebuilt=1
   fi
+
+  # Decide the reconnect banner. Under --all (reload), fishhawk-mcp ALWAYS
+  # rebuilds, so rebuilt_list membership is uninformative — keying the nag off it
+  # would fire on every post-merge reload even when the merge never touched the
+  # MCP server. Consult the pull's merge-aware diff (HEAD@{1}..HEAD) and fire only
+  # when it actually touched fishhawk-mcp source. Quote 'HEAD@{1}' so zsh leaves
+  # the brace literal; run the git call as an if-condition so set -e is suppressed
+  # and an unresolvable reflog (fresh clone / detached HEAD) branches to the safe
+  # fallback (fire the banner) rather than aborting cmd_up.
+  local reflog_ok=0 merge_diff=""
+  if merge_diff="$(git diff --name-only 'HEAD@{1}' HEAD 2>/dev/null)"; then
+    reflog_ok=1
+  fi
+  local mcp_signal
+  mcp_signal="$(_decide_mcp_signal "$mcp_rebuilt" "$force_all" "$reflog_ok" "$merge_diff")"
 
   # Migrate
   print "applying migrations..."
@@ -266,7 +337,7 @@ cmd_up() {
   print "fishhawkd started (pid ${pid}) — logs: ${LOG_FILE}"
 
   # Last line(s): tell the operator whether a /mcp reconnect is required.
-  _signal_mcp_activation "$mcp_rebuilt"
+  _signal_mcp_activation "$mcp_signal"
 }
 
 cmd_down() {
@@ -302,16 +373,20 @@ cmd_down() {
   rm -f "$PID_FILE"
 }
 
-# One-step post-merge command: stop fishhawkd (if running), rebuild changed
+# One-step post-merge command: stop fishhawkd (if running), rebuild ALL four
 # binaries, restart fishhawkd, and emit the MCP reconnect signal. Plain `up`
 # no-ops when fishhawkd is already running, so it never rebuilds after a merge;
-# reload (down-then-up) closes that gap. Flags (--all/--start-deps) forward to
-# cmd_up.
+# reload (down-then-up) closes that gap. reload forces --all because the
+# post-merge `origin/main...HEAD` diff is empty (HEAD == origin/main), so the
+# rebuild matrix would match nothing and silently skip runner/CLI/mcp. The MCP
+# reconnect banner is decoupled from the rebuild: it consults the merge-aware
+# diff (HEAD@{1}..HEAD), so a full rebuild does not false-nag a reconnect.
+# Extra flags (--start-deps, a redundant --all) forward to cmd_up unchanged.
 cmd_reload() {
   if [[ -f "$PID_FILE" ]]; then
     cmd_down
   fi
-  cmd_up "$@"
+  cmd_up --all "$@"
 }
 
 _usage() {

--- a/scripts/test-dev
+++ b/scripts/test-dev
@@ -56,8 +56,66 @@ if print -r -- "$reload_body" | grep -q '"\$@"'; then
 else
   fail "cmd_reload should forward \"\$@\" to cmd_up"
 fi
+# reload must force a full rebuild (--all) so the empty post-merge
+# origin/main...HEAD diff doesn't silently skip runner/CLI/mcp.
+if print -r -- "$reload_body" | grep -q -- '--all'; then
+  pass "cmd_reload forces a full rebuild (--all)"
+else
+  fail "cmd_reload should force --all"
+fi
 
-# 4. Parse check: scripts/dev is valid zsh.
+# 4. _diff_touches_mcp: pure matcher mirrors the rebuild matrix's mcp routing.
+if _diff_touches_mcp "backend/cmd/fishhawk-mcp/main.go"; then
+  pass "_diff_touches_mcp matches backend/cmd/fishhawk-mcp/"
+else
+  fail "_diff_touches_mcp should match backend/cmd/fishhawk-mcp/"
+fi
+if _diff_touches_mcp "backend/internal/plan/validate.go"; then
+  pass "_diff_touches_mcp matches shared lib backend/internal/plan/"
+else
+  fail "_diff_touches_mcp should match backend/internal/plan/"
+fi
+if _diff_touches_mcp "backend/internal/spec/load.go"; then
+  pass "_diff_touches_mcp matches shared lib backend/internal/spec/"
+else
+  fail "_diff_touches_mcp should match backend/internal/spec/"
+fi
+# #612 case: --all rebuilt mcp, but the merge delta touched only runner source.
+if _diff_touches_mcp "runner/internal/plan/coerce.go"; then
+  fail "_diff_touches_mcp should NOT match runner-only delta"
+else
+  pass "_diff_touches_mcp stays quiet for runner-only delta"
+fi
+
+# 5. _decide_mcp_signal: all three branches plus the reflog-unavailable fallback.
+# Args: <mcp_rebuilt> <force_all> <reflog_ok> <merge_diff_text>
+if [[ "$(_decide_mcp_signal 0 1 1 'backend/cmd/fishhawk-mcp/main.go')" == 0 ]]; then
+  pass "_decide_mcp_signal: mcp not rebuilt -> 0"
+else
+  fail "_decide_mcp_signal: mcp not rebuilt should be 0"
+fi
+if [[ "$(_decide_mcp_signal 1 1 1 'backend/cmd/fishhawk-mcp/main.go')" == 1 ]]; then
+  pass "_decide_mcp_signal: rebuilt + --all + diff touches mcp -> 1"
+else
+  fail "_decide_mcp_signal: rebuilt + --all + mcp delta should be 1"
+fi
+if [[ "$(_decide_mcp_signal 1 1 1 'runner/internal/plan/coerce.go')" == 0 ]]; then
+  pass "_decide_mcp_signal: rebuilt + --all + diff misses mcp -> 0"
+else
+  fail "_decide_mcp_signal: rebuilt + --all + non-mcp delta should be 0"
+fi
+if [[ "$(_decide_mcp_signal 1 1 0 '')" == 1 ]]; then
+  pass "_decide_mcp_signal: rebuilt + --all + no reflog -> 1 (fallback)"
+else
+  fail "_decide_mcp_signal: reflog-unavailable fallback should be 1"
+fi
+if [[ "$(_decide_mcp_signal 1 0 1 'runner/internal/plan/coerce.go')" == 1 ]]; then
+  pass "_decide_mcp_signal: rebuilt under branch-diff up -> 1"
+else
+  fail "_decide_mcp_signal: branch-diff up rebuild should be 1"
+fi
+
+# 6. Parse check: scripts/dev is valid zsh.
 if zsh -n "${REPO_ROOT}/scripts/dev"; then
   pass "scripts/dev parses clean (zsh -n)"
 else


### PR DESCRIPTION
## Summary

`scripts/dev reload` is the documented post-merge command, but its rebuild auto-detection diffs `origin/main...HEAD` — which is **empty once the merge is pulled** (`HEAD == origin/main`). So post-merge it rebuilt only the baseline `fishhawkd` and **silently skipped** just-merged `fishhawk-runner` / `fishhawk` (CLI) / `fishhawk-mcp` binaries. Caught merging #612: `bin/fishhawk-runner` stayed stale and the fix wasn't live in the loop until a hand-build.

**Hybrid fix:**

1. **`cmd_reload` ⇒ `cmd_up --all`** — every binary refreshes after a pull. `up` keeps its branch-diff detection for the dev loop.
2. **Decouple the MCP-reconnect banner from the rebuild action.** Under `--all`, `bin/fishhawk-mcp` *always* rebuilds, so keying the banner off "was it rebuilt" would fire the reconnect nag on **every** reload even when the merge never touched the MCP server (a false-positive that erodes the signal). Gate it on a **merge-aware diff** (`git diff --name-only HEAD@{1} HEAD`) and fire only when that delta touches a path the rebuild matrix routes to `fishhawk-mcp` (`backend/cmd/fishhawk-mcp/`, or the shared libs `backend/internal/plan/` + `backend/internal/spec/`). **Fallback:** when `HEAD@{1}` is unresolvable (fresh clone / no reflog / detached HEAD), fire the banner — never a false-negative silent-stale mcp.

The merge-aware gating is **scoped to the `force_all` branch only**; plain branch-diff `up` stays on `rebuilt_list` keying, which there genuinely means mcp source differs from main (applying `HEAD@{1}` gating to `up` could introduce a false-negative after an unrelated checkout). The banner decision is extracted into a pure `_decide_mcp_signal` helper so all three branches + the fallback are hermetically tested.

Built and verified end-to-end through the Fishhawk local loop (run `84835231`, after a reject→re-plan to fold in the banner-scoping): plan-review `approve`, implement-review `approve`. **Bonus:** this PR's own implement stage (scripts + docs + a shell test, no Go) **passed `tests_added_or_updated`** — live confirmation of the #610 fix that previously blocked exactly this shape of change.

## Test plan

- `zsh scripts/test-dev` — hermetic, **17 assertions, all green**, including:
  - `_diff_touches_mcp` for `backend/cmd/fishhawk-mcp/`, the shared libs, and the runner-only #612 case (stays quiet).
  - `_decide_mcp_signal` all five branches: not-rebuilt→0; `--all`+diff-touches-mcp→1; `--all`+diff-misses-mcp→0; `--all`+no-reflog→1 (fallback); branch-diff `up`→1.
  - `cmd_reload` forces `--all`; existing `cmd_down`/`cmd_up`/`"$@"`-forwarding assertions.
- `zsh -n scripts/dev` parse check.
- No Go module / schema / API files touched — Go coverage gate, schema-sync, and auth checklists N/A.

## Notes

- `CLAUDE.md` Rebuild matrix section updated: `reload` always rebuilds all four; the reconnect banner is now keyed to whether the pull's merge-aware diff touched mcp source, with the no-reflog fallback noted.
- Supersedes the manual `reload --all` workaround documented mid-session.

Closes #616