### PR TITLE
Pin CI/release tooling fetched from unpinned moving refs

### DIFF
--- a/.github/workflows/backend-release.yml
+++ b/.github/workflows/backend-release.yml
@@ -47,7 +47,11 @@ jobs:
 
       - name: Install golangci-lint
         run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
+          # Pin install.sh to the v2.8.0 tag, NOT master: the master script
+          # is unpinned and an upstream change to it broke CI (exit 1 right
+          # after resolving v2.8.0) with no change on our side. The tagged
+          # script matches the version it installs and is reproducible.
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v2.8.0/install.sh \
             | sh -s -- -b "$(go env GOPATH)/bin" v2.8.0
 
       - name: Verify the tagged commit passes lint + tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,7 +197,10 @@ jobs:
           node-version: '22'
       - name: Lint OpenAPI spec
         run: |
-          npx -y @redocly/cli@latest lint \
+          # Pin to a concrete published version, NOT @latest: a floating
+          # ref lets an upstream release red-line CI with no change on our
+          # side. Bump deliberately. See #607/#608.
+          npx -y @redocly/cli@2.31.5 lint \
             --config docs/api/redocly.yaml \
             docs/api/v0.openapi.yaml
 

--- a/.github/workflows/mcp-release.yml
+++ b/.github/workflows/mcp-release.yml
@@ -54,7 +54,11 @@ jobs:
 
       - name: Install golangci-lint
         run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
+          # Pin install.sh to the v2.8.0 tag, NOT master: the master script
+          # is unpinned and an upstream change to it broke CI (exit 1 right
+          # after resolving v2.8.0) with no change on our side. The tagged
+          # script matches the version it installs and is reproducible.
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v2.8.0/install.sh \
             | sh -s -- -b "$(go env GOPATH)/bin" v2.8.0
 
       - name: Verify the tagged commit passes lint + tests

--- a/.github/workflows/runner-release.yml
+++ b/.github/workflows/runner-release.yml
@@ -56,7 +56,11 @@ jobs:
 
       - name: Install golangci-lint
         run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
+          # Pin install.sh to the v2.8.0 tag, NOT master: the master script
+          # is unpinned and an upstream change to it broke CI (exit 1 right
+          # after resolving v2.8.0) with no change on our side. The tagged
+          # script matches the version it installs and is reproducible.
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v2.8.0/install.sh \
             | sh -s -- -b "$(go env GOPATH)/bin" v2.8.0
 
       - name: Verify the tagged commit passes lint + tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Pre-alpha. Most code referenced in `docs/MVP_SPEC.md` doesn't exist yet — it's
 - `docs/BRAND_FOUNDATIONS.md` — voice, naming, positioning.
 - `docs/METHODOLOGY.md` — autonomy tiers (low/medium/high).
 - `docs/spec/` — canonical JSON Schemas + reference docs for the workflow spec (`.fishhawk/workflows.yaml`) and the plan artifact (`standard_v1`). Validate with `check-jsonschema --schemafile <schema> <yaml-or-json>`.
-- `docs/api/` — REST API surface: `v0.openapi.yaml` is source of truth, `v0.md` is the human companion. Lint with `npx -y @redocly/cli@latest lint --config docs/api/redocly.yaml docs/api/v0.openapi.yaml`.
+- `docs/api/` — REST API surface: `v0.openapi.yaml` is source of truth, `v0.md` is the human companion. Lint with `npx -y @redocly/cli@2.31.5 lint --config docs/api/redocly.yaml docs/api/v0.openapi.yaml` (pinned version — see the pinning rule under "Build, test, lint").
 - `.fishhawk/workflows.yaml` — placeholder; executed by the product itself starting Day 21 (~2026-05-20).
 
 ## Documentation surfaces
@@ -40,6 +40,8 @@ golangci-lint run ./backend/...
 ```
 
 `.golangci.yml` is **v2 format** (`version: "2"` at top). Local install must be golangci-lint v2.x; v1 binaries reject this config.
+
+**Pin executable tooling fetched inside CI/release `run:` steps.** Any tool a workflow downloads and executes at run time — install scripts piped to a shell (`curl … | sh`), `npx` packages — MUST be pinned to a specific immutable tag or version, never `master`/`main`/`latest`/a floating major. A third-party repo can change its `master` install script or publish a new `@latest` and red-line the entire pipeline (including `main`) with zero change on our side — exactly what happened when golangci-lint's `master/install.sh` broke CI (#607/#608). Current pins: golangci-lint `install.sh` → the `v2.8.0` tag (all four workflows: `ci.yml` + the three `*-release.yml`); `@redocly/cli` → `2.31.5` (in `ci.yml` and the `docs/api/` lint/preview commands — keep these in sync). GitHub Action refs (`actions/checkout@vN`, etc.) are the exception: they stay on floating major tags because `.github/dependabot.yml`'s `github-actions` entry bumps them deliberately and reviewably. npx-in-run-step pins are not yet Dependabot-tracked, so bump them by hand.
 
 **Coverage gate**: aggregate ≥ 80% across **all** registered modules, excluding sqlc-generated `*/db/` packages (CI uses `--exclude '/db/'` so new sqlc packages auto-skip). Tiered targets in `docs/ARCHITECTURE.md` §9. CI fails `CI Pass` if the threshold drops. `scripts/test coverage` runs the same check. The underlying loop (CI uses the same shape):
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -27,10 +27,10 @@ Per ADR (#46) and `MVP_SPEC.md` §5.1.1:
 
 ```sh
 # Lint
-npx -y @redocly/cli@latest lint --config docs/api/redocly.yaml docs/api/v0.openapi.yaml
+npx -y @redocly/cli@2.31.5 lint --config docs/api/redocly.yaml docs/api/v0.openapi.yaml
 
 # Preview rendered docs
-npx -y @redocly/cli@latest preview-docs docs/api/v0.openapi.yaml
+npx -y @redocly/cli@2.31.5 preview-docs docs/api/v0.openapi.yaml
 ```
 
 When adding an endpoint:

--- a/docs/api/v0.md
+++ b/docs/api/v0.md
@@ -229,10 +229,10 @@ are implemented; codes are additive and never repurposed.
 
 ```sh
 # Lint (uses docs/api/redocly.yaml for project-specific rule overrides)
-npx -y @redocly/cli@latest lint --config docs/api/redocly.yaml docs/api/v0.openapi.yaml
+npx -y @redocly/cli@2.31.5 lint --config docs/api/redocly.yaml docs/api/v0.openapi.yaml
 
 # Render preview
-npx -y @redocly/cli@latest preview-docs docs/api/v0.openapi.yaml
+npx -y @redocly/cli@2.31.5 preview-docs docs/api/v0.openapi.yaml
 ```
 
 The lint config disables `operation-2xx-response` (the OAuth redirect


### PR DESCRIPTION
## Summary

CI broke on every PR and `main` (2026-05-31) when golangci-lint's **unpinned `master/install.sh`** changed upstream — a third-party repo red-lining the whole pipeline with no change on our side. #607 pinned `ci.yml`; this closes the remaining gaps and documents the convention.

- **golangci-lint `install.sh`: `master` → `v2.8.0` tag** in the three release workflows (`backend-release.yml`, `runner-release.yml`, `mcp-release.yml`), matching `ci.yml`. The tagged script is immutable and matches the version it installs.
- **`@redocly/cli`: `@latest` → `2.31.5`** (a concrete pin, not a floating major) in `ci.yml`'s OpenAPI lint step and the `docs/api/` lint+preview commands, kept in sync.
- **CLAUDE.md**: documents the pin-executable-tooling convention.

## Test plan

- `grep -rn 'golangci-lint/master/install.sh\|@redocly/cli@latest' .github docs CLAUDE.md` → **zero matches**.
- All four workflows now reference `golangci-lint/v2.8.0/install.sh`.
- `npx -y @redocly/cli@2.31.5 lint --config docs/api/redocly.yaml docs/api/v0.openapi.yaml` → **valid** (4 pre-existing warnings), confirming the pinned version is real and the gate still passes.
- The three release workflows are tag-triggered only and can't run on this PR branch; their correctness rests on the `install.sh`-pinned-to-tag pattern already proven green in `ci.yml` by #607.

## Notes

**Authored human-led.** A change to `.github/workflows/**` is forbidden to the agent loop *by design* — all three agent-capable workflows block it (`feature_change` via `forbidden_paths`, `routine_change` via its `allowed_paths` allowlist); CI/load-bearing edits belong to the `human_led_change` lane ("the agent is not the author"). An agent must not edit the CI that gates its own PRs. The agent drafted these edits; every line was reviewed and verified before this human-authored, signed-off commit.

**GitHub Action `@vN` major tags are intentionally left as-is**: the existing `.github/dependabot.yml` `github-actions` entry bumps them deliberately and reviewably, so they're managed rather than rotting. Full action SHA-pinning is out of scope (the issue frames it as Optional). The npx redocly pin is not Dependabot-tracked (no manifest for an inline `npx`), so it bumps by hand.

Closes #608