### PR TITLE
Ingest GitHub issue comments into issue_context + plan prompt (#618)

### DIFF
--- a/backend/cmd/fishhawk-mcp/client.go
+++ b/backend/cmd/fishhawk-mcp/client.go
@@ -92,10 +92,21 @@ type Run struct {
 // server populates this from `gh issue view` when an agent passes
 // the `issue` input — same pattern the CLI uses.
 type IssueContext struct {
-	Title  string `json:"title"`
-	Body   string `json:"body"`
-	URL    string `json:"url"`
-	Number int    `json:"number"`
+	Title    string         `json:"title"`
+	Body     string         `json:"body"`
+	URL      string         `json:"url"`
+	Number   int            `json:"number"`
+	Comments []IssueComment `json:"comments,omitempty"`
+}
+
+// IssueComment is one issue comment carried alongside the body in
+// IssueContext (#618). Captured at run-create from `gh issue view
+// --json comments` so the plan agent sees refinements/decisions
+// posted as comments, not just the title+body snapshot.
+type IssueComment struct {
+	Author    string `json:"author"`
+	Body      string `json:"body"`
+	CreatedAt string `json:"created_at"`
 }
 
 type listRunsResult struct {

--- a/backend/cmd/fishhawk-mcp/issue_fetch.go
+++ b/backend/cmd/fishhawk-mcp/issue_fetch.go
@@ -53,18 +53,28 @@ func resolveIssueRef(raw string) (int, error) {
 	return n, nil
 }
 
-// ghIssue is the subset of `gh issue view --json title,body,url,number`
-// output the MCP server consumes. gh emits camelCase; mirror it
-// verbatim so the JSON decoder picks the right keys.
+// ghIssue is the subset of `gh issue view --json
+// title,body,url,number,comments` output the MCP server consumes. gh
+// emits camelCase; mirror it verbatim so the JSON decoder picks the
+// right keys. Each comment carries a nested `author` object (we read
+// its `login`), plus `body` and `createdAt`.
 type ghIssue struct {
-	Title  string `json:"title"`
-	Body   string `json:"body"`
-	URL    string `json:"url"`
-	Number int    `json:"number"`
+	Title    string `json:"title"`
+	Body     string `json:"body"`
+	URL      string `json:"url"`
+	Number   int    `json:"number"`
+	Comments []struct {
+		Author struct {
+			Login string `json:"login"`
+		} `json:"author"`
+		Body      string `json:"body"`
+		CreatedAt string `json:"createdAt"`
+	} `json:"comments"`
 }
 
 // fetchIssueViaGh shells to `gh issue view N --repo owner/name
-// --json title,body,url,number` and returns the parsed result.
+// --json title,body,url,number,comments` and returns the parsed
+// result.
 //
 // Best-effort by design — when `gh` is missing, unauthed, or the
 // repo blocks the operator, the startRun handler logs a warning to
@@ -81,7 +91,7 @@ func fetchIssueViaGh(repo string, issueNumber int) (*IssueContext, error) {
 		return nil, ErrGhNotInstalled
 	}
 	cmd := ghIssueCommand("gh", "issue", "view", strconv.Itoa(issueNumber),
-		"--repo", repo, "--json", "title,body,url,number")
+		"--repo", repo, "--json", "title,body,url,number,comments")
 	out, err := cmd.Output()
 	if err != nil {
 		var exitErr *exec.ExitError
@@ -95,12 +105,20 @@ func fetchIssueViaGh(repo string, issueNumber int) (*IssueContext, error) {
 	if err := json.Unmarshal(out, &iss); err != nil {
 		return nil, fmt.Errorf("gh issue view: decode: %w", err)
 	}
-	return &IssueContext{
+	ic := &IssueContext{
 		Title:  iss.Title,
 		Body:   iss.Body,
 		URL:    iss.URL,
 		Number: iss.Number,
-	}, nil
+	}
+	for _, c := range iss.Comments {
+		ic.Comments = append(ic.Comments, IssueComment{
+			Author:    c.Author.Login,
+			Body:      c.Body,
+			CreatedAt: c.CreatedAt,
+		})
+	}
+	return ic, nil
 }
 
 // ErrGhNotInstalled signals the `gh` binary is missing on the

--- a/backend/cmd/fishhawk-mcp/issue_fetch_test.go
+++ b/backend/cmd/fishhawk-mcp/issue_fetch_test.go
@@ -116,6 +116,24 @@ func TestFetchIssueViaGh_Success(t *testing.T) {
 	}
 }
 
+func TestFetchIssueViaGh_DecodesComments(t *testing.T) {
+	withFakeGh(t, `{"title":"Add foo","body":"We need foo.","url":"https://github.com/x/y/issues/42","number":42,"comments":[{"author":{"login":"alice"},"body":"Refinement here.","createdAt":"2026-05-01T10:00:00Z"},{"author":{"login":"bob"},"body":"Second comment.","createdAt":"2026-05-02T11:00:00Z"}]}`)
+	got, err := fetchIssueViaGh("x/y", 42)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if len(got.Comments) != 2 {
+		t.Fatalf("want 2 comments, got %d: %+v", len(got.Comments), got.Comments)
+	}
+	if got.Comments[0].Author != "alice" || got.Comments[0].Body != "Refinement here." ||
+		got.Comments[0].CreatedAt != "2026-05-01T10:00:00Z" {
+		t.Errorf("comment[0] mismatch: %+v", got.Comments[0])
+	}
+	if got.Comments[1].Author != "bob" {
+		t.Errorf("comment[1] author = %q, want bob", got.Comments[1].Author)
+	}
+}
+
 func TestFetchIssueViaGh_NotInstalled(t *testing.T) {
 	withFakeGhMissing(t)
 	_, err := fetchIssueViaGh("x/y", 42)

--- a/backend/internal/prompt/prompt.go
+++ b/backend/internal/prompt/prompt.go
@@ -108,6 +108,16 @@ type ScopeConstraint struct {
 	SiblingHints []string
 }
 
+// IssueComment is one issue comment in Trigger.IssueComments, a
+// snapshot taken at trigger time (#618). Author is the commenter's
+// GitHub login; CreatedAt is the RFC3339 timestamp from the GitHub
+// API. Rendered into the plan-stage prompt by writeIssueContext.
+type IssueComment struct {
+	Author    string
+	Body      string
+	CreatedAt string
+}
+
 // Trigger captures the bits of the originating event needed to
 // construct an issue-driven prompt. Empty IssueTitle / IssueBody
 // for non-issue triggers; for v0, those triggers all come from
@@ -128,6 +138,13 @@ type Trigger struct {
 	// implement stage links to the issue and lets the agent fetch
 	// (#244).
 	IssueBody string
+	// IssueComments are the issue's comments at trigger time, a
+	// snapshot captured alongside IssueBody (#618). Only the
+	// plan-stage prompt renders them — after the body — so
+	// comment-borne refinements/decisions reach the plan agent on
+	// the first attempt. Empty/nil for non-issue triggers, issues
+	// with no comments, or runs whose issue_context predates #618.
+	IssueComments []IssueComment
 	// IssueURL is the canonical github.com URL for the triggering
 	// issue. Set by the server-side prompt handler from
 	// repo + IssueNumber. Used by the implement-stage prompt's
@@ -920,7 +937,84 @@ func writeIssueContext(b *strings.Builder, t Trigger) {
 		b.WriteString(t.IssueBody)
 		b.WriteString("\n")
 	}
+	writeIssueComments(b, t.IssueComments)
 	b.WriteString("\n")
+}
+
+// writeIssueComments renders the issue's comments into the plan-stage
+// prompt after the body (#618). Comment-borne refinements/decisions
+// would otherwise never reach the plan agent, which only saw
+// title+body — the #616 case where a refinement posted as a comment
+// needed a reject->re-plan to land.
+//
+// Rules:
+//   - Drop comments whose author login ends in `[bot]` (CI bots and
+//     Fishhawk's own #377 footer) so the agent doesn't read its own
+//     output back as new guidance.
+//   - Render survivors chronologically (oldest->newest), each prefixed
+//     with the author login and timestamp.
+//   - Cap each comment body (maxCommentBytes) and the total rendered
+//     size (maxTotalCommentBytes). When over the total budget, drop the
+//     OLDEST comments first — recency is load-bearing because a later
+//     comment may supersede the body — and prepend an omission marker.
+//   - Lead with a one-line preface that later comments may supersede
+//     the body.
+//
+// Renders nothing when no comments survive the bot filter (the
+// body-only fallback is unchanged).
+func writeIssueComments(b *strings.Builder, comments []IssueComment) {
+	surviving := make([]IssueComment, 0, len(comments))
+	for _, c := range comments {
+		if strings.HasSuffix(c.Author, "[bot]") {
+			continue
+		}
+		surviving = append(surviving, c)
+	}
+	if len(surviving) == 0 {
+		return
+	}
+
+	// Per-comment cap so a single long comment can't dominate the
+	// budget. Same capped-injection style as PriorRejectionFeedback's
+	// maxFeedbackBytes.
+	const maxCommentBytes = 2000
+	rendered := make([]string, len(surviving))
+	for i, c := range surviving {
+		body := c.Body
+		if len(body) > maxCommentBytes {
+			body = body[:maxCommentBytes] + "...[truncated]"
+		}
+		author := c.Author
+		if author == "" {
+			author = "unknown"
+		}
+		rendered[i] = fmt.Sprintf("**@%s** (%s):\n%s", author, c.CreatedAt, body)
+	}
+
+	// Total budget: walk newest->oldest accumulating bytes; once over
+	// budget, drop everything older (recency is load-bearing). The
+	// newest comment always survives — the per-comment cap is below the
+	// total budget.
+	const maxTotalCommentBytes = 12000
+	start := 0
+	total := 0
+	for i := len(rendered) - 1; i >= 0; i-- {
+		total += len(rendered[i])
+		if total > maxTotalCommentBytes {
+			start = i + 1
+			break
+		}
+	}
+
+	b.WriteString("\n### Issue comments\n\n")
+	b.WriteString("The issue has the following comments (oldest first). A later comment may refine or supersede the issue body above — weigh the most recent guidance accordingly.\n\n")
+	if start > 0 {
+		fmt.Fprintf(b, "[%d older comment(s) omitted to fit budget]\n\n", start)
+	}
+	for i := start; i < len(rendered); i++ {
+		b.WriteString(rendered[i])
+		b.WriteString("\n\n")
+	}
 }
 
 // quoteRepo backticks an "owner/name" string for inline display.

--- a/backend/internal/prompt/prompt_test.go
+++ b/backend/internal/prompt/prompt_test.go
@@ -1349,3 +1349,172 @@ func TestBuild_ImplementReview_ProducesNoPRDescriptionGuidance(t *testing.T) {
 		t.Errorf("implement_review prompt must not carry implement-stage PR guidance:\n%s", got)
 	}
 }
+
+// TestBuild_Plan_IssueCommentsRendered is the headline #618 / #616
+// acceptance check: a comment that contradicts the body renders in the
+// '### Issue comments' section with its author + timestamp and the
+// supersede preface, chronologically after the body.
+func TestBuild_Plan_IssueCommentsRendered(t *testing.T) {
+	got, err := Build("plan", Trigger{
+		IssueNumber: 616,
+		IssueTitle:  "Add a foo flag",
+		IssueBody:   "We need a --foo flag that defaults to off.",
+		Repo:        "x/y",
+		IssueComments: []IssueComment{
+			{Author: "alice", Body: "First thought: make it a bool.", CreatedAt: "2026-05-01T10:00:00Z"},
+			{Author: "bob", Body: "Correction: --foo must default to ON, not off.", CreatedAt: "2026-05-02T12:30:00Z"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	wants := []string{
+		"### Issue comments",
+		"supersede", // the preface
+		"**@alice** (2026-05-01T10:00:00Z):",
+		"First thought: make it a bool.",
+		"**@bob** (2026-05-02T12:30:00Z):",
+		"Correction: --foo must default to ON, not off.",
+	}
+	for _, w := range wants {
+		if !strings.Contains(got, w) {
+			t.Errorf("plan prompt missing %q\n---\n%s", w, got)
+		}
+	}
+	// Chronological order: body, then alice, then bob.
+	bodyIdx := strings.Index(got, "We need a --foo flag")
+	aliceIdx := strings.Index(got, "**@alice**")
+	bobIdx := strings.Index(got, "**@bob**")
+	if bodyIdx >= aliceIdx || aliceIdx >= bobIdx {
+		t.Errorf("expected body < alice < bob ordering, got body=%d alice=%d bob=%d", bodyIdx, aliceIdx, bobIdx)
+	}
+}
+
+// TestBuild_Plan_BotCommentsFiltered confirms comments authored by a
+// login ending in [bot] (CI bots, Fishhawk's own #377 footer) are
+// dropped from the rendered section while human comments survive.
+func TestBuild_Plan_BotCommentsFiltered(t *testing.T) {
+	got, err := Build("plan", Trigger{
+		IssueNumber: 7,
+		IssueTitle:  "T",
+		IssueBody:   "Body.",
+		Repo:        "x/y",
+		IssueComments: []IssueComment{
+			{Author: "github-actions[bot]", Body: "CI failed on main.", CreatedAt: "2026-05-01T00:00:00Z"},
+			{Author: "carol", Body: "Human refinement here.", CreatedAt: "2026-05-02T00:00:00Z"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if strings.Contains(got, "CI failed on main.") || strings.Contains(got, "github-actions[bot]") {
+		t.Errorf("bot-authored comment should be filtered:\n%s", got)
+	}
+	if !strings.Contains(got, "Human refinement here.") {
+		t.Errorf("human comment should survive the bot filter:\n%s", got)
+	}
+}
+
+// TestBuild_Plan_AllBotComments_SectionAbsent guards the distinct case
+// where EVERY comment is bot-authored: the '### Issue comments' section
+// is absent entirely (not rendered empty) and the body-only fallback is
+// unchanged. Distinct from the nil-slice case below.
+func TestBuild_Plan_AllBotComments_SectionAbsent(t *testing.T) {
+	got, err := Build("plan", Trigger{
+		IssueNumber: 7,
+		IssueTitle:  "T",
+		IssueBody:   "Body stays.",
+		Repo:        "x/y",
+		IssueComments: []IssueComment{
+			{Author: "github-actions[bot]", Body: "CI failed.", CreatedAt: "2026-05-01T00:00:00Z"},
+			{Author: "dependabot[bot]", Body: "Bump dep.", CreatedAt: "2026-05-02T00:00:00Z"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if strings.Contains(got, "### Issue comments") {
+		t.Errorf("section must be absent when all comments are bot-authored:\n%s", got)
+	}
+	if !strings.Contains(got, "Body stays.") {
+		t.Errorf("body-only fallback should be unchanged:\n%s", got)
+	}
+}
+
+// TestBuild_Plan_NoIssueComments confirms the body-only fallback is
+// unchanged when IssueComments is nil (the pre-#618 shape).
+func TestBuild_Plan_NoIssueComments(t *testing.T) {
+	got, err := Build("plan", Trigger{
+		IssueNumber: 7,
+		IssueTitle:  "T",
+		IssueBody:   "Just the body.",
+		Repo:        "x/y",
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if strings.Contains(got, "### Issue comments") {
+		t.Errorf("no comments section expected for nil IssueComments:\n%s", got)
+	}
+	if !strings.Contains(got, "Just the body.") {
+		t.Errorf("body should still render:\n%s", got)
+	}
+}
+
+// TestBuild_Plan_PerCommentTruncation confirms an over-cap comment body
+// is truncated with the ...[truncated] marker.
+func TestBuild_Plan_PerCommentTruncation(t *testing.T) {
+	huge := strings.Repeat("x", 5000)
+	got, err := Build("plan", Trigger{
+		IssueNumber:   7,
+		IssueBody:     "Body.",
+		Repo:          "x/y",
+		IssueComments: []IssueComment{{Author: "alice", Body: huge, CreatedAt: "2026-05-01T00:00:00Z"}},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if !strings.Contains(got, "...[truncated]") {
+		t.Errorf("expected per-comment truncation marker:\n%s", got)
+	}
+	if strings.Contains(got, huge) {
+		t.Error("full over-cap comment body should not appear verbatim")
+	}
+}
+
+// TestBuild_Plan_TotalBudgetDropsOldest confirms that when the total
+// comment budget is exceeded, the OLDEST comments are dropped first
+// (recency is load-bearing) and the omission marker is prepended. The
+// newest comment always survives.
+func TestBuild_Plan_TotalBudgetDropsOldest(t *testing.T) {
+	// Each comment is ~1900 bytes (under the 2000 per-comment cap); 10
+	// of them (~19KB) blows past the 12KB total budget so the oldest
+	// get dropped.
+	var comments []IssueComment
+	for i := 0; i < 10; i++ {
+		comments = append(comments, IssueComment{
+			Author:    "u",
+			Body:      strings.Repeat("a", 1900) + "_comment" + string(rune('0'+i)),
+			CreatedAt: "2026-05-01T00:00:0" + string(rune('0'+i)) + "Z",
+		})
+	}
+	got, err := Build("plan", Trigger{
+		IssueNumber:   7,
+		IssueBody:     "Body.",
+		Repo:          "x/y",
+		IssueComments: comments,
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if !strings.Contains(got, "older comment(s) omitted to fit budget") {
+		t.Errorf("expected omission marker when over total budget:\n%s", got)
+	}
+	// Newest (index 9) survives; oldest (index 0) is dropped.
+	if !strings.Contains(got, "_comment9") {
+		t.Errorf("newest comment must survive:\n%s", got)
+	}
+	if strings.Contains(got, "_comment0") {
+		t.Errorf("oldest comment should be dropped when over budget:\n%s", got)
+	}
+}

--- a/backend/internal/run/run.go
+++ b/backend/internal/run/run.go
@@ -255,10 +255,22 @@ type Run struct {
 // the agent and any rendered surfaces link directly to what humans
 // see.
 type IssueContext struct {
-	Title  string `json:"title"`
-	Body   string `json:"body"`
-	URL    string `json:"url"`
-	Number int    `json:"number"`
+	Title    string         `json:"title"`
+	Body     string         `json:"body"`
+	URL      string         `json:"url"`
+	Number   int            `json:"number"`
+	Comments []IssueComment `json:"comments,omitempty"`
+}
+
+// IssueComment is one issue comment captured alongside the body at
+// run-create (#618). Persisted inside the runs.issue_context JSONB
+// payload (additive — existing rows lacking the key unmarshal to a
+// nil slice). The prompt builder renders these into the plan-stage
+// prompt so comment-borne refinements reach the plan agent.
+type IssueComment struct {
+	Author    string `json:"author"`
+	Body      string `json:"body"`
+	CreatedAt string `json:"created_at"`
 }
 
 // RunnerKind enumerates the execution backends Fishhawk supports.

--- a/backend/internal/server/prompt.go
+++ b/backend/internal/server/prompt.go
@@ -696,6 +696,17 @@ func (s *Server) fillIssueContext(ctx context.Context, github issueGetter, runRo
 	if runRow.IssueContext != nil {
 		trigger.IssueTitle = runRow.IssueContext.Title
 		trigger.IssueBody = runRow.IssueContext.Body
+		// Comments (#618): map the cached comment snapshot into the
+		// trigger so the plan-stage prompt can render comment-borne
+		// refinements. Branch 2 (webhook fetch) does not yet fetch
+		// comments — see the follow-up issue referenced in the PR.
+		for _, c := range runRow.IssueContext.Comments {
+			trigger.IssueComments = append(trigger.IssueComments, prompt.IssueComment{
+				Author:    c.Author,
+				Body:      c.Body,
+				CreatedAt: c.CreatedAt,
+			})
+		}
 		return
 	}
 

--- a/backend/internal/server/prompt_test.go
+++ b/backend/internal/server/prompt_test.go
@@ -421,6 +421,94 @@ func TestGetStagePrompt_CachedIssueContext_PreferredOverGitHubFetch(t *testing.T
 	}
 }
 
+// TestGetStagePrompt_CachedIssueComments_MappedIntoTrigger is the
+// #618 check: a cached IssueContext carrying comments renders the
+// '### Issue comments' section in the plan-stage prompt with the
+// commenter's login.
+func TestGetStagePrompt_CachedIssueComments_MappedIntoTrigger(t *testing.T) {
+	s, rr, sf, gh := newPromptServer(t)
+	runID := uuid.New()
+	stageID := uuid.New()
+	priv, _ := sf.issue(t, runID)
+
+	triggerRef := "issue:42"
+	rr.runRow = &run.Run{
+		ID:            runID,
+		Repo:          "kuhlman-labs/example",
+		WorkflowID:    "feature_change",
+		TriggerSource: run.TriggerGitHubIssue,
+		TriggerRef:    &triggerRef,
+		IssueContext: &run.IssueContext{
+			Number: 42,
+			Title:  "Cached title",
+			Body:   "Cached body.",
+			URL:    "https://github.com/kuhlman-labs/example/issues/42",
+			Comments: []run.IssueComment{
+				{Author: "alice", Body: "Comment-borne refinement.", CreatedAt: "2026-05-01T10:00:00Z"},
+			},
+		},
+	}
+	rr.stage = &run.Stage{ID: stageID, RunID: runID, Type: run.StageTypePlan}
+
+	w := promptRequest(t, s, runID, stageID, priv, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200:\n%s", w.Code, w.Body.String())
+	}
+	if gh.called {
+		t.Errorf("GetIssue should NOT be called when IssueContext is cached")
+	}
+	var resp promptResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if !contains(resp.Prompt, "### Issue comments") {
+		t.Errorf("prompt missing comments section:\n%s", resp.Prompt)
+	}
+	if !contains(resp.Prompt, "Comment-borne refinement.") {
+		t.Errorf("prompt missing comment body:\n%s", resp.Prompt)
+	}
+	if !contains(resp.Prompt, "@alice") {
+		t.Errorf("prompt missing comment author:\n%s", resp.Prompt)
+	}
+}
+
+// TestGetStagePrompt_CachedIssueContext_NoComments guards the
+// regression case: a cached IssueContext with no comments still
+// renders the body-only plan prompt unchanged — no comments section.
+func TestGetStagePrompt_CachedIssueContext_NoComments(t *testing.T) {
+	s, rr, sf, _ := newPromptServer(t)
+	runID := uuid.New()
+	stageID := uuid.New()
+	priv, _ := sf.issue(t, runID)
+
+	triggerRef := "issue:42"
+	rr.runRow = &run.Run{
+		ID:            runID,
+		Repo:          "kuhlman-labs/example",
+		WorkflowID:    "feature_change",
+		TriggerSource: run.TriggerGitHubIssue,
+		TriggerRef:    &triggerRef,
+		IssueContext: &run.IssueContext{
+			Number: 42,
+			Title:  "Cached title",
+			Body:   "Cached body.",
+			URL:    "https://github.com/kuhlman-labs/example/issues/42",
+		},
+	}
+	rr.stage = &run.Stage{ID: stageID, RunID: runID, Type: run.StageTypePlan}
+
+	w := promptRequest(t, s, runID, stageID, priv, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200:\n%s", w.Code, w.Body.String())
+	}
+	var resp promptResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if contains(resp.Prompt, "### Issue comments") {
+		t.Errorf("no comments section expected when IssueContext has no comments:\n%s", resp.Prompt)
+	}
+	if !contains(resp.Prompt, "Cached body.") {
+		t.Errorf("body-only prompt should still render the body:\n%s", resp.Prompt)
+	}
+}
+
 func TestGetStagePrompt_UnsupportedStageType(t *testing.T) {
 	s, rr, sf, _ := newPromptServer(t)
 	runID := uuid.New()

--- a/cli/cmd/fishhawk/issue_fetch.go
+++ b/cli/cmd/fishhawk/issue_fetch.go
@@ -54,18 +54,28 @@ func resolveIssueRef(raw string) (int, error) {
 	return n, nil
 }
 
-// ghIssue is the subset of `gh issue view --json title,body,url,number`
-// output the CLI consumes. gh emits camelCase; mirror it verbatim
-// so the JSON decoder picks the right keys.
+// ghIssue is the subset of `gh issue view --json
+// title,body,url,number,comments` output the CLI consumes. gh emits
+// camelCase; mirror it verbatim so the JSON decoder picks the right
+// keys. Each comment carries a nested `author` object (we read its
+// `login`), plus `body` and `createdAt`.
 type ghIssue struct {
-	Title  string `json:"title"`
-	Body   string `json:"body"`
-	URL    string `json:"url"`
-	Number int    `json:"number"`
+	Title    string `json:"title"`
+	Body     string `json:"body"`
+	URL      string `json:"url"`
+	Number   int    `json:"number"`
+	Comments []struct {
+		Author struct {
+			Login string `json:"login"`
+		} `json:"author"`
+		Body      string `json:"body"`
+		CreatedAt string `json:"createdAt"`
+	} `json:"comments"`
 }
 
 // fetchIssueViaGh shells to `gh issue view N --repo owner/name
-// --json title,body,url,number` and returns the parsed result.
+// --json title,body,url,number,comments` and returns the parsed
+// result.
 //
 // Best-effort by design — when `gh` is missing, unauthed, or the
 // repo blocks the operator, runStart warns to stderr and proceeds
@@ -83,7 +93,7 @@ func fetchIssueViaGh(repo string, issueNumber int) (*httpclient.IssueContext, er
 		return nil, ErrGhNotInstalled
 	}
 	cmd := ghIssueCommand("gh", "issue", "view", strconv.Itoa(issueNumber),
-		"--repo", repo, "--json", "title,body,url,number")
+		"--repo", repo, "--json", "title,body,url,number,comments")
 	out, err := cmd.Output()
 	if err != nil {
 		var exitErr *exec.ExitError
@@ -97,12 +107,20 @@ func fetchIssueViaGh(repo string, issueNumber int) (*httpclient.IssueContext, er
 	if err := json.Unmarshal(out, &iss); err != nil {
 		return nil, fmt.Errorf("gh issue view: decode: %w", err)
 	}
-	return &httpclient.IssueContext{
+	ic := &httpclient.IssueContext{
 		Title:  iss.Title,
 		Body:   iss.Body,
 		URL:    iss.URL,
 		Number: iss.Number,
-	}, nil
+	}
+	for _, c := range iss.Comments {
+		ic.Comments = append(ic.Comments, httpclient.IssueComment{
+			Author:    c.Author.Login,
+			Body:      c.Body,
+			CreatedAt: c.CreatedAt,
+		})
+	}
+	return ic, nil
 }
 
 // ErrGhNotInstalled signals the `gh` binary is missing on the

--- a/cli/cmd/fishhawk/issue_fetch_test.go
+++ b/cli/cmd/fishhawk/issue_fetch_test.go
@@ -114,6 +114,24 @@ func TestFetchIssueViaGh_Success(t *testing.T) {
 	}
 }
 
+func TestFetchIssueViaGh_DecodesComments(t *testing.T) {
+	withFakeGh(t, `{"title":"Add foo","body":"We need foo.","url":"https://github.com/x/y/issues/42","number":42,"comments":[{"author":{"login":"alice"},"body":"Refinement here.","createdAt":"2026-05-01T10:00:00Z"},{"author":{"login":"bob"},"body":"Second comment.","createdAt":"2026-05-02T11:00:00Z"}]}`)
+	got, err := fetchIssueViaGh("x/y", 42)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if len(got.Comments) != 2 {
+		t.Fatalf("want 2 comments, got %d: %+v", len(got.Comments), got.Comments)
+	}
+	if got.Comments[0].Author != "alice" || got.Comments[0].Body != "Refinement here." ||
+		got.Comments[0].CreatedAt != "2026-05-01T10:00:00Z" {
+		t.Errorf("comment[0] mismatch: %+v", got.Comments[0])
+	}
+	if got.Comments[1].Author != "bob" {
+		t.Errorf("comment[1] author = %q, want bob", got.Comments[1].Author)
+	}
+}
+
 func TestFetchIssueViaGh_NotInstalled(t *testing.T) {
 	withFakeGhMissing(t)
 	_, err := fetchIssueViaGh("x/y", 42)

--- a/cli/internal/httpclient/httpclient.go
+++ b/cli/internal/httpclient/httpclient.go
@@ -94,10 +94,21 @@ type Run struct {
 // run-create (#415). Stored on the run row so the prompt builder
 // reads it without needing a backend-side GitHub fetch.
 type IssueContext struct {
-	Title  string `json:"title"`
-	Body   string `json:"body"`
-	URL    string `json:"url"`
-	Number int    `json:"number"`
+	Title    string         `json:"title"`
+	Body     string         `json:"body"`
+	URL      string         `json:"url"`
+	Number   int            `json:"number"`
+	Comments []IssueComment `json:"comments,omitempty"`
+}
+
+// IssueComment is one issue comment carried alongside the body in
+// IssueContext (#618). Captured at run-create from `gh issue view
+// --json comments` so the plan agent sees refinements/decisions
+// posted as comments, not just the title+body snapshot.
+type IssueComment struct {
+	Author    string `json:"author"`
+	Body      string `json:"body"`
+	CreatedAt string `json:"created_at"`
 }
 
 // CreateRunInput is what StartRun marshals into the request body.

--- a/docs/api/v0.md
+++ b/docs/api/v0.md
@@ -142,6 +142,12 @@ GET  /v0/runs/{run_id}                     → poll until state in {succeeded, f
 GET  /v0/runs/{run_id}/stages              → final stage breakdown
 ```
 
+For issue-triggered runs the CLI (and MCP server) also ship an inline
+`issue_context` — title, body, url, number, and the issue's `comments`
+(see the `IssueContext` schema) — captured via `gh issue view` so the
+plan agent reads comment-borne refinements without a backend-side
+GitHub fetch (#415, #618).
+
 ### Runner: ship a signed trace
 
 ```

--- a/docs/api/v0.openapi.yaml
+++ b/docs/api/v0.openapi.yaml
@@ -242,10 +242,13 @@ components:
     IssueContext:
       type: object
       description: |
-        Cached GitHub issue payload — title, body, url, and
-        number — fetched by the operator's `gh issue view` at
+        Cached GitHub issue payload — title, body, url, number, and
+        comments — fetched by the operator's `gh issue view` at
         run-create time so the backend's prompt builder doesn't
-        need an installation_id to look up the issue (#415).
+        need an installation_id to look up the issue (#415). The
+        optional `comments` array carries the issue's comments so the
+        plan agent sees refinements/decisions posted as comments, not
+        just the title+body snapshot (#618).
       required: [title, body, url, number]
       properties:
         title:
@@ -258,6 +261,24 @@ components:
         number:
           type: integer
           minimum: 1
+        comments:
+          type: array
+          description: |
+            Issue comments captured at run-create time, oldest first.
+            Optional and additive — runs whose issue_context predates
+            #618 omit the field.
+          items:
+            type: object
+            required: [author, body, created_at]
+            properties:
+              author:
+                type: string
+                description: Commenter's GitHub login.
+              body:
+                type: string
+              created_at:
+                type: string
+                format: date-time
 
     Stage:
       type: object


### PR DESCRIPTION
## Summary

The plan agent saw **title + body only** — comment-borne refinements and decisions never reached it. The motivating #616 case: a design refinement posted as an issue *comment* forced a reject→re-plan to convey context that already existed at plan time.

This fetches `comments` at both `gh issue view` sites (MCP server + CLI), threads a `Comments []IssueComment` field through the three `IssueContext` structs (`backend/cmd/fishhawk-mcp/client.go`, `cli/internal/httpclient`, `backend/internal/run`) and `prompt.Trigger`, and renders a labeled `### Issue comments` section after the body in the **plan** prompt:

- **Bot filter** — drop authors whose login ends in `[bot]` (CI bots + the Fishhawk App's own #377 footer) so the agent doesn't read its own output back as guidance.
- **Chronological** (oldest→newest), each prefixed `@author` + timestamp, with a preface that later comments may supersede the body.
- **Byte budget** mirroring `PriorRejectionFeedback`: per-comment 2000-byte cap; 12000-byte total, dropping **oldest** first (recency is load-bearing — newest always survives) with an `[N older comment(s) omitted]` marker.
- Renders nothing when no comments survive the filter (body-only fallback unchanged).

JSONB-additive (`runs.issue_context`) — **no migration**. OpenAPI `issue_context` gains an optional `comments` array (not in `required`).

Built and verified end-to-end through the Fishhawk local loop (run `2a6f8f32`): plan-review `approve_with_concerns` (all three concerns addressed or deferred), implement-review `approve`.

## Test plan

- `prompt_test.go`: comment section renders with author+timestamp + supersede preface; `[bot]` authors filtered; **all-bots-filtered → section absent** (not empty); nil-slice body-only unchanged; per-comment truncation; total-budget oldest-first drop with marker.
- `server/prompt_test.go`: cached `Comments` mapped into the Trigger; no-comments cached context still body-only.
- `issue_fetch_test.go` (MCP + CLI): gh `comments` JSON decodes into `Comments` (`author.login`→`Author`).
- `scripts/test coverage` — full `-race` suite, aggregate **81.5% ≥ 80%**. `golangci-lint` clean on all touched packages. `redocly lint` valid (no new warnings).

## Notes

- **Scope:** branch 1 of `fillIssueContext` (operator `gh` fetch / local-runner loop / MCP+CLI `issue` input) and the **plan** prompt. Deferred follow-ups, filed + on Project #7:
  - **#621** — fetch comments on the webhook/installation-token path (branch 2; needs a separate paginated GitHub API call).
  - **#622** — render comments in the plan-review and implement-review prompts (the medium-severity concern from this PR's plan review; those prompts render issue context inline and don't yet share the renderer).
- **Redaction:** comment bodies ride in the same constructed prompt text as the issue body, so they flow through the runner's `RedactDefault` pass into the redacted trace variant exactly like the body — no separate redaction path.

Closes #618