### PR TITLE
Make the claudecode reviewer retry budget operator-tunable

### DIFF
--- a/backend/cmd/fishhawkd/main_test.go
+++ b/backend/cmd/fishhawkd/main_test.go
@@ -106,3 +106,35 @@ func TestEnvOr(t *testing.T) {
 		}
 	})
 }
+
+// TestEnvOrInt_PlanReviewMaxRetries covers the FISHHAWKD_PLAN_REVIEW_MAX_RETRIES
+// resolution through envOrInt: unset->default, explicit "0"->0 (the retry-
+// disable path, NOT treated as empty), a positive value, and a non-integer
+// falling back to the default.
+func TestEnvOrInt_PlanReviewMaxRetries(t *testing.T) {
+	const key = "FISHHAWKD_PLAN_REVIEW_MAX_RETRIES"
+	t.Run("unset returns default 1", func(t *testing.T) {
+		t.Setenv(key, "")
+		if got := envOrInt(key, 1); got != 1 {
+			t.Errorf("got %d, want 1", got)
+		}
+	})
+	t.Run("explicit 0 resolves to 0", func(t *testing.T) {
+		t.Setenv(key, "0")
+		if got := envOrInt(key, 1); got != 0 {
+			t.Errorf("got %d, want 0 (explicit 0 must reach the setter as disable)", got)
+		}
+	})
+	t.Run("positive value resolves verbatim", func(t *testing.T) {
+		t.Setenv(key, "3")
+		if got := envOrInt(key, 1); got != 3 {
+			t.Errorf("got %d, want 3", got)
+		}
+	})
+	t.Run("non-integer falls back to default", func(t *testing.T) {
+		t.Setenv(key, "notanint")
+		if got := envOrInt(key, 1); got != 1 {
+			t.Errorf("got %d, want 1 (garbage falls back to default)", got)
+		}
+	})
+}

--- a/backend/cmd/fishhawkd/serve.go
+++ b/backend/cmd/fishhawkd/serve.go
@@ -142,6 +142,11 @@ func runServe(args []string, logSink io.Writer) int {
 	planReviewMaxTokens := fs.Int("plan-review-max-tokens",
 		envOrInt("FISHHAWKD_PLAN_REVIEW_MAX_TOKENS", 4096),
 		"maximum tokens for plan-review agent responses")
+	planReviewMaxRetries := fs.Int("plan-review-max-retries",
+		envOrInt("FISHHAWKD_PLAN_REVIEW_MAX_RETRIES", 1),
+		"in-adapter retry budget for the local-mode `claude` reviewer's transient-crash class (#620); "+
+			"counts retries not attempts (N => N+1 attempts), 0 disables retry (single attempt), unset defaults to 1. "+
+			"Used only by the claudecode adapter — the anthropic SDK adapter has no retry field")
 	planReviewTimeout := fs.Duration("plan-review-timeout",
 		envOrDuration("FISHHAWKD_PLAN_REVIEW_TIMEOUT", 300*time.Second),
 		"effective per-invocation bound for plan-review agent calls (since #584); "+
@@ -177,17 +182,23 @@ func runServe(args []string, logSink io.Writer) int {
 			slog.Int("max_tokens", *planReviewMaxTokens),
 			slog.Duration("timeout", *planReviewTimeout))
 	case *enableLocalClaudeReviewer:
-		cfg.PlanReviewer = claudecode.NewReviewer(claudecode.Config{
+		reviewer := claudecode.NewReviewer(claudecode.Config{
 			Binary:    *localClaudeBinary,
 			Model:     *localClaudeModel,
 			MaxTokens: *planReviewMaxTokens,
 			Timeout:   *planReviewTimeout,
 		})
+		// Apply the env-resolved retry budget past NewClient's zero->1
+		// normalisation: an explicit 0 means retry disabled (single
+		// attempt), which the constructor alone cannot express.
+		reviewer.SetMaxRetries(*planReviewMaxRetries)
+		cfg.PlanReviewer = reviewer
 		logger.Info("plan review agent configured",
 			slog.String("adapter", "claudecode"),
 			slog.String("binary", *localClaudeBinary),
 			slog.String("model", *localClaudeModel),
 			slog.Int("max_tokens", *planReviewMaxTokens),
+			slog.Int("max_retries", *planReviewMaxRetries),
 			slog.Duration("timeout", *planReviewTimeout))
 	default:
 		// #574 / ADR-027: tightened from the plain "gateless" warning so

--- a/backend/internal/claudecode/reviewer.go
+++ b/backend/internal/claudecode/reviewer.go
@@ -31,6 +31,22 @@ func NewReviewer(cfg Config) *Reviewer {
 	return &Reviewer{client: NewClient(cfg)}
 }
 
+// SetMaxRetries overrides the retry budget on the underlying Client AFTER
+// construction, assigning n directly and bypassing NewClient's zero->1
+// normalisation. This is the explicit-override path the env wiring uses: Go
+// cannot distinguish an unset field from an explicit 0, so NewClient always
+// defaults a zero MaxRetries to 1 (production retries a transient crash once),
+// and an operator who passes 0 to disable retry must route through this setter.
+// A negative n is clamped to 0 (a single attempt, retry disabled). The caller
+// owns the default — this mirrors the documented "set MaxRetries after
+// NewClient" idiom on Config.MaxRetries.
+func (r *Reviewer) SetMaxRetries(n int) {
+	if n < 0 {
+		n = 0
+	}
+	r.client.cfg.MaxRetries = n
+}
+
 // Review invokes the `claude` CLI with the full promptText, JSON-decodes the
 // envelope's result text into a ReviewVerdict, and validates the verdict
 // belongs to the closed set. Subprocess failure, non-JSON output, and an

--- a/backend/internal/claudecode/reviewer_test.go
+++ b/backend/internal/claudecode/reviewer_test.go
@@ -42,6 +42,11 @@ func TestHelperProcess(t *testing.T) {
 		// itself, surfacing as an *exec.ExitError ("signal: killed") with
 		// ctx.Err()==nil (an external/OOM kill, the retryable class).
 		_ = syscall.Kill(os.Getpid(), syscall.SIGKILL)
+		// SIGKILL delivery is asynchronous; block so the deferred
+		// os.Exit(0) cannot win the race and exit 0 with empty output
+		// before the signal lands (which would surface as a non-retryable
+		// decode error and flake the retry-class tests).
+		select {}
 	case "slow":
 		// Sleep past a short Timeout so the per-attempt deadline fires and
 		// the child is killed with ctx.Err()==DeadlineExceeded (the
@@ -236,6 +241,58 @@ func TestReviewer_RetryDisabled(t *testing.T) {
 	}
 	if attempts != 1 {
 		t.Errorf("attempts = %d, want 1 (MaxRetries=0 disables retry)", attempts)
+	}
+}
+
+// TestReviewer_SetMaxRetriesDisablesRetry asserts SetMaxRetries(0) yields a
+// single attempt even on the retryable crash class — proving the explicit-0
+// override bypasses NewClient's zero->1 normalisation (the env disable path).
+func TestReviewer_SetMaxRetriesDisablesRetry(t *testing.T) {
+	var attempts int
+	r := NewReviewer(testConfig())
+	r.SetMaxRetries(0)
+	r.client.Cmd = countingHelperCommand("killed", &attempts)
+
+	_, _, err := r.Review(context.Background(), "review this plan")
+	if err == nil {
+		t.Fatal("expected error from crashing subprocess, got nil")
+	}
+	if attempts != 1 {
+		t.Errorf("attempts = %d, want 1 (SetMaxRetries(0) disables retry)", attempts)
+	}
+}
+
+// TestReviewer_SetMaxRetriesBudget asserts SetMaxRetries(3) yields 4 attempts
+// (N retries => N+1 attempts) on a persistently retryable crash.
+func TestReviewer_SetMaxRetriesBudget(t *testing.T) {
+	var attempts int
+	r := NewReviewer(testConfig())
+	r.SetMaxRetries(3)
+	r.client.Cmd = countingHelperCommand("killed", &attempts)
+
+	_, _, err := r.Review(context.Background(), "review this plan")
+	if err == nil {
+		t.Fatal("expected error from exhausted retries, got nil")
+	}
+	if attempts != 4 {
+		t.Errorf("attempts = %d, want 4 (SetMaxRetries(3) => 3+1 attempts)", attempts)
+	}
+}
+
+// TestReviewer_SetMaxRetriesClampsNegative asserts a negative budget is clamped
+// to 0, yielding a single attempt rather than panicking or looping unbounded.
+func TestReviewer_SetMaxRetriesClampsNegative(t *testing.T) {
+	var attempts int
+	r := NewReviewer(testConfig())
+	r.SetMaxRetries(-1)
+	r.client.Cmd = countingHelperCommand("killed", &attempts)
+
+	_, _, err := r.Review(context.Background(), "review this plan")
+	if err == nil {
+		t.Fatal("expected error from crashing subprocess, got nil")
+	}
+	if attempts != 1 {
+		t.Errorf("attempts = %d, want 1 (negative budget clamps to 0)", attempts)
 	}
 }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -117,12 +117,15 @@ When a stage's `reviewers.agent > 0` is configured in the workflow spec, the bac
 | `FISHHAWKD_ANTHROPIC_API_KEY` | `` (empty) | Anthropic API key; empty disables the SDK adapter |
 | `FISHHAWKD_PLAN_REVIEW_MODEL` | `claude-sonnet-4-6` | Model used for each SDK review invocation |
 | `FISHHAWKD_PLAN_REVIEW_MAX_TOKENS` | `4096` | Maximum output tokens per review call (both adapters) |
+| `FISHHAWKD_PLAN_REVIEW_MAX_RETRIES` | `1` | Bounds the local-mode `claude` reviewer's in-adapter transient-crash retry (#620). Counts **retries, not attempts** (N retries => N+1 attempts). Unset defaults to 1 (one retry); an explicit `0` disables retry (single attempt); negatives clamp to 0. Governs only the claudecode adapter — the anthropic SDK adapter has no retry field. |
 | `FISHHAWKD_PLAN_REVIEW_TIMEOUT` | `300s` | Per-invocation timeout (both adapters). Since #584 this is the **effective** per-invocation bound: the reviewer context is detached from the upload request via `context.WithoutCancel`, so the adapter's own `context.WithTimeout(reviewCtx, this)` is no longer clamped by the runner's upload-client disconnect. Raised 60s→300s in #606 to cover review of large (10+ file) `standard_v1` plans observed timing out at the old bound; small plans still finish well inside it. The env override is unchanged. Distinct from the ~1s immediate-crash mode owned by #620. See **Review dispatch: advisory-async vs. gating-sync** below. |
 | `FISHHAWKD_ENABLE_LOCAL_CLAUDE_REVIEWER` | `false` | Opt-in local-mode subprocess adapter; ignored when the API key is set |
 | `FISHHAWKD_LOCAL_CLAUDE_BINARY` | `claude` | Executable name/path for the local-mode `claude` CLI |
 | `FISHHAWKD_LOCAL_CLAUDE_MODEL` | `claude-sonnet-4-6` | Model the local-mode `claude` CLI uses for review |
 
 **Local-mode wire-up** (`backend/internal/claudecode/`, #575). The local-mode adapter is the dogfood sibling of `anthropic.Reviewer`: instead of provisioning an API key, it spawns the operator's existing `claude` CLI as a subprocess (`claude --print --output-format json --model <model> -p <prompt>`), inheriting `os.Environ()` so the operator's subscription auth or already-present `ANTHROPIC_API_KEY` is reused with zero new plumbing. It decodes the CLI's single JSON envelope, reads the `result` field, and validates the verdict against the same closed set (`approve` / `approve_with_concerns` / `reject`) as the SDK adapter.
+
+The retry budget (`FISHHAWKD_PLAN_REVIEW_MAX_RETRIES`, see the env-var table) is wired through a post-construction `(*claudecode.Reviewer).SetMaxRetries` call rather than `claudecode.Config.MaxRetries` directly: `NewClient` normalises a zero `MaxRetries` to 1, so passing the env value through the constructor could never express *disable*. `serve.go` therefore constructs the reviewer, then calls `SetMaxRetries(*planReviewMaxRetries)` to assign the env-resolved value past that normalisation. The result: unset → 1 (one retry, unchanged from #620's code default), an explicit `0` → retry disabled (single attempt), `N` → N+1 attempts, and a negative value clamps to 0.
 
 Recommended local config for dogfooding (copy-pasteable):
 


### PR DESCRIPTION
## Summary

#620 added a bounded retry to the local `claudecode` reviewer (`claudecode.Config.MaxRetries`, defaulted to 1) as a **code-level default only**. This exposes it as the operator env var **`FISHHAWKD_PLAN_REVIEW_MAX_RETRIES`**, alongside the existing `FISHHAWKD_PLAN_REVIEW_TIMEOUT`/`_MODEL`/`_MAX_TOKENS` knobs.

**The crux — zero-normalization.** `NewClient` normalizes any zero `MaxRetries` to 1 (Go can't distinguish unset from explicit `0`), so the env value can't express *disable* through the constructor. Resolved with an exported post-construction setter **`(*Reviewer).SetMaxRetries(n)`** that assigns past the normalization (negatives clamped to 0). `serve.go` constructs the reviewer, then calls `SetMaxRetries(envOrInt("FISHHAWKD_PLAN_REVIEW_MAX_RETRIES", 1))`:

- unset → **1** (one retry, unchanged from #620)
- explicit **`0`** → retry disabled (single attempt)
- **`N`** → N+1 attempts
- negative → clamps to 0

Only the claudecode adapter is wired — the anthropic SDK adapter has no retry field (verified). Scope is env-var-only; the `MaxRetries` doc-comment correction already shipped separately in `f56c5ce`.

## Test plan

`go build ./...` + `golangci-lint run ./internal/claudecode/ ./cmd/fishhawkd/` → clean. Tests (all green):

- `TestReviewer_SetMaxRetriesDisablesRetry` (0 → single attempt), `_SetMaxRetriesBudget` (N → N+1), `_SetMaxRetriesClampsNegative` — asserted via the fake-`Cmd` harness on the **retryable external/OOM fault class** through `Client.Inference`'s real retry loop (not a mock).
- `TestEnvOrInt_PlanReviewMaxRetries` — unset→1, `"0"`→0, `"3"`→3, garbage→1.

## Notes

Additive: one env var, one exported setter, doc rows; no schema/wire/persistence change (rollback = revert; unset reproduces the exact pre-change default). In-process config wiring, no serialization seam → no integration test needed. Follow-up from #620.

Closes #634