### PR TITLE
Add weekly cost budget to feature_change workflow

### DIFF
--- a/.fishhawk/workflows.yaml
+++ b/.fishhawk/workflows.yaml
@@ -11,7 +11,7 @@
 # When the product can execute this spec, the syntax may be revised to
 # match the frozen v0 schema. The intent expressed here will not change.
 
-version: "0.3"
+version: "0.4"
 
 roles:
   founder:
@@ -28,6 +28,18 @@ workflows:
       Human approves plan and PR; agent does the implementation.
     policy:
       max_stage_runtime: "30m"
+    # Periodic cost ceiling (ADR-030 / #688). Advisory — emits a
+    # budget_alert audit entry + originating-issue comment at warn_at
+    # (80%) and the 100% crossing; never blocks a run. Calibrated from
+    # recorded feature_change run costs (avg ~$3.4, max ~$8.4 over the
+    # first 29 costed runs). Weekly reset so the alert re-exercises
+    # during active dogfooding. Flip enforcement to `blocking` to also
+    # dogfood admission-time refusal once the period limit is exhausted.
+    budgets:
+      - period: weekly
+        limit_usd: 50
+        warn_at: 0.8
+        enforcement: advisory
     # Auto-retry once on CI failure (#276). The human approves the
     # plan; the agent should self-heal on a routine test or lint
     # regression without forcing the reviewer back into the loop.


### PR DESCRIPTION
## Summary

Wires the periodic per-workflow cost ceiling (ADR-030 / #688) into Fishhawk's own `feature_change` workflow, so the budget feature is dogfooded on every run going forward.

- Bumps the spec `version` `0.3 → 0.4` (required for `workflow.budgets`; the schema enum and the backend `spec` validator have recognized 0.4 since #688 merged).
- Adds a single **advisory, weekly** budget: `limit_usd: 50`, `warn_at: 0.8`.

Calibrated from the first 29 costed `feature_change` runs (avg ~$3.42/run, max ~$8.42, $99.24 total). At ~$3.4/run the 80% warn crosses around ~12 runs and 100% around ~15 — a few days of active dogfooding — so the alert actually fires and is observable. Advisory never blocks a run; it emits a `budget_alert` audit entry + an originating-issue comment at the `warn_at` and 100% crossings. Weekly reset re-exercises the alert (and the period-boundary logic) repeatedly.

## Test plan

- `check-jsonschema --schemafile docs/spec/workflow-v0.schema.json .fishhawk/workflows.yaml` → `ok`.
- `go test ./internal/spec/` (backend) → pass (validator accepts `version: 0.4` + `budgets`).
- Live: the spec is auto-discovered from `.fishhawk/workflows.yaml` fresh at each `fishhawk_start_run` and snapshotted onto the run row, so no `fishhawkd` reload / `/mcp` reconnect is needed — the next dogfood run picks it up and the `budget_alert` will surface in the audit log as cumulative weekly spend crosses $40 / $50.

## Notes

- **Human-led change.** `.fishhawk/**` is in the implement-stage `forbidden_paths`, so this is authored directly by the operator, not through the agent loop (`human_led_change`). No `Closes #` — there is no tracking issue; this is operational config enabling dogfooding of #688.
- This covers only the **periodic** axis of ADR-030. The **per-run tripwire** (#653) is operator config (`FISHHAWKD_MAX_RUN_USD` / `FISHHAWKD_MAX_RUN_TOKENS`), not a spec field, and is not enabled here. The **rate-anomaly `spend_alert`** (#649) is automatic.
- Flip `enforcement: advisory → blocking` later to additionally dogfood admission-time refusal once the weekly limit is exhausted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)