### PR TITLE
Enable the #651 verify loop on feature_change (dogfood)

### DIFF
--- a/.fishhawk/workflows.yaml
+++ b/.fishhawk/workflows.yaml
@@ -83,6 +83,20 @@ workflows:
         type: implement
         executor:
           agent: claude-code
+          # #651 DOGFOOD (temporary, 2026-06-06): execution-grounded
+          # verifier. After the agent exits, run the project test command
+          # against the COMMITTED scope-only tree (the #800/#766 worktree),
+          # NOT the working tree; on a test failure, feed the captured output
+          # back to the agent for a bounded fix loop, then re-verify, before
+          # the PR opens. max_iterations=1 = one fix attempt (cost-bounded for
+          # the first dogfood); 0 (or removing this block) restores the prior
+          # single-shot behavior. scripts/test is hermetic — integration tests
+          # use testcontainers. See #651; robustness follow-up #804. Revert
+          # this block when the dogfood is done (it slows every feature_change).
+          verify:
+            command: "scripts/test"
+            timeout: "12m"
+            max_iterations: 1
         # Advisory implement-review (ADR-027 impl 2/2, #561): an agent
         # reviewer reads the diff against the approved plan and surfaces a
         # verdict (incl. scope-drift flag). agent>0 + human>0 → advisory, so


### PR DESCRIPTION
## Summary

Enable the execution-grounded verifier (#651) on the `feature_change` implement stage to dogfood it against this repo: `executor.verify.{command: scripts/test, timeout: 12m, max_iterations: 1}`. After the implement agent exits, `scripts/test` runs against the **committed scope-only tree** (the #800/#766 worktree); on a test failure the captured output is fed back for one bounded fix attempt before the PR opens.

Direct **human-led config change** — `.fishhawk/**` is a forbidden path in every agent workflow, so workflow-spec edits can't go through the loop; this is the operator path. (An uncommitted working-tree edit pollutes the implement commit — see the failed first attempt, run dcb992a5 / closed PR #805.)

**Temporary** — revert the verify block when the dogfood is done; it adds a full `scripts/test` run (`-race`, testcontainers) to every `feature_change` implement run.

## Test plan

- `check-jsonschema --schemafile docs/spec/workflow-v0.schema.json .fishhawk/workflows.yaml` → ok.
- Dogfood: re-run #763 through `feature_change`; observe `verify_run` (against the committed tree) + `verify_summary` on the implement stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)