### PR TITLE
Update the #651 verify-block comment to reflect it is kept

### DIFF
--- a/.fishhawk/workflows.yaml
+++ b/.fishhawk/workflows.yaml
@@ -83,16 +83,17 @@ workflows:
         type: implement
         executor:
           agent: claude-code
-          # #651 DOGFOOD (temporary, 2026-06-06): execution-grounded
-          # verifier. After the agent exits, run the project test command
-          # against the COMMITTED scope-only tree (the #800/#766 worktree),
-          # NOT the working tree; on a test failure, feed the captured output
-          # back to the agent for a bounded fix loop, then re-verify, before
-          # the PR opens. max_iterations=1 = one fix attempt (cost-bounded for
-          # the first dogfood); 0 (or removing this block) restores the prior
-          # single-shot behavior. scripts/test is hermetic — integration tests
-          # use testcontainers. See #651; robustness follow-up #804. Revert
-          # this block when the dogfood is done (it slows every feature_change).
+          # #651 execution-grounded verifier (KEPT 2026-06-06, after the
+          # dogfood caught a real drift-excluded test failure and the fix loop
+          # converged it before the PR opened). After the agent exits, run the
+          # project test command against the COMMITTED scope-only tree (the
+          # #800/#766 worktree), NOT the working tree; on a test failure, feed
+          # the captured output back to the agent for a bounded fix loop, then
+          # re-verify, before the PR opens. max_iterations=1 = one fix attempt;
+          # 0 (or removing this block) restores the prior single-shot behavior.
+          # scripts/test is hermetic — integration tests use testcontainers.
+          # Accepted cost: a full scripts/test (-race + testcontainers) runs on
+          # every feature_change implement stage. See #651; robustness #804.
           verify:
             command: "scripts/test"
             timeout: "12m"


### PR DESCRIPTION
## Summary

Comment-only tidy. The execution-grounded verifier on `feature_change.implement` (#651) is now a **kept feature** — its first real run caught a drift-excluded test failure and the fix loop converged it before the PR opened — so the comment is updated from "DOGFOOD (temporary)… revert when done" to describe it as kept, with the accepted `scripts/test` cost noted. **The verify config itself is unchanged.**

## Test plan

- `check-jsonschema --schemafile docs/spec/workflow-v0.schema.json .fishhawk/workflows.yaml` → ok.
- Comment-only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)