### PR TITLE
Wire App JWT onto backend GitHub client via NewWithSigner

### DIFF
--- a/backend/cmd/fishhawkd/serve.go
+++ b/backend/cmd/fishhawkd/serve.go
@@ -380,7 +380,7 @@ func runServe(args []string, logSink io.Writer) int {
 			return exitFailure
 		}
 		cfg.GitHubTokens = githubapp.NewCachedProvider(githubapp.NewClient(signer))
-		cfg.GitHub = githubclient.New(cfg.GitHubTokens)
+		cfg.GitHub = githubclient.NewWithSigner(cfg.GitHubTokens, signer)
 		logger.Info("github app + REST client configured",
 			slog.Int64("app_id", appID))
 	} else {

--- a/backend/internal/githubclient/client.go
+++ b/backend/internal/githubclient/client.go
@@ -106,11 +106,38 @@ type Client struct {
 
 // New returns a Client with sensible defaults. tokens is required;
 // without it every call returns an error before touching the wire.
+//
+// New leaves AppJWT nil, so App-level endpoints (GetRepoInstallation)
+// fail the nil guard in buildAppJWTRequest. Production must construct
+// via NewWithSigner so those endpoints authenticate; New is for
+// installation-only callers and tests that wire AppJWT by hand.
 func New(tokens githubapp.TokenProvider) *Client {
 	return &Client{
 		Tokens: tokens,
 		HTTP:   &http.Client{Timeout: 30 * time.Second},
 	}
+}
+
+// AppJWTSigner mints an App-level JWT. Satisfied by *githubapp.Signer
+// (its Sign(ttl time.Duration) (string, error) method). Declared here
+// so NewWithSigner depends on the minting capability, not the concrete
+// signer type.
+type AppJWTSigner interface {
+	Sign(ttl time.Duration) (string, error)
+}
+
+// NewWithSigner is the production constructor: it builds a Client via
+// New(tokens) and wires AppJWT from the App signer, so App-level
+// endpoints (GetRepoInstallation) authenticate with a fresh App JWT
+// instead of hitting the nil guard. This is the single wiring path
+// production must use; serve.go constructs cfg.GitHub through it.
+//
+// signer.Sign(0) clamps to githubapp.DefaultJWTTTL (9m), safely under
+// GitHub's 10-minute App-JWT cap.
+func NewWithSigner(tokens githubapp.TokenProvider, signer AppJWTSigner) *Client {
+	c := New(tokens)
+	c.AppJWT = func() (string, error) { return signer.Sign(0) }
+	return c
 }
 
 // GetFile fetches a single file from a repo at the given ref.

--- a/backend/internal/githubclient/client_test.go
+++ b/backend/internal/githubclient/client_test.go
@@ -1953,3 +1953,66 @@ func TestGetRepoInstallation_NoAppJWT(t *testing.T) {
 		t.Errorf("err = %v, want AppJWT-not-configured error", err)
 	}
 }
+
+// fakeSigner is a minimal AppJWTSigner for wiring tests: returns a
+// canned JWT (or an error) and records the TTL it was called with.
+type fakeSigner struct {
+	jwt    string
+	err    error
+	gotTTL time.Duration
+	calls  int
+}
+
+func (s *fakeSigner) Sign(ttl time.Duration) (string, error) {
+	s.calls++
+	s.gotTTL = ttl
+	if s.err != nil {
+		return "", s.err
+	}
+	return s.jwt, nil
+}
+
+// TestNewWithSigner_WiresAppJWT is the regression test for #721: it
+// drives GetRepoInstallation through the PRODUCTION constructor
+// (NewWithSigner) rather than a hand-wired Client, so it would have
+// caught the missing AppJWT wiring that left serve.go's GetRepoInstallation
+// hitting the nil guard and stamping installation_id=NULL. The earlier
+// hand-built test set AppJWT directly and so masked the omission.
+func TestNewWithSigner_WiresAppJWT(t *testing.T) {
+	fg, srv := newFakeGitHub(t)
+	signer := &fakeSigner{jwt: "fake.app.jwt"}
+
+	// Construct exactly as production does, then point at the fake.
+	c := NewWithSigner(&stubTokens{token: "ghs_canned_token"}, signer)
+	c.BaseURL = srv.URL
+	if c.AppJWT == nil {
+		t.Fatal("NewWithSigner left AppJWT nil; App-level endpoints would hit the nil guard")
+	}
+
+	// 200 → installation id, via the App-JWT path (not the nil guard).
+	id, err := c.GetRepoInstallation(context.Background(), RepoRef{Owner: "x", Name: "y"})
+	if err != nil {
+		t.Fatalf("GetRepoInstallation through NewWithSigner: %v", err)
+	}
+	if id != 12345 {
+		t.Errorf("installation id = %d, want 12345", id)
+	}
+	// The outbound request must carry the App JWT minted by the signer.
+	if fg.gotAuth != "Bearer fake.app.jwt" {
+		t.Errorf("Authorization = %q, want %q (App JWT from signer)", fg.gotAuth, "Bearer fake.app.jwt")
+	}
+	if signer.calls == 0 {
+		t.Error("signer.Sign was never called; AppJWT did not reach the wire")
+	}
+	// signer.Sign(0) → DefaultJWTTTL (9m), under GitHub's 10m cap.
+	if signer.gotTTL != 0 {
+		t.Errorf("signer called with ttl = %v, want 0 (clamps to DefaultJWTTTL)", signer.gotTTL)
+	}
+
+	// 404 → ErrNotInstalled, still through the production-wired client.
+	fg.getInstallationStatus = http.StatusNotFound
+	fg.getInstallationBody = `{"message":"Not Found"}`
+	if _, err := c.GetRepoInstallation(context.Background(), RepoRef{Owner: "x", Name: "y"}); !errors.Is(err, ErrNotInstalled) {
+		t.Errorf("err = %v, want ErrNotInstalled", err)
+	}
+}

--- a/backend/internal/githubclient/client_test.go
+++ b/backend/internal/githubclient/client_test.go
@@ -2016,3 +2016,28 @@ func TestNewWithSigner_WiresAppJWT(t *testing.T) {
 		t.Errorf("err = %v, want ErrNotInstalled", err)
 	}
 }
+
+// TestNewWithSigner_SignError_Propagates covers the path where the App
+// signer fails to mint a JWT: GetRepoInstallation must surface that error
+// (wrapped) instead of reaching the wire. Exercises the fakeSigner.err
+// injection the wiring test leaves unused.
+func TestNewWithSigner_SignError_Propagates(t *testing.T) {
+	fg, srv := newFakeGitHub(t)
+	signErr := errors.New("sign boom")
+	signer := &fakeSigner{err: signErr}
+
+	c := NewWithSigner(&stubTokens{token: "ghs_canned_token"}, signer)
+	c.BaseURL = srv.URL
+
+	_, err := c.GetRepoInstallation(context.Background(), RepoRef{Owner: "x", Name: "y"})
+	if err == nil {
+		t.Fatal("GetRepoInstallation: want error when signer.Sign fails, got nil")
+	}
+	if !errors.Is(err, signErr) {
+		t.Errorf("err = %v, want it to wrap the signer error", err)
+	}
+	// The App-JWT mint failed, so no request should have reached the wire.
+	if fg.gotAuth != "" {
+		t.Errorf("Authorization = %q, want empty (request must not be sent when Sign fails)", fg.gotAuth)
+	}
+}


### PR DESCRIPTION
## Summary

- `serve.go` built `cfg.GitHub` via `githubclient.New(...)` and never set `AppJWT`, so `GetRepoInstallation` (GET `/repos/{owner}/{repo}/installation`) hit the nil guard and returned "AppJWT not configured". That made `handleCreateRun`'s #713 installation resolver stamp `installation_id=NULL`; the runner then fell back to `gh_cli` and the merge reconciler skipped the run (nil installation), parking it at review awaiting approval.
- Add `githubclient.NewWithSigner(tokens, signer)` — the single production wiring path — which builds the client via `New(tokens)` then wires `AppJWT` from the App signer (`signer.Sign(0)` → `DefaultJWTTTL` 9m, under GitHub's 10m cap). Introduce a small `AppJWTSigner` interface (already satisfied by `*githubapp.Signer`) so the constructor depends on the JWT-minting capability, not the concrete type.
- Use `NewWithSigner` in `serve.go`, reusing the signer already built a few lines above; no other serve wiring changes.

## Test plan

- [ ] `(cd backend && go test ./internal/githubclient/... ./cmd/fishhawkd/...)` passes.
- [ ] `(cd backend && golangci-lint run ./internal/githubclient/... ./cmd/fishhawkd/...)` reports 0 issues.
- [ ] `go build ./backend/...` from repo root compiles `serve.go` against the new constructor signature.
- [ ] New regression test `TestNewWithSigner_WiresAppJWT` drives `GetRepoInstallation` through the production `NewWithSigner` constructor: asserts `AppJWT != nil`, that the outbound request carries the signer-minted App JWT in the `Authorization` header (reaching the JWT path, not the nil guard), that a 200 returns the installation id, and that a 404 returns `ErrNotInstalled`.

## Notes

- The prior hand-wired `GetRepoInstallation` tests set `AppJWT` directly on a constructed `Client`, which masked the missing production wiring (the #713 test-double-vs-production gap). The new test exercises the real construction seam, so this class of omission is now caught.
- Post-merge dogfood check (operator, not an automated gate here): an MCP/local run should now stamp a non-nil `installation_id`, the runner should report `source: backend`, and the merge reconciler should resolve the review on PR merge. Wiring `AppJWT` also reveals whether the dev App is actually installed on `kuhlman-labs/fishhawk` — `GetRepoInstallation` success vs a genuine `ErrNotInstalled`.

Closes #721

---
_Opened by [Fishhawk](https://github.com/kuhlman-labs/fishhawk) for run `3ce12d9f-5175-4e72-81bc-69fcf5fd0c82`, stage `62023a59-1e2e-4c0b-bb73-10e4d2a84587`._
_Branch: `fishhawk/run-3ce12d9f/stage-62023a59` · Audit log: `http://localhost:8080/v0/runs/3ce12d9f-5175-4e72-81bc-69fcf5fd0c82/audit`._
