### PR TITLE
Raise plan-review timeout to 300s + trim review prompt (#606)

### DIFF
--- a/backend/cmd/fishhawkd/serve.go
+++ b/backend/cmd/fishhawkd/serve.go
@@ -143,8 +143,9 @@ func runServe(args []string, logSink io.Writer) int {
 		envOrInt("FISHHAWKD_PLAN_REVIEW_MAX_TOKENS", 4096),
 		"maximum tokens for plan-review agent responses")
 	planReviewTimeout := fs.Duration("plan-review-timeout",
-		envOrDuration("FISHHAWKD_PLAN_REVIEW_TIMEOUT", 60*time.Second),
-		"per-invocation HTTP timeout for plan-review agent calls")
+		envOrDuration("FISHHAWKD_PLAN_REVIEW_TIMEOUT", 300*time.Second),
+		"effective per-invocation bound for plan-review agent calls (since #584); "+
+			"must cover review of large standard_v1 plans — raised from 60s to 300s (#606)")
 	if err := fs.Parse(args); err != nil {
 		return exitFailure
 	}

--- a/backend/internal/prompt/prompt.go
+++ b/backend/internal/prompt/prompt.go
@@ -547,8 +547,10 @@ func buildPlanReview(t Trigger) string {
 	}
 
 	// Verdict schema — inline so the reviewer doesn't need to fetch it.
+	// The JSON shape below is load-bearing and kept verbatim; surrounding
+	// prose is trimmed to keep the per-call token cost down (#606).
 	b.WriteString("### Verdict schema\n\n")
-	b.WriteString("Emit exactly this JSON shape. All fields shown; omit `concerns` and `free_form` when empty:\n\n")
+	b.WriteString("Emit exactly this JSON shape; omit `concerns` and `free_form` when empty:\n\n")
 	b.WriteString("{\n")
 	b.WriteString("  \"verdict\": \"approve\" | \"approve_with_concerns\" | \"reject\",\n")
 	b.WriteString("  \"concerns\": [\n")
@@ -561,33 +563,27 @@ func buildPlanReview(t Trigger) string {
 	b.WriteString("  \"free_form\": \"<optional overall commentary>\"\n")
 	b.WriteString("}\n\n")
 
-	// Review criteria — what the agent should assess.
+	// Review criteria — what the agent should assess. Record a concern per gap.
 	b.WriteString("### Review criteria\n\n")
-	b.WriteString("Assess the plan against the following criteria. Record a concern for each gap found:\n\n")
-	b.WriteString("1. **Scope completeness**: Does the file list cover all changes implied by the approach steps? " +
-		"Are operations (create/modify/delete) accurate?\n")
-	b.WriteString("2. **Approach feasibility**: Are the approach steps actionable and internally consistent? " +
-		"Do they address the issue as stated?\n")
-	b.WriteString("3. **Verification adequacy**: Does the test strategy catch the load-bearing behaviour? " +
-		"Is the rollback plan realistic?\n")
-	b.WriteString("4. **Risk coverage**: Are meaningful risks identified? Are assumptions cited or testable?\n")
-	b.WriteString("5. **Schema compliance**: Does the plan conform to the standard_v1 shape? " +
-		"(docs/spec/plan-standard-v1.md)\n")
-	b.WriteString("6. **Grounded citations**: Any rule you cite — from CLAUDE.md, a style guide, or a project " +
-		"convention — MUST be one you can quote verbatim from the context provided in this prompt or from a " +
-		"repository file you actually read during this review. Do NOT assert rules from memory. If you cannot " +
-		"verify the rule exists, do NOT raise the concern. Ground every concern in the plan, issue, and context " +
-		"actually provided.\n\n")
+	b.WriteString("Record a concern for each gap found:\n\n")
+	b.WriteString("1. **Scope completeness**: file list covers all changes implied by the approach; " +
+		"create/modify/delete operations accurate.\n")
+	b.WriteString("2. **Approach feasibility**: steps actionable, internally consistent, address the issue.\n")
+	b.WriteString("3. **Verification adequacy**: test strategy catches load-bearing behaviour; rollback realistic.\n")
+	b.WriteString("4. **Risk coverage**: meaningful risks identified; assumptions cited or testable.\n")
+	b.WriteString("5. **Schema compliance**: plan conforms to standard_v1 (docs/spec/plan-standard-v1.md).\n")
+	b.WriteString("6. **Grounded citations**: any rule you cite — from CLAUDE.md, a style guide, or a project " +
+		"convention — MUST be one you can quote verbatim from the context in this prompt or a repository file you " +
+		"actually read during this review. Do NOT assert rules from memory; if you cannot verify the rule exists, " +
+		"do NOT raise the concern.\n\n")
 
 	// Verdict decision rule.
 	b.WriteString("### Verdict decision rule\n\n")
-	b.WriteString("- `approve`: plan is sound; all criteria met or concerns are cosmetic.\n")
-	b.WriteString("- `approve_with_concerns`: plan is implementable but has non-blocking gaps; " +
-		"record each gap as a concern with appropriate severity.\n")
-	b.WriteString("- `reject`: plan has one or more blocking problems that must be resolved before implementation; " +
-		"record each blocker as a `high`-severity concern.\n\n")
+	b.WriteString("- `approve`: all criteria met or concerns cosmetic.\n")
+	b.WriteString("- `approve_with_concerns`: implementable with non-blocking gaps; record each as a concern.\n")
+	b.WriteString("- `reject`: one or more blocking problems; record each as a `high`-severity concern.\n\n")
 
-	b.WriteString("Emit your verdict now. Remember: JSON only, no surrounding prose.\n")
+	b.WriteString("Emit your verdict now. JSON only, no surrounding prose.\n")
 	return b.String()
 }
 

--- a/backend/internal/prompt/prompt_test.go
+++ b/backend/internal/prompt/prompt_test.go
@@ -1093,6 +1093,34 @@ func TestBuild_PlanReview_ReviewCriteriaPresent(t *testing.T) {
 	}
 }
 
+func TestBuild_PlanReview_TrimmedBelowBaseline(t *testing.T) {
+	// #606: the verbose verdict-schema / review-criteria / decision-rule
+	// preamble was trimmed to lower the per-call token cost on the local
+	// reviewer (no prompt caching — the full prompt is one -p argument). Pin
+	// the size reduction so a future reword can't silently re-bloat the
+	// prompt. The baseline below is the byte length of the prompt (with this
+	// fixture) BEFORE the #606 trim. Load-bearing tokens are covered by the
+	// other TestBuild_PlanReview_* tests; this one guards the token budget.
+	const preTrimBaselineLen = 3333
+	got := buildPlanReview(Trigger{
+		Repo:         "kuhlman-labs/example",
+		IssueNumber:  42,
+		IssueTitle:   "Add foo",
+		IssueBody:    "We need a foo function in pkg/bar.",
+		ApprovedPlan: fixturePlan(),
+	})
+	if len(got) >= preTrimBaselineLen {
+		t.Errorf("buildPlanReview not trimmed: got %d bytes, expected materially below pre-trim baseline %d",
+			len(got), preTrimBaselineLen)
+	}
+	// Require a material reduction, not a one-byte cosmetic change.
+	const minReduction = 300
+	if preTrimBaselineLen-len(got) < minReduction {
+		t.Errorf("buildPlanReview trim immaterial: got %d bytes, only %d below baseline %d (want >= %d shorter)",
+			len(got), preTrimBaselineLen-len(got), preTrimBaselineLen, minReduction)
+	}
+}
+
 func TestBuild_PlanReview_GroundsRuleCitations(t *testing.T) {
 	// #595: review agents fabricated a CLAUDE.md comment-length rule that
 	// does not exist. The grounding constraint must instruct the reviewer to

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -117,7 +117,7 @@ When a stage's `reviewers.agent > 0` is configured in the workflow spec, the bac
 | `FISHHAWKD_ANTHROPIC_API_KEY` | `` (empty) | Anthropic API key; empty disables the SDK adapter |
 | `FISHHAWKD_PLAN_REVIEW_MODEL` | `claude-sonnet-4-6` | Model used for each SDK review invocation |
 | `FISHHAWKD_PLAN_REVIEW_MAX_TOKENS` | `4096` | Maximum output tokens per review call (both adapters) |
-| `FISHHAWKD_PLAN_REVIEW_TIMEOUT` | `60s` | Per-invocation timeout (both adapters). Since #584 this is the **effective** per-invocation bound: the reviewer context is detached from the upload request via `context.WithoutCancel`, so the adapter's own `context.WithTimeout(reviewCtx, this)` is no longer clamped by the runner's upload-client disconnect. See **Review dispatch: advisory-async vs. gating-sync** below. |
+| `FISHHAWKD_PLAN_REVIEW_TIMEOUT` | `300s` | Per-invocation timeout (both adapters). Since #584 this is the **effective** per-invocation bound: the reviewer context is detached from the upload request via `context.WithoutCancel`, so the adapter's own `context.WithTimeout(reviewCtx, this)` is no longer clamped by the runner's upload-client disconnect. Raised 60s→300s in #606 to cover review of large (10+ file) `standard_v1` plans observed timing out at the old bound; small plans still finish well inside it. The env override is unchanged. Distinct from the ~1s immediate-crash mode owned by #620. See **Review dispatch: advisory-async vs. gating-sync** below. |
 | `FISHHAWKD_ENABLE_LOCAL_CLAUDE_REVIEWER` | `false` | Opt-in local-mode subprocess adapter; ignored when the API key is set |
 | `FISHHAWKD_LOCAL_CLAUDE_BINARY` | `claude` | Executable name/path for the local-mode `claude` CLI |
 | `FISHHAWKD_LOCAL_CLAUDE_MODEL` | `claude-sonnet-4-6` | Model the local-mode `claude` CLI uses for review |
@@ -129,7 +129,10 @@ Recommended local config for dogfooding (copy-pasteable):
 ```sh
 export FISHHAWKD_ENABLE_LOCAL_CLAUDE_REVIEWER=true
 export FISHHAWKD_LOCAL_CLAUDE_MODEL=claude-sonnet-4-6
+export FISHHAWKD_PLAN_REVIEW_TIMEOUT=300
 ```
+
+Large-plan expectation (#606): small plans review in ~60–90s, but large backend `standard_v1` plans (10+ files) need the wider budget — the old 60s default timed them out and the agent verdict never landed. Because advisory plan review is async/detached (#584), a longer budget blocks nothing: it only lengthens the worst-case `pending` window that `fishhawk_await_review` already returns gracefully (#600). The override above is redundant with the new 300s code default but kept in the copy-pasteable block for explicitness. This is the genuine timeout-on-large-plans mode only; the separate ~1s immediate-crash mode is owned by #620.
 
 The review model (`claude-sonnet-4-6`) deliberately differs from the plan **author's** typical default (Opus): the plan-review prompt's self-review guard keys on the model identifier, so reviewing with a different model than authored keeps the self-review WARN meaningful rather than firing on every plan. The adapter returns the configured `FISHHAWKD_LOCAL_CLAUDE_MODEL` verbatim as the verdict's model identifier (the CLI envelope does not reliably echo the model), keeping that guard deterministic.
 


### PR DESCRIPTION
## Summary

Agent plan-review was effectively unavailable for large `standard_v1` plans: `claude-sonnet-4-6` reviewing a 10+-file plan exceeded the effective per-invocation bound and was killed before producing a verdict — exactly the plans where a second opinion is most valuable. (Distinct from #620, the ~1s immediate-crash mode, which is **out of scope** here.)

Two operator-approved levers (1 + 3; faster model skipped — it trades against review quality on the plans that most warrant it):

- **Lever 1** — raise the `FISHHAWKD_PLAN_REVIEW_TIMEOUT` code default **60s → 300s** (`serve.go`). Review is async/detached (#584), so a wider budget blocks nothing — it only lengthens the worst-case `pending` window, which #600's `await_review` already handles gracefully.
- **Lever 3** — trim the verbose verdict-schema / review-criteria / decision-rule preamble in `buildPlanReview` to lower per-call token cost (local mode sends the full prompt as one `-p` argument, no prompt caching). **All load-bearing tokens preserved**: the full verdict set, the verdict JSON shape, section headers, criterion #6 (grounded-citation guard), the decision-rule lines, and `PlanReviewSplitMarker`. Plan/issue content untouched.

## Test plan

- `TestBuild_PlanReview_TrimmedBelowBaseline` (new): pins the size reduction against a captured pre-trim baseline with a ≥300-byte floor, so a future reword can't silently re-bloat the prompt. Existing `TestBuild_PlanReview_*` structural assertions (verdict set, headers, grounded-citation guard, split marker) still pass — they cover the preserved tokens.
- `go build ./cmd/fishhawkd/...` compiles; `scripts/test coverage` — full `-race` suite, aggregate **81.5% ≥ 80%**; `golangci-lint` clean on both touched packages.

## Notes

- `docs/ARCHITECTURE.md` env-var table default updated 60s→300s + the recommended local-config block gains the explicit export and a large-plan expectation note; #606 and #620 distinguished so the levers aren't conflated.
- **Dogfood milestone:** this plan was steered by an operator **comment** on #606 (raise timeout + trim, skip faster model, scope vs #620) that reached the plan agent **on the first pass** — the first live end-to-end exercise of #618 (comment ingestion) + #624 (the wire-path fix). No reject→re-plan was needed to convey the steer.

Closes #606