### PR TITLE
Plan-review + plan-prompt: require an e2e test for cross-boundary changes (#627)

### DIFF
--- a/backend/internal/prompt/prompt.go
+++ b/backend/internal/prompt/prompt.go
@@ -443,6 +443,11 @@ func buildPlan(t Trigger) string {
 	b.WriteString("- decomposition.sub_plans[i]: {\"title\": \"...\", \"scope_hint\": \"...\", \"predicted_runtime_minutes\": N, \"predicted_runtime_confidence\": \"low|medium|high\"} object — use the FULL canonical field names; \"confidence\" / \"minutes\" shorthand will be rejected\n")
 	b.WriteString("The validator rejects any plan where these fields contain bare strings instead of their required structured shapes.\n")
 	b.WriteString("\n")
+	b.WriteString("Cross-boundary test rule: when scope.files spans multiple architectural layers (request/response " +
+		"payload, domain type, persistence, render/consumer), verification.test_strategy MUST name an " +
+		"integration/end-to-end test that crosses those layers, not only per-layer unit tests. Per-layer units " +
+		"pass while the seam between them breaks (cf. #618).\n")
+	b.WriteString("\n")
 	b.WriteString("If your plan scope includes any file under docs/spec/, the verification steps must include: " +
 		"run scripts/sync-schemas after editing the canonical copy; CI schema-sync gate will catch embedded copies that drift.\n")
 	b.WriteString("\n")
@@ -575,7 +580,13 @@ func buildPlanReview(t Trigger) string {
 	b.WriteString("6. **Grounded citations**: any rule you cite — from CLAUDE.md, a style guide, or a project " +
 		"convention — MUST be one you can quote verbatim from the context in this prompt or a repository file you " +
 		"actually read during this review. Do NOT assert rules from memory; if you cannot verify the rule exists, " +
-		"do NOT raise the concern.\n\n")
+		"do NOT raise the concern.\n")
+	b.WriteString("7. **Cross-boundary integration test**: when the plan adds or changes a field/value that flows " +
+		"across layers (request/response payload -> domain type -> persistence -> render/consumer), verify " +
+		"verification.test_strategy includes a test that exercises the full path end-to-end, not only per-layer " +
+		"unit tests. Flag (concern, category coverage) if any serialization boundary in that data flow is absent " +
+		"from scope.files, or if the test strategy is unit-only for a cross-boundary change. Scope this to genuinely " +
+		"cross-boundary changes; do not raise it for incidental multi-file changes.\n\n")
 
 	// Verdict decision rule.
 	b.WriteString("### Verdict decision rule\n\n")

--- a/backend/internal/prompt/prompt_test.go
+++ b/backend/internal/prompt/prompt_test.go
@@ -159,6 +159,9 @@ func TestBuild_Plan(t *testing.T) {
 		"scripts/sync-schemas",
 		"docs/spec/",
 		"citation",
+		// #627: cross-boundary test directive — pin the greppable anchors.
+		"spans multiple architectural layers",
+		"integration/end-to-end test",
 	}
 	for _, w := range wants {
 		if !strings.Contains(got, w) {
@@ -1083,12 +1086,39 @@ func TestBuild_PlanReview_ReviewCriteriaPresent(t *testing.T) {
 		"Verification adequacy",
 		"Risk coverage",
 		"Schema compliance",
+		"Cross-boundary integration test",
+		"end-to-end",
 		"Verdict decision rule",
 		"approve_with_concerns",
 	}
 	for _, w := range wants {
 		if !strings.Contains(got, w) {
 			t.Errorf("plan_review prompt missing review criteria element %q:\n%s", w, got)
+		}
+	}
+}
+
+// TestBuild_PlanReview_CrossBoundaryTestCriterion pins the load-bearing
+// substrings of criterion #7 (#627). Mirrors
+// TestBuild_PlanReview_GroundsRuleCitations. The criterion is advisory: it
+// instructs the reviewer to record a concern (approve_with_concerns) when a
+// cross-boundary change lacks an end-to-end test, not to hard-reject.
+func TestBuild_PlanReview_CrossBoundaryTestCriterion(t *testing.T) {
+	got, err := Build("plan_review", Trigger{
+		Repo:         "x/y",
+		ApprovedPlan: fixturePlan(),
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	wants := []string{
+		"serialization boundary",
+		"absent from scope.files",
+		"unit-only",
+	}
+	for _, w := range wants {
+		if !strings.Contains(got, w) {
+			t.Errorf("plan_review prompt missing cross-boundary criterion substring %q:\n%s", w, got)
 		}
 	}
 }
@@ -1101,7 +1131,15 @@ func TestBuild_PlanReview_TrimmedBelowBaseline(t *testing.T) {
 	// prompt. The baseline below is the byte length of the prompt (with this
 	// fixture) BEFORE the #606 trim. Load-bearing tokens are covered by the
 	// other TestBuild_PlanReview_* tests; this one guards the token budget.
-	const preTrimBaselineLen = 3333
+	//
+	// #627 raised this baseline to keep the trim-guard meaningful after
+	// criterion #7 (cross-boundary integration test) was added. The guard's
+	// meaning is "the #606 trim still removes >= minReduction bytes vs the
+	// untrimmed version" — so the baseline must represent the untrimmed prompt
+	// that ALSO includes criterion #7, NOT current_size + minReduction (which
+	// would make the assertion tautological). New baseline = the original
+	// pre-#606 untrimmed length (3333) PLUS the 583 bytes criterion #7 adds.
+	const preTrimBaselineLen = 3916
 	got := buildPlanReview(Trigger{
 		Repo:         "kuhlman-labs/example",
 		IssueNumber:  42,


### PR DESCRIPTION
## Summary

Builds the #618 escape into the plan gate, systematically. #618 threaded a field across layers (MCP struct, CLI struct, domain, render) but **missed the server wire payload** and shipped with **no test crossing the POST→persist→render seam** — every per-layer unit test passed, both agent reviews approved, all gates green, and it broke on first live use (#624). Coverage measures lines executed, not whether the *integration path* is exercised.

Two complementary prompt levers (extending ADR-027's review-criteria policy):

- **`buildPlanReview` criterion #7 (Cross-boundary integration test):** when a plan threads a field/value across layers (request/response payload → domain → persistence → render/consumer), flag a **concern (category `coverage`)** if `test_strategy` is unit-only or a serialization boundary is **absent from `scope.files`**. **Advisory** (`approve_with_concerns`, not a hard reject), and **scoped to genuinely cross-boundary changes** — not incidental multi-file ones; the semantic reviewer makes that distinction (no policy-engine glob, per the issue's "explicitly not doing").
- **`buildPlan` directive:** when `scope.files` spans multiple layers, `test_strategy` MUST name an integration/e2e test crossing them (cf. #618).

## Test plan

- `prompt_test.go`: new `TestBuild_PlanReview_CrossBoundaryTestCriterion` + extended `TestBuild_PlanReview_ReviewCriteriaPresent` pin criterion #7's load-bearing substrings; `TestBuild_Plan` extended for the directive anchor.
- `TestBuild_PlanReview_TrimmedBelowBaseline` constant raised **3333 → 3916** = original pre-#606 untrimmed length (3333) + the 583 bytes criterion #7 adds — preserving the #606 trim-guard's meaning (still proves the trim removes ≥300 bytes vs the untrimmed-with-#7 version) rather than making it tautological.
- `go test ./internal/prompt/` + `golangci-lint` clean; `scripts/test coverage` aggregate **81.5% ≥ 80%**.

## Notes

- **Retro check (acceptance criterion).** Tracing the #618 plan against the new criterion #7: that plan's `scope.files` added `comments` to the domain type + MCP struct but **omitted `issueContextPayload`** (a serialization boundary in the request→persist path), and its `test_strategy` was **unit-only** (per-layer). Criterion #7 keys on exactly that — a value threaded across the wire→domain→render boundary with a boundary file missing from scope and no end-to-end test — so the reviewer would have raised a `coverage` concern, surfacing the gap at the plan gate instead of on first live run. ✅
- This change is itself pure deterministic prompt-string construction (no serialization/cross-process boundary), so unit tests are sufficient — criterion #7 does not apply to it.
- Prompt-only (`backend/internal/prompt`); merge → `fishhawkd` rebuild on `scripts/dev reload`, no `/mcp` reconnect.

Closes #627