### PR TITLE
Wire Codex agent + OpenAI key through the Actions layer

### DIFF
--- a/.github/workflows/fishhawk.yml
+++ b/.github/workflows/fishhawk.yml
@@ -35,7 +35,11 @@ on:
         required: true
         type: string
       stage:
-        description: 'Stage executor ref (e.g. claude-code) — informational'
+        # The backend dispatcher sends the stage's executor ref here
+        # (run.Stage.ExecutorRef, e.g. claude-code or codex). It is the
+        # agent-provider identifier and is forwarded to the runner action's
+        # `agent` input below to select which CLI is installed/invoked.
+        description: 'Stage executor ref / agent provider (claude-code|codex)'
         required: false
         type: string
         default: claude-code
@@ -125,7 +129,16 @@ jobs:
           backend-url: ${{ vars.FISHHAWK_BACKEND_URL || 'http://localhost:8080' }}
           workflow: ${{ inputs.workflow_id }}
           stage: ${{ inputs.stage }}
+          # agent: the executor ref carried by the `stage` dispatch input
+          # selects the provider CLI. The action installs Claude Code for
+          # claude-code and Codex for codex, and exports only that
+          # provider's API key. Defaults to claude-code, so existing
+          # dispatches keep working with only ANTHROPIC_API_KEY set.
+          agent: ${{ inputs.stage }}
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # openai-api-key: consumed only when agent=codex. Unset/empty for
+          # Claude dispatches, so OPENAI_API_KEY is not a new required secret.
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           github-token: ${{ steps.fishhawk-auth.outputs.token }}
           # fetch-prompt: runner pulls the constructed prompt from
           # GET /v0/stages/{stage-id}/prompt and writes it to a

--- a/runner/action.yml
+++ b/runner/action.yml
@@ -151,9 +151,13 @@ runs:
     - name: Run fishhawk-runner
       shell: bash
       working-directory: ${{ github.action_path }}
+      # Export only the key the selected agent consumes: ANTHROPIC_API_KEY
+      # for claude-code, OPENAI_API_KEY for codex. Forwarding the unused
+      # provider's key would needlessly widen the secret surface inside the
+      # runner subprocess; the conditional collapses the other to ''.
       env:
-        ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
-        OPENAI_API_KEY: ${{ inputs.openai-api-key }}
+        ANTHROPIC_API_KEY: ${{ inputs.agent == 'claude-code' && inputs.anthropic-api-key || '' }}
+        OPENAI_API_KEY: ${{ inputs.agent == 'codex' && inputs.openai-api-key || '' }}
       run: |
         go run ./cmd/fishhawk-runner \
           --run-id "${{ inputs.run-id }}" \


### PR DESCRIPTION
## Summary

Completes the GitHub Actions wiring for provider selection (#839) and the Codex adapter (#840). The `agent`/`openai-api-key` action inputs and the conditional CLI installs already landed with #896/#897; this PR closes the two remaining gaps:

- **`runner/action.yml`** — export only the selected provider's key: `ANTHROPIC_API_KEY` solely when `agent=claude-code`, `OPENAI_API_KEY` solely when `agent=codex`. Previously both were exported unconditionally; the unused provider's key now collapses to `''`. This also makes the implementation match the already-written README descriptions ("forwarded ... when `agent=claude-code`/`codex`").
- **`.github/workflows/fishhawk.yml`** — forward the executor ref to the runner action's `agent` input and pass `secrets.OPENAI_API_KEY` as `openai-api-key`. The executor ref is already carried by the `stage` dispatch input (the backend dispatcher sends `run.Stage.ExecutorRef` there, e.g. `claude-code` or `codex`), so this is the value that selects the provider. Both default/empty for Claude.

### Why forward `inputs.stage` rather than add a new `agent` dispatch input
The backend dispatcher (`backend/internal/webhook/dispatcher.go`) sends the stage's `ExecutorRef` — the `executor.agent` value from `.fishhawk/workflows.yaml` — under the `stage` dispatch key. A brand-new `agent` dispatch input would never be populated by the backend and would always default to `claude-code`, making codex unselectable. Forwarding the existing executor ref is the functional path and needs no backend change.

## Test plan

- `actionlint .github/workflows/fishhawk.yml` → clean (exit 0).
- `go test ./...` in `runner/` → all packages pass (including `internal/agent/codex` and `internal/redaction`).
- Both YAML files parse.
- Verified `--stage` is informational in the runner (manifest/log field), so reusing the executor ref for both `stage` and `agent` is consistent with existing behavior; agent selection is driven solely by `--agent`.

## Notes

- Workflow-file edits are intentionally low-autonomy: current Fishhawk constraints forbid agent-authored `.github/workflows/**` changes, so this was implemented directly (outside the workflow loop) and authored by the operator.
- Existing Claude dispatches continue to work with only `ANTHROPIC_API_KEY` set; `OPENAI_API_KEY` is not a new required secret (unset/empty resolves to `''` and is only consumed when `agent=codex`).
- No schema, API, or backend changes; `runner/README.md` already documents both inputs (from #896/#897) and its descriptions now match the implementation exactly.

Closes #841

🤖 Generated with [Claude Code](https://claude.com/claude-code)
