### PR TITLE
runner: propagate local plan-validation failure to backend stage-failed (#613)

### DIFF
--- a/runner/cmd/fishhawk-runner/main.go
+++ b/runner/cmd/fishhawk-runner/main.go
@@ -361,6 +361,14 @@ func run(args []string, logSink io.Writer) (exitCode int) {
 		invokeErr error
 		diff      *constraint.Diff
 		diffErr   error
+		// planValidationFailed records that res.OK was demoted
+		// specifically by a LOCAL plan-validation failure — not an agent
+		// category-A failure, a constraint violation, or a verify-gate
+		// failure. It widens the plan-upload gate below so the
+		// known-invalid plan is still POSTed, letting the backend's
+		// handleShipPlan accept-and-reject path own the running->failed(B)
+		// transition (#613).
+		planValidationFailed bool
 	)
 
 	for {
@@ -384,6 +392,7 @@ func run(args []string, logSink io.Writer) (exitCode int) {
 				res.FailureCategory = "B"
 				res.FailureReason = demote.Error()
 				invokeErr = demote
+				planValidationFailed = true
 			} else {
 				res.Events = append(res.Events, ev)
 			}
@@ -630,7 +639,19 @@ func run(args []string, logSink io.Writer) (exitCode int) {
 		// plan upload is category-C unless the backend rejected the
 		// body as schema-invalid (ErrPlanInvalid) — that's category-B
 		// since it's the agent's output that's bad, not the network.
-		if res.OK && cfg.planOut != "" && stageType != "implement" && stageType != "review" {
+		// planValidationFailed widens the gate so a locally-invalid plan
+		// is still shipped (#613): the backend's handleShipPlan FailStage-B
+		// path (#603) then transitions the stage to failed promptly with
+		// the validation error in the audit trail, instead of leaving it
+		// in `running` until the SLA watchdog reaps it. uploadPlan returns
+		// ErrPlanInvalid in this case, so the success path is never reached
+		// and the existing error handler maps it to category B below.
+		if (res.OK || planValidationFailed) && cfg.planOut != "" && stageType != "implement" && stageType != "review" {
+			if planValidationFailed {
+				_, _ = fmt.Fprintf(logSink,
+					`{"event":"plan_invalid_shipped","run_id":%q,"stage_id":%q}`+"\n",
+					cfg.runID, cfg.stageID)
+			}
 			if err := uploadPlan(ctx, cfg, logSink, client, issuedKey); err != nil {
 				res.OK = false
 				if errors.Is(err, upload.ErrPlanInvalid) {

--- a/runner/cmd/fishhawk-runner/main_test.go
+++ b/runner/cmd/fishhawk-runner/main_test.go
@@ -1729,6 +1729,58 @@ func TestRun_UploadPlan_PlanInvalid_CategoryB(t *testing.T) {
 	}
 }
 
+func TestRun_PlanValidationInvalid_ShipsToBackend(t *testing.T) {
+	// #613: when local plan-validation fails, the runner must STILL POST
+	// the invalid plan (with --upload-trace) so the backend's
+	// handleShipPlan accept-and-reject path owns the running->failed(B)
+	// transition rather than leaving the stage in `running` until the SLA
+	// watchdog reaps it.
+	dir := t.TempDir()
+	promptPath := filepath.Join(dir, "prompt.txt")
+	planPath := filepath.Join(dir, "plan.json")
+	if err := os.WriteFile(promptPath, []byte("p"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Drop required field "summary" — schema rejects (a violation class
+	// coercion cannot synthesize), mirroring
+	// TestRun_PlanValidationInvalid_DemotesToCategoryB.
+	bad := strings.Replace(validPlanJSON(), `"summary": "Add a thing.",`, "", 1)
+	if err := os.WriteFile(planPath, []byte(bad), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	withFakeInvoker(t, &fakeInvoker{canned: agent.Result{OK: true}})
+	fu := newFakeUploader(t)
+	// Mirror the backend's 400 plan_invalid response on the shipped body.
+	fu.planErr = upload.ErrPlanInvalid
+	withFakeUploader(t, fu)
+
+	runID := "11111111-2222-3333-4444-555555555555"
+	stageID := "22222222-3333-4444-5555-666666666666"
+	var stderr strings.Builder
+	got := run([]string{
+		"--run-id", runID, "--backend-url", "https://api.fishhawk.test",
+		"--workflow", "feature_change", "--stage", "plan",
+		"--prompt-file", promptPath,
+		"--plan-out", planPath,
+		"--upload-trace",
+		"--stage-id", stageID,
+	}, &stderr)
+	if got != exitFailure {
+		t.Fatalf("run = %d, want exitFailure:\n%s", got, stderr.String())
+	}
+	out := stderr.String()
+	// Regression guard (#613): ShipPlan WAS called with the invalid plan.
+	if fu.gotPlanArgs == nil {
+		t.Fatal("ShipPlan not called — locally-invalid plan must still be shipped")
+	}
+	if !strings.Contains(out, `"event":"plan_invalid_shipped"`) {
+		t.Errorf("missing plan_invalid_shipped log:\n%s", out)
+	}
+	if !strings.Contains(out, `"category":"B"`) {
+		t.Errorf("expected category-B propagated from backend reject:\n%s", out)
+	}
+}
+
 func TestRun_UploadPlan_NotShippedWithoutPlanOut(t *testing.T) {
 	dir := t.TempDir()
 	promptPath := filepath.Join(dir, "prompt.txt")


### PR DESCRIPTION
## Summary

Closes the deferred "Related gap" from #612. When the runner fails plan-validation **locally** (post-coercion plan still invalid), it demoted `res.OK=false` (category B) and then **skipped the plan upload** (that block was gated on `res.OK`). The backend never received the plan, so its #603 `handleShipPlan` → `FailStage(FailureB)` + `advanceAfterFailure` path never fired — the plan stage was left in `running` until the slow SLA watchdog reaped it, opaque to the operator/agent.

**Fix (option 1 from the issue):** a `planValidationFailed` flag, set **only** in the local plan-validation demotion branch (not agent category-A, constraint, or verify-gate failures), widens the plan-upload gate to `(res.OK || planValidationFailed)` so the known-invalid plan is still POSTed. The backend's accept-and-reject path then owns the `running → failed(B)` transition and writes the validation error into the audit trail.

Key correctness point: the backend returns `400 plan_invalid` **after** `FailStage` + `advanceAfterFailure` but **before** `ArtifactRepo.Create` (`backend/internal/server/plan.go:199-245`), so **no invalid artifact is persisted**. `uploadPlan`'s existing `ErrPlanInvalid → category-B` handler then logs and exits. A `plan_invalid_shipped` log line marks the intentional invalid-ship so it isn't mistaken for a network error.

## Test plan

- `TestRun_PlanValidationInvalid_ShipsToBackend` (new): fake invoker OK + schema-invalid `--plan-out` + `--upload-trace`; asserts `run()` returns `exitFailure`, **`ShipPlan` WAS called with the invalid plan** (the #613 regression guard), `plan_invalid_shipped` emitted, and category-B propagated.
- Existing guards stay green: `TestRun_PlanValidationInvalid_DemotesToCategoryB` (no `--upload-trace` → unchanged), `TestRun_PlanValidationSkippedOnAgentFailure` (agent category-A → `planValidationFailed` false → no upload attempted), `TestRun_UploadPlan_*`.
- `scripts/test coverage` — full `-race` suite, aggregate **81.5% ≥ 80%**. `golangci-lint` clean on the touched package.

## Notes

- Runner-only change (`runner/cmd/fishhawk-runner/`). No schema/API/DB/backend changes — reuses the existing #603 backend path. After merge, this binary is picked up automatically (runner is spawned fresh from `bin/` per `fishhawk_run_stage`), though `scripts/dev reload` (now `--all` post-#616) will rebuild it.
- **Loop note:** the advisory plan-reviewer was killed mid-run on this one (`signal: killed` — recurring local `claudecode` flakiness, see below); approved on operator review per the #574 advisory-degradation model. The implement-reviewer ran clean (`approve`).

Closes #613