### PR TITLE
fishhawk_run_stage: resolve stage_id from (run_id, stage type) (#602)

### DIFF
--- a/backend/cmd/fishhawk-mcp/run_stage.go
+++ b/backend/cmd/fishhawk-mcp/run_stage.go
@@ -93,7 +93,7 @@ type AuditPointer struct {
 // MCP composes the same arguments the CLI would.
 type RunStageInput struct {
 	RunID         string `json:"run_id" jsonschema:"Fishhawk run UUID minted by fishhawk_start_run"`
-	StageID       string `json:"stage_id" jsonschema:"stage UUID inside the run"`
+	StageID       string `json:"stage_id,omitempty" jsonschema:"stage UUID inside the run; optional — when omitted it is auto-resolved from (run_id, stage type). Pass explicitly only to disambiguate, or for back-compat; when supplied it must match the resolved stage of the requested type"`
 	Workflow      string `json:"workflow" jsonschema:"workflow ID matching the run's workflow"`
 	Stage         string `json:"stage" jsonschema:"stage type: plan | implement | review"`
 	WorkingDir    string `json:"working_dir,omitempty" jsonschema:"checkout the agent runs in; defaults to the MCP server's cwd"`
@@ -237,17 +237,34 @@ host; this tool is local-only by design (ADR-024 Q5).
 //  6. on context cancellation, SIGTERM + grace + SIGKILL the child.
 //  7. wait for exit; fetch the post-run stage state for the result.
 func (r *runResolver) runStage(ctx context.Context, req *mcp.CallToolRequest, in RunStageInput) (*mcp.CallToolResult, RunStageOutput, error) {
-	// (1) Input validation.
-	if in.RunID == "" || in.StageID == "" || in.Workflow == "" || in.Stage == "" {
-		return nil, RunStageOutput{}, errors.New("run_id, stage_id, workflow, and stage are all required")
+	// (1) Input validation. stage_id is optional: when omitted it is
+	// resolved tool-side from (run_id, stage type) below.
+	if in.RunID == "" || in.Workflow == "" || in.Stage == "" {
+		return nil, RunStageOutput{}, errors.New("run_id, workflow, and stage are all required")
 	}
 	runUUID, err := uuid.Parse(in.RunID)
 	if err != nil {
 		return nil, RunStageOutput{}, fmt.Errorf("run_id %q is not a valid UUID: %w", in.RunID, err)
 	}
-	stageUUID, err := uuid.Parse(in.StageID)
+	// Only parse stage_id when explicitly supplied — preserve the
+	// "not a valid UUID" error for a non-empty bad value.
+	if in.StageID != "" {
+		if _, perr := uuid.Parse(in.StageID); perr != nil {
+			return nil, RunStageOutput{}, fmt.Errorf("stage_id %q is not a valid UUID: %w", in.StageID, perr)
+		}
+	}
+
+	// Resolve the stage id from (run_id, stage type), honouring an
+	// explicit stage_id when supplied (back-compat) and erroring when
+	// it disagrees. This replaces the hand-copied-UUID error class
+	// (#602) and folds in #583's belongs-to-run validation.
+	resolvedStageID, err := r.resolveStageID(ctx, runUUID, in.Stage, in.StageID)
 	if err != nil {
-		return nil, RunStageOutput{}, fmt.Errorf("stage_id %q is not a valid UUID: %w", in.StageID, err)
+		return nil, RunStageOutput{}, err
+	}
+	stageUUID, err := uuid.Parse(resolvedStageID)
+	if err != nil {
+		return nil, RunStageOutput{}, fmt.Errorf("resolved stage_id %q is not a valid UUID: %w", resolvedStageID, err)
 	}
 
 	// (2) Resolve the runner binary.
@@ -307,7 +324,7 @@ func (r *runResolver) runStage(ctx context.Context, req *mcp.CallToolRequest, in
 		"--backend-url", r.api.baseURL,
 		"--workflow", in.Workflow,
 		"--stage", in.Stage,
-		"--stage-id", in.StageID,
+		"--stage-id", resolvedStageID,
 		"--working-dir", workingDir,
 		"--fetch-prompt",
 		"--upload-trace",
@@ -519,6 +536,62 @@ func (r *runResolver) runStage(ctx context.Context, req *mcp.CallToolRequest, in
 		AuditPointer: auditPointer,
 		RunURL:       runURL,
 	}, nil
+}
+
+// resolveStageID resolves the stage UUID to spawn the runner against
+// from (run_id, stage type). It lists the run's stages (ListRunStages)
+// and matches on Stage.Type:
+//
+//   - explicitStageID != "": back-compat path. The explicit id must be
+//     one of the run's stages of stageType; otherwise it errors. This
+//     also enforces #583's belongs-to-run invariant on the explicit
+//     path — a fat-fingered or wrong-run UUID no longer spawns.
+//   - explicitStageID == "": auto-resolve. Requires exactly one stage
+//     of stageType. Zero matches errors naming the available stage
+//     types; more than one errors (ambiguous) naming the duplicate ids
+//     rather than silently picking one.
+//
+// Uses a bounded context mirroring the post-run stage fetch.
+func (r *runResolver) resolveStageID(ctx context.Context, runUUID uuid.UUID, stageType, explicitStageID string) (string, error) {
+	fetchCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	stages, err := r.api.ListRunStages(fetchCtx, runUUID)
+	if err != nil {
+		return "", fmt.Errorf("resolve stage_id: list stages for run %s: %w", runUUID, err)
+	}
+
+	var matches []string
+	available := make([]string, 0, len(stages))
+	for _, s := range stages {
+		available = append(available, s.Type)
+		if s.Type == stageType {
+			matches = append(matches, s.ID)
+		}
+	}
+
+	if explicitStageID != "" {
+		for _, id := range matches {
+			if id == explicitStageID {
+				return explicitStageID, nil
+			}
+		}
+		return "", fmt.Errorf(
+			"stage_id %s does not match a %q stage in run %s; available stage types: %v",
+			explicitStageID, stageType, runUUID, available)
+	}
+
+	switch len(matches) {
+	case 1:
+		return matches[0], nil
+	case 0:
+		return "", fmt.Errorf(
+			"stage type %q not found in run %s; available: %v",
+			stageType, runUUID, available)
+	default:
+		return "", fmt.Errorf(
+			"stage type %q is ambiguous in run %s (matched %d stages: %s); pass stage_id explicitly",
+			stageType, runUUID, len(matches), strings.Join(matches, ", "))
+	}
 }
 
 // runStageParseEvents reads JSONL lines from r and appends each

--- a/backend/cmd/fishhawk-mcp/run_stage_test.go
+++ b/backend/cmd/fishhawk-mcp/run_stage_test.go
@@ -82,17 +82,39 @@ func withShortGrace(t *testing.T, d time.Duration) {
 	t.Cleanup(func() { runStageGracePeriod = orig })
 }
 
-// seedStage seeds a fake-backend stage so the post-run fetch
-// populates StageState in the tool output.
+// seedStage seeds a single fake-backend "plan" stage so the post-run
+// fetch populates StageState in the tool output. Thin wrapper over
+// seedStageOfType for the common plan case.
 func seedStage(fb *fakeBackend, runID, stageID uuid.UUID, state string) {
+	seedStageOfType(fb, runID, stageID, "plan", state)
+}
+
+// seedStageOfType seeds a single fake-backend stage of the given type.
+// stage_id is now resolved tool-side from (run_id, stage type), so the
+// seeded stage's Type must match the input's Stage for resolution to
+// succeed.
+func seedStageOfType(fb *fakeBackend, runID, stageID uuid.UUID, stageType, state string) {
 	fb.mu.Lock()
 	defer fb.mu.Unlock()
-	fb.stagesByRun[runID] = []Stage{{ID: stageID.String(), RunID: runID.String(), State: state, Type: "plan"}}
+	fb.stagesByRun[runID] = []Stage{{ID: stageID.String(), RunID: runID.String(), State: state, Type: stageType}}
+}
+
+// seedStages seeds an arbitrary set of stages on a run. Used by the
+// resolution tests (absent / ambiguous / multi-type cases).
+func seedStages(fb *fakeBackend, runID uuid.UUID, stages ...Stage) {
+	fb.mu.Lock()
+	defer fb.mu.Unlock()
+	fb.stagesByRun[runID] = stages
 }
 
 // --- input validation ---
 
-func TestRunStage_RequiresAllFourIDs(t *testing.T) {
+// TestRunStage_RequiresRunWorkflowStage asserts the three remaining
+// required inputs. stage_id is now optional (resolved tool-side from
+// (run_id, stage type)), so its absence is no longer a "required"
+// error — see TestRunStage_ResolvesStageIDWhenOmitted and the
+// absent/ambiguous resolution tests for that path.
+func TestRunStage_RequiresRunWorkflowStage(t *testing.T) {
 	_, srv := newFakeBackend(t)
 	r := newResolver(srv, nil)
 	withFakeRunner(t, "exit 0")
@@ -102,7 +124,6 @@ func TestRunStage_RequiresAllFourIDs(t *testing.T) {
 		in   RunStageInput
 	}{
 		{"missing run_id", RunStageInput{StageID: uuid.NewString(), Workflow: "w", Stage: "plan"}},
-		{"missing stage_id", RunStageInput{RunID: uuid.NewString(), Workflow: "w", Stage: "plan"}},
 		{"missing workflow", RunStageInput{RunID: uuid.NewString(), StageID: uuid.NewString(), Stage: "plan"}},
 		{"missing stage", RunStageInput{RunID: uuid.NewString(), StageID: uuid.NewString(), Workflow: "w"}},
 	}
@@ -135,18 +156,197 @@ func TestRunStage_InvalidRunUUIDFails(t *testing.T) {
 	}
 }
 
+// --- stage_id resolution (#602) ---
+
+// captureArgv swaps in a runStageCommand fake that records the runner
+// argv and exits 0, plus a LookPath stub. Returns a pointer to the
+// captured slice.
+func captureArgv(t *testing.T) *[]string {
+	t.Helper()
+	captured := new([]string)
+	origCmd := runStageCommand
+	origLook := runStageLookPath
+	runStageCommand = func(_ string, args ...string) *exec.Cmd {
+		*captured = args
+		return exec.Command("sh", "-c", "exit 0")
+	}
+	runStageLookPath = func(_ string) (string, error) { return "/fake/fishhawk-runner", nil }
+	t.Cleanup(func() {
+		runStageCommand = origCmd
+		runStageLookPath = origLook
+	})
+	return captured
+}
+
+// TestRunStage_ResolvesStageIDWhenOmitted verifies step 6a: when
+// stage_id is omitted, it resolves from (run_id, stage type) and the
+// composed argv carries the resolved --stage-id.
+func TestRunStage_ResolvesStageIDWhenOmitted(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	r := newResolver(srv, nil)
+	argv := captureArgv(t)
+
+	runID := uuid.New()
+	planStage := uuid.New()
+	implStage := uuid.New()
+	seedStages(fb, runID,
+		Stage{ID: planStage.String(), RunID: runID.String(), Type: "plan", State: "succeeded"},
+		Stage{ID: implStage.String(), RunID: runID.String(), Type: "implement", State: "running"},
+	)
+
+	_, _, err := r.runStage(context.Background(), nil, RunStageInput{
+		RunID:      runID.String(),
+		Workflow:   "w",
+		Stage:      "implement",
+		GitHubRepo: "x/y",
+	})
+	if err != nil {
+		t.Fatalf("runStage: %v", err)
+	}
+	if !strings.Contains(strings.Join(*argv, " "), "--stage-id "+implStage.String()) {
+		t.Errorf("argv should carry the resolved implement stage id %s\nfull: %v", implStage, *argv)
+	}
+}
+
+// TestRunStage_AbsentStageTypeErrors verifies step 6b: a stage type
+// not present in the run errors, naming the available stage types.
+func TestRunStage_AbsentStageTypeErrors(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	r := newResolver(srv, nil)
+	withFakeRunner(t, "exit 0")
+
+	runID := uuid.New()
+	seedStages(fb, runID,
+		Stage{ID: uuid.NewString(), RunID: runID.String(), Type: "plan", State: "succeeded"},
+	)
+
+	_, _, err := r.runStage(context.Background(), nil, RunStageInput{
+		RunID:      runID.String(),
+		Workflow:   "w",
+		Stage:      "implement",
+		GitHubRepo: "x/y",
+	})
+	if err == nil {
+		t.Fatal("expected stage-not-found error")
+	}
+	if !strings.Contains(err.Error(), "not found") || !strings.Contains(err.Error(), "plan") {
+		t.Errorf("err should say the type is not found and name available types (plan): %v", err)
+	}
+}
+
+// TestRunStage_AmbiguousStageTypeErrors verifies step 6c: two stages
+// of the same type with no explicit stage_id errors, naming the
+// duplicate ids rather than picking one.
+func TestRunStage_AmbiguousStageTypeErrors(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	r := newResolver(srv, nil)
+	withFakeRunner(t, "exit 0")
+
+	runID := uuid.New()
+	dup1 := uuid.NewString()
+	dup2 := uuid.NewString()
+	seedStages(fb, runID,
+		Stage{ID: dup1, RunID: runID.String(), Type: "implement", State: "running"},
+		Stage{ID: dup2, RunID: runID.String(), Type: "implement", State: "running"},
+	)
+
+	_, _, err := r.runStage(context.Background(), nil, RunStageInput{
+		RunID:      runID.String(),
+		Workflow:   "w",
+		Stage:      "implement",
+		GitHubRepo: "x/y",
+	})
+	if err == nil {
+		t.Fatal("expected ambiguous-stage error")
+	}
+	if !strings.Contains(err.Error(), "ambiguous") {
+		t.Errorf("err should say ambiguous: %v", err)
+	}
+	if !strings.Contains(err.Error(), dup1) || !strings.Contains(err.Error(), dup2) {
+		t.Errorf("err should name both duplicate ids %s, %s: %v", dup1, dup2, err)
+	}
+}
+
+// TestRunStage_ExplicitStageIDDisagreesErrors verifies step 6d: an
+// explicit stage_id that is not a stage of the requested type errors.
+func TestRunStage_ExplicitStageIDDisagreesErrors(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	r := newResolver(srv, nil)
+	withFakeRunner(t, "exit 0")
+
+	runID := uuid.New()
+	planStage := uuid.New()
+	implStage := uuid.New()
+	seedStages(fb, runID,
+		Stage{ID: planStage.String(), RunID: runID.String(), Type: "plan", State: "succeeded"},
+		Stage{ID: implStage.String(), RunID: runID.String(), Type: "implement", State: "running"},
+	)
+
+	// Pass the plan stage id but ask to run the implement stage.
+	_, _, err := r.runStage(context.Background(), nil, RunStageInput{
+		RunID:      runID.String(),
+		StageID:    planStage.String(),
+		Workflow:   "w",
+		Stage:      "implement",
+		GitHubRepo: "x/y",
+	})
+	if err == nil {
+		t.Fatal("expected disagreement error")
+	}
+	if !strings.Contains(err.Error(), "does not match") || !strings.Contains(err.Error(), planStage.String()) {
+		t.Errorf("err should say the explicit id does not match the requested type: %v", err)
+	}
+}
+
+// TestRunStage_ExplicitStageIDAgreesWorks verifies step 6e
+// (back-compat): an explicit stage_id that matches the resolved type
+// still works and flows into the argv.
+func TestRunStage_ExplicitStageIDAgreesWorks(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	r := newResolver(srv, nil)
+	argv := captureArgv(t)
+
+	runID := uuid.New()
+	planStage := uuid.New()
+	implStage := uuid.New()
+	seedStages(fb, runID,
+		Stage{ID: planStage.String(), RunID: runID.String(), Type: "plan", State: "succeeded"},
+		Stage{ID: implStage.String(), RunID: runID.String(), Type: "implement", State: "running"},
+	)
+
+	_, _, err := r.runStage(context.Background(), nil, RunStageInput{
+		RunID:      runID.String(),
+		StageID:    implStage.String(),
+		Workflow:   "w",
+		Stage:      "implement",
+		GitHubRepo: "x/y",
+	})
+	if err != nil {
+		t.Fatalf("runStage: %v", err)
+	}
+	if !strings.Contains(strings.Join(*argv, " "), "--stage-id "+implStage.String()) {
+		t.Errorf("argv should carry the agreed explicit stage id %s\nfull: %v", implStage, *argv)
+	}
+}
+
 // --- binary resolution ---
 
 func TestRunStage_MissingBinaryReturnsCleanError(t *testing.T) {
-	_, srv := newFakeBackend(t)
+	fb, srv := newFakeBackend(t)
 	r := newResolver(srv, nil)
 	withFakeRunnerMissing(t)
 	// os.Executable sibling probe must also fail so we reach the error rung.
 	withFakeExecutable(t, t.TempDir(), false /* no sibling */)
 
+	// Seed a matching stage so stage resolution passes and we reach the
+	// binary-resolution error rung this test is about.
+	runID := uuid.New()
+	stageID := uuid.New()
+	seedStage(fb, runID, stageID, "awaiting_approval")
+
 	_, _, err := r.runStage(context.Background(), nil, RunStageInput{
-		RunID:    uuid.NewString(),
-		StageID:  uuid.NewString(),
+		RunID:    runID.String(),
+		StageID:  stageID.String(),
 		Workflow: "w",
 		Stage:    "plan",
 	})
@@ -390,7 +590,7 @@ func TestRunStage_ArgvComposition_ImplementStageNoPlanOut(t *testing.T) {
 
 	runID := uuid.New()
 	stageID := uuid.New()
-	seedStage(fb, runID, stageID, "succeeded")
+	seedStageOfType(fb, runID, stageID, "implement", "succeeded")
 
 	_, _, err := r.runStage(context.Background(), nil, RunStageInput{
 		RunID:      runID.String(),
@@ -431,7 +631,7 @@ func TestRunStage_PushAndOpenPR_DropsNoPRFlag(t *testing.T) {
 
 	runID := uuid.New()
 	stageID := uuid.New()
-	seedStage(fb, runID, stageID, "succeeded")
+	seedStageOfType(fb, runID, stageID, "implement", "succeeded")
 
 	_, _, err := r.runStage(context.Background(), nil, RunStageInput{
 		RunID:         runID.String(),
@@ -511,14 +711,21 @@ func TestRunStage_GitHubRepoAutoDetectFails_WarnsWithoutPush(t *testing.T) {
 }
 
 func TestRunStage_GitHubRepoAutoDetectFails_WithPushErrors(t *testing.T) {
-	_, srv := newFakeBackend(t)
+	fb, srv := newFakeBackend(t)
 	r := newResolver(srv, nil)
 	withFakeGitRemote(t, "", errors.New("nope"))
 	withFakeRunner(t, "exit 0")
 
+	// Seed a matching implement stage so stage resolution passes and the
+	// test reaches the github_repo auto-detect failure it actually
+	// exercises (resolveStageID runs before the github_repo check).
+	runID := uuid.New()
+	stageID := uuid.New()
+	seedStageOfType(fb, runID, stageID, "implement", "running")
+
 	_, _, err := r.runStage(context.Background(), nil, RunStageInput{
-		RunID:         uuid.NewString(),
-		StageID:       uuid.NewString(),
+		RunID:         runID.String(),
+		StageID:       stageID.String(),
 		Workflow:      "w",
 		Stage:         "implement",
 		PushAndOpenPR: true,
@@ -806,7 +1013,7 @@ func TestRunStage_DiffSummary_PopulatedFromGitDiffEvent(t *testing.T) {
 
 	runID := uuid.New()
 	stageID := uuid.New()
-	seedStage(fb, runID, stageID, "succeeded")
+	seedStageOfType(fb, runID, stageID, "implement", "succeeded")
 
 	_, out, err := r.runStage(context.Background(), nil, RunStageInput{
 		RunID:      runID.String(),
@@ -846,7 +1053,7 @@ func TestRunStage_AuditPointer_NilOnBackend500(t *testing.T) {
 
 	runID := uuid.New()
 	stageID := uuid.New()
-	seedStage(fb, runID, stageID, "succeeded")
+	seedStageOfType(fb, runID, stageID, "implement", "succeeded")
 
 	warningsBefore := 0
 	_, out, err := r.runStage(context.Background(), nil, RunStageInput{
@@ -890,7 +1097,7 @@ func TestRunStage_RunURL_ContainsRunID(t *testing.T) {
 
 	runID := uuid.New()
 	stageID := uuid.New()
-	seedStage(fb, runID, stageID, "succeeded")
+	seedStageOfType(fb, runID, stageID, "implement", "succeeded")
 
 	_, out, err := r.runStage(context.Background(), nil, RunStageInput{
 		RunID:      runID.String(),

--- a/docs/mcp/install.md
+++ b/docs/mcp/install.md
@@ -146,6 +146,8 @@ The composition matches the CLI's `fishhawk run start --working-dir … --issue 
 
 The `fishhawk_run_stage` tool requires the `fishhawk-runner` binary on the MCP server's host (`PATH` lookup, overridable via `FISHHAWK_RUNNER_BIN` env or the tool's `runner_binary` input). The MCP server runs locally on an operator's workstation today, so this is always satisfied; a future hosted MCP deployment will surface a clean tool error.
 
+`stage_id` is optional ([#602](https://github.com/kuhlman-labs/fishhawk/issues/602)): when omitted, the tool resolves it from `(run_id, stage)` by listing the run's stages and matching on stage type, so you no longer hand-copy a stage UUID. Pass `stage_id` explicitly only to disambiguate or for back-compat — when supplied it must match a stage of the requested type, or the call errors rather than spawning against the wrong stage. A v0 run has at most one stage per type, so the requested type normally resolves uniquely; the >1 case is reported as an ambiguous error naming the duplicate ids rather than silently picking one.
+
 Cancellation: cancelling the `fishhawk_run_stage` tool call sends `SIGTERM` to the runner, waits 30 seconds, then escalates to `SIGKILL`. The runner handles SIGTERM cooperatively (#435) — `ctx.Done()` propagates to the long-running calls (agent invocation + trace/plan/PR uploads), the deferred cancel-emit writes a `runner_cancelled` JSONL line on stdout, and the process exits with code 130 (`128 + SIGINT` convention). The bundle that was packed up to the cancellation point still ships best-effort, so the backend receives whatever events the agent produced.
 
 ## Runner integration
@@ -165,6 +167,8 @@ Cancellation: cancelling the `fishhawk_run_stage` tool call sends `SIGTERM` to t
 | `fishhawk: HTTP 404` from `fishhawk_get_plan` | Run id valid but the plan stage hasn't terminated — the tool returns a structured `no_plan_yet` response, not an error. Other 404s usually mean the run id is wrong. |
 | `no plan stage on run …` from `fishhawk_approve_plan` | The run's workflow doesn't have a plan stage (e.g. `routine_change`). Approve at the stage level directly via the CLI / SPA. |
 | `fishhawk-runner not on PATH` from `fishhawk_run_stage` | The binary could not be resolved via any rung of the resolution chain (input → env → sibling → PATH). Remediate in order of preference: (1) install `fishhawk-runner` in the same directory as `fishhawk-mcp` — the sibling-binary probe resolves it automatically; (2) set `--env FISHHAWK_RUNNER_BIN=<path>` in `claude mcp add` (see step 4); (3) pass `runner_binary` per tool call as a last resort. |
+| `stage type "…" not found in run …` from `fishhawk_run_stage` | The run has no stage of the requested `stage` type — the error lists the run's available stage types. Check that `stage` matches the run's workflow (e.g. `routine_change` has no plan stage) and that the prior stage actually created the one you're asking to run. |
+| `stage type "…" is ambiguous in run …` from `fishhawk_run_stage` | The run has more than one stage of the requested type (unusual for v0). The error names the duplicate stage ids; pass the intended one as `stage_id` explicitly to disambiguate. |
 
 ## See also
 


### PR DESCRIPTION
## Summary

`fishhawk_run_stage` required both `stage` (the type) and `stage_id` (the UUID), forcing the driver to hand-copy a 36-char UUID out of a `get_run_status` blob every stage — error-prone (a fat-fingered UUID this session spawned the runner against a non-existent stage; #602, pairs with #583).

Make `stage_id` **optional**. When omitted, `resolveStageID` lists the run's stages (existing `ListRunStages`) and matches on `Stage.Type`:
- exactly one match → use it;
- zero → error naming the run's available stage types;
- more than one → ambiguous error naming the duplicate ids (**never** picks one silently).

When `stage_id` **is** supplied it's validated against the run's stages and must match the requested type (folds in #583's belongs-to-run check) — a genuine mismatch errors instead of spawning against the wrong stage. The explicit-and-agreeing path stays back-compatible. Resolution runs right after run_id parsing; the resolved id flows into both the runner argv (`--stage-id`) and the post-run stage-state fetch.

## Test plan

- New cases through the `fakeBackend` HTTP server (so the `ListRunStages` seam is exercised end-to-end, not mocked in isolation): resolve-when-omitted, absent-type, ambiguous-type, explicit-disagree, explicit-agree (back-compat).
- Updated the two existing tests the new ordering touched: `TestRunStage_RequiresAllFourIDs` → `_RequiresRunWorkflowStage` (the now-optional `stage_id` case dropped); the github-repo-autodetect and binary-resolution tests seed a matching stage so resolution passes and they still reach their intended error rungs.
- `go test ./cmd/fishhawk-mcp/...` + `golangci-lint` clean; `scripts/test coverage` aggregate **81.6% ≥ 80%**.

## Notes

- MCP-tool change (`backend/cmd/fishhawk-mcp`) — adapter-package altitude, no field crosses a serialization boundary, so per criterion #7 unit/handler tests are the correct level (the new tests do go through the fakeBackend HTTP boundary anyway). **After merge this needs a `/mcp` reconnect** (fishhawk-mcp source changed) — the first since #618.
- `RunStageInput.stage_id` jsonschema now advertises optional + auto-resolved; the `json` tag gained `,omitempty` (helps the MCP framework mark it optional — benign).
- Pairs with #583 (the defensive belongs-to-run validation); together they remove the hand-copied-UUID error class.

Closes #602