### PR TITLE
Fix cost rollup: record once per bundle + surface cost fields in run API

### DIFF
--- a/backend/internal/server/runs.go
+++ b/backend/internal/server/runs.go
@@ -37,8 +37,15 @@ type runResponse struct {
 	MaxRetriesSnapshot int                  `json:"max_retries_snapshot"`
 	RunnerKind         string               `json:"runner_kind"`
 	IssueContext       *issueContextPayload `json:"issue_context,omitempty"`
-	CreatedAt          time.Time            `json:"created_at"`
-	UpdatedAt          time.Time            `json:"updated_at"`
+	// CostUSDTotal is the rolled estimated USD cost of the run's model
+	// usage from signed manifest token counts (#649). Always emitted (0
+	// for legacy rows that predate the rollup).
+	CostUSDTotal float64 `json:"cost_usd_total"`
+	// ResolvedModel pins the agent model id the run executed under
+	// (#649). Always emitted (empty string for legacy/unstamped runs).
+	ResolvedModel string    `json:"resolved_model"`
+	CreatedAt     time.Time `json:"created_at"`
+	UpdatedAt     time.Time `json:"updated_at"`
 }
 
 // issueContextPayload mirrors run.IssueContext on the wire. Kept
@@ -78,6 +85,8 @@ func toRunResponse(r *run.Run) runResponse {
 		RetryAttempt:       r.RetryAttempt,
 		MaxRetriesSnapshot: r.MaxRetriesSnapshot,
 		RunnerKind:         r.RunnerKind,
+		CostUSDTotal:       r.CostUSDTotal,
+		ResolvedModel:      r.ResolvedModel,
 		CreatedAt:          r.CreatedAt,
 		UpdatedAt:          r.UpdatedAt,
 	}

--- a/backend/internal/server/runs_test.go
+++ b/backend/internal/server/runs_test.go
@@ -1,12 +1,16 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/kuhlman-labs/fishhawk/backend/internal/run"
 )
 
 func TestErrorEnvelope_Shape(t *testing.T) {
@@ -24,5 +28,56 @@ func TestErrorEnvelope_Shape(t *testing.T) {
 	}
 	if env.Error.Code == "" || env.Error.Message == "" {
 		t.Errorf("error envelope missing code/message: %+v", env)
+	}
+}
+
+// TestGetRun_SurfacesCostFields closes the persist→response seam for the
+// cost rollup (#649 / #678 Bug 2): runs.cost_usd_total and
+// runs.resolved_model are populated in the DB but were absent from the
+// GET /v0/runs/{id} response because toRunResponse never surfaced them.
+// Seed a run with a non-zero cost + a resolved model, fetch it through
+// the handler, and assert both fields decode with the seeded values.
+func TestGetRun_SurfacesCostFields(t *testing.T) {
+	repo := newFakeRepo()
+	s := newServer(t, repo)
+
+	seeded, _ := repo.CreateRun(context.Background(), run.CreateRunParams{
+		Repo: "kuhlman-labs/fishhawk", WorkflowID: "w", WorkflowSHA: "s",
+		TriggerSource: run.TriggerCLI,
+	})
+	// fakeRepo stores the run by pointer; stamp the cost rollup fields
+	// the trace handler would have accumulated.
+	seeded.CostUSDTotal = 2.99
+	seeded.ResolvedModel = "claude-opus-4-8"
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/v0/runs/%s", seeded.ID), nil)
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200:\n%s", w.Code, w.Body.String())
+	}
+
+	// Decode into a map so a missing key is distinguishable from a
+	// zero value — the bug was the fields being absent entirely.
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(w.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if _, ok := raw["cost_usd_total"]; !ok {
+		t.Error("response missing cost_usd_total field")
+	}
+	if _, ok := raw["resolved_model"]; !ok {
+		t.Error("response missing resolved_model field")
+	}
+
+	var resp runResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode runResponse: %v", err)
+	}
+	if resp.CostUSDTotal != 2.99 {
+		t.Errorf("cost_usd_total = %v, want 2.99", resp.CostUSDTotal)
+	}
+	if resp.ResolvedModel != "claude-opus-4-8" {
+		t.Errorf("resolved_model = %q, want claude-opus-4-8", resp.ResolvedModel)
 	}
 }

--- a/backend/internal/server/trace.go
+++ b/backend/internal/server/trace.go
@@ -204,7 +204,18 @@ func (s *Server) handleShipTrace(w http.ResponseWriter, r *http.Request) {
 	// per-run total. Best-effort: the trace is already stored + audited,
 	// so a manifest-parse / audit-write / rollup failure logs at WARN
 	// and never unwinds the upload.
-	s.recordCost(r.Context(), runID, stageID, body)
+	//
+	// Gate on the raw variant so cost is recorded exactly once per stage
+	// bundle (#678). The runner POSTs both the raw and the redacted
+	// variant of the same bundle with identical signed manifest token
+	// counts; recording on every variant double-counted the cost (2x).
+	// Raw is the first/authoritative upload and is always shipped in v0
+	// (tracestore always stores raw; only its exposure is restricted —
+	// see the get-stage-trace handler), so gating on raw records the cost
+	// on the bundle's canonical upload.
+	if variant == tracestore.VariantRaw {
+		s.recordCost(r.Context(), runID, stageID, body)
+	}
 
 	// Advance the stage so the approval handler can act on it.
 	// The state machine requires dispatched → running →
@@ -884,6 +895,13 @@ type runCostRecorder interface {
 // cost_recorded audit entry tying the figure to the run, and
 // accumulates the per-run total (pinning the resolved model id) when
 // the RunRepo supports it (#649).
+//
+// This MUST be invoked once per stage bundle, not once per variant
+// upload (#678). The caller gates it on the raw variant; the runner
+// ships both the raw and redacted variant of the same bundle with
+// identical manifest token counts, so calling this on every variant
+// double-counts the cost. Do not move this call out from under the
+// raw-variant guard without re-introducing the 2x double-count.
 //
 // Every step is best-effort: the bundle is already stored + audited by
 // the time this runs, so a missing/unparsable manifest, a nil

--- a/backend/internal/server/trace_test.go
+++ b/backend/internal/server/trace_test.go
@@ -1108,6 +1108,73 @@ func TestShipTrace_RecordsCost(t *testing.T) {
 	}
 }
 
+// TestShipTrace_RecordsCostOncePerBundle is the regression test for the
+// 2x double-count (#678). The runner POSTs each stage bundle twice — once
+// as the raw variant, once as the redacted variant — with identical
+// signed manifest token counts. Before the fix, recordCost ran on every
+// variant upload, so the per-run cost and the cost_recorded ledger were
+// doubled. This double-uploads both variants of the SAME bundle and
+// asserts cost is recorded exactly once: one cost_recorded audit entry
+// and an un-doubled CostUSDTotal. It fails if recordCost is not gated on
+// the raw variant.
+func TestShipTrace_RecordsCostOncePerBundle(t *testing.T) {
+	s, sf, _, au := newTraceServer(t)
+	rr := newApprovalRunRepo()
+	stage := rr.seedStage(run.StageStateDispatched)
+	rr.seedRun(&run.Run{ID: stage.RunID, Repo: "kuhlman-labs/fishhawk"})
+	s.cfg.RunRepo = rr
+
+	const model = "claude-opus-4-8"
+	const inTok, outTok = 1000, 2000
+	wantUSD, ok := pricing.Cost(model, inTok, outTok)
+	if !ok {
+		t.Fatalf("pricing.Cost returned ok=false for %q — fixture model must be priced", model)
+	}
+
+	bundleBytes := packManifestBundle(t, bundle.Manifest{
+		BundleSchema: "trace-bundle-v0",
+		RunID:        stage.RunID.String(),
+		StageID:      stage.ID.String(),
+		Agent:        "claude-code",
+		Model:        model,
+		InputTokens:  inTok,
+		OutputTokens: outTok,
+		GeneratedAt:  time.Now().UTC().Format(time.RFC3339),
+	})
+
+	priv, _ := sf.issue(t, stage.RunID)
+	// Raw first (authoritative), then redacted — the runner's real
+	// two-POST sequence for a single bundle.
+	if w := shipRequest(t, s, stage.RunID, stage.ID, "raw", priv, bundleBytes, ""); w.Code != http.StatusAccepted {
+		t.Fatalf("raw upload status = %d, want 202:\n%s", w.Code, w.Body.String())
+	}
+	if w := shipRequest(t, s, stage.RunID, stage.ID, "redacted", priv, bundleBytes, ""); w.Code != http.StatusAccepted {
+		t.Fatalf("redacted upload status = %d, want 202:\n%s", w.Code, w.Body.String())
+	}
+
+	// Exactly one cost_recorded entry across both uploads — not two.
+	au.mu.Lock()
+	costEntries := 0
+	for i := range au.appended {
+		if au.appended[i].Category == "cost_recorded" {
+			costEntries++
+		}
+	}
+	au.mu.Unlock()
+	if costEntries != 1 {
+		t.Fatalf("cost_recorded entries = %d, want 1 (double-uploaded raw+redacted must record cost once)", costEntries)
+	}
+
+	// Per-run total is the single un-doubled pricing figure, not 2x.
+	got, err := rr.GetRun(t.Context(), stage.RunID)
+	if err != nil {
+		t.Fatalf("GetRun: %v", err)
+	}
+	if got.CostUSDTotal != wantUSD {
+		t.Errorf("run.CostUSDTotal = %v, want %v (not doubled to %v)", got.CostUSDTotal, wantUSD, 2*wantUSD)
+	}
+}
+
 // TestShipTrace_RecordsCost_UnknownModelZero pins the unknown-model
 // arm: an unpriced model id records a cost_recorded entry at usd=0 with
 // known_model=false rather than being dropped or guessed, and the run

--- a/docs/api/v0.md
+++ b/docs/api/v0.md
@@ -113,7 +113,7 @@ state layered up through `backend/internal/run`, `backend/internal/audit`,
 
 | Resource | Source of truth | Notes |
 |---|---|---|
-| `Run` | `runs` table; state machine in `internal/run/transition.go` | All state transitions validated against the table; FOR UPDATE lock per write |
+| `Run` | `runs` table; state machine in `internal/run/transition.go` | All state transitions validated against the table; FOR UPDATE lock per write. `cost_usd_total` + `resolved_model` (#649) are rolled from each stage bundle's signed manifest token counts — recorded once per bundle (raw trace variant only, #678); both always present in the response (0 / empty string for legacy rows) |
 | `Stage` | `stages` table | One stage per workflow stage; `executor` is `{kind: agent|human, ref}` |
 | `Artifact` | `artifacts` table | Plans (`kind=plan`) validated against `docs/spec/plan-standard-v1.schema.json` |
 | `AuditEntry` | `audit_entries` table; chain in `internal/audit/chain.go` | Append-only at three layers: API surface, static-analysis test, DB triggers |

--- a/docs/api/v0.openapi.yaml
+++ b/docs/api/v0.openapi.yaml
@@ -138,7 +138,8 @@ components:
         table in `backend/internal/run/transition.go`.
       required:
         [id, repo, workflow_id, workflow_sha, trigger_source, state,
-         retry_attempt, max_retries_snapshot, runner_kind, created_at, updated_at]
+         retry_attempt, max_retries_snapshot, runner_kind,
+         cost_usd_total, resolved_model, created_at, updated_at]
       properties:
         id: { $ref: '#/components/schemas/UUID' }
         repo:
@@ -232,6 +233,24 @@ components:
             of refetching from GitHub. Null on webhook-dispatched
             runs (which fetch fresh from GitHub at prompt-build
             time) and on non-issue triggers.
+        cost_usd_total:
+          type: number
+          format: double
+          minimum: 0
+          description: |
+            Rolled estimated US-dollar cost of the run's model usage
+            (#649), accumulated from each stage bundle's signed manifest
+            token counts via the shared pricing table. Recorded once per
+            stage bundle (the raw trace variant only — see #678). 0 for
+            legacy rows that predate the rollup.
+          example: 2.99
+        resolved_model:
+          type: string
+          description: |
+            Pinned agent model id the run executed under (#649), stamped
+            from the trace manifest at cost-rollup time. Empty string for
+            legacy/unstamped runs.
+          example: claude-opus-4-8
         created_at:
           type: string
           format: date-time


### PR DESCRIPTION
## Summary

Two defects in #649's cost rollup, found **live-testing** run `1441acb3`.

**Bug 1 — 2× double-count.** `handleShipTrace` called `recordCost` once per trace *variant*, but a stage uploads both `raw` and `redacted` variants of the same bundle with identical signed manifest tokens — so `cost_recorded` was written twice and `runs.cost_usd_total` was exactly 2× (`5.98701 = 2 × 2.993505`). **Fix**: gate `recordCost` on `variant == tracestore.VariantRaw` → recorded once per stage bundle, on the authoritative first upload. Doc comment updated against regression.

**Bug 2 — cost invisible via API.** `runs.cost_usd_total` + `resolved_model` are populated in the DB (migration 0028) but `toRunResponse` never surfaced them. Added both to `runResponse` (always emitted; `resolved_model` empty + cost 0 for legacy rows) + the OpenAPI Run schema + `v0.md`.

## Test plan

`go build`, server tests, `golangci-lint`, `npx @redocly/cli@2.31.5 lint` → all green.
- **`TestShipTrace_RecordsCostOncePerBundle`** — double-uploads raw+redacted, asserts **exactly one** `cost_recorded` + an un-doubled `CostUSDTotal` (the two-variant path the original single-bundle test missed — #618/#627 lesson).
- `runs_test.go` reads the total back through `GET /v0/runs/{id}`, closing the persist→response seam for Bug 2.
- Spend-alert tests unchanged (the alert is a ratio — the removed 2× cancelled there anyway).

## Notes

Forward-only: existing doubled rows aren't backfilled (dev data). Surfaced testing the budget features post-#649; companion follow-up #679 adds a dev OTLP collector to verify the OTel spans end-to-end.

Closes #678