### PR TITLE
Extend plan-stage calibration advisory to the medium band

### DIFF
--- a/backend/internal/prompt/prompt.go
+++ b/backend/internal/prompt/prompt.go
@@ -488,6 +488,17 @@ func buildPlan(t Trigger) string {
 					highBand.WithinScale, highBand.Samples)
 			}
 		}
+		if medBand, ok := t.CalibrationHint.ConfidenceBands["medium"]; ok && medBand.Samples >= 5 {
+			if float64(medBand.WithinScale)/float64(medBand.Samples) <= 0.25 {
+				fmt.Fprintf(&b, "→ \"medium\" has degraded too (%d/%d within 1.5x) — you over-predict here as well. ",
+					medBand.WithinScale, medBand.Samples)
+				if t.CalibrationHint.CalibrationRatio > 0 {
+					fmt.Fprintf(&b, "Estimates in this band run about %.1fx too high; size your raw estimate DOWN by that factor. ",
+						1.0/t.CalibrationHint.CalibrationRatio)
+				}
+				b.WriteString("Drop to \"low\" for small, well-scoped changes rather than reaching for a higher band.\n")
+			}
+		}
 	}
 	return b.String()
 }

--- a/backend/internal/prompt/prompt_test.go
+++ b/backend/internal/prompt/prompt_test.go
@@ -601,6 +601,100 @@ func TestBuild_Plan_CalibrationHint_NoAdvisoryAboveThreshold(t *testing.T) {
 	}
 }
 
+func TestBuild_Plan_CalibrationHint_MediumBandAdvisory(t *testing.T) {
+	// Medium band at 1/10 within 1.5x (10% ≤ 25%) → advisory fires naming
+	// "medium" and surfacing the 1/ratio sizing-down factor. ratio 0.17 → ~5.9x.
+	got, err := Build("plan", Trigger{
+		IssueNumber: 7,
+		Repo:        "x/y",
+		CalibrationHint: &CalibrationHint{
+			Samples:          10,
+			CalibrationRatio: 0.17,
+			ActualP50Minutes: 60.0,
+			ActualP95Minutes: 90.0,
+			ConfidenceBands: map[string]CalibrationBand{
+				"medium": {Samples: 10, WithinScale: 1},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	wants := []string{
+		"\"medium\" has degraded too",
+		"1/10 within 1.5x",
+		"about 5.9x too high",
+		"Drop to \"low\"",
+	}
+	for _, w := range wants {
+		if !strings.Contains(got, w) {
+			t.Errorf("plan prompt missing medium advisory string %q:\n%s", w, got)
+		}
+	}
+	// The medium advisory must never steer toward "high".
+	if strings.Contains(got, "reaching for a higher band") == false {
+		t.Errorf("medium advisory should steer away from higher bands:\n%s", got)
+	}
+}
+
+func TestBuild_Plan_CalibrationHint_BothBandsBadFireBoth(t *testing.T) {
+	// Both high and medium at 1/10 → both advisories fire independently.
+	got, err := Build("plan", Trigger{
+		IssueNumber: 7,
+		Repo:        "x/y",
+		CalibrationHint: &CalibrationHint{
+			Samples:          20,
+			CalibrationRatio: 0.50,
+			ActualP50Minutes: 30.0,
+			ActualP95Minutes: 50.0,
+			ConfidenceBands: map[string]CalibrationBand{
+				"high":   {Samples: 10, WithinScale: 1},
+				"medium": {Samples: 10, WithinScale: 1},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	wants := []string{
+		"LEAST accurate band historically", // high-band advisory
+		"\"medium\" has degraded too",      // medium-band advisory
+	}
+	for _, w := range wants {
+		if !strings.Contains(got, w) {
+			t.Errorf("plan prompt missing advisory string %q (both bands should fire):\n%s", w, got)
+		}
+	}
+}
+
+func TestBuild_Plan_CalibrationHint_NoMediumAdvisoryWhenAccurate(t *testing.T) {
+	// Medium at 8/10 (80% > 25%) → medium advisory must NOT fire, while the
+	// rest of the calibration hint still renders.
+	got, err := Build("plan", Trigger{
+		IssueNumber: 7,
+		Repo:        "x/y",
+		CalibrationHint: &CalibrationHint{
+			Samples:          10,
+			CalibrationRatio: 1.00,
+			ActualP50Minutes: 10.0,
+			ActualP95Minutes: 15.0,
+			ConfidenceBands: map[string]CalibrationBand{
+				"medium": {Samples: 10, WithinScale: 8},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if strings.Contains(got, "\"medium\" has degraded too") {
+		t.Errorf("medium-band advisory must not fire when medium band is accurate (8/10):\n%s", got)
+	}
+	// The hint body still renders.
+	if !strings.Contains(got, "Confidence-band accuracy:") {
+		t.Errorf("calibration hint body should still render:\n%s", got)
+	}
+}
+
 func TestBuild_Plan_ScopeFilesShapeGuidance(t *testing.T) {
 	got, err := Build("plan", Trigger{
 		IssueNumber: 7,


### PR DESCRIPTION
## Summary

The high-band advisory (#567) steered the agent off the `high` band, but the miscalibration **moved to `medium`** rather than disappearing — recent data shows the medium band at ~10% within-1.5x (systemic ~6x over-prediction), the same accuracy shape `high` had pre-#567.

This adds a sibling advisory in `buildPlan` (`backend/internal/prompt/prompt.go`) that evaluates the **medium** band independently, gated on the same `Samples >= 5 && within-1.5x <= 25%` thresholds as the high-band block. The medium copy:

- surfaces the raw X/Y accuracy numbers,
- gives a concrete **sizing-down factor** (`1 / CalibrationRatio`, e.g. "about 5.9x too high"),
- steers toward `"low"` for small/well-scoped changes — **never toward `"high"`**, which the existing advisory already flags as worse.

A `CalibrationRatio > 0` guard avoids a `+Inf` render on a malformed zero-ratio hint (defensive; real hints always carry a positive ratio). The high-band block is left **byte-for-byte unchanged** so the high path cannot regress; both advisories fire independently.

## Test plan

`go test -count=1 ./internal/prompt/` + `golangci-lint run ./internal/prompt/` (backend module) — all green, 0 lint issues. New tests:

- `TestBuild_Plan_CalibrationHint_MediumBandAdvisory` — medium at 1/10, asserts band name + `5.9x` sizing factor + raw numbers + steer-away-from-higher-band.
- `TestBuild_Plan_CalibrationHint_BothBandsBadFireBoth` — high AND medium at 1/10, asserts both advisories fire independently (high-path regression guard).
- `TestBuild_Plan_CalibrationHint_NoMediumAdvisoryWhenAccurate` — medium at 8/10, asserts the medium advisory is absent while the hint body still renders.

All pre-existing calibration-hint tests continue to pass.

## Notes

Pure additive change to one string-building function + new tests; no schema, API, or cross-layer seam (rollback = revert the commit). Out of scope per the issue: low-band advisory, server-side auto-downgrade (rejected by ADR-027/#564), per-band ratios (revisit ~N=30/band).

Closes #576