### PR TITLE
scripts/dev: gate cmd_up spawn on a /healthz readiness probe (#628)

### DIFF
--- a/scripts/dev
+++ b/scripts/dev
@@ -38,6 +38,42 @@ _minio_ready() {
   curl --silent --fail --max-time 3 "${endpoint}/minio/health/live" &>/dev/null
 }
 
+# Derive the fishhawkd health endpoint from FISHHAWKD_ADDR (default ':8080').
+# FISHHAWKD_ADDR may be ':8080' or '127.0.0.1:8080'; take the port after the
+# last colon, defaulting to 8080 when unset/portless. Emits the /healthz URL so
+# the readiness gate stays correct if the operator overrides the listen address
+# in .env (.env.example documents FISHHAWKD_ADDR defaulting to :8080).
+_healthz_url() {
+  local addr="${FISHHAWKD_ADDR:-:8080}"
+  local port="${addr##*:}"
+  [[ -z "$port" || "$port" == "$addr" ]] && port=8080
+  print "http://localhost:${port}/healthz"
+}
+
+# Poll <url> until fishhawkd <pid> answers GET /healthz, for up to <deadline>
+# seconds (default 10). Returns 0 on the first healthy response. Returns 1 early
+# if the process has already exited (kill -0 fails — spawn-then-die fails fast
+# instead of waiting the full deadline) or if the deadline elapses. Reuses the
+# minio curl flags for consistency; runs the checks inside if-conditions so
+# `set -e` does not abort the loop.
+_await_healthz() {
+  local pid="$1"
+  local url="$2"
+  local deadline="${3:-10}"
+  local i=0
+  while (( i < deadline )); do
+    if ! kill -0 "$pid" 2>/dev/null; then
+      return 1
+    fi
+    if curl --silent --fail --max-time 2 "$url" &>/dev/null; then
+      return 0
+    fi
+    sleep 1
+    (( i++ ))
+  done
+  return 1
+}
+
 # Populates global rebuild_set: binary_name -> trigger_reason.
 # trigger_reason values: "__baseline__" (fishhawkd always-on), a changed file path
 # (matrix match), or unset (no trigger found for this binary).
@@ -333,7 +369,21 @@ cmd_up() {
   mkdir -p "${REPO_ROOT}/.fishhawk"
   "${BIN}" serve >> "$LOG_FILE" 2>&1 &
   local pid=$!
+  disown
   print "$pid" > "$PID_FILE"
+
+  # Readiness gate: the spawn above is fire-and-forget — without confirming the
+  # process is alive and listening, a silent no-op reads as a false 'started'
+  # and only surfaces later as 'connection refused'. Poll /healthz; on timeout
+  # or spawn-then-die, fail loud (log tail + non-zero exit) so reload surfaces it.
+  if ! _await_healthz "$pid" "$(_healthz_url)" 10; then
+    print -u2 "error: fishhawkd did not become healthy within 10s"
+    print -u2 "last ${LOG_FILE} lines:"
+    tail -n 15 "$LOG_FILE" >&2
+    rm -f "$PID_FILE"
+    exit 1
+  fi
+
   print "fishhawkd started (pid ${pid}) — logs: ${LOG_FILE}"
 
   # Last line(s): tell the operator whether a /mcp reconnect is required.

--- a/scripts/test-dev
+++ b/scripts/test-dev
@@ -115,6 +115,57 @@ else
   fail "_decide_mcp_signal: branch-diff up rebuild should be 1"
 fi
 
+# 7. _healthz_url: derives the port from FISHHAWKD_ADDR, default 8080.
+unset FISHHAWKD_ADDR
+if [[ "$(_healthz_url)" == "http://localhost:8080/healthz" ]]; then
+  pass "_healthz_url defaults to port 8080 when FISHHAWKD_ADDR unset"
+else
+  fail "_healthz_url should default to 8080 (got: $(_healthz_url))"
+fi
+FISHHAWKD_ADDR=':9090'
+if [[ "$(_healthz_url)" == "http://localhost:9090/healthz" ]]; then
+  pass "_healthz_url respects ':9090' override"
+else
+  fail "_healthz_url should use port 9090 for ':9090' (got: $(_healthz_url))"
+fi
+FISHHAWKD_ADDR='127.0.0.1:9091'
+if [[ "$(_healthz_url)" == "http://localhost:9091/healthz" ]]; then
+  pass "_healthz_url respects '127.0.0.1:9091' override"
+else
+  fail "_healthz_url should use port 9091 for '127.0.0.1:9091' (got: $(_healthz_url))"
+fi
+unset FISHHAWKD_ADDR
+
+# 8. _await_healthz: returns non-zero quickly for an already-exited pid (the
+# spawn-then-die early-exit path) without needing a live server.
+( exit 0 ) &
+dead_pid=$!
+wait "$dead_pid" 2>/dev/null
+if _await_healthz "$dead_pid" "http://localhost:1/healthz" 10; then
+  fail "_await_healthz should return non-zero for an already-exited pid"
+else
+  pass "_await_healthz returns non-zero promptly for a dead pid"
+fi
+
+# 9. cmd_up readiness gate: body must poll _await_healthz, tail the log, and
+# exit 1 on failure — mirroring the existing cmd_reload body-grep assertions.
+up_body="$(typeset -f cmd_up)"
+if print -r -- "$up_body" | grep -q '_await_healthz'; then
+  pass "cmd_up gates the spawn on _await_healthz"
+else
+  fail "cmd_up should call _await_healthz after spawning fishhawkd"
+fi
+if print -r -- "$up_body" | grep -q 'tail -n 15'; then
+  pass "cmd_up tails the log on a failed readiness gate"
+else
+  fail "cmd_up should tail the log on readiness-gate failure"
+fi
+if print -r -- "$up_body" | grep -q 'exit 1'; then
+  pass "cmd_up exits non-zero on a failed readiness gate"
+else
+  fail "cmd_up should exit 1 on readiness-gate failure"
+fi
+
 # 6. Parse check: scripts/dev is valid zsh.
 if zsh -n "${REPO_ROOT}/scripts/dev"; then
   pass "scripts/dev parses clean (zsh -n)"


### PR DESCRIPTION
## Summary

`cmd_up` spawned fishhawkd **fire-and-forget** (bare `&`, `scripts/dev:334-337`) and printed `started (pid X)` + wrote the PID file unconditionally — with no confirmation the process was alive and listening. So an intermittent **silent reload no-op** (observed ~5× this session in non-interactive / agent-driven use) read as a *false success* and only surfaced later as `connection refused`. Investigation ruled out port conflict, crash, and shell-exit teardown; the defect that made it invisible was the missing readiness verification.

Add a readiness gate after the spawn:
- `_await_healthz <pid> <url> <deadline>` polls `GET /healthz` for up to 10s, using `kill -0` to **fail fast on a spawn-then-die** rather than waiting the full window; `curl` runs inside `if`-conditions so `set -e` doesn't abort the loop.
- `_healthz_url` derives the port from `FISHHAWKD_ADDR` (default `:8080`), so an overridden listen address is still polled correctly.
- On **success**: the existing `started (pid X)` line + MCP-reconnect banner print **unchanged**.
- On **timeout / early-exit**: loud error to stderr + `tail -15` of the log + remove the stale PID file + `exit 1` — which propagates through `cmd_reload` so a failed reload is *visible and retryable*, never a false "started."
- `disown` the spawn to make the reparent-survival intent explicit.

This converts the silent false-success into a loud, retryable failure **and instruments the underlying intermittent trigger** (captured log tail) for future root-causing. It does not itself claim to fix the non-interactive-shell race — per the issue's explicit scope.

## Test plan

- `zsh scripts/test-dev` — **24 hermetic assertions, all green** (17 existing + 7 new, `DEV_LIB_ONLY`, no live stack): `_healthz_url` default + `:9090` + `127.0.0.1:9091` overrides; `_await_healthz` returns non-zero promptly for a dead pid; `cmd_up` body-greps for the gate call / log tail / `exit 1` (mirroring the existing `cmd_reload` body-grep pattern).
- `zsh -n scripts/dev` parses clean.
- No Go / schema / API surface touched — coverage gate, schema-sync, OpenAPI lint N/A.

## Notes

- Shell-only (`scripts/dev` + `scripts/test-dev`). After merge, the post-merge `reload` of *this* change is itself a live test: if the silent no-op recurs, it will now **fail loud** instead of silently.
- Pairs with the operator workaround recorded mid-session (verify `healthz==200` after reload); this makes the tool enforce it.

Closes #628