### PR TITLE
Resolve approver login in the status comment's activity line (#755)

### DIFF
--- a/backend/internal/issuecomment/status_template.go
+++ b/backend/internal/issuecomment/status_template.go
@@ -145,7 +145,9 @@ func renderActivityLine(e *audit.Entry) string {
 	case "plan_generated":
 		return "Plan posted"
 	case "approval_submitted":
-		return fmt.Sprintf("%s %s the plan", actor, approvalDecisionVerb(e.Payload))
+		// Prefer the resolved GitHub login (#751); never @-mention the raw
+		// token subject (#755) — approverMention falls back to "an approver".
+		return fmt.Sprintf("%s %s the plan", approverMention(e), approvalDecisionVerb(e.Payload))
 	case "plan_approved_via_reaction":
 		return fmt.Sprintf("%s approved on GitHub (reaction)", actor)
 	case "ci_failure_retry_dispatched":
@@ -170,11 +172,49 @@ func renderActivityLine(e *audit.Entry) string {
 	}
 }
 
+// actorMention renders an audit actor as a GitHub `@`-mention ONLY when
+// the subject is a syntactically valid GitHub login (validApproverLogin,
+// notifier.go — same package). A non-login subject (e.g. the MCP token
+// subject "brett@local-mcp", or the "anonymous"/"system"/"github-webhook"
+// sentinels) returns "" so it never produces a bogus mention that pings an
+// unrelated GitHub user (#755). Webhook-sourced rows carry real logins and
+// are unaffected.
 func actorMention(actor *string) string {
-	if actor == nil || *actor == "" || *actor == "anonymous" || *actor == "system" || *actor == "github-webhook" {
+	if actor == nil || !validApproverLogin(*actor) {
 		return ""
 	}
 	return "@" + *actor
+}
+
+// approverMention renders the approver for an approval_submitted activity
+// row, preferring the resolved GitHub login the MCP loop threads through
+// (#751, approver_github_login) and falling back to the acting subject
+// only when it is itself a valid login; otherwise "an approver" — so a
+// non-login token subject is never `@`-mentioned (#755). Mirrors the
+// plan-status footer's renderApproverHandle preference order.
+func approverMention(e *audit.Entry) string {
+	if login := approverGithubLogin(e.Payload); validApproverLogin(login) {
+		return "@" + login
+	}
+	if e.ActorSubject != nil && validApproverLogin(*e.ActorSubject) {
+		return "@" + *e.ActorSubject
+	}
+	return "an approver"
+}
+
+// approverGithubLogin extracts the resolved GitHub login (#751) from an
+// approval_submitted payload; "" when absent or unparseable.
+func approverGithubLogin(payload json.RawMessage) string {
+	if len(payload) == 0 {
+		return ""
+	}
+	var p struct {
+		ApproverGithubLogin string `json:"approver_github_login"`
+	}
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return ""
+	}
+	return p.ApproverGithubLogin
 }
 
 func approvalDecisionVerb(payload json.RawMessage) string {

--- a/backend/internal/issuecomment/status_template_test.go
+++ b/backend/internal/issuecomment/status_template_test.go
@@ -284,6 +284,44 @@ func TestRenderStatusBody_ApprovalDecisionVerb(t *testing.T) {
 	}
 }
 
+// TestRenderStatusBody_ApproverMention_PrefersGithubLogin guards #755: the
+// "Latest activity" approval row must @-mention the resolved GitHub login
+// (#751, approver_github_login) — and must NEVER @-mention the raw MCP token
+// subject (brett@local-mcp), which would ping an unrelated real user.
+func TestRenderStatusBody_ApproverMention_PrefersGithubLogin(t *testing.T) {
+	runID := uuid.New()
+	r, stages := statusRun(t, runID)
+	now := time.Now()
+
+	t.Run("resolved github login preferred over token subject", func(t *testing.T) {
+		entries := []*audit.Entry{
+			auditEntry(runID, 1, "approval_submitted", "brett@local-mcp", now.Add(-1*time.Minute),
+				map[string]any{"decision": "approve", "approver_github_login": "kuhlman-labs"}),
+		}
+		body := issuecomment.RenderStatusBody(r, stages, entries, "https://x", now)
+		if !strings.Contains(body, "@kuhlman-labs approved the plan") {
+			t.Errorf("expected @kuhlman-labs mention\n---\n%s", body)
+		}
+		if strings.Contains(body, "brett@local-mcp") {
+			t.Errorf("must NOT render the raw token subject (#755)\n---\n%s", body)
+		}
+	})
+
+	t.Run("non-login subject with no resolved login falls back to an approver", func(t *testing.T) {
+		entries := []*audit.Entry{
+			auditEntry(runID, 1, "approval_submitted", "brett@local-mcp", now.Add(-1*time.Minute),
+				map[string]any{"decision": "approve"}),
+		}
+		body := issuecomment.RenderStatusBody(r, stages, entries, "https://x", now)
+		if !strings.Contains(body, "an approver approved the plan") {
+			t.Errorf("expected \"an approver\" fallback\n---\n%s", body)
+		}
+		if strings.Contains(body, "@brett") {
+			t.Errorf("must NOT @-mention a non-login subject (#755)\n---\n%s", body)
+		}
+	})
+}
+
 func TestRenderStatusBody_CIRetryAttemptSuffix(t *testing.T) {
 	// ci_failure_retry_dispatched payload carries retry_attempt +
 	// max_retries; the rendered line includes "(attempt N/M)".


### PR DESCRIPTION
## Summary

- #751 fixed the **plan-status footer** to prefer the resolved GitHub login, but missed the **run-status comment's "Latest activity" row** — it rendered `@` + the raw MCP token subject (`brett@local-mcp`) verbatim, pinging an unrelated real GitHub user. Closes #755.
- `actorMention` now `@`-mentions **only** a syntactically valid GitHub login (`validApproverLogin`, `notifier.go`); a non-login subject (the MCP token subject, or the `anonymous`/`system`/`github-webhook` sentinels) renders no mention.
- The `approval_submitted` row uses a new `approverMention` that prefers the resolved `approver_github_login` (#751) and falls back to **"an approver"** rather than ever `@`-mentioning the raw subject.
- **Swept every `@`-prefixing site in the `issuecomment` package** (the lesson from this miss): all four are now gated by `validApproverLogin`, so a non-login subject can never produce a bogus mention anywhere.

## Why direct (not via the dogfood loop)

Driving this through the MCP loop would post an approval status comment and **re-trigger the very bug** (ping the wrong user) while fixing it. Implemented directly and authored as the operator; reviewer = human.

## Test plan

- [x] `go test -race ./backend/internal/issuecomment/...` (new `TestRenderStatusBody_ApproverMention_PrefersGithubLogin`: resolved-login preferred + raw subject never rendered; non-login subject → "an approver", never `@brett`).
- [x] Existing `TestRenderStatusBody_ApprovalDecisionVerb` (`@alice`) still green — a valid login still mentions.
- [x] `golangci-lint run ./backend/internal/issuecomment/...` clean.

## Notes

Behavior change limited to non-login actors: webhook-sourced rows (`pr_merged`, `pr_approved_on_github`, …) carry real logins and render `@login` unchanged. Provenance is unaffected — the audit `approver` field still records the acting token subject.

🤖 Generated with [Claude Code](https://claude.com/claude-code)