### PR TITLE
Fetch issue comments on the webhook/installation-token path

### DIFF
--- a/backend/internal/githubclient/client.go
+++ b/backend/internal/githubclient/client.go
@@ -795,6 +795,98 @@ func nextPageURL(link string) string {
 	return ""
 }
 
+// FetchedIssueComment is the subset of a GitHub issue-comment Fishhawk
+// reads when fetching an issue's comment thread (#621). It is distinct
+// from IssueComment, which models the create/update *response* shape
+// (id/body/html_url) those helpers decode. The fetch side surfaces the
+// author login, body, and creation timestamp the plan-stage prompt
+// renders.
+type FetchedIssueComment struct {
+	Author    string
+	Body      string
+	CreatedAt string
+}
+
+// ListIssueComments fetches the comment thread on an issue (or PR —
+// GitHub treats PR conversations as issue threads).
+//
+//	GET /repos/{owner}/{repo}/issues/{number}/comments?per_page=100
+//
+// Used by the webhook/installation-token prompt path (branch 2 of
+// fillIssueContext) to populate the plan-stage prompt with
+// comment-borne refinements, matching the operator gh-fetch path
+// (#618). Pages until exhaustion via the rel="next" Link header —
+// the same mechanism ListTeamMembers relies on.
+//
+// Returns ErrNotFound when the issue or repo isn't visible to the
+// installation, ErrForbidden on auth issues.
+func (c *Client) ListIssueComments(ctx context.Context, installationID int64, repo RepoRef, number int) ([]FetchedIssueComment, error) {
+	if c.Tokens == nil {
+		return nil, errors.New("githubclient: client missing TokenProvider")
+	}
+	if repo.Owner == "" || repo.Name == "" {
+		return nil, errors.New("githubclient: repo owner and name required")
+	}
+	if number <= 0 {
+		return nil, errors.New("githubclient: issue number must be > 0")
+	}
+
+	pagePath := "/repos/" + url.PathEscape(repo.Owner) +
+		"/" + url.PathEscape(repo.Name) +
+		"/issues/" + url.PathEscape(fmt.Sprintf("%d", number)) +
+		"/comments?per_page=100"
+	endpoint := c.endpoint(pagePath)
+
+	var out []FetchedIssueComment
+	for endpoint != "" {
+		req, err := c.buildRequest(ctx, http.MethodGet, endpoint, nil, installationID)
+		if err != nil {
+			return nil, err
+		}
+
+		resp, err := c.HTTP.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("githubclient: list issue comments: %w", err)
+		}
+		comments, next, err := decodeIssueCommentsPage(resp)
+		_ = resp.Body.Close()
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, comments...)
+		endpoint = next
+	}
+	return out, nil
+}
+
+// decodeIssueCommentsPage handles one page of issue comments and
+// returns the next-page URL if Link advertises one. Mirrors
+// decodeTeamMembersPage so the pagination loop above stays readable.
+func decodeIssueCommentsPage(resp *http.Response) ([]FetchedIssueComment, string, error) {
+	if err := classifyStatus("list issue comments", resp); err != nil {
+		return nil, "", err
+	}
+	var body []struct {
+		User struct {
+			Login string `json:"login"`
+		} `json:"user"`
+		Body      string `json:"body"`
+		CreatedAt string `json:"created_at"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return nil, "", fmt.Errorf("githubclient: decode issue comments: %w", err)
+	}
+	out := make([]FetchedIssueComment, 0, len(body))
+	for _, c := range body {
+		out = append(out, FetchedIssueComment{
+			Author:    c.User.Login,
+			Body:      c.Body,
+			CreatedAt: c.CreatedAt,
+		})
+	}
+	return out, nextPageURL(resp.Header.Get("Link")), nil
+}
+
 // DispatchInputs is the JSON body of a workflow_dispatch event.
 // Per GitHub's contract, inputs is a flat map[string]string —
 // non-string values must be JSON-encoded by the caller.

--- a/backend/internal/githubclient/client_test.go
+++ b/backend/internal/githubclient/client_test.go
@@ -48,6 +48,14 @@ type fakeGitHub struct {
 	getIssueStatus int
 	getIssueBody   string
 
+	listIssueCommentsStatus int
+	// listIssueCommentsPages holds one JSON body per page; the handler
+	// serves them in order and advertises a rel="next" Link to itself
+	// until the last page, so a multi-page case proves pagination
+	// accumulates. listIssueCommentsHits counts requests served.
+	listIssueCommentsPages []string
+	listIssueCommentsHits  int
+
 	createCheckRunStatus int
 	createCheckRunBody   string
 
@@ -97,6 +105,7 @@ func newFakeGitHub(t *testing.T) (*fakeGitHub, *httptest.Server) {
 		getFileStatus:             http.StatusOK,
 		dispatchStatus:            http.StatusNoContent,
 		getIssueStatus:            http.StatusOK,
+		listIssueCommentsStatus:   http.StatusOK,
 		createCheckRunStatus:      http.StatusCreated,
 		createCheckRunBody:        `{"id":987654,"html_url":"https://github.com/x/y/runs/987654"}`,
 		createIssueCommentStatus:  http.StatusCreated,
@@ -160,6 +169,32 @@ func newFakeGitHub(t *testing.T) (*fakeGitHub, *httptest.Server) {
 			if fg.getIssueBody != "" {
 				_, _ = io.WriteString(w, fg.getIssueBody)
 			}
+		})
+
+	mux.HandleFunc("GET /repos/{owner}/{repo}/issues/{number}/comments",
+		func(w http.ResponseWriter, r *http.Request) {
+			capture(r)
+			w.Header().Set("Content-Type", "application/json")
+			if fg.listIssueCommentsStatus != http.StatusOK {
+				w.WriteHeader(fg.listIssueCommentsStatus)
+				if len(fg.listIssueCommentsPages) > 0 {
+					_, _ = io.WriteString(w, fg.listIssueCommentsPages[0])
+				}
+				return
+			}
+			idx := fg.listIssueCommentsHits
+			fg.listIssueCommentsHits++
+			if idx >= len(fg.listIssueCommentsPages) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = io.WriteString(w, "[]")
+				return
+			}
+			if idx+1 < len(fg.listIssueCommentsPages) {
+				next := "http://" + r.Host + r.URL.Path + "?page=" + strconv.Itoa(idx+2)
+				w.Header().Set("Link", "<"+next+`>; rel="next"`)
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, fg.listIssueCommentsPages[idx])
 		})
 
 	mux.HandleFunc("POST /repos/{owner}/{repo}/check-runs",
@@ -692,6 +727,97 @@ func TestGetIssue_DecodeError(t *testing.T) {
 	_, err := c.GetIssue(context.Background(), 1, RepoRef{Owner: "x", Name: "y"}, 1)
 	if err == nil {
 		t.Fatalf("expected decode error")
+	}
+}
+
+// --- ListIssueComments ---
+
+func TestListIssueComments_HappyPath(t *testing.T) {
+	fg, srv := newFakeGitHub(t)
+	fg.listIssueCommentsPages = []string{
+		`[{"user":{"login":"alice"},"body":"First.","created_at":"2026-05-01T10:00:00Z"},` +
+			`{"user":{"login":"bob"},"body":"Second.","created_at":"2026-05-01T11:00:00Z"}]`,
+	}
+	c, _ := newTestClient(t, srv, nil)
+
+	got, err := c.ListIssueComments(context.Background(), 99, RepoRef{Owner: "x", Name: "y"}, 42)
+	if err != nil {
+		t.Fatalf("ListIssueComments: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d comments, want 2: %+v", len(got), got)
+	}
+	if got[0] != (FetchedIssueComment{Author: "alice", Body: "First.", CreatedAt: "2026-05-01T10:00:00Z"}) {
+		t.Errorf("comment[0] = %+v", got[0])
+	}
+	if got[1].Author != "bob" || got[1].Body != "Second." {
+		t.Errorf("comment[1] = %+v", got[1])
+	}
+	if fg.gotMethod != "GET" {
+		t.Errorf("method = %q", fg.gotMethod)
+	}
+	if fg.gotPath != "/repos/x/y/issues/42/comments" {
+		t.Errorf("path = %q", fg.gotPath)
+	}
+}
+
+func TestListIssueComments_Paginates(t *testing.T) {
+	fg, srv := newFakeGitHub(t)
+	fg.listIssueCommentsPages = []string{
+		`[{"user":{"login":"alice"},"body":"p1.","created_at":"2026-05-01T10:00:00Z"}]`,
+		`[{"user":{"login":"bob"},"body":"p2.","created_at":"2026-05-01T11:00:00Z"}]`,
+	}
+	c, _ := newTestClient(t, srv, nil)
+
+	got, err := c.ListIssueComments(context.Background(), 99, RepoRef{Owner: "x", Name: "y"}, 42)
+	if err != nil {
+		t.Fatalf("ListIssueComments: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d comments, want 2 across pages: %+v", len(got), got)
+	}
+	if got[0].Author != "alice" || got[1].Author != "bob" {
+		t.Errorf("pagination did not accumulate in order: %+v", got)
+	}
+	if fg.listIssueCommentsHits != 2 {
+		t.Errorf("server served %d pages, want 2", fg.listIssueCommentsHits)
+	}
+}
+
+func TestListIssueComments_NotFound(t *testing.T) {
+	fg, srv := newFakeGitHub(t)
+	fg.listIssueCommentsStatus = http.StatusNotFound
+	fg.listIssueCommentsPages = []string{`{"message":"Not Found"}`}
+	c, _ := newTestClient(t, srv, nil)
+
+	_, err := c.ListIssueComments(context.Background(), 1, RepoRef{Owner: "x", Name: "y"}, 1)
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestListIssueComments_DecodeError(t *testing.T) {
+	fg, srv := newFakeGitHub(t)
+	fg.listIssueCommentsPages = []string{`not json`}
+	c, _ := newTestClient(t, srv, nil)
+
+	_, err := c.ListIssueComments(context.Background(), 1, RepoRef{Owner: "x", Name: "y"}, 1)
+	if err == nil {
+		t.Fatalf("expected decode error")
+	}
+}
+
+func TestListIssueComments_ValidationErrors(t *testing.T) {
+	c := &Client{Tokens: &stubTokens{}}
+	if _, err := c.ListIssueComments(context.Background(), 1, RepoRef{}, 1); err == nil {
+		t.Errorf("expected error for empty repo")
+	}
+	if _, err := c.ListIssueComments(context.Background(), 1, RepoRef{Owner: "x", Name: "y"}, 0); err == nil {
+		t.Errorf("expected error for zero issue number")
+	}
+	c2 := &Client{}
+	if _, err := c2.ListIssueComments(context.Background(), 1, RepoRef{Owner: "x", Name: "y"}, 1); err == nil {
+		t.Errorf("expected error for missing TokenProvider")
 	}
 }
 

--- a/backend/internal/server/prompt.go
+++ b/backend/internal/server/prompt.go
@@ -94,6 +94,7 @@ func scopeFilesFromPlan(p *plan.Plan) []scopeFile {
 // in production.
 type issueGetter interface {
 	GetIssue(ctx context.Context, installationID int64, repo githubclient.RepoRef, number int) (*githubclient.Issue, error)
+	ListIssueComments(ctx context.Context, installationID int64, repo githubclient.RepoRef, number int) ([]githubclient.FetchedIssueComment, error)
 }
 
 // handleGetStagePrompt implements GET /v0/stages/{stage_id}/prompt.
@@ -698,8 +699,8 @@ func (s *Server) fillIssueContext(ctx context.Context, github issueGetter, runRo
 		trigger.IssueBody = runRow.IssueContext.Body
 		// Comments (#618): map the cached comment snapshot into the
 		// trigger so the plan-stage prompt can render comment-borne
-		// refinements. Branch 2 (webhook fetch) does not yet fetch
-		// comments — see the follow-up issue referenced in the PR.
+		// refinements. Branch 2 (webhook fetch) fetches comments via
+		// ListIssueComments below to populate the same shape.
 		for _, c := range runRow.IssueContext.Comments {
 			trigger.IssueComments = append(trigger.IssueComments, prompt.IssueComment{
 				Author:    c.Author,
@@ -726,6 +727,28 @@ func (s *Server) fillIssueContext(ctx context.Context, github issueGetter, runRo
 	}
 	trigger.IssueTitle = issue.Title
 	trigger.IssueBody = issue.Body
+
+	// Comments (#621): fetch the issue's comment thread so webhook-
+	// triggered runs render comment-borne refinements identically to
+	// branch 1. Best-effort: a fetch error degrades to title+body
+	// rather than failing the prompt build (same WARN-and-proceed
+	// posture as the GetIssue failure above).
+	comments, err := github.ListIssueComments(ctx, *runRow.InstallationID, repo, issueNumber)
+	if err != nil {
+		s.cfg.Logger.LogAttrs(ctx, slog.LevelWarn, "prompt: list issue comments failed",
+			slog.String("run_id", runRow.ID.String()),
+			slog.Int("issue", issueNumber),
+			slog.String("error", err.Error()),
+		)
+		return
+	}
+	for _, c := range comments {
+		trigger.IssueComments = append(trigger.IssueComments, prompt.IssueComment{
+			Author:    c.Author,
+			Body:      c.Body,
+			CreatedAt: c.CreatedAt,
+		})
+	}
 }
 
 // issueGetter returns the configured client cast to the small

--- a/backend/internal/server/prompt_test.go
+++ b/backend/internal/server/prompt_test.go
@@ -155,6 +155,16 @@ type stubIssueGetter struct {
 	gotInst int64
 	gotRepo githubclient.RepoRef
 	gotNum  int
+
+	// Comment-fetch seam (#621): canned thread + optional error, plus
+	// a recorded-call flag and args so branch-2 tests can assert the
+	// fetch happened with the right installation/repo/number.
+	comments        []githubclient.FetchedIssueComment
+	commentsErr     error
+	commentsCalled  bool
+	commentsGotInst int64
+	commentsGotRepo githubclient.RepoRef
+	commentsGotNum  int
 }
 
 func (s *stubIssueGetter) GetIssue(_ context.Context, installationID int64, repo githubclient.RepoRef, number int) (*githubclient.Issue, error) {
@@ -166,6 +176,17 @@ func (s *stubIssueGetter) GetIssue(_ context.Context, installationID int64, repo
 		return nil, s.getErr
 	}
 	return s.issue, nil
+}
+
+func (s *stubIssueGetter) ListIssueComments(_ context.Context, installationID int64, repo githubclient.RepoRef, number int) ([]githubclient.FetchedIssueComment, error) {
+	s.commentsCalled = true
+	s.commentsGotInst = installationID
+	s.commentsGotRepo = repo
+	s.commentsGotNum = number
+	if s.commentsErr != nil {
+		return nil, s.commentsErr
+	}
+	return s.comments, nil
 }
 
 func newPromptServer(t *testing.T) (*Server, *promptRunRepo, *signingFake, *stubIssueGetter) {
@@ -506,6 +527,99 @@ func TestGetStagePrompt_CachedIssueContext_NoComments(t *testing.T) {
 	}
 	if !contains(resp.Prompt, "Cached body.") {
 		t.Errorf("body-only prompt should still render the body:\n%s", resp.Prompt)
+	}
+}
+
+// TestGetStagePrompt_WebhookFetchedComments_MappedIntoTrigger is the
+// #621 headline check: a webhook-triggered run (InstallationID set, no
+// cached IssueContext) fetches the issue comment thread via branch 2
+// and renders it in the plan-stage prompt. It also proves the shared
+// writeIssueComments bot-filter applies on this path — a [bot]-authored
+// comment is dropped — exercising fetch -> server mapping -> render end
+// to end.
+func TestGetStagePrompt_WebhookFetchedComments_MappedIntoTrigger(t *testing.T) {
+	s, rr, sf, gh := newPromptServer(t)
+	runID := uuid.New()
+	stageID := uuid.New()
+	priv, _ := sf.issue(t, runID)
+
+	var installation int64 = 555
+	triggerRef := "issue:42"
+	rr.runRow = &run.Run{
+		ID:             runID,
+		Repo:           "kuhlman-labs/example",
+		WorkflowID:     "feature_change",
+		TriggerSource:  run.TriggerGitHubIssue,
+		TriggerRef:     &triggerRef,
+		InstallationID: &installation,
+		// No IssueContext — forces branch 2 (webhook fetch).
+	}
+	rr.stage = &run.Stage{ID: stageID, RunID: runID, Type: run.StageTypePlan}
+	gh.issue = &githubclient.Issue{Number: 42, Title: "Add foo", Body: "Body text", State: "open"}
+	gh.comments = []githubclient.FetchedIssueComment{
+		{Author: "alice", Body: "Comment-borne refinement.", CreatedAt: "2026-05-01T10:00:00Z"},
+		{Author: "github-actions[bot]", Body: "CI failed on main.", CreatedAt: "2026-05-01T11:00:00Z"},
+	}
+
+	w := promptRequest(t, s, runID, stageID, priv, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200:\n%s", w.Code, w.Body.String())
+	}
+	if !gh.commentsCalled {
+		t.Fatalf("ListIssueComments should be called on the webhook branch")
+	}
+	if gh.commentsGotInst != installation || gh.commentsGotNum != 42 ||
+		gh.commentsGotRepo != (githubclient.RepoRef{Owner: "kuhlman-labs", Name: "example"}) {
+		t.Errorf("ListIssueComments args = inst %d repo %+v num %d",
+			gh.commentsGotInst, gh.commentsGotRepo, gh.commentsGotNum)
+	}
+	var resp promptResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if !contains(resp.Prompt, "### Issue comments") {
+		t.Errorf("prompt missing comments section:\n%s", resp.Prompt)
+	}
+	if !contains(resp.Prompt, "Comment-borne refinement.") || !contains(resp.Prompt, "@alice") {
+		t.Errorf("prompt missing human comment:\n%s", resp.Prompt)
+	}
+	if contains(resp.Prompt, "CI failed on main.") || contains(resp.Prompt, "github-actions[bot]") {
+		t.Errorf("bot-authored comment should be filtered on the webhook path:\n%s", resp.Prompt)
+	}
+}
+
+// TestGetStagePrompt_WebhookCommentsFetchError_DegradesToBody confirms a
+// ListIssueComments failure on the webhook path is best-effort: the
+// prompt still returns 200 with title+body and no comments section.
+func TestGetStagePrompt_WebhookCommentsFetchError_DegradesToBody(t *testing.T) {
+	s, rr, sf, gh := newPromptServer(t)
+	runID := uuid.New()
+	stageID := uuid.New()
+	priv, _ := sf.issue(t, runID)
+
+	var installation int64 = 555
+	triggerRef := "issue:42"
+	rr.runRow = &run.Run{
+		ID:             runID,
+		Repo:           "kuhlman-labs/example",
+		WorkflowID:     "feature_change",
+		TriggerSource:  run.TriggerGitHubIssue,
+		TriggerRef:     &triggerRef,
+		InstallationID: &installation,
+	}
+	rr.stage = &run.Stage{ID: stageID, RunID: runID, Type: run.StageTypePlan}
+	gh.issue = &githubclient.Issue{Number: 42, Title: "Add foo", Body: "Body text", State: "open"}
+	gh.commentsErr = errors.New("boom")
+
+	w := promptRequest(t, s, runID, stageID, priv, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200:\n%s", w.Code, w.Body.String())
+	}
+	var resp promptResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if !contains(resp.Prompt, "Body text") {
+		t.Errorf("title+body should still render on comment-fetch failure:\n%s", resp.Prompt)
+	}
+	if contains(resp.Prompt, "### Issue comments") {
+		t.Errorf("no comments section expected when the fetch failed:\n%s", resp.Prompt)
 	}
 }
 


### PR DESCRIPTION
## Summary

#618 added issue-comment ingestion into `issue_context` only for **branch 1** of `fillIssueContext` (the operator `gh issue view` fetch). **Branch 2** — the webhook/installation-token path calling `githubclient.GetIssue` — was deliberately left out, so webhook-triggered runs still saw title+body only. This closes that gap.

- **`githubclient.ListIssueComments`** (paginated, follows the `rel="next"` Link header), modeled on the existing `ListTeamMembers` pattern. Returns a new **`FetchedIssueComment{Author, Body, CreatedAt}`** shape — named distinctly from the pre-existing `IssueComment{ID, Body, HTMLURL}` PATCH-response type to avoid a duplicate-type collision.
- **Branch 2 wiring** in `fillIssueContext`: after `GetIssue`, fetch comments over the installation token and map them into the same `prompt.IssueComment` slice branch 1 builds. **Best-effort** — a fetch error WARN-logs and degrades to title+body, never failing the prompt fetch.
- **Reuses `prompt.writeIssueComments` unchanged** (#618): bot-filter, per-comment 2000-byte cap, 12000-byte total budget — no prompt-side changes.

## Test plan

`go build ./...` + `golangci-lint run ./internal/githubclient/ ./internal/server/` → clean. New tests (all green):

- `TestListIssueComments_HappyPath` / `_Paginates` (two-page accumulation via Link header) / `_NotFound` / `_DecodeError` / `_ValidationErrors`.
- `TestGetStagePrompt_WebhookFetchedComments_MappedIntoTrigger` — **handler-level integration test** crossing fetch→server→render: asserts fetched comments + `@alice` render, and a `github-actions[bot]` comment is **filtered** out.
- `TestGetStagePrompt_WebhookCommentsFetchError_DegradesToBody` — fetch error → title+body-only prompt, no error.

## Notes

Pure additive change across 4 files; no schema/wire/env change (rollback = revert). The advisory plan reviewer caught a type-name collision (`IssueComment` already exists); resolved at the plan gate via a binding rename condition (`FetchedIssueComment`), honored exactly.

Paired follow-on: **#622** renders these comments in the plan-review and implement-review prompts (next on the roadmap).

Closes #621