### PR TITLE
Thread issue_context.comments through the server wire payload (#624, #618 regression fix)

### DIFF
--- a/backend/internal/server/runs.go
+++ b/backend/internal/server/runs.go
@@ -45,10 +45,22 @@ type runResponse struct {
 // distinct from the domain type so a future field change in the
 // store doesn't accidentally leak through the API surface.
 type issueContextPayload struct {
-	Title  string `json:"title"`
-	Body   string `json:"body"`
-	URL    string `json:"url"`
-	Number int    `json:"number"`
+	Title    string                `json:"title"`
+	Body     string                `json:"body"`
+	URL      string                `json:"url"`
+	Number   int                   `json:"number"`
+	Comments []issueCommentPayload `json:"comments,omitempty"`
+}
+
+// issueCommentPayload mirrors run.IssueComment on the wire. Field
+// names match the OpenAPI issue-comment schema (required [author,
+// body, created_at]) that #618 published; because the POST /v0/runs
+// decoder uses DisallowUnknownFields, these tags must stay exactly
+// comments/author/body/created_at or a commented issue 400s.
+type issueCommentPayload struct {
+	Author    string `json:"author"`
+	Body      string `json:"body"`
+	CreatedAt string `json:"created_at"`
 }
 
 func toRunResponse(r *run.Run) runResponse {
@@ -75,6 +87,17 @@ func toRunResponse(r *run.Run) runResponse {
 			Body:   r.IssueContext.Body,
 			URL:    r.IssueContext.URL,
 			Number: r.IssueContext.Number,
+		}
+		if len(r.IssueContext.Comments) > 0 {
+			comments := make([]issueCommentPayload, len(r.IssueContext.Comments))
+			for i, c := range r.IssueContext.Comments {
+				comments[i] = issueCommentPayload{
+					Author:    c.Author,
+					Body:      c.Body,
+					CreatedAt: c.CreatedAt,
+				}
+			}
+			resp.IssueContext.Comments = comments
 		}
 	}
 	return resp
@@ -396,6 +419,17 @@ func (s *Server) handleCreateRun(w http.ResponseWriter, r *http.Request) {
 			Body:   req.IssueContext.Body,
 			URL:    req.IssueContext.URL,
 			Number: req.IssueContext.Number,
+		}
+		if len(req.IssueContext.Comments) > 0 {
+			comments := make([]run.IssueComment, len(req.IssueContext.Comments))
+			for i, c := range req.IssueContext.Comments {
+				comments[i] = run.IssueComment{
+					Author:    c.Author,
+					Body:      c.Body,
+					CreatedAt: c.CreatedAt,
+				}
+			}
+			createParams.IssueContext.Comments = comments
 		}
 	}
 	if idempKey != "" {

--- a/backend/internal/server/runs_create_issue_test.go
+++ b/backend/internal/server/runs_create_issue_test.go
@@ -59,6 +59,84 @@ func TestCreateRun_IssueContext_PersistedOnRun(t *testing.T) {
 	}
 }
 
+// TestCreateRun_IssueContext_CommentsPersisted is the #624
+// regression guard: an issue_context carrying a comments array must
+// be accepted (201, not 400 — the DisallowUnknownFields rejection
+// #618 left behind), persisted on CreateRunParams so the prompt
+// builder reads the comments from the row, and echoed back in the
+// response.
+func TestCreateRun_IssueContext_CommentsPersisted(t *testing.T) {
+	repo := newFakeRepo()
+	s := newServer(t, repo)
+
+	body, _ := json.Marshal(map[string]any{
+		"repo":           "x/y",
+		"workflow_id":    "trivial",
+		"workflow_sha":   "abc",
+		"trigger_source": "github_issue",
+		"trigger_ref":    "issue:42",
+		"workflow_spec":  minimalSpecYAML,
+		"issue_context": map[string]any{
+			"title":  "Add foo",
+			"body":   "We need foo helpers.",
+			"url":    "https://github.com/x/y/issues/42",
+			"number": 42,
+			"comments": []map[string]any{
+				{
+					"author":     "octocat",
+					"body":       "Please also cover the bar case.",
+					"created_at": "2026-06-01T12:00:00Z",
+				},
+				{
+					"author":     "hubot",
+					"body":       "Agreed, bar is in scope.",
+					"created_at": "2026-06-01T13:30:00Z",
+				},
+			},
+		},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/v0/runs", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.handleCreateRun(w, withAuth(req))
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201:\n%s", w.Code, w.Body.String())
+	}
+
+	// Response echoes the comments back.
+	var got runResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &got)
+	if got.IssueContext == nil {
+		t.Fatal("response missing IssueContext")
+	}
+	if len(got.IssueContext.Comments) != 2 {
+		t.Fatalf("response IssueContext.Comments len = %d, want 2: %+v",
+			len(got.IssueContext.Comments), got.IssueContext.Comments)
+	}
+	if got.IssueContext.Comments[0].Author != "octocat" ||
+		got.IssueContext.Comments[0].Body != "Please also cover the bar case." ||
+		got.IssueContext.Comments[0].CreatedAt != "2026-06-01T12:00:00Z" {
+		t.Errorf("response comment[0] mismatch: %+v", got.IssueContext.Comments[0])
+	}
+
+	// The seam #618's unit tests skipped: comments must reach the
+	// persisted CreateRunParams so the prompt builder reads them from
+	// the row, not just echo back in the response.
+	if repo.lastCreateRunParams.IssueContext == nil {
+		t.Fatal("IssueContext not forwarded to repo CreateRun")
+	}
+	if len(repo.lastCreateRunParams.IssueContext.Comments) != 2 {
+		t.Fatalf("repo IssueContext.Comments len = %d, want 2",
+			len(repo.lastCreateRunParams.IssueContext.Comments))
+	}
+	if repo.lastCreateRunParams.IssueContext.Comments[1].Author != "hubot" ||
+		repo.lastCreateRunParams.IssueContext.Comments[1].Body != "Agreed, bar is in scope." ||
+		repo.lastCreateRunParams.IssueContext.Comments[1].CreatedAt != "2026-06-01T13:30:00Z" {
+		t.Errorf("repo comment[1] mismatch: %+v",
+			repo.lastCreateRunParams.IssueContext.Comments[1])
+	}
+}
+
 // TestCreateRun_IssueContext_RejectedOnNonIssueTrigger documents
 // the narrow shape: shipping issue_context with a non-issue
 // trigger_source returns 400 rather than silently dropping it,


### PR DESCRIPTION
## Summary

Fixes a **regression introduced by #618**, caught on the first live MCP run after the post-merge `/mcp` reconnect.

#618 added issue-comment ingestion but only threaded `comments` through *part* of the wire path: the MCP client **sends** `comments` in the `issue_context` POST body (`client.go:99`), and the domain type (`run.IssueContext.Comments`) + the prompt renderer (`fillIssueContext`) both **consume** them — but the server's `issueContextPayload` (`runs.go:47`) had no `Comments` field. Because `POST /v0/runs` uses `dec.DisallowUnknownFields()`, any issue carrying comments returned **HTTP 400 (validation_failed: contains unknown fields)**, breaking the MCP-driven loop for any commented issue (reproduced against #606). Even if accepted, both conversions copied only Title/Body/URL/Number, so comments would have been dropped.

This adds `issueCommentPayload{author, body, created_at}` (matching the OpenAPI shape #618 already published) + a `Comments` field on `issueContextPayload` (`omitempty`), and threads it through both conversions: request→domain (`handleCreateRun`) and domain→response (`toRunResponse`). **No OpenAPI or migration change** — the wire shape was already published and `issue_context` is JSONB.

Why #618 missed it: every unit test covered a layer in isolation (MCP decode, prompt render, domain), but **no test exercised the end-to-end POST→persist→render path with comments present** — and `omitempty` meant comment-less issues slipped through silently. The dogfood loop surfaced it immediately on the first commented issue.

## Test plan

- `TestCreateRun_IssueContext_CommentsPersisted` (new, the missing seam): `POST /v0/runs` with `issue_context.comments` → **201** (was 400 — regression guard), comments reach the persisted `CreateRunParams.IssueContext.Comments`, and the response round-trips them.
- `TestCreateRun_IssueContext_PersistedOnRun` (comment-less) stays green — the `omitempty` regression guard.
- `scripts/test coverage` — full `-race` suite, aggregate **81.5% ≥ 80%**. `golangci-lint` clean on the touched package.

## Notes

- Unblocks the MCP loop for commented issues — including #606, which I'll resume immediately after this merges (it currently 400s because of my dogfood comment on it).
- Completes #618's primary path; the other #618 follow-ups remain: #621 (webhook/branch-2 fetch), #622 (comments in review prompts).

Closes #624