### PR TITLE
Reframe core docs: "governed, auditable workflow"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # fishhawk
 
-The workflow and governance layer for agent-driven software development.
+The governed, auditable workflow for agent-driven software development.
 
 Agents do the work. Your team approves the work. Fishhawk holds the record.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6,7 +6,7 @@
 
 ## 1. System summary
 
-Fishhawk is a **governance and workflow layer for agent-driven software changes**. A customer commits a YAML workflow spec to their repo, triggers it (issue label, CLI, UI), and the system runs the agent on their CI under typed constraints, captures a signed trace, and gates each stage on human approval. The product surface is the workflow execution and audit history; the agent itself is pluggable.
+Fishhawk is **a governed, auditable workflow layer for agent-driven software changes**. A customer commits a YAML workflow spec to their repo, triggers it (issue label, CLI, UI), and the system runs the agent on their CI under typed constraints, captures a signed trace, and gates each stage on human approval. The product surface is the workflow execution and audit history; the agent itself is pluggable.
 
 See `docs/MVP_SPEC.md` §1–§4 for product framing, primitives, and customer-side spec syntax.
 

--- a/docs/BRAND_FOUNDATIONS.md
+++ b/docs/BRAND_FOUNDATIONS.md
@@ -11,7 +11,7 @@
 
 ## 1. The product, in one sentence
 
-Fishhawk is the workflow and governance layer for agent-driven software development. It gives engineering teams an opinionated, auditable process for how AI agents plan, implement, and ship changes — without locking them into any specific agent, tracker, or stack.
+Fishhawk is the governed, auditable workflow for agent-driven software development. It gives engineering teams an opinionated, auditable process for how AI agents plan, implement, and ship changes — without locking them into any specific agent, tracker, or stack.
 
 ## 2. The name
 
@@ -49,7 +49,7 @@ FISH-hawk. The two syllables get roughly equal stress. Slight elision is natural
 
 ### What Fishhawk is
 
-The opinionated workflow and governance layer for engineering teams using AI coding agents. The product where teams encode their process for how AI does work, enforce that process automatically, and prove afterward what was done and why.
+The opinionated, governed workflow for engineering teams using AI coding agents. The product where teams encode their process for how AI does work, enforce that process automatically, and prove afterward what was done and why.
 
 ### What Fishhawk is not
 
@@ -143,7 +143,7 @@ Fishhawk speaks to senior engineers who have seen tools come and go. Treat them 
 ### Voice examples
 
 **Landing page hero — good:**
-> The workflow and governance layer for AI-driven software development. Agents do the work. Your team approves the work. Fishhawk holds the record.
+> The governed, auditable workflow for AI-driven software development. Agents do the work. Your team approves the work. Fishhawk holds the record.
 
 **Landing page hero — bad:**
 > Fishhawk empowers enterprise engineering teams to harness the power of AI agents with industry-leading governance, observability, and compliance.

--- a/docs/METHODOLOGY.md
+++ b/docs/METHODOLOGY.md
@@ -3,7 +3,7 @@
 > **Status:** Draft v0.1
 > **Last revised:** 2026-04-30
 
-Fishhawk is the workflow and governance layer for agent-driven software development. Fishhawk is also built that way. This document explains what that means in practice and what readers can expect to see in this repository over time.
+Fishhawk is the governed, auditable workflow for agent-driven software development. Fishhawk is also built that way. This document explains what that means in practice and what readers can expect to see in this repository over time.
 
 This is a methodology commitment, not a marketing line. The honest version of "built by AI" is *specific* and *verifiable*. The commitments below are the form that takes here.
 

--- a/docs/MVP_SPEC.md
+++ b/docs/MVP_SPEC.md
@@ -11,7 +11,7 @@
 
 Coding agents are now capable enough that the bottleneck has shifted from "can the agent write the code" to "can the business trust what the agent did, prove it, and reproduce the process across a team." No one is selling that as a first-class product.
 
-Fishhawk is the **governance and workflow layer that sits above coding agents**. It is agent-agnostic, tool-agnostic, and opinionated about *process*. It is not a coding agent. It is the layer that turns a collection of agent invocations into a governed, auditable, organizational workflow.
+Fishhawk is the **governed, auditable workflow that sits above coding agents**. It is agent-agnostic, tool-agnostic, and opinionated about *process*. It is not a coding agent. It is the layer that turns a collection of agent invocations into a governed, auditable, organizational workflow.
 
 ### What Fishhawk is
 
@@ -50,7 +50,7 @@ The future of software development is **humans setting direction and approving o
 
 ## 3. Positioning
 
-> Fishhawk is the workflow and governance layer for agent-driven software development. We give engineering teams an opinionated, auditable process for how AI agents plan, implement, and ship changes — without locking you into any specific agent, tracker, or stack.
+> Fishhawk is the governed, auditable workflow for agent-driven software development. We give engineering teams an opinionated, auditable process for how AI agents plan, implement, and ship changes — without locking you into any specific agent, tracker, or stack.
 
 **Differentiation against incumbents:**
 

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -2,7 +2,7 @@
 
 > Executive-level architecture. For the technical realization, see [`docs/ARCHITECTURE.md`](../ARCHITECTURE.md).
 
-**Fishhawk is a governance layer for agent-driven software changes.** Teams commit a workflow spec to their repo; Fishhawk runs the coding agent under typed constraints, captures a signed audit trail, and gates every stage on human approval.
+**Fishhawk is the governed, auditable workflow for agent-driven software changes.** Teams commit a workflow spec to their repo; Fishhawk runs the coding agent under typed constraints, captures a signed audit trail, and gates every stage on human approval.
 
 ---
 


### PR DESCRIPTION
## Summary

Evaluated a proposal to reframe Fishhawk as *"an agent harness workflow for SDLC with governance and auditability"* and landed on a smaller, grounded evolution instead.

The canonical one-liner moves from:

> the **workflow and governance layer** for agent-driven software development

to:

> the **governed, auditable workflow** for agent-driven software development

`governed` (policy) and `auditable` (the audit trail) move to the lead, and **workflow** becomes the active head noun in place of the more passive "layer" — capturing that the product actively drives the end-to-end process. Positioning *structure* is unchanged; this is a head-phrase swap across the core docs, not a repositioning.

**Why not "agent harness":** a harness is the thing that wraps and runs an agent — in Fishhawk that role belongs to the agent's *own* harness (e.g. Claude Code), invoked by the runner. Naming the whole product an "agent harness" contradicts the standing *agent-agnostic / not a coding agent / pluggable agent* boundary and demotes the governance + audit differentiator (the wedge vs. generic agent orchestration) to a trailing qualifier.

Sites updated (9 occurrences, 6 files):
- `README.md` (tagline)
- `docs/BRAND_FOUNDATIONS.md` §1, §3, §5 hero example
- `docs/MVP_SPEC.md` §1 thesis, §3 positioning
- `docs/METHODOLOGY.md` intro
- `docs/ARCHITECTURE.md` §1 (keeps "software **changes**" + "**layer**" — technical register)
- `docs/architecture/system-overview.md` opening line (merged via #934)

Deliberately left intact: the core promise ("Agents do the work. Your team approves the work. Fishhawk holds the record."), the "What Fishhawk is not" lists, the "sits above agents / agent-agnostic / pluggable" boundary clauses, and the BRAND §3.2 conviction "Governance is the product, not a feature."

## Test plan

Docs-only; no build/test gates apply.

- `grep -rn -iE "workflow and governance layer|governance and workflow layer|governance layer for agent" README.md docs/` → **zero** matches (every site converted).
- Read-through of each edited line confirms the follow-on copy still reads grammatically and the boundary clauses are intact.
- Confirmed the core promise and BRAND §3.2 are untouched.

## Notes

- Positioning/voice is a human-led surface (CLAUDE.md: "Voice/naming → BRAND_FOUNDATIONS"); the new phrase is a recommendation and the exact wording is the founder's to finalize at review.
- The `system-overview.md` line was reconciled here after #934 merged with the prior wording, so all surfaces land on the new framing together.