### PR TITLE
Render issue comments in the plan-review and implement-review prompts

### DIFF
--- a/backend/internal/prompt/prompt.go
+++ b/backend/internal/prompt/prompt.go
@@ -139,11 +139,12 @@ type Trigger struct {
 	// (#244).
 	IssueBody string
 	// IssueComments are the issue's comments at trigger time, a
-	// snapshot captured alongside IssueBody (#618). Only the
-	// plan-stage prompt renders them — after the body — so
-	// comment-borne refinements/decisions reach the plan agent on
-	// the first attempt. Empty/nil for non-issue triggers, issues
-	// with no comments, or runs whose issue_context predates #618.
+	// snapshot captured alongside IssueBody (#618). The plan-stage,
+	// plan-review, and implement-review prompts render them — after
+	// the body — so comment-borne refinements/decisions reach the
+	// plan agent and both reviewers on the first attempt (#622).
+	// Empty/nil for non-issue triggers, issues with no comments, or
+	// runs whose issue_context predates #618.
 	IssueComments []IssueComment
 	// IssueURL is the canonical github.com URL for the triggering
 	// issue. Set by the server-side prompt handler from
@@ -540,27 +541,7 @@ func buildPlanReview(t Trigger) string {
 
 	// Issue context: give the reviewer the originating motivation so
 	// they can assess whether the plan actually addresses the issue.
-	if t.IssueNumber > 0 || t.IssueTitle != "" || t.IssueBody != "" {
-		b.WriteString("### Originating issue\n\n")
-		if t.IssueNumber > 0 {
-			fmt.Fprintf(&b, "Issue: #%d", t.IssueNumber)
-			if t.IssueTitle != "" {
-				b.WriteString(" · ")
-				b.WriteString(t.IssueTitle)
-			}
-			b.WriteString("\n")
-		} else if t.IssueTitle != "" {
-			b.WriteString("Title: ")
-			b.WriteString(t.IssueTitle)
-			b.WriteString("\n")
-		}
-		if t.IssueBody != "" {
-			b.WriteString("\n")
-			b.WriteString(t.IssueBody)
-			b.WriteString("\n")
-		}
-		b.WriteString("\n")
-	}
+	writeReviewIssueContext(&b, t)
 
 	// Verdict schema — inline so the reviewer doesn't need to fetch it.
 	// The JSON shape below is load-bearing and kept verbatim; surrounding
@@ -687,27 +668,7 @@ func buildImplementReview(t Trigger) string {
 	}
 
 	// Issue context: the originating motivation.
-	if t.IssueNumber > 0 || t.IssueTitle != "" || t.IssueBody != "" {
-		b.WriteString("### Originating issue\n\n")
-		if t.IssueNumber > 0 {
-			fmt.Fprintf(&b, "Issue: #%d", t.IssueNumber)
-			if t.IssueTitle != "" {
-				b.WriteString(" · ")
-				b.WriteString(t.IssueTitle)
-			}
-			b.WriteString("\n")
-		} else if t.IssueTitle != "" {
-			b.WriteString("Title: ")
-			b.WriteString(t.IssueTitle)
-			b.WriteString("\n")
-		}
-		if t.IssueBody != "" {
-			b.WriteString("\n")
-			b.WriteString(t.IssueBody)
-			b.WriteString("\n")
-		}
-		b.WriteString("\n")
-	}
+	writeReviewIssueContext(&b, t)
 
 	// Verdict schema — inline so the reviewer doesn't need to fetch it.
 	b.WriteString("### Verdict schema\n\n")
@@ -946,6 +907,38 @@ func writeIssueContext(b *strings.Builder, t Trigger) {
 		fmt.Fprintf(b, "Triggering issue: #%d\n", t.IssueNumber)
 	}
 	if t.IssueTitle != "" {
+		b.WriteString("Title: ")
+		b.WriteString(t.IssueTitle)
+		b.WriteString("\n")
+	}
+	if t.IssueBody != "" {
+		b.WriteString("\n")
+		b.WriteString(t.IssueBody)
+		b.WriteString("\n")
+	}
+	writeIssueComments(b, t.IssueComments)
+	b.WriteString("\n")
+}
+
+// writeReviewIssueContext renders the "### Originating issue" block shared by
+// the plan-review and implement-review prompts (#622). It mirrors
+// writeIssueContext's ordering — title/body then the bot-filtered,
+// budget-capped issue comments via writeIssueComments — so the reviewers judge
+// the plan/diff against the same comment-borne refinements the planner saw
+// (#618). Renders nothing when no issue context is present.
+func writeReviewIssueContext(b *strings.Builder, t Trigger) {
+	if t.IssueNumber == 0 && t.IssueTitle == "" && t.IssueBody == "" {
+		return
+	}
+	b.WriteString("### Originating issue\n\n")
+	if t.IssueNumber > 0 {
+		fmt.Fprintf(b, "Issue: #%d", t.IssueNumber)
+		if t.IssueTitle != "" {
+			b.WriteString(" · ")
+			b.WriteString(t.IssueTitle)
+		}
+		b.WriteString("\n")
+	} else if t.IssueTitle != "" {
 		b.WriteString("Title: ")
 		b.WriteString(t.IssueTitle)
 		b.WriteString("\n")

--- a/backend/internal/prompt/prompt_test.go
+++ b/backend/internal/prompt/prompt_test.go
@@ -1510,6 +1510,135 @@ func TestBuild_ImplementReview_ProducesNoPRDescriptionGuidance(t *testing.T) {
 	}
 }
 
+// TestBuild_PlanReview_IssueCommentsRendered is the #622 acceptance check
+// for the plan-review path: the reviewer must see the same comment-borne
+// refinements the planner saw, with the supersede preface, author +
+// timestamp prefixes, and chronological order after the body.
+func TestBuild_PlanReview_IssueCommentsRendered(t *testing.T) {
+	got, err := Build("plan_review", Trigger{
+		IssueNumber:  616,
+		IssueTitle:   "Add a foo flag",
+		IssueBody:    "We need a --foo flag that defaults to off.",
+		Repo:         "x/y",
+		ApprovedPlan: fixturePlan(),
+		IssueComments: []IssueComment{
+			{Author: "alice", Body: "First thought: make it a bool.", CreatedAt: "2026-05-01T10:00:00Z"},
+			{Author: "bob", Body: "Correction: --foo must default to ON, not off.", CreatedAt: "2026-05-02T12:30:00Z"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	wants := []string{
+		"### Issue comments",
+		"supersede", // the preface
+		"**@alice** (2026-05-01T10:00:00Z):",
+		"First thought: make it a bool.",
+		"**@bob** (2026-05-02T12:30:00Z):",
+		"Correction: --foo must default to ON, not off.",
+	}
+	for _, w := range wants {
+		if !strings.Contains(got, w) {
+			t.Errorf("plan_review prompt missing %q\n---\n%s", w, got)
+		}
+	}
+	// Chronological order: body, then alice, then bob.
+	bodyIdx := strings.Index(got, "We need a --foo flag")
+	aliceIdx := strings.Index(got, "**@alice**")
+	bobIdx := strings.Index(got, "**@bob**")
+	if bodyIdx >= aliceIdx || aliceIdx >= bobIdx {
+		t.Errorf("expected body < alice < bob ordering, got body=%d alice=%d bob=%d", bodyIdx, aliceIdx, bobIdx)
+	}
+}
+
+// TestBuild_PlanReview_AllBotComments_SectionAbsent confirms the
+// plan-review prompt is byte-identical to the no-comments case when every
+// comment is bot-authored — the body-only review prompt is unchanged.
+func TestBuild_PlanReview_AllBotComments_SectionAbsent(t *testing.T) {
+	got, err := Build("plan_review", Trigger{
+		IssueNumber:  7,
+		IssueTitle:   "T",
+		IssueBody:    "Body stays.",
+		Repo:         "x/y",
+		ApprovedPlan: fixturePlan(),
+		IssueComments: []IssueComment{
+			{Author: "github-actions[bot]", Body: "CI failed.", CreatedAt: "2026-05-01T00:00:00Z"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if strings.Contains(got, "### Issue comments") {
+		t.Errorf("plan_review section must be absent when all comments are bot-authored:\n%s", got)
+	}
+	if !strings.Contains(got, "Body stays.") {
+		t.Errorf("plan_review body-only fallback should be unchanged:\n%s", got)
+	}
+}
+
+// TestBuild_ImplementReview_IssueCommentsRendered is the #622 acceptance
+// check for the implement-review path: the reviewer sees the comment-borne
+// refinements with preface, author + timestamp, and chronological order.
+func TestBuild_ImplementReview_IssueCommentsRendered(t *testing.T) {
+	got, err := Build("implement_review", Trigger{
+		IssueNumber:  616,
+		IssueTitle:   "Add a foo flag",
+		IssueBody:    "We need a --foo flag that defaults to off.",
+		Repo:         "x/y",
+		ApprovedPlan: fixturePlan(),
+		Diff:         "- M pkg/foo/foo.go\n",
+		IssueComments: []IssueComment{
+			{Author: "alice", Body: "First thought: make it a bool.", CreatedAt: "2026-05-01T10:00:00Z"},
+			{Author: "bob", Body: "Correction: --foo must default to ON, not off.", CreatedAt: "2026-05-02T12:30:00Z"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	wants := []string{
+		"### Issue comments",
+		"supersede",
+		"**@alice** (2026-05-01T10:00:00Z):",
+		"First thought: make it a bool.",
+		"**@bob** (2026-05-02T12:30:00Z):",
+		"Correction: --foo must default to ON, not off.",
+	}
+	for _, w := range wants {
+		if !strings.Contains(got, w) {
+			t.Errorf("implement_review prompt missing %q\n---\n%s", w, got)
+		}
+	}
+	bodyIdx := strings.Index(got, "We need a --foo flag")
+	aliceIdx := strings.Index(got, "**@alice**")
+	bobIdx := strings.Index(got, "**@bob**")
+	if bodyIdx >= aliceIdx || aliceIdx >= bobIdx {
+		t.Errorf("expected body < alice < bob ordering, got body=%d alice=%d bob=%d", bodyIdx, aliceIdx, bobIdx)
+	}
+}
+
+// TestBuild_ImplementReview_NilComments_SectionAbsent confirms the
+// implement-review body-only fallback is unchanged when no comments are
+// present (the pre-#622 shape).
+func TestBuild_ImplementReview_NilComments_SectionAbsent(t *testing.T) {
+	got, err := Build("implement_review", Trigger{
+		IssueNumber:  7,
+		IssueTitle:   "T",
+		IssueBody:    "Just the body.",
+		Repo:         "x/y",
+		ApprovedPlan: fixturePlan(),
+		Diff:         "- M pkg/foo/foo.go\n",
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if strings.Contains(got, "### Issue comments") {
+		t.Errorf("implement_review section expected absent for nil IssueComments:\n%s", got)
+	}
+	if !strings.Contains(got, "Just the body.") {
+		t.Errorf("implement_review body should still render:\n%s", got)
+	}
+}
+
 // TestBuild_Plan_IssueCommentsRendered is the headline #618 / #616
 // acceptance check: a comment that contradicts the body renders in the
 // '### Issue comments' section with its author + timestamp and the

--- a/backend/internal/server/plan.go
+++ b/backend/internal/server/plan.go
@@ -512,6 +512,16 @@ func (s *Server) runPlanReviews(ctx context.Context, runID, stageID uuid.UUID, p
 	if runRow.IssueContext != nil {
 		trig.IssueTitle = runRow.IssueContext.Title
 		trig.IssueBody = runRow.IssueContext.Body
+		// Map the cached comments so the plan-review prompt renders the
+		// same comment-borne refinements the planner saw (#622) — identical
+		// shape to fillIssueContext branch 1.
+		for _, c := range runRow.IssueContext.Comments {
+			trig.IssueComments = append(trig.IssueComments, prompt.IssueComment{
+				Author:    c.Author,
+				Body:      c.Body,
+				CreatedAt: c.CreatedAt,
+			})
+		}
 	}
 	if runRow.TriggerRef != nil {
 		if n, ok := parseIssueRef(*runRow.TriggerRef); ok {

--- a/backend/internal/server/plan_test.go
+++ b/backend/internal/server/plan_test.go
@@ -817,6 +817,54 @@ func TestShipPlan_ReviewAgents_Advisory_RecordsVerdictDoesNotBlock(t *testing.T)
 	}
 }
 
+// TestShipPlan_ReviewAgents_IssueCommentsReachReviewPrompt is the #622
+// cross-boundary check: a comment cached on the run's IssueContext must
+// flow through the server's plan-review trigger mapping into the rendered
+// plan-review prompt. This crosses the persistence(IssueContext) -> server
+// trigger mapping -> prompt render seam that the per-layer prompt-package
+// tests cannot exercise (the bug fixed here was precisely a missing mapping
+// at that seam, cf. #618).
+func TestShipPlan_ReviewAgents_IssueCommentsReachReviewPrompt(t *testing.T) {
+	runID, stageID := uuid.New(), uuid.New()
+	reviewer := &fakePlanReviewer{
+		verdict: &planreview.ReviewVerdict{Verdict: planreview.VerdictApprove},
+		model:   "claude-sonnet-4-6",
+	}
+	s, sf, _, _, rr := newPlanServerWithReviewer(t, runID, stageID, reviewer, specAdvisoryReviewers)
+	// Seed the cached issue context with a comment that refines the body.
+	rr.getRuns[runID].IssueContext = &run.IssueContext{
+		Title:  "Add a foo flag",
+		Body:   "We need a --foo flag that defaults to off.",
+		Number: 622,
+		Comments: []run.IssueComment{
+			{Author: "carol", Body: "Correction: --foo must default to ON.", CreatedAt: "2026-05-02T00:00:00Z"},
+		},
+	}
+	priv, _ := sf.issue(t, runID)
+	body := validPlanBytes(t)
+
+	w := shipPlanRequest(t, s, runID, stageID, priv, body, "")
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201:\n%s", w.Code, w.Body.String())
+	}
+	// Advisory review runs detached (#584); drain it before inspecting the
+	// captured prompt.
+	s.waitBackgroundReviews()
+
+	reviewer.mu.Lock()
+	defer reviewer.mu.Unlock()
+	if len(reviewer.calls) != 1 {
+		t.Fatalf("reviewer calls = %d, want 1", len(reviewer.calls))
+	}
+	got := reviewer.calls[0]
+	if !strings.Contains(got, "Correction: --foo must default to ON.") {
+		t.Errorf("plan-review prompt missing the cached issue comment body — mapping seam broken:\n%s", got)
+	}
+	if !strings.Contains(got, "### Issue comments") {
+		t.Errorf("plan-review prompt missing the issue-comments section:\n%s", got)
+	}
+}
+
 // TestShipPlan_ReviewAgents_GatingReject_StageFailedB verifies that in
 // gating mode (agent>0 && human==0) a reject verdict transitions the
 // stage to failed-B so trace-driven awaiting_approval is blocked.

--- a/backend/internal/server/trace.go
+++ b/backend/internal/server/trace.go
@@ -969,6 +969,16 @@ func (s *Server) runImplementReviews(ctx context.Context, runID, stageID uuid.UU
 	if runRow.IssueContext != nil {
 		trig.IssueTitle = runRow.IssueContext.Title
 		trig.IssueBody = runRow.IssueContext.Body
+		// Map the cached comments so the implement-review prompt renders the
+		// same comment-borne refinements the planner saw (#622) — identical
+		// shape to fillIssueContext branch 1.
+		for _, c := range runRow.IssueContext.Comments {
+			trig.IssueComments = append(trig.IssueComments, prompt.IssueComment{
+				Author:    c.Author,
+				Body:      c.Body,
+				CreatedAt: c.CreatedAt,
+			})
+		}
 	}
 	if runRow.TriggerRef != nil {
 		if n, ok := parseIssueRef(*runRow.TriggerRef); ok {


### PR DESCRIPTION
## Summary

#618 rendered issue comments in the **plan** prompt, but the **review** builders render issue context inline and never called the shared renderer — so the plan-review and implement-review agents judged against **title+body only**. That's a coherence gap: the planner saw comment-borne refinements the reviewer couldn't, so the reviewer could flag a concern a comment already resolved. (Flagged by the plan-review agent itself during #618's review.)

- **Factor `writeReviewIssueContext(b, t)`** — renders the `### Originating issue` block and calls `writeIssueComments`, reusing the bot-filter, per-comment + total byte budget, and supersede preface verbatim. `buildPlanReview` and `buildImplementReview` now call it (net DRY: −47/+ lines in the inline blocks).
- **The real substance — two server-side mappings.** The review triggers are built in `server/plan.go` (`runPlanReviews`) and `server/trace.go` (implement-review), **not** `fillIssueContext`, and those sites mapped only Title/Body. Map `IssueContext.Comments → trig.IssueComments` at both, or the render has nothing to show.
- Update the stale `Trigger.IssueComments` doc comment.

## Test plan

`go build ./...` + `golangci-lint run ./internal/prompt/ ./internal/server/` → clean. New tests (all green):

- `TestBuild_PlanReview_IssueCommentsRendered` / `TestBuild_ImplementReview_IssueCommentsRendered` — comments section, supersede preface, author+timestamp, chronological order.
- `TestBuild_PlanReview_AllBotComments_SectionAbsent` / `TestBuild_ImplementReview_NilComments_SectionAbsent` — absent-section cases.
- `TestShipPlan_ReviewAgents_IssueCommentsReachReviewPrompt` — **server-level integration test** driving the plan-review path with a populated `runRow.IssueContext.Comments`, asserting the comment body reaches the prompt captured by `fakePlanReviewer` (crosses persistence→server-mapping→render).
- Existing `TrimmedBelowBaseline` + split-marker tests **unaffected** — an empty-comments review prompt is byte-identical to before.

## Notes

Pure additive prompt content + two server trigger mappings; no schema/wire/env change (rollback = revert). Completes the #618→#621→#622 comment-context arc: ingested (#618/#621), now visible to the planner **and** both review agents. The review path reads only the cached `runRow.IssueContext` (consistent with the existing Title/Body behavior there); no live fetch added.

Closes #622