### PR TITLE
Add PeriodicBudget spec type + workflow-v0.4 schema (ADR-030, #688 1/4)

### DIFF
--- a/backend/internal/spec/schemas/workflow-v0.schema.json
+++ b/backend/internal/spec/schemas/workflow-v0.schema.json
@@ -11,8 +11,8 @@
   "properties": {
     "version": {
       "type": "string",
-      "enum": ["0.3"],
-      "description": "Spec syntax version. 0.3 adds workflow.on_ci_failure.max_retries for the auto-retry epic (#276 / #277), workflow.policy.max_stage_runtime and stage.executor.timeout for spec-governed agent timeouts (#452). 0.2 dropped gate.blocking_checks (ADR-017 / #249); 0.1 is rejected. Old specs in the audit log remain readable forever via the historical schemas; this enum gates *new* specs only."
+      "enum": ["0.3", "0.4"],
+      "description": "Spec syntax version. 0.4 adds workflow.budgets — periodic per-workflow cost ceilings (ADR-030 / #688), additive within workflow-v0.x. 0.3 adds workflow.on_ci_failure.max_retries for the auto-retry epic (#276 / #277), workflow.policy.max_stage_runtime and stage.executor.timeout for spec-governed agent timeouts (#452). 0.2 dropped gate.blocking_checks (ADR-017 / #249); 0.1 is rejected. Old specs in the audit log remain readable forever via the historical schemas; this enum gates *new* specs only."
     },
     "roles": {
       "type": "object",
@@ -65,7 +65,12 @@
           "items": { "$ref": "#/$defs/stage" }
         },
         "on_ci_failure": { "$ref": "#/$defs/on_ci_failure" },
-        "policy": { "$ref": "#/$defs/policy" }
+        "policy": { "$ref": "#/$defs/policy" },
+        "budgets": {
+          "type": "array",
+          "description": "Periodic per-workflow cost ceilings (ADR-030 / #688). Each entry caps total USD spend across all runs of this workflow within a calendar period, resetting at the period boundary. Distinct from the per-stage `budget` ($defs/budget: token/runtime caps on one stage execution). Requires version 0.4+.",
+          "items": { "$ref": "#/$defs/periodic_budget" }
+        }
       }
     },
 
@@ -303,6 +308,36 @@
           "type": "string",
           "enum": ["advisory", "blocking"],
           "description": "v0 ships advisory only; blocking arrives in v0.x with the Fishhawk-issued ephemeral key path."
+        }
+      }
+    },
+
+    "periodic_budget": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["period", "limit_usd"],
+      "description": "A workflow-level recurring cost ceiling (ADR-030 / #688). Caps aggregate USD spend across all runs of the workflow within a calendar period. Distinct from the per-stage `budget` def, which caps token/runtime on a single stage execution.",
+      "properties": {
+        "period": {
+          "type": "string",
+          "enum": ["weekly", "monthly"],
+          "description": "Calendar reset cadence. weekly resets at the start of the ISO week; monthly resets on the first of the month. Boundaries are timezone-aware."
+        },
+        "limit_usd": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "Cost ceiling in USD for the period, summed from runs.cost_usd_total across the workflow's runs created within the current period."
+        },
+        "enforcement": {
+          "type": "string",
+          "enum": ["advisory", "blocking"],
+          "description": "advisory (default): emit a budget_alert audit entry + issue comment on warn_at and 100% crossings; never blocks. blocking: refuse a NEW run at admission once the period spend exhausts limit_usd; in-flight runs are untouched and an operator can override."
+        },
+        "warn_at": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Optional fraction in [0,1] (e.g. 0.8 for 80%) at which an advisory warning fires ahead of the 100% crossing. Absent means only the 100% threshold is surfaced."
         }
       }
     },

--- a/backend/internal/spec/spec.go
+++ b/backend/internal/spec/spec.go
@@ -111,11 +111,43 @@ type Role struct {
 // Workflow is one named pipeline (e.g. "feature_change") with an
 // ordered list of stages.
 type Workflow struct {
-	Description string       `json:"description,omitempty" yaml:"description,omitempty"`
-	Stages      []Stage      `json:"stages" yaml:"stages"`
-	OnCIFailure *OnCIFailure `json:"on_ci_failure,omitempty" yaml:"on_ci_failure,omitempty"`
-	Policy      *Policy      `json:"policy,omitempty" yaml:"policy,omitempty"`
+	Description string           `json:"description,omitempty" yaml:"description,omitempty"`
+	Stages      []Stage          `json:"stages" yaml:"stages"`
+	OnCIFailure *OnCIFailure     `json:"on_ci_failure,omitempty" yaml:"on_ci_failure,omitempty"`
+	Policy      *Policy          `json:"policy,omitempty" yaml:"policy,omitempty"`
+	Budgets     []PeriodicBudget `json:"budgets,omitempty" yaml:"budgets,omitempty"`
 }
+
+// PeriodicBudget is a workflow-level recurring cost ceiling (ADR-030).
+// It caps total USD spend across all runs of the workflow within a
+// calendar period (weekly or monthly), resetting at the period
+// boundary. Distinct from the per-stage Budget (token/runtime caps on
+// a single stage execution): a PeriodicBudget governs aggregate spend
+// across runs, not a single stage's resource use.
+//
+// Enforcement reuses the BudgetEnforcement modes:
+//
+//   - advisory — a budget_alert audit entry + issue comment fires when
+//     period spend crosses WarnAt and again at 100%; runs never block.
+//   - blocking — a NEW run is refused at admission once the calendar
+//     period's spend exhausts LimitUSD; in-flight runs are untouched
+//     and an operator can override.
+//
+// WarnAt is an optional fraction in [0,1] (e.g. 0.8 for 80%) at which
+// the advisory warning fires ahead of the 100% crossing. A nil WarnAt
+// means only the 100% threshold is surfaced.
+type PeriodicBudget struct {
+	Period      string            `json:"period" yaml:"period"`
+	LimitUSD    float64           `json:"limit_usd" yaml:"limit_usd"`
+	Enforcement BudgetEnforcement `json:"enforcement,omitempty" yaml:"enforcement,omitempty"`
+	WarnAt      *float64          `json:"warn_at,omitempty" yaml:"warn_at,omitempty"`
+}
+
+// Budget period values for PeriodicBudget.Period.
+const (
+	BudgetPeriodWeekly  = "weekly"
+	BudgetPeriodMonthly = "monthly"
+)
 
 // OnCIFailure is the per-workflow auto-retry policy (#276 / #277).
 // When set, the dispatcher fires a fresh implement workflow_dispatch

--- a/backend/internal/spec/spec_test.go
+++ b/backend/internal/spec/spec_test.go
@@ -185,6 +185,140 @@ workflows:
 	}
 }
 
+// --- Periodic budgets (ADR-030 / #688) ---
+
+func TestParse_Budgets_RoundTrip(t *testing.T) {
+	// A workflow with a budgets entry decodes into Workflow.Budgets
+	// with every field populated. version 0.4 advertises the field.
+	yml := []byte(`
+version: "0.4"
+workflows:
+  feature_change:
+    description: "x"
+    budgets:
+      - period: weekly
+        limit_usd: 50
+        enforcement: blocking
+        warn_at: 0.8
+      - period: monthly
+        limit_usd: 200.5
+    stages:
+      - id: implement
+        type: implement
+        executor:
+          agent: claude-code
+        produces:
+          - artifact: pull_request
+`)
+	s, err := spec.ParseBytes(yml)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	wf := s.Workflows["feature_change"]
+	if got, want := len(wf.Budgets), 2; got != want {
+		t.Fatalf("budgets count = %d, want %d", got, want)
+	}
+	b0 := wf.Budgets[0]
+	if b0.Period != spec.BudgetPeriodWeekly {
+		t.Errorf("budgets[0].period = %q, want weekly", b0.Period)
+	}
+	if b0.LimitUSD != 50 {
+		t.Errorf("budgets[0].limit_usd = %v, want 50", b0.LimitUSD)
+	}
+	if b0.Enforcement != spec.EnforcementBlocking {
+		t.Errorf("budgets[0].enforcement = %q, want blocking", b0.Enforcement)
+	}
+	if b0.WarnAt == nil || *b0.WarnAt != 0.8 {
+		t.Errorf("budgets[0].warn_at = %v, want 0.8", b0.WarnAt)
+	}
+	// Second entry omits enforcement + warn_at: enforcement is the
+	// zero value (caller defaults to advisory) and WarnAt is nil.
+	b1 := wf.Budgets[1]
+	if b1.Period != spec.BudgetPeriodMonthly {
+		t.Errorf("budgets[1].period = %q, want monthly", b1.Period)
+	}
+	if b1.LimitUSD != 200.5 {
+		t.Errorf("budgets[1].limit_usd = %v, want 200.5", b1.LimitUSD)
+	}
+	if b1.WarnAt != nil {
+		t.Errorf("budgets[1].warn_at = %v, want nil for an omitted field", b1.WarnAt)
+	}
+}
+
+func TestParse_Budgets_Absent_NilSlice(t *testing.T) {
+	// No budgets block → Workflow.Budgets is nil; the admission gate
+	// and advisory wiring are no-ops for such a workflow.
+	s, err := spec.ParseBytes(readFixture(t, "valid/minimal.yaml"))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if wf := s.Workflows["trivial"]; wf.Budgets != nil {
+		t.Errorf("Budgets = %v, want nil for an absent block", wf.Budgets)
+	}
+}
+
+func TestParse_Budgets_UnknownPeriod_Rejected(t *testing.T) {
+	// period is a closed enum (weekly|monthly); an unknown value is a
+	// schema error refused before the spec lands on a run row.
+	_, err := spec.ParseBytes([]byte(`
+version: "0.4"
+workflows:
+  feature_change:
+    budgets:
+      - period: daily
+        limit_usd: 10
+    stages:
+      - id: x
+        type: plan
+        executor: { agent: claude-code }
+`))
+	var se *spec.SchemaError
+	if !errors.As(err, &se) {
+		t.Fatalf("err = %v, want *SchemaError", err)
+	}
+}
+
+func TestParse_Budgets_MissingLimit_Rejected(t *testing.T) {
+	// limit_usd is required on a budget entry; its absence is a
+	// schema error.
+	_, err := spec.ParseBytes([]byte(`
+version: "0.4"
+workflows:
+  feature_change:
+    budgets:
+      - period: weekly
+    stages:
+      - id: x
+        type: plan
+        executor: { agent: claude-code }
+`))
+	var se *spec.SchemaError
+	if !errors.As(err, &se) {
+		t.Fatalf("err = %v, want *SchemaError", err)
+	}
+}
+
+func TestParse_Budgets_WarnAtOutOfRange_Rejected(t *testing.T) {
+	// warn_at must be a fraction in [0,1]; >1 is a schema error.
+	_, err := spec.ParseBytes([]byte(`
+version: "0.4"
+workflows:
+  feature_change:
+    budgets:
+      - period: monthly
+        limit_usd: 100
+        warn_at: 1.5
+    stages:
+      - id: x
+        type: plan
+        executor: { agent: claude-code }
+`))
+	var se *spec.SchemaError
+	if !errors.As(err, &se) {
+		t.Fatalf("err = %v, want *SchemaError", err)
+	}
+}
+
 // --- YAML errors ---
 
 func TestParse_EmptyDocument(t *testing.T) {

--- a/cli/internal/spec/schemas/workflow-v0.schema.json
+++ b/cli/internal/spec/schemas/workflow-v0.schema.json
@@ -11,8 +11,8 @@
   "properties": {
     "version": {
       "type": "string",
-      "enum": ["0.3"],
-      "description": "Spec syntax version. 0.3 adds workflow.on_ci_failure.max_retries for the auto-retry epic (#276 / #277), workflow.policy.max_stage_runtime and stage.executor.timeout for spec-governed agent timeouts (#452). 0.2 dropped gate.blocking_checks (ADR-017 / #249); 0.1 is rejected. Old specs in the audit log remain readable forever via the historical schemas; this enum gates *new* specs only."
+      "enum": ["0.3", "0.4"],
+      "description": "Spec syntax version. 0.4 adds workflow.budgets — periodic per-workflow cost ceilings (ADR-030 / #688), additive within workflow-v0.x. 0.3 adds workflow.on_ci_failure.max_retries for the auto-retry epic (#276 / #277), workflow.policy.max_stage_runtime and stage.executor.timeout for spec-governed agent timeouts (#452). 0.2 dropped gate.blocking_checks (ADR-017 / #249); 0.1 is rejected. Old specs in the audit log remain readable forever via the historical schemas; this enum gates *new* specs only."
     },
     "roles": {
       "type": "object",
@@ -65,7 +65,12 @@
           "items": { "$ref": "#/$defs/stage" }
         },
         "on_ci_failure": { "$ref": "#/$defs/on_ci_failure" },
-        "policy": { "$ref": "#/$defs/policy" }
+        "policy": { "$ref": "#/$defs/policy" },
+        "budgets": {
+          "type": "array",
+          "description": "Periodic per-workflow cost ceilings (ADR-030 / #688). Each entry caps total USD spend across all runs of this workflow within a calendar period, resetting at the period boundary. Distinct from the per-stage `budget` ($defs/budget: token/runtime caps on one stage execution). Requires version 0.4+.",
+          "items": { "$ref": "#/$defs/periodic_budget" }
+        }
       }
     },
 
@@ -303,6 +308,36 @@
           "type": "string",
           "enum": ["advisory", "blocking"],
           "description": "v0 ships advisory only; blocking arrives in v0.x with the Fishhawk-issued ephemeral key path."
+        }
+      }
+    },
+
+    "periodic_budget": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["period", "limit_usd"],
+      "description": "A workflow-level recurring cost ceiling (ADR-030 / #688). Caps aggregate USD spend across all runs of the workflow within a calendar period. Distinct from the per-stage `budget` def, which caps token/runtime on a single stage execution.",
+      "properties": {
+        "period": {
+          "type": "string",
+          "enum": ["weekly", "monthly"],
+          "description": "Calendar reset cadence. weekly resets at the start of the ISO week; monthly resets on the first of the month. Boundaries are timezone-aware."
+        },
+        "limit_usd": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "Cost ceiling in USD for the period, summed from runs.cost_usd_total across the workflow's runs created within the current period."
+        },
+        "enforcement": {
+          "type": "string",
+          "enum": ["advisory", "blocking"],
+          "description": "advisory (default): emit a budget_alert audit entry + issue comment on warn_at and 100% crossings; never blocks. blocking: refuse a NEW run at admission once the period spend exhausts limit_usd; in-flight runs are untouched and an operator can override."
+        },
+        "warn_at": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Optional fraction in [0,1] (e.g. 0.8 for 80%) at which an advisory warning fires ahead of the 100% crossing. Absent means only the 100% threshold is surfaced."
         }
       }
     },

--- a/docs/spec/workflow-v0.md
+++ b/docs/spec/workflow-v0.md
@@ -15,7 +15,7 @@ Reference for `.fishhawk/workflows.yaml`. The canonical schema is [`workflow-v0.
 ## Top-level shape
 
 ```yaml
-version: "0.3" # required, exactly "0.3" in v0
+version: "0.3" # required; "0.3" or "0.4" (0.4 adds workflow.budgets)
 roles: # optional; named groups referenced by gates
   <role_id>:
     members: ["@org/team", "@user"]
@@ -24,6 +24,7 @@ workflows: # required; at least one workflow
     description: "..."
     on_ci_failure: # optional; auto-retry policy (#276)
       max_retries: 1 # default when the block is absent
+    budgets: [...] # optional; periodic per-workflow cost ceilings (ADR-030, v0.4+)
     stages: [...]
 ```
 
@@ -167,7 +168,7 @@ constraints:
 
 Constraints are evaluated **post-hoc on the runner** (E5.5 / #53) against the produced diff. Hits become **category B** failures (MVP_SPEC §6).
 
-## Budget
+## Budget (per-stage)
 
 ```yaml
 budget:
@@ -176,7 +177,33 @@ budget:
   enforcement: advisory | blocking
 ```
 
-v0 ships `advisory` enforcement only — the runner reports overruns but does not abort. `blocking` arrives in v0.x once Fishhawk issues ephemeral agent keys (so the proxy can hard-cap).
+A per-stage cap on token / runtime usage for a single stage execution. v0 ships `advisory` enforcement only — the runner reports overruns but does not abort. `blocking` arrives in v0.x once Fishhawk issues ephemeral agent keys (so the proxy can hard-cap).
+
+This is distinct from the workflow-level `budgets` below: the per-stage `budget` governs one stage's resource use; `budgets` govern aggregate USD spend across runs.
+
+## Periodic budgets (workflow-level, v0.4+)
+
+A workflow-level list of recurring cost ceilings (ADR-030 / #688). Each entry caps total USD spend across **all runs** of the workflow within a calendar period, resetting at the period boundary. Requires `version: "0.4"`.
+
+```yaml
+workflows:
+  feature_change:
+    budgets:
+      - period: weekly | monthly   # calendar reset cadence
+        limit_usd: 50              # ceiling in USD for the period (> 0)
+        enforcement: advisory | blocking  # optional; defaults to advisory
+        warn_at: 0.8               # optional fraction [0,1]; warn at 80% before 100%
+    stages: [...]
+```
+
+- **`period`** — `weekly` resets at the start of the ISO week; `monthly` resets on the first of the month. Boundaries are timezone-aware.
+- **`limit_usd`** — the ceiling, summed from `runs.cost_usd_total` (#649/#680/#684) across the workflow's runs created within the current period.
+- **`enforcement`**:
+  - `advisory` (default) — a `budget_alert` audit entry + issue comment fires when period spend crosses `warn_at` and again at 100%. Runs never block.
+  - `blocking` — a **new** run is refused at admission once the period spend exhausts `limit_usd`. In-flight runs are never touched (the gate is admission-only); an operator can override to force a run past the ceiling.
+- **`warn_at`** — optional fraction in `[0,1]` (e.g. `0.8` for 80%) at which the advisory warning fires ahead of the 100% crossing. Absent means only the 100% threshold is surfaced.
+
+> Cost honesty caveat: `known_usage=false` bundles undercount spend (#685), so a ceiling may be crossed later than true spend would imply. Admission blocking is deterministic against the recorded `runs.cost_usd_total`, not a live proxy.
 
 ## Gates
 
@@ -274,7 +301,9 @@ Per-workflow auto-retry policy (#276 / E16). When a required CI check fails on t
 
 | Field                       | Pattern / values                                                             | Notes                                                                                               |
 | --------------------------- | ---------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| `version`                   | `"0.3"`                                                                      | current value; 0.2 added v0.2's `blocking_checks` drop, 0.3 adds `on_ci_failure.max_retries` (#277) |
+| `version`                   | `"0.3"` \| `"0.4"`                                                          | 0.4 adds workflow-level `budgets` (ADR-030 / #688); 0.3 adds `on_ci_failure.max_retries` (#277); 0.2 dropped `blocking_checks` |
+| `budgets[].period`          | `weekly` \| `monthly`                                                        | workflow-level periodic budget reset cadence (v0.4+)                                                |
+| `budgets[].enforcement`     | `advisory` \| `blocking`                                                     | advisory warns; blocking refuses a new run at admission                                             |
 | Role / workflow / stage IDs | `^[a-z][a-z0-9_]*$`                                                          | snake_case                                                                                          |
 | Member refs                 | `^@[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)?$`                                    | GitHub user or team                                                                                 |
 | Stage `type`                | `plan` \| `implement` \| `review`                                            | closed set                                                                                          |

--- a/docs/spec/workflow-v0.schema.json
+++ b/docs/spec/workflow-v0.schema.json
@@ -11,8 +11,8 @@
   "properties": {
     "version": {
       "type": "string",
-      "enum": ["0.3"],
-      "description": "Spec syntax version. 0.3 adds workflow.on_ci_failure.max_retries for the auto-retry epic (#276 / #277), workflow.policy.max_stage_runtime and stage.executor.timeout for spec-governed agent timeouts (#452). 0.2 dropped gate.blocking_checks (ADR-017 / #249); 0.1 is rejected. Old specs in the audit log remain readable forever via the historical schemas; this enum gates *new* specs only."
+      "enum": ["0.3", "0.4"],
+      "description": "Spec syntax version. 0.4 adds workflow.budgets — periodic per-workflow cost ceilings (ADR-030 / #688), additive within workflow-v0.x. 0.3 adds workflow.on_ci_failure.max_retries for the auto-retry epic (#276 / #277), workflow.policy.max_stage_runtime and stage.executor.timeout for spec-governed agent timeouts (#452). 0.2 dropped gate.blocking_checks (ADR-017 / #249); 0.1 is rejected. Old specs in the audit log remain readable forever via the historical schemas; this enum gates *new* specs only."
     },
     "roles": {
       "type": "object",
@@ -65,7 +65,12 @@
           "items": { "$ref": "#/$defs/stage" }
         },
         "on_ci_failure": { "$ref": "#/$defs/on_ci_failure" },
-        "policy": { "$ref": "#/$defs/policy" }
+        "policy": { "$ref": "#/$defs/policy" },
+        "budgets": {
+          "type": "array",
+          "description": "Periodic per-workflow cost ceilings (ADR-030 / #688). Each entry caps total USD spend across all runs of this workflow within a calendar period, resetting at the period boundary. Distinct from the per-stage `budget` ($defs/budget: token/runtime caps on one stage execution). Requires version 0.4+.",
+          "items": { "$ref": "#/$defs/periodic_budget" }
+        }
       }
     },
 
@@ -303,6 +308,36 @@
           "type": "string",
           "enum": ["advisory", "blocking"],
           "description": "v0 ships advisory only; blocking arrives in v0.x with the Fishhawk-issued ephemeral key path."
+        }
+      }
+    },
+
+    "periodic_budget": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["period", "limit_usd"],
+      "description": "A workflow-level recurring cost ceiling (ADR-030 / #688). Caps aggregate USD spend across all runs of the workflow within a calendar period. Distinct from the per-stage `budget` def, which caps token/runtime on a single stage execution.",
+      "properties": {
+        "period": {
+          "type": "string",
+          "enum": ["weekly", "monthly"],
+          "description": "Calendar reset cadence. weekly resets at the start of the ISO week; monthly resets on the first of the month. Boundaries are timezone-aware."
+        },
+        "limit_usd": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "Cost ceiling in USD for the period, summed from runs.cost_usd_total across the workflow's runs created within the current period."
+        },
+        "enforcement": {
+          "type": "string",
+          "enum": ["advisory", "blocking"],
+          "description": "advisory (default): emit a budget_alert audit entry + issue comment on warn_at and 100% crossings; never blocks. blocking: refuse a NEW run at admission once the period spend exhausts limit_usd; in-flight runs are untouched and an operator can override."
+        },
+        "warn_at": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Optional fraction in [0,1] (e.g. 0.8 for 80%) at which an advisory warning fires ahead of the 100% crossing. Absent means only the 100% threshold is surfaced."
         }
       }
     },


### PR DESCRIPTION
## Summary

Sub-plan **1 of 4** of the #688 periodic per-workflow cost budget fan-out (ADR-030 / #687). Introduces the workflow-level budget vocabulary in the spec + schema. **No enforcement yet** — that lands in sub-plans 3 (advisory) and 4 (blocking).

- **`spec.go`** — new `PeriodicBudget` type (`Period`/`LimitUSD`/`Enforcement`/`WarnAt`) + `Budgets []PeriodicBudget` on `Workflow`. Deliberately distinct from the existing per-stage `Budget` at `spec.go:271` (token/runtime caps on one stage) — a `PeriodicBudget` governs aggregate USD spend across runs. Reuses the existing `BudgetEnforcement` (`advisory`|`blocking`) enum.
- **`workflow-v0.schema.json`** — additive. `version` enum gains `"0.4"` (keeps `"0.3"`); new `$defs/periodic_budget` (`additionalProperties:false`, required `[period, limit_usd]`); the `budgets` array `$ref`s the **new** def, not the per-stage `$defs/budget`. `scripts/sync-schemas` mirrors both embedded copies (backend + cli).
- **`workflow-v0.md`** — documents the `budgets` block, the per-stage-vs-workflow distinction, calendar/timezone-aware reset, `advisory`|`blocking`, and `warn_at`.
- **`spec_test.go`** — round-trip (every field populated), absent→nil slice, and three schema-rejection cases (unknown period, missing `limit_usd`, `warn_at > 1`).

## Test plan

- `go build ./internal/spec/...` + `go test ./internal/spec/...` — green.
- `golangci-lint run ./internal/spec/...` — 0 issues.
- `scripts/sync-schemas` clean: both embedded copies byte-equal to the canonical schema.
- Round-trip test parses a `version: "0.4"` budgets-bearing workflow; rejection tests assert `*SchemaError`.

## Notes

- Version recognition is schema-enum-driven (no hardcoded Go version set anywhere — verified by grep), so the `0.4` enum bump *is* the version-advertising update per the CLAUDE.md schema-change checklist. Additive within `workflow-v0.x`.
- `scope_drift` fired on `spec_test.go` + `cli/internal/spec/schemas/workflow-v0.schema.json` during implement — both expected and necessary (the fan-out hands each child the parent's full `scope.files`, which under-specified this slice; the cli embed is a `sync-schemas` target). Reviewed and intentionally included.

Part of #688