### PR TITLE
Carry per-sub-plan scope.files to fan-out children (fix #676)

### DIFF
--- a/backend/internal/plan/plan.go
+++ b/backend/internal/plan/plan.go
@@ -49,8 +49,14 @@ const (
 
 // SubPlanSummary describes one sub-plan within a Decomposition.
 type SubPlanSummary struct {
-	Title                      string            `json:"title"`
-	ScopeHint                  string            `json:"scope_hint"`
+	Title     string `json:"title"`
+	ScopeHint string `json:"scope_hint"`
+	// Scope is the optional per-sub-plan file list. When set, the
+	// decomposition fan-out child for this sub-plan bounds its run scope
+	// (scope_handoff + scope-drift) to these files instead of the parent
+	// plan's full scope.files. Nil means inherit the parent plan's full
+	// scope.
+	Scope                      *Scope            `json:"scope,omitempty"`
 	PredictedRuntimeMinutes    int               `json:"predicted_runtime_minutes"`
 	PredictedRuntimeConfidence RuntimeConfidence `json:"predicted_runtime_confidence"`
 }

--- a/backend/internal/plan/plan_test.go
+++ b/backend/internal/plan/plan_test.go
@@ -352,6 +352,61 @@ func TestParse_DecompositionTwoSubPlans_Succeeds(t *testing.T) {
 	}
 }
 
+// TestParse_SubPlanScope_RoundTrips covers the additive per-sub-plan
+// scope field (#676): a decomposition whose sub_plans carry their own
+// scope.files validates against the schema and decodes into the typed
+// SubPlanSummary.Scope.
+func TestParse_SubPlanScope_RoundTrips(t *testing.T) {
+	m := planfixture.Valid(func(m map[string]any) {
+		m["decomposition"] = map[string]any{
+			"rationale": "split by layer",
+			"sub_plans": []any{
+				map[string]any{
+					"title": "Part A", "scope_hint": "first slice",
+					"scope": map[string]any{
+						"files": []any{
+							map[string]any{"path": "pkg/a/a.go", "operation": "create"},
+						},
+					},
+					"predicted_runtime_minutes": 10, "predicted_runtime_confidence": "high",
+				},
+				map[string]any{
+					"title": "Part B", "scope_hint": "second slice",
+					"predicted_runtime_minutes": 15, "predicted_runtime_confidence": "medium",
+				},
+			},
+		}
+	})
+	p, err := plan.Parse(marshalFixture(t, m))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	subs := p.Decomposition.SubPlans
+	if subs[0].Scope == nil {
+		t.Fatal("sub_plans[0].Scope should be non-nil")
+	}
+	if got, want := len(subs[0].Scope.Files), 1; got != want {
+		t.Fatalf("sub_plans[0].Scope.Files len = %d, want %d", got, want)
+	}
+	if got, want := subs[0].Scope.Files[0].Path, "pkg/a/a.go"; got != want {
+		t.Errorf("sub_plans[0].Scope.Files[0].Path = %q, want %q", got, want)
+	}
+	// Sub-plan without scope decodes to a nil pointer — the field is
+	// absent (additive optional), confirming backward compatibility.
+	if subs[1].Scope != nil {
+		t.Errorf("sub_plans[1].Scope = %+v, want nil (field omitted)", subs[1].Scope)
+	}
+}
+
+// TestParse_SubPlanWithoutScope_StillValidates confirms the additive field
+// did not become required: an existing decomposition shape lacking
+// sub-plan scope continues to validate.
+func TestParse_SubPlanWithoutScope_StillValidates(t *testing.T) {
+	if _, err := plan.Parse(marshalFixture(t, planfixture.Decomposed())); err != nil {
+		t.Fatalf("Parse decomposed fixture without sub-plan scope: %v", err)
+	}
+}
+
 // --- decomposition semantic errors ---
 
 func TestParse_DecompositionDuplicateTitles_IsSemanticError(t *testing.T) {

--- a/backend/internal/plan/schemas/plan-standard-v1.schema.json
+++ b/backend/internal/plan/schemas/plan-standard-v1.schema.json
@@ -219,6 +219,10 @@
           "type": "string",
           "description": "Brief description of what this sub-plan covers. Helps the reviewer understand the split."
         },
+        "scope": {
+          "$ref": "#/$defs/scope",
+          "description": "Optional. The files THIS sub-plan's slice will touch. When present, the decomposition fan-out child for this sub-plan narrows its run scope (scope_handoff commit bounding and scope-drift detection) to these files instead of inheriting the parent plan's full scope.files. Omitted means the child inherits the parent's full scope."
+        },
         "predicted_runtime_minutes": {
           "type": "integer",
           "minimum": 1,

--- a/backend/internal/prompt/prompt.go
+++ b/backend/internal/prompt/prompt.go
@@ -461,7 +461,7 @@ func buildPlan(t Trigger) string {
 	b.WriteString("- ticket_reference: {\"type\": \"...\", \"url\": \"...\", \"id\": \"...\"} object\n")
 	b.WriteString("- generated_by: {\"agent\": \"...\", \"model\": \"...\", \"timestamp\": \"...\"} object\n")
 	b.WriteString("- decomposition (when present): {\"rationale\": \"...\", \"sub_plans\": [...]} object — when you are NOT decomposing, OMIT this field entirely; do NOT set it to null\n")
-	b.WriteString("- decomposition.sub_plans[i]: {\"title\": \"...\", \"scope_hint\": \"...\", \"predicted_runtime_minutes\": N, \"predicted_runtime_confidence\": \"low|medium|high\"} object — use the FULL canonical field names; \"confidence\" / \"minutes\" shorthand will be rejected\n")
+	b.WriteString("- decomposition.sub_plans[i]: {\"title\": \"...\", \"scope_hint\": \"...\", \"scope\": {\"files\": [...]}, \"predicted_runtime_minutes\": N, \"predicted_runtime_confidence\": \"low|medium|high\"} object — use the FULL canonical field names; \"confidence\" / \"minutes\" shorthand will be rejected. Author each sub-plan's own scope.files (the files THAT slice will touch, same {\"path\", \"operation\"} shape as the top-level scope.files) in addition to scope_hint — it narrows the fan-out child run's scope to that slice instead of the parent's full scope.files. scope is optional but recommended; omit it only when the slice's files are not yet known.\n")
 	b.WriteString("The validator rejects any plan where these fields contain bare strings instead of their required structured shapes.\n")
 	b.WriteString("\n")
 	b.WriteString("Cross-boundary test rule: when scope.files spans multiple architectural layers (request/response " +

--- a/backend/internal/prompt/prompt_test.go
+++ b/backend/internal/prompt/prompt_test.go
@@ -1015,6 +1015,8 @@ func TestBuild_Plan_CompoundFieldDirective(t *testing.T) {
 		"decomposition.sub_plans[i]",
 		"shorthand will be rejected",
 		"do NOT set it to null",
+		"the files THAT slice will touch",
+		"narrows the fan-out child run's scope",
 	}
 	for _, w := range wants {
 		if !strings.Contains(got, w) {

--- a/backend/internal/server/prompt.go
+++ b/backend/internal/server/prompt.go
@@ -77,11 +77,23 @@ type scopeFile struct {
 // declares no files, so the field is omitted and the runner falls
 // back to `git add -A`.
 func scopeFilesFromPlan(p *plan.Plan) []scopeFile {
-	if p == nil || len(p.Scope.Files) == 0 {
+	if p == nil {
 		return nil
 	}
-	out := make([]scopeFile, 0, len(p.Scope.Files))
-	for _, f := range p.Scope.Files {
+	return scopeFilesFromScope(&p.Scope)
+}
+
+// scopeFilesFromScope converts a plan.Scope's files into the
+// prompt-response wire shape. Returns nil when the scope is nil or
+// declares no files. Shared by scopeFilesFromPlan (top-level scope)
+// and resolveDecomposedScopeFiles (per-sub-plan scope) so both produce
+// identical wire shapes.
+func scopeFilesFromScope(sc *plan.Scope) []scopeFile {
+	if sc == nil || len(sc.Files) == 0 {
+		return nil
+	}
+	out := make([]scopeFile, 0, len(sc.Files))
+	for _, f := range sc.Files {
 		out = append(out, scopeFile{Path: f.Path, Operation: string(f.Operation)})
 	}
 	return out
@@ -202,7 +214,15 @@ func (s *Server) handleGetStagePrompt(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		scopeFiles = scopeFilesFromPlan(approvedPlan)
-		trigger.ScopeConstraint = s.resolveDecomposedScopeConstraint(r.Context(), runRow)
+		// Decomposition fan-out (#676): a child run narrows its scope to
+		// the matched sub-plan's own scope.files when present, so the
+		// runner's scope_handoff + scope-drift bound to this slice rather
+		// than the parent's full scope. Falls back to the parent scope
+		// when the sub-plan omits scope or the run isn't a decomposed child.
+		if childScope := s.resolveDecomposedScopeFiles(r.Context(), runRow, approvedPlan); len(childScope) > 0 {
+			scopeFiles = childScope
+		}
+		trigger.ScopeConstraint = s.resolveDecomposedScopeConstraint(r.Context(), runRow, approvedPlan)
 		trigger.ApprovalConditions = s.loadApprovalConditions(r.Context(), runRow.ID)
 	}
 
@@ -354,7 +374,15 @@ func (s *Server) handleGetStagePromptRender(w http.ResponseWriter, r *http.Reque
 			}
 		}
 		scopeFiles = scopeFilesFromPlan(approvedPlan)
-		trigger.ScopeConstraint = s.resolveDecomposedScopeConstraint(r.Context(), runRow)
+		// Decomposition fan-out (#676): a child run narrows its scope to
+		// the matched sub-plan's own scope.files when present, so the
+		// runner's scope_handoff + scope-drift bound to this slice rather
+		// than the parent's full scope. Falls back to the parent scope
+		// when the sub-plan omits scope or the run isn't a decomposed child.
+		if childScope := s.resolveDecomposedScopeFiles(r.Context(), runRow, approvedPlan); len(childScope) > 0 {
+			scopeFiles = childScope
+		}
+		trigger.ScopeConstraint = s.resolveDecomposedScopeConstraint(r.Context(), runRow, approvedPlan)
 		trigger.ApprovalConditions = s.loadApprovalConditions(r.Context(), runRow.ID)
 	}
 
@@ -1091,48 +1119,50 @@ func (s *Server) loadPriorSchemaValidationError(ctx context.Context, runID uuid.
 	return nil
 }
 
-// resolveDecomposedScopeConstraint builds a *prompt.ScopeConstraint for
-// child runs of a decomposed plan. Returns nil when:
+// matchDecomposedSubPlan returns the sub-plan whose title prefixes the
+// child run's IssueContext.Body, plus its index within the decomposition's
+// sub_plans. Returns (nil, -1) when:
 //   - the run is not decomposed (DecomposedFrom == nil)
 //   - the run has no cached IssueContext (can't match a sub-plan without it)
-//   - ArtifactRepo is unconfigured (nil-guard: avoids a panic in tryLoadPlanForRun)
-//   - the parent plan can't be loaded (degrade gracefully — agent gets an unconstrained prompt)
-//   - no sub-plan title matches the child's IssueContext.Body prefix (defensive — wrong constraint is worse than none)
+//   - parentPlan is nil or carries no decomposition (degrade gracefully)
+//   - no sub-plan title matches the child's IssueContext.Body prefix
+//     (defensive — a wrong match is worse than none)
+//
+// parentPlan is the already-loaded approved plan for the child run; for a
+// decomposed child loadApprovedPlanForRun walks ParentRunID up to the
+// parent's decomposed plan, so the caller's single load is reused here
+// instead of re-reading the artifact.
 //
 // Matching uses strings.HasPrefix(body, "## "+title+"\n\n"), which is the
 // invariant enforced by childIssueContextFromSubPlan in orchestrator.go.
-func (s *Server) resolveDecomposedScopeConstraint(ctx context.Context, runRow *run.Run) *prompt.ScopeConstraint {
+func matchDecomposedSubPlan(runRow *run.Run, parentPlan *plan.Plan) (*plan.SubPlanSummary, int) {
 	if runRow.DecomposedFrom == nil || runRow.IssueContext == nil {
-		return nil
+		return nil, -1
 	}
-	if s.cfg.ArtifactRepo == nil {
-		return nil
+	if parentPlan == nil || parentPlan.Decomposition == nil {
+		return nil, -1
 	}
-	parentPlan, found, err := s.tryLoadPlanForRun(ctx, *runRow.DecomposedFrom)
-	if err != nil {
-		s.cfg.Logger.LogAttrs(ctx, slog.LevelWarn, "prompt: resolve scope constraint: load parent plan failed",
-			slog.String("parent_run_id", runRow.DecomposedFrom.String()),
-			slog.String("error", err.Error()),
-		)
-		return nil
-	}
-	if !found || parentPlan == nil || parentPlan.Decomposition == nil {
-		return nil
-	}
-
 	body := runRow.IssueContext.Body
-	matchIdx := -1
-	for i, sub := range parentPlan.Decomposition.SubPlans {
+	for i := range parentPlan.Decomposition.SubPlans {
+		sub := &parentPlan.Decomposition.SubPlans[i]
 		if strings.HasPrefix(body, "## "+sub.Title+"\n\n") {
-			matchIdx = i
-			break
+			return sub, i
 		}
 	}
-	if matchIdx < 0 {
+	return nil, -1
+}
+
+// resolveDecomposedScopeConstraint builds a *prompt.ScopeConstraint for
+// child runs of a decomposed plan. Returns nil when the child doesn't
+// match a sub-plan (see matchDecomposedSubPlan). parentPlan is the
+// caller's already-loaded approved plan — for a decomposed child this is
+// the parent's decomposed plan — so no additional artifact read happens.
+func (s *Server) resolveDecomposedScopeConstraint(ctx context.Context, runRow *run.Run, parentPlan *plan.Plan) *prompt.ScopeConstraint {
+	matched, matchIdx := matchDecomposedSubPlan(runRow, parentPlan)
+	if matched == nil {
 		return nil
 	}
 
-	matched := parentPlan.Decomposition.SubPlans[matchIdx]
 	var siblingHints []string
 	for i, sub := range parentPlan.Decomposition.SubPlans {
 		if i != matchIdx {
@@ -1150,6 +1180,31 @@ func (s *Server) resolveDecomposedScopeConstraint(ctx context.Context, runRow *r
 		ParentRunID:  runRow.DecomposedFrom.String(),
 		SiblingHints: siblingHints,
 	}
+}
+
+// resolveDecomposedScopeFiles returns the matched sub-plan's own
+// scope.files for a decomposed child, converted to the prompt-response
+// wire shape. Returns nil when the child doesn't match a sub-plan or the
+// matched sub-plan omits scope — in which case the caller keeps the
+// parent plan's full scope.files (backward-compatible fallback).
+// parentPlan is the caller's already-loaded approved plan, reused here
+// rather than re-read.
+func (s *Server) resolveDecomposedScopeFiles(ctx context.Context, runRow *run.Run, parentPlan *plan.Plan) []scopeFile {
+	matched, _ := matchDecomposedSubPlan(runRow, parentPlan)
+	if matched == nil || matched.Scope == nil {
+		return nil
+	}
+	files := scopeFilesFromScope(matched.Scope)
+	if len(files) == 0 {
+		return nil
+	}
+	s.cfg.Logger.LogAttrs(ctx, slog.LevelInfo,
+		"prompt: narrowed scope_files to sub-plan slice for decomposed child",
+		slog.String("child_run_id", runRow.ID.String()),
+		slog.String("parent_run_id", runRow.DecomposedFrom.String()),
+		slog.Int("file_count", len(files)),
+	)
+	return files
 }
 
 // loadLastDecomposeRejectionReason scans the run's approval_submitted

--- a/backend/internal/server/prompt_test.go
+++ b/backend/internal/server/prompt_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -1737,6 +1738,7 @@ func TestGetStagePrompt_DecomposedChild_ScopeConstraintInjected(t *testing.T) {
 		Repo:           "o/r",
 		WorkflowID:     "feature_change",
 		TriggerSource:  run.TriggerCLI,
+		ParentRunID:    &parentRunID,
 		DecomposedFrom: &parentRunID,
 		IssueContext: &run.IssueContext{
 			Title: "Part A title",
@@ -1778,4 +1780,149 @@ func TestGetStagePrompt_DecomposedChild_ScopeConstraintInjected(t *testing.T) {
 			t.Errorf("prompt missing %q\n---\n%s", want, resp.Prompt)
 		}
 	}
+}
+
+// TestGetStagePrompt_DecomposedChild_ScopeFiles is the cross-boundary seam
+// test for #676: it threads a per-sub-plan scope.files slice through schema
+// validation -> backend plan domain type -> the prompt-response wire payload
+// (the field the runner's scope_handoff/scope_drift consumer reads), and
+// asserts the child's prompt response carries the MATCHED sub-plan's slice,
+// not the parent's full union. The fallback subtest asserts a sub-plan
+// without scope inherits the parent's full scope.files (backward compat).
+func TestGetStagePrompt_DecomposedChild_ScopeFiles(t *testing.T) {
+	// Parent decomposed plan: full scope is the union (a.go, b.go), but each
+	// sub-plan carries its own narrower slice. Part B intentionally omits
+	// scope to exercise the parent-scope fallback.
+	newParentPlan := func() *plan.Plan {
+		return &plan.Plan{
+			PlanVersion: "standard_v1",
+			Summary:     "parent plan",
+			Scope: plan.Scope{
+				Files: []plan.ScopeFile{
+					{Path: "pkg/a/a.go", Operation: plan.FileOpCreate},
+					{Path: "pkg/b/b.go", Operation: plan.FileOpModify},
+				},
+			},
+			Verification: plan.Verification{TestStrategy: "ts", RollbackPlan: "rb"},
+			Decomposition: &plan.Decomposition{
+				Rationale: "scope split",
+				SubPlans: []plan.SubPlanSummary{
+					{
+						Title:     "Part A title",
+						ScopeHint: "Implement Part A in pkg/a.",
+						Scope: &plan.Scope{
+							Files: []plan.ScopeFile{
+								{Path: "pkg/a/a.go", Operation: plan.FileOpCreate},
+							},
+						},
+					},
+					{
+						Title:     "Part B title",
+						ScopeHint: "Implement Part B in pkg/b.",
+						// No Scope — must fall back to the parent's full scope.
+					},
+				},
+			},
+		}
+	}
+
+	// seedChildPrompt seeds a parent plan artifact + a decomposed child run
+	// whose IssueContext.Body matches the sub-plan named by childTitle, then
+	// fetches the child's implement-stage prompt response.
+	seedChildPrompt := func(t *testing.T, childTitle, childHint string) promptResponse {
+		t.Helper()
+		rr := newPromptRunRepo()
+		sf := newSigningFake()
+		art := newFakeArtifactRepo()
+
+		parentRunID := uuid.New()
+		childRunID := uuid.New()
+		parentPlanStageID := uuid.New()
+		childStageID := uuid.New()
+
+		planBytes, err := json.Marshal(newParentPlan())
+		if err != nil {
+			t.Fatalf("marshal parent plan: %v", err)
+		}
+		sv := "standard_v1"
+		if _, err := art.Create(context.Background(), artifact.CreateParams{
+			StageID:       parentPlanStageID,
+			Kind:          artifact.KindPlan,
+			SchemaVersion: &sv,
+			Content:       planBytes,
+		}); err != nil {
+			t.Fatalf("seed plan artifact: %v", err)
+		}
+
+		rr.stagesByRunID = map[uuid.UUID][]*run.Stage{
+			parentRunID: {
+				{ID: parentPlanStageID, RunID: parentRunID, Type: run.StageTypePlan},
+			},
+		}
+		rr.getRuns[parentRunID] = &run.Run{ID: parentRunID, Repo: "o/r"}
+
+		childBody := "## " + childTitle + "\n\n" + childHint + "\n\n---\n*Decomposed sub-plan.*"
+		rr.getRuns[childRunID] = &run.Run{
+			ID:             childRunID,
+			Repo:           "o/r",
+			WorkflowID:     "feature_change",
+			TriggerSource:  run.TriggerCLI,
+			ParentRunID:    &parentRunID,
+			DecomposedFrom: &parentRunID,
+			IssueContext: &run.IssueContext{
+				Title: childTitle,
+				Body:  childBody,
+			},
+		}
+		rr.getStages[childStageID] = &run.Stage{
+			ID:    childStageID,
+			RunID: childRunID,
+			Type:  run.StageTypeImplement,
+		}
+
+		priv, _ := sf.issue(t, childRunID)
+		s := New(Config{
+			Addr:         "127.0.0.1:0",
+			RunRepo:      rr,
+			SigningRepo:  sf,
+			ArtifactRepo: art,
+		})
+		s.promptIssueGetterOverride = &stubIssueGetter{}
+
+		w := promptRequest(t, s, childRunID, childStageID, priv, "")
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200:\n%s", w.Code, w.Body.String())
+		}
+		var resp promptResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		return resp
+	}
+
+	scopePaths := func(sfs []scopeFile) []string {
+		out := make([]string, 0, len(sfs))
+		for _, f := range sfs {
+			out = append(out, f.Path)
+		}
+		return out
+	}
+
+	t.Run("sub-plan with scope narrows to its own slice", func(t *testing.T) {
+		resp := seedChildPrompt(t, "Part A title", "Implement Part A in pkg/a.")
+		got := scopePaths(resp.ScopeFiles)
+		want := []string{"pkg/a/a.go"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("scope_files = %v, want the sub-plan's slice %v (NOT the parent union)", got, want)
+		}
+	})
+
+	t.Run("sub-plan without scope falls back to parent full scope", func(t *testing.T) {
+		resp := seedChildPrompt(t, "Part B title", "Implement Part B in pkg/b.")
+		got := scopePaths(resp.ScopeFiles)
+		want := []string{"pkg/a/a.go", "pkg/b/b.go"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("scope_files = %v, want the parent's full scope %v", got, want)
+		}
+	})
 }

--- a/docs/spec/plan-standard-v1.md
+++ b/docs/spec/plan-standard-v1.md
@@ -223,8 +223,11 @@ Required array with at least two entries. Each entry is a `SubPlanSummary`:
 |---|---|---|---|
 | `title` | string (1–200 chars) | yes | Must be unique within the array |
 | `scope_hint` | string | yes | What this sub-plan covers |
+| `scope` | `{ "files": [...] }` object | no | The files THIS slice will touch. Same shape as the top-level `scope`. |
 | `predicted_runtime_minutes` | integer ≥ 1 | yes | Estimate for this sub-plan's implement stage |
 | `predicted_runtime_confidence` | `"low"` / `"medium"` / `"high"` | yes | Confidence in the sub-plan estimate |
+
+When `scope` is present, the decomposition fan-out child minted for this sub-plan uses the sub-plan's `scope.files` — rather than the parent plan's full `scope.files` — for its implement-stage `scope_handoff` (commit bounding) and scope-drift detection. This keeps each child bounded to its own slice instead of the whole parent change. When `scope` is omitted, the child falls back to the parent plan's full `scope.files` (the pre-existing behavior).
 
 **Runtime-sum invariant**: the validator warns (but does not reject) when the sum of `sub_plans[*].predicted_runtime_minutes` is less than the parent `predicted_runtime_minutes`. The agent may legitimately compress work when breaking it into smaller pieces; the soft warning surfaces the gap for human review.
 

--- a/docs/spec/plan-standard-v1.schema.json
+++ b/docs/spec/plan-standard-v1.schema.json
@@ -219,6 +219,10 @@
           "type": "string",
           "description": "Brief description of what this sub-plan covers. Helps the reviewer understand the split."
         },
+        "scope": {
+          "$ref": "#/$defs/scope",
+          "description": "Optional. The files THIS sub-plan's slice will touch. When present, the decomposition fan-out child for this sub-plan narrows its run scope (scope_handoff commit bounding and scope-drift detection) to these files instead of inheriting the parent plan's full scope.files. Omitted means the child inherits the parent's full scope."
+        },
         "predicted_runtime_minutes": {
           "type": "integer",
           "minimum": 1,

--- a/runner/internal/plan/schemas/plan-standard-v1.schema.json
+++ b/runner/internal/plan/schemas/plan-standard-v1.schema.json
@@ -219,6 +219,10 @@
           "type": "string",
           "description": "Brief description of what this sub-plan covers. Helps the reviewer understand the split."
         },
+        "scope": {
+          "$ref": "#/$defs/scope",
+          "description": "Optional. The files THIS sub-plan's slice will touch. When present, the decomposition fan-out child for this sub-plan narrows its run scope (scope_handoff commit bounding and scope-drift detection) to these files instead of inheriting the parent plan's full scope.files. Omitted means the child inherits the parent's full scope."
+        },
         "predicted_runtime_minutes": {
           "type": "integer",
           "minimum": 1,


### PR DESCRIPTION
## Summary

On the first decomposition fan-out (#649), every child's `scope_handoff` + scope-drift bounding used the **parent** plan's full `scope.files`, not the sub-plan's slice — so per-child enforcement was coarse and `scope_drift` fired on every child (the operator had to `git add` the drifted-but-necessary files each time, and it bit us repeatedly during the #688 build).

Add an optional **`scope`** to `decomposition.sub_plans[i]` in `standard_v1` (additive; `$ref`s the existing `#/$defs/scope`) and have the implement-stage prompt response echo the **matched sub-plan's** `scope.files` for a decomposed child instead of the parent's full list.

**Key insight (verified):** the runner derives *both* `scope_handoff` (commit bounding) and `scope_drift` purely from the prompt response's `scope_files` — so overriding it at the server fixes both acceptance criteria with **no runner change**. A child whose sub-plan omits `scope` falls back to the parent's full scope (backward compat).

- **Schema** — optional `scope` on the `sub-plan-summary` `$def` (omitted from `required`); `scripts/sync-schemas` mirrors both embedded copies (backend + runner plan schemas). `plan.go` gets `SubPlanSummary.Scope *Scope` (nil = inherit parent).
- **Server** — `resolveDecomposedScopeFiles` returns the matched sub-plan's `scope.files`; both prompt call sites override `scopeFiles` for a decomposed child. The already-loaded `approvedPlan` is passed into both decomposed resolvers (no redundant third artifact load — per advisory review).
- **Activation** — the plan-generation prompt's `sub_plans[i]` enumeration (`internal/prompt/prompt.go`) now includes `scope`, so decompositions actually author per-slice scope; without it the field would stay empty and the feature inert.
- **Tests** — server-layer cross-boundary seam test (`TestGetStagePrompt_DecomposedChild_ScopeFiles`: child gets the matched slice, not the parent union; omitted-scope falls back to parent) + `plan_test.go` round-trip with/without the additive field.

## Test plan

- `go build ./...` (backend + runner) — green; `go test -race ./internal/plan/... ./internal/server/... ./internal/prompt/...` — green; `golangci-lint` — 0 issues.
- `scripts/sync-schemas` clean (both embeds byte-equal to canonical); `check-jsonschema --check-metaschema` on the schema — valid.

## Notes

- **Additive within `standard_v1.x`** (new *optional* field, absent from `required`) — no major bump, no soak period needed (it does not become required). Per the CLAUDE.md schema-change checklist; the plan validator recognizes `standard_v1` and unmarshals the optional field via `SubPlanSummary.Scope`.
- Sibling fan-out finding #677 (propagate parent approval-conditions to children + per-child review) remains separate.

Closes #676