### PR TITLE
Gate the fishhawkd Docker build in PR CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
       go: ${{ steps.filter.outputs.go }}
       ts: ${{ steps.filter.outputs.ts }}
       openapi: ${{ steps.filter.outputs.openapi }}
+      docker: ${{ steps.filter.outputs.docker }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v4
@@ -47,6 +48,23 @@ jobs:
               - '.github/workflows/ci.yml'
             openapi:
               - 'docs/api/**'
+              - '.github/workflows/ci.yml'
+            # The fishhawkd image build (backend/Dockerfile) resolves the
+            # whole go.work workspace inside the container. A module added
+            # to go.work without being wired into the Dockerfile's COPY
+            # steps breaks `go mod download` — invisible to the `go` job
+            # (which builds against the on-disk workspace) and previously
+            # only caught post-merge by backend-build.yml (#733). Trigger
+            # the build-only docker job on anything that changes the module
+            # graph or the build context: go.mod/go.sum (any module),
+            # go.work, the Dockerfile, and the ignore file.
+            docker:
+              - '**/go.mod'
+              - '**/go.sum'
+              - 'go.work'
+              - 'go.work.sum'
+              - 'backend/Dockerfile'
+              - '.dockerignore'
               - '.github/workflows/ci.yml'
 
   go:
@@ -204,13 +222,45 @@ jobs:
             --config docs/api/redocly.yaml \
             docs/api/v0.openapi.yaml
 
+  docker-build:
+    name: Docker build (fishhawkd image, no push)
+    needs: detect
+    if: ${{ needs.detect.outputs.docker == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      # Build-only validation of the release build context. This mirrors
+      # backend-build.yml's build step but with push/sign/sbom stripped:
+      # no registry login, no credentials, no publish — the point is to
+      # fail a PR when the go.work workspace no longer resolves inside the
+      # container (the #733 class), not to produce an artifact. Reads the
+      # release job's warm cache (scope=backend-build) for speed but writes
+      # its own scope so a PR can never poison the published image's cache.
+      - name: Build fishhawkd image (no push)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: backend/Dockerfile
+          push: false
+          load: false
+          build-args: |
+            VERSION=ci-${{ github.sha }}
+          cache-from: type=gha,scope=backend-build
+          cache-to: type=gha,mode=max,scope=ci-docker-build
+          provenance: false
+          sbom: false
+
   # Rollup gate. The repo ruleset requires only this job; it inherits
   # the result of every job listed in `needs`. Add new jobs to that
   # list and they automatically become part of the gate without
   # touching the ruleset.
   ci-pass:
     name: CI Pass
-    needs: [detect, go, ts, openapi]
+    needs: [detect, go, ts, openapi, docker-build]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,7 @@ Because `--all` always rebuilds `fishhawk-mcp`, the `/mcp` reconnect banner is *
 1. `mkdir <name> && cd <name> && go mod init github.com/kuhlman-labs/fishhawk/<name>`
 2. Append `use ./<name>` to `/go.work`.
 3. Verify: `(cd <name> && go build ./... && go test ./... && golangci-lint run ./...)`.
+4. **Wire the module into `backend/Dockerfile`** if the image build must resolve it. The image runs `go mod download` against the whole `go.work` workspace inside the container, so EVERY module listed in `go.work` must have its `go.mod` copied before that step — add `COPY <name>/go.mod[ <name>/go.sum] ./<name>/` to the first COPY phase (omit `go.sum` if the module has none) and `COPY <name> ./<name>` to the source phase. A module added to `go.work` but not the Dockerfile fails `go mod download` with `cannot load module ../<name>` — and this was invisible at PR time until the PR-CI `docker-build` gate landed (#735), because the on-disk workspace the `go` job builds against always has the module present (the #733 / #672 break: red main for 5 merges).
 
 ## Git flow
 


### PR DESCRIPTION
## Summary

- Adds a **build-only, no-push** `docker-build` job to `ci.yml` that builds `backend/Dockerfile` (the fishhawkd image) so a `go.work` module-graph break is caught at **PR time**, not only post-merge by `backend-build.yml`.
- Closes #735. Motivated by #733: #672 added the `pricing` module to `go.work` but not the Dockerfile; PR CI was green (it builds against the on-disk workspace) so it merged, then `backend-build.yml` failed at `go mod download` on every push to `main` for 5 merges across 2 days before anyone noticed.
- Mirrors `backend-build.yml`'s build step with push/sign/sbom stripped — `push: false`, `load: false`, **no registry login, no credentials, no publish**. Reads the release job's warm cache (`scope=backend-build`) but writes its own scope (`ci-docker-build`) so a PR can never poison the published image's cache.
- New `docker` paths filter (`**/go.mod`, `**/go.sum`, `go.work`, `go.work.sum`, `backend/Dockerfile`, `.dockerignore`, this workflow) gates the job; added to the `ci-pass` rollup's `needs` so it joins the required gate **without a ruleset change**. No new workflow permissions.
- Adds step 4 to the "Adding a Go module" checklist in `CLAUDE.md`: wire the module into `backend/Dockerfile`'s COPY phases.

## Why human-led

Touches `.github/workflows/ci.yml`, which is in the implement-stage `forbidden_paths` — so this is authored/reviewed by a human (drafted by the agent), not driven through the dogfood loop, per the CI-workflow discipline established by #608.

## Test plan

- [ ] `actionlint .github/workflows/ci.yml` is clean (verified locally).
- [ ] On this PR, the new **Docker build (fishhawkd image, no push)** check runs (the diff touches `go.work`-adjacent paths via the workflow file itself) and passes against current `main` (which builds green as of #734).
- [ ] `CI Pass` stays green and now inherits `docker-build`.
- [ ] Negative check (manual, optional): a scratch commit adding a `use ./foo` to `go.work` without a Dockerfile COPY should fail the new job — reproducing the #733 break pre-merge.

## Notes

The `docker` filter includes `.github/workflows/ci.yml`, so this PR triggers the new job itself — a self-validating first run. On push to `main` the job is redundant with `backend-build.yml` (which builds + pushes), but it's cheap, cached, and keeps `ci-pass` uniform across events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)