### PR TITLE
Stage untracked files in brand-new directories (fix #691)

### DIFF
--- a/runner/internal/gitops/commit.go
+++ b/runner/internal/gitops/commit.go
@@ -289,14 +289,20 @@ func (p *Pusher) CommitAndPush(ctx context.Context, args CommitAndPushArgs) (*Co
 
 // StageScoped stages exactly the declared scope paths and returns the
 // set of dirty-but-undeclared paths (scope drift). It reads `git status
-// --porcelain` to enumerate every dirty path, stages the ones that
+// --porcelain -uall` to enumerate every dirty path, stages the ones that
 // match a declared path via a single `git add -A -- <paths>` (per-path
 // -A covers create, modify, AND delete), and returns the remainder as
 // drift. Drift paths are never staged; declared paths that are clean
 // are a no-op. Staging only the paths git already reports dirty means
 // `git add` never errors on a pathspec that matches nothing.
+//
+// -uall (--untracked-files=all) enumerates untracked files inside a
+// brand-new directory individually rather than collapsing them to a
+// single directory entry (e.g. `?? backend/internal/budget/`), which
+// matches no file-level scope.files entry and would be misclassified as
+// drift, leaving the declared file unstaged (#691).
 func (p *Pusher) StageScoped(ctx context.Context, repoDir string, scopeFiles []string) (drift []string, err error) {
-	status, err := p.runOut(ctx, repoDir, "status", "--porcelain")
+	status, err := p.runOut(ctx, repoDir, "status", "--porcelain", "-uall")
 	if err != nil {
 		return nil, fmt.Errorf("gitops: status: %w", err)
 	}

--- a/runner/internal/gitops/commit_test.go
+++ b/runner/internal/gitops/commit_test.go
@@ -177,6 +177,47 @@ func TestStageScoped_StagesDeclaredExcludesStray(t *testing.T) {
 	}
 }
 
+// TestStageScoped_StagesFileInBrandNewDir is the #691 gating test: when a
+// declared file lives inside an entirely-untracked new directory, plain
+// `git status --porcelain` collapses the directory to one entry that
+// matches no file-level scope path, so the declared file never stages and
+// the stage fails as a false category-B. The -uall flag enumerates the
+// untracked files individually so the declared one matches and stages
+// while its undeclared sibling is still surfaced as drift.
+func TestStageScoped_StagesFileInBrandNewDir(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	repo := initRepo(t)
+
+	// A brand-new, entirely-untracked directory with two files: one
+	// declared in scope, one undeclared sibling.
+	newDir := filepath.Join(repo, "pkg", "budget")
+	if err := os.MkdirAll(newDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(newDir, "budget.go"), []byte("package budget\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(newDir, "extra.go"), []byte("package budget\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p := &Pusher{}
+	drift, err := p.StageScoped(context.Background(), repo, []string{"pkg/budget/budget.go"})
+	if err != nil {
+		t.Fatalf("StageScoped: %v", err)
+	}
+
+	staged := mustGitOut(t, repo, "diff", "--cached", "--name-only")
+	if staged != "pkg/budget/budget.go" {
+		t.Errorf("staged files = %q, want only pkg/budget/budget.go", staged)
+	}
+	if len(drift) != 1 || drift[0] != "pkg/budget/extra.go" {
+		t.Errorf("drift = %v, want [pkg/budget/extra.go]", drift)
+	}
+}
+
 // TestCommitAndPush_ScopeBounded_CommitsOnlyDeclared exercises the full
 // commit boundary: the stray file is excluded from the commit and
 // surfaced as ScopeDrift while still left dirty in the working tree.


### PR DESCRIPTION
## Summary

`gitops.StageScoped` enumerated dirty paths from `git status --porcelain`, which **collapses an entirely-untracked directory** into a single entry (e.g. `?? backend/internal/budget/`). That directory path matches no file-level `scope.files` entry, so a brand-new package was classified as **drift** and never staged → an empty `git diff --cached` → a **false category-B** `tests_added_or_updated` failure even though the agent wrote correct code and tests. Observed live on #688 sub-plan 2 (which then couldn't be re-driven — #692).

Read **`git status --porcelain -uall`** so untracked files inside a new directory are enumerated individually and match file-level `scope.files`. `porcelainPath` needs no change (the extra `?? <file>` lines have the shape it already parses); tracked modify/delete/rename are unaffected (granularity flag only).

## Test plan

- `go test -race ./internal/gitops/...` (runner module) — green; `golangci-lint` — 0 issues; `go build ./...` — OK.
- New gating test **`TestStageScoped_StagesFileInBrandNewDir`**: a declared file inside a brand-new untracked directory is staged, while an undeclared sibling is still flagged as drift. **Verified to fail pre-fix** (staged `""`, drift `[the collapsed dir]`) and pass post-fix — so it genuinely guards the regression.
- Existing `TestStageScoped_StagesDeclaredExcludesStray` + `TestCommitAndPush_ScopeBounded_*` continue to pass (modify/stray/rename/delete paths unaffected).

## Notes

First of the loop-friction fixes from the #688 build. The companion recovery gap (a false category-B is un-redrivable — #692) and the implement-review drift blindness (#695) are tracked separately.

Closes #691