### PR TITLE
Add pure budget evaluation package (ADR-030, #688 2/4)

### DIFF
--- a/backend/internal/budget/budget.go
+++ b/backend/internal/budget/budget.go
@@ -1,0 +1,119 @@
+// Package budget evaluates a workflow's spend against a periodic
+// (calendar weekly or monthly) cost ceiling. It is the decision core
+// behind ADR-030's periodic per-workflow budgets: advisory budgets warn
+// when period spend crosses a configured fraction and 100%; blocking
+// budgets refuse a NEW run at admission once the period is exhausted.
+//
+// Like the spendalert package, the detector is deliberately a pure
+// function with NO repository dependency. The caller supplies the
+// already-summed period spend (the backend sums runs.cost_usd_total over
+// the period's date range) and Evaluate returns a fully-populated
+// Decision; the package never queries. Keeping it free of storage makes
+// the calendar/timezone arithmetic and the threshold logic trivially
+// testable, and means the trace/admission wiring only has to shuttle a
+// dollar figure in and a Decision out.
+//
+// Period boundaries are computed timezone-aware in a supplied
+// *time.Location via time.Date(...): weekly resets at the start of the
+// ISO week (Monday 00:00 local), monthly at the first of the month
+// (00:00 local). The standard library handles DST transitions, so a
+// boundary that straddles a clock change still lands on local midnight.
+package budget
+
+import "time"
+
+// Decision is the outcome of an Evaluate call. It is fully populated
+// regardless of whether any threshold was crossed so the caller can log
+// or surface the figures either way; Over and WarnCrossed are the gates
+// the caller keys emission and admission off.
+type Decision struct {
+	// PeriodStart is the inclusive start of the current calendar period
+	// in the supplied location. The caller uses it (with PeriodRange) to
+	// bound the [from, to) cost sum that produced Spent.
+	PeriodStart time.Time
+	// Spent is the period spend the caller passed in (echoed for logging).
+	Spent float64
+	// Limit is the configured ceiling in US dollars (echoed for logging).
+	Limit float64
+	// Fraction is Spent/Limit, or 0 when Limit is non-positive. Surfaced so
+	// an alert payload can report how close to the ceiling the workflow is.
+	Fraction float64
+	// Over is true when Spent has reached or exceeded Limit (exact 100%
+	// counts as over). It is the admission gate for a blocking budget and
+	// the 100% emit gate for an advisory one.
+	Over bool
+	// WarnCrossed is true when a warn_at fraction was configured and
+	// Fraction has reached or exceeded it. It is the warn-threshold emit
+	// gate for an advisory budget. Note that once Over is true WarnCrossed
+	// is also true (warn_at <= 1), so the caller de-dups the two thresholds
+	// separately rather than treating them as mutually exclusive.
+	WarnCrossed bool
+}
+
+// Period values, mirroring the workflow-v0 schema's periodic_budget enum.
+const (
+	PeriodWeekly  = "weekly"
+	PeriodMonthly = "monthly"
+)
+
+// PeriodRange returns the half-open [start, end) calendar period that
+// contains now, evaluated in loc. Weekly periods run Monday 00:00 local
+// to the following Monday; monthly periods run the first of the month
+// 00:00 local to the first of the next month. The caller uses this to
+// bound the cost sum (created_at in [start, end)).
+//
+// A nil loc is treated as UTC. An unrecognized period yields a zero
+// range — the schema enum makes that unreachable in practice, but the
+// caller can detect it via start.IsZero() rather than silently bucketing
+// into the wrong period.
+func PeriodRange(period string, now time.Time, loc *time.Location) (start, end time.Time) {
+	if loc == nil {
+		loc = time.UTC
+	}
+	n := now.In(loc)
+	switch period {
+	case PeriodWeekly:
+		// Weekday() is Sunday=0..Saturday=6; shift so Monday=0..Sunday=6
+		// to find how many days back the current ISO week began.
+		offset := (int(n.Weekday()) + 6) % 7
+		start = time.Date(n.Year(), n.Month(), n.Day(), 0, 0, 0, 0, loc).AddDate(0, 0, -offset)
+		end = start.AddDate(0, 0, 7)
+		return start, end
+	case PeriodMonthly:
+		start = time.Date(n.Year(), n.Month(), 1, 0, 0, 0, 0, loc)
+		end = start.AddDate(0, 1, 0)
+		return start, end
+	default:
+		return time.Time{}, time.Time{}
+	}
+}
+
+// Evaluate compares already-summed period spend against the limit and
+// reports whether the warn_at fraction and the 100% ceiling have been
+// crossed. The caller is responsible for summing spent over the period
+// returned by PeriodRange before calling; Evaluate never queries.
+//
+// warnAt is an optional fraction in (0, 1]; a nil warnAt disables the
+// warn threshold (WarnCrossed stays false). A non-positive limit is
+// treated as no usable ceiling — Fraction stays 0 and nothing is crossed
+// — so a misconfigured budget never blocks every run. A nil loc is UTC.
+func Evaluate(spent, limit float64, warnAt *float64, period string, now time.Time, loc *time.Location) Decision {
+	start, _ := PeriodRange(period, now, loc)
+
+	d := Decision{
+		PeriodStart: start,
+		Spent:       spent,
+		Limit:       limit,
+	}
+
+	if limit <= 0 {
+		return d
+	}
+
+	d.Fraction = spent / limit
+	d.Over = spent >= limit
+	if warnAt != nil && *warnAt > 0 {
+		d.WarnCrossed = d.Fraction >= *warnAt
+	}
+	return d
+}

--- a/backend/internal/budget/budget_test.go
+++ b/backend/internal/budget/budget_test.go
@@ -1,0 +1,218 @@
+package budget
+
+import (
+	"testing"
+	"time"
+)
+
+func floatPtr(f float64) *float64 { return &f }
+
+func TestPeriodRange_WeeklyResetsOnMonday(t *testing.T) {
+	// 2026-06-03 is a Wednesday; the ISO week began Monday 2026-06-01 and
+	// ends the following Monday 2026-06-08, both at local midnight.
+	now := time.Date(2026, 6, 3, 14, 30, 0, 0, time.UTC)
+
+	start, end := PeriodRange(PeriodWeekly, now, time.UTC)
+
+	wantStart := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	wantEnd := time.Date(2026, 6, 8, 0, 0, 0, 0, time.UTC)
+	if !start.Equal(wantStart) {
+		t.Errorf("weekly start = %v, want %v", start, wantStart)
+	}
+	if !end.Equal(wantEnd) {
+		t.Errorf("weekly end = %v, want %v", end, wantEnd)
+	}
+}
+
+func TestPeriodRange_WeeklyOnSundayStaysInPriorMonday(t *testing.T) {
+	// Sunday 2026-06-07 still belongs to the week that began Monday
+	// 2026-06-01 — the reset is Monday, not Sunday.
+	now := time.Date(2026, 6, 7, 23, 59, 0, 0, time.UTC)
+
+	start, _ := PeriodRange(PeriodWeekly, now, time.UTC)
+
+	want := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	if !start.Equal(want) {
+		t.Errorf("Sunday weekly start = %v, want %v", start, want)
+	}
+}
+
+func TestPeriodRange_MonthlyResetsOnFirst(t *testing.T) {
+	now := time.Date(2026, 6, 17, 9, 0, 0, 0, time.UTC)
+
+	start, end := PeriodRange(PeriodMonthly, now, time.UTC)
+
+	wantStart := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	wantEnd := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	if !start.Equal(wantStart) {
+		t.Errorf("monthly start = %v, want %v", start, wantStart)
+	}
+	if !end.Equal(wantEnd) {
+		t.Errorf("monthly end = %v, want %v", end, wantEnd)
+	}
+}
+
+func TestPeriodRange_MonthlyDecemberWrapsToJanuary(t *testing.T) {
+	now := time.Date(2026, 12, 25, 0, 0, 0, 0, time.UTC)
+
+	start, end := PeriodRange(PeriodMonthly, now, time.UTC)
+
+	wantStart := time.Date(2026, 12, 1, 0, 0, 0, 0, time.UTC)
+	wantEnd := time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC)
+	if !start.Equal(wantStart) {
+		t.Errorf("December monthly start = %v, want %v", start, wantStart)
+	}
+	if !end.Equal(wantEnd) {
+		t.Errorf("December monthly end = %v, want %v", end, wantEnd)
+	}
+}
+
+func TestPeriodRange_TimezoneBoundary(t *testing.T) {
+	// A non-UTC location whose local midnight differs from UTC midnight.
+	// At 2026-06-01T02:00Z it is still 2026-05-31T22:00 in America/New_York
+	// (UTC-4 in June), so the monthly period there is still May, while in
+	// UTC it has already rolled to June. This pins the reset to the
+	// supplied location rather than UTC.
+	ny, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Skipf("tzdata unavailable: %v", err)
+	}
+	instant := time.Date(2026, 6, 1, 2, 0, 0, 0, time.UTC)
+
+	utcStart, _ := PeriodRange(PeriodMonthly, instant, time.UTC)
+	if want := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC); !utcStart.Equal(want) {
+		t.Errorf("UTC monthly start = %v, want %v", utcStart, want)
+	}
+
+	nyStart, _ := PeriodRange(PeriodMonthly, instant, ny)
+	if want := time.Date(2026, 5, 1, 0, 0, 0, 0, ny); !nyStart.Equal(want) {
+		t.Errorf("NY monthly start = %v, want %v (local time was still May)", nyStart, want)
+	}
+}
+
+func TestPeriodRange_NilLocationIsUTC(t *testing.T) {
+	now := time.Date(2026, 6, 17, 9, 0, 0, 0, time.UTC)
+
+	gotStart, gotEnd := PeriodRange(PeriodMonthly, now, nil)
+	wantStart, wantEnd := PeriodRange(PeriodMonthly, now, time.UTC)
+	if !gotStart.Equal(wantStart) || !gotEnd.Equal(wantEnd) {
+		t.Errorf("nil location = [%v,%v), want UTC [%v,%v)", gotStart, gotEnd, wantStart, wantEnd)
+	}
+}
+
+func TestPeriodRange_UnknownPeriodIsZero(t *testing.T) {
+	now := time.Date(2026, 6, 17, 9, 0, 0, 0, time.UTC)
+
+	start, end := PeriodRange("quarterly", now, time.UTC)
+	if !start.IsZero() || !end.IsZero() {
+		t.Errorf("unknown period = [%v,%v), want zero range", start, end)
+	}
+}
+
+func TestEvaluate_UnderBudgetNoCrossing(t *testing.T) {
+	now := time.Date(2026, 6, 17, 9, 0, 0, 0, time.UTC)
+
+	d := Evaluate(40.0, 100.0, floatPtr(0.8), PeriodMonthly, now, time.UTC)
+
+	if d.Over {
+		t.Error("did not expect Over at 40% spend")
+	}
+	if d.WarnCrossed {
+		t.Error("did not expect WarnCrossed below the 80% warn_at")
+	}
+	if d.Fraction != 0.4 {
+		t.Errorf("Fraction = %v, want 0.4", d.Fraction)
+	}
+	if d.Spent != 40.0 || d.Limit != 100.0 {
+		t.Errorf("echoed Spent/Limit = %v/%v, want 40/100", d.Spent, d.Limit)
+	}
+	if want := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC); !d.PeriodStart.Equal(want) {
+		t.Errorf("PeriodStart = %v, want %v", d.PeriodStart, want)
+	}
+}
+
+func TestEvaluate_WarnAtCrossing(t *testing.T) {
+	now := time.Date(2026, 6, 17, 9, 0, 0, 0, time.UTC)
+	warn := floatPtr(0.8)
+
+	// Just below the warn threshold: 79% < 80%.
+	below := Evaluate(79.0, 100.0, warn, PeriodMonthly, now, time.UTC)
+	if below.WarnCrossed {
+		t.Error("did not expect WarnCrossed at 79%")
+	}
+
+	// Exactly at the warn threshold crosses (>= warn_at).
+	at := Evaluate(80.0, 100.0, warn, PeriodMonthly, now, time.UTC)
+	if !at.WarnCrossed {
+		t.Error("expected WarnCrossed at exactly 80%")
+	}
+	if at.Over {
+		t.Error("did not expect Over at 80%")
+	}
+}
+
+func TestEvaluate_NilWarnAtNeverWarns(t *testing.T) {
+	now := time.Date(2026, 6, 17, 9, 0, 0, 0, time.UTC)
+
+	d := Evaluate(99.0, 100.0, nil, PeriodMonthly, now, time.UTC)
+	if d.WarnCrossed {
+		t.Error("expected no WarnCrossed when warn_at is nil")
+	}
+	if d.Over {
+		t.Error("did not expect Over at 99%")
+	}
+}
+
+func TestEvaluate_ExactHundredPercentIsOver(t *testing.T) {
+	now := time.Date(2026, 6, 17, 9, 0, 0, 0, time.UTC)
+
+	d := Evaluate(100.0, 100.0, floatPtr(0.8), PeriodMonthly, now, time.UTC)
+	if !d.Over {
+		t.Error("expected Over at exactly 100% (spent == limit)")
+	}
+	if !d.WarnCrossed {
+		t.Error("expected WarnCrossed at 100% (fraction >= warn_at)")
+	}
+	if d.Fraction != 1.0 {
+		t.Errorf("Fraction = %v, want 1.0", d.Fraction)
+	}
+}
+
+func TestEvaluate_OverBudget(t *testing.T) {
+	now := time.Date(2026, 6, 17, 9, 0, 0, 0, time.UTC)
+
+	d := Evaluate(150.0, 100.0, floatPtr(0.8), PeriodMonthly, now, time.UTC)
+	if !d.Over {
+		t.Error("expected Over at 150% spend")
+	}
+	if d.Fraction != 1.5 {
+		t.Errorf("Fraction = %v, want 1.5", d.Fraction)
+	}
+}
+
+func TestEvaluate_NonPositiveLimitNeverBlocks(t *testing.T) {
+	now := time.Date(2026, 6, 17, 9, 0, 0, 0, time.UTC)
+
+	d := Evaluate(50.0, 0, floatPtr(0.8), PeriodMonthly, now, time.UTC)
+	if d.Over {
+		t.Error("a non-positive limit must not register as Over")
+	}
+	if d.WarnCrossed {
+		t.Error("a non-positive limit must not warn")
+	}
+	if d.Fraction != 0 {
+		t.Errorf("Fraction = %v, want 0 for non-positive limit", d.Fraction)
+	}
+}
+
+func TestEvaluate_WeeklyPeriodStart(t *testing.T) {
+	// Wednesday 2026-06-03; weekly period started Monday 2026-06-01.
+	now := time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC)
+
+	d := Evaluate(10.0, 100.0, nil, PeriodWeekly, now, time.UTC)
+
+	want := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	if !d.PeriodStart.Equal(want) {
+		t.Errorf("weekly PeriodStart = %v, want %v", d.PeriodStart, want)
+	}
+}


### PR DESCRIPTION
## Summary

Sub-plan **2 of 4** of the #688 periodic per-workflow cost budget fan-out (ADR-030 / #687). The decision core: a pure, repository-free package (mirrors the `spendalert` shape) — the caller supplies already-summed period spend and `Evaluate` returns a fully-populated `Decision`. **No enforcement wiring yet** (advisory lands in sub-plan 3, blocking in sub-plan 4).

- **`PeriodRange(period, now, loc) -> [start, end)`** — the half-open calendar period containing `now`, timezone-aware (weekly = ISO-week Monday 00:00 local; monthly = first-of-month 00:00 local; nil `loc` = UTC). Exported so the sub-plan-3 caller derives the `[from,to)` bounds, sums cost over that range, **then** calls `Evaluate` — resolving the carried call-order review concern (no double-`Evaluate` to discover the period).
- **`Evaluate(spent, limit, warnAt, period, now, loc) -> Decision{PeriodStart, Spent, Limit, Fraction, Over, WarnCrossed}`** — `limit<=0` is no usable ceiling (never blocks); exact 100% counts as `Over`; nil/zero `warnAt` disables the warn threshold.
- **`budget_test.go`** — weekly Monday reset (+ the Sunday-stays-in-prior-Monday edge), monthly first-of-month (+ December→January wrap), a non-UTC timezone boundary that lands in a *different* period than UTC, nil-loc, and `Evaluate` threshold cases. **100% statement coverage.**

## Test plan

- `go build ./internal/budget/...` + `go test ./internal/budget/...` — green.
- `go test -cover` — **100.0% of statements**.
- `golangci-lint run ./internal/budget/...` — 0 issues.

## Notes

This slice was produced by the dogfood loop, but its implement child hit a **false category-B** (empty diff) from a **runner staging bug**: `StageScoped` (`gitops/commit.go:298`) enumerates dirty paths from `git status --porcelain`, which collapses an *entirely-untracked new directory* to the directory path (`?? backend/internal/budget/`) — never matching the file-level scope entries, so the new package was misclassified as drift and never staged. The child is un-redrivable (`retry_stage` refuses category-B; `run_stage` refuses `failed`), so this loop-produced + verified work is committed directly per the agreed recovery path. The runner bug and the loop recovery-gap are filed as separate issues. Sub-plans 3 (all-modifies) and 4 (new files in the existing `server/` dir) don't trigger the bug.

Part of #688