### PR TITLE
Update README to reflect current project state

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,18 @@ Agents do the work. Your team approves the work. Fishhawk holds the record.
 
 ## Status
 
-Pre-alpha, but the v0 build is largely landed:
+Pre-alpha. The v0 build has largely landed, and Fishhawk now develops itself through Fishhawk:
 
 - **Backend control plane (`fishhawkd`)** — REST API, run/stage state machine on Postgres, signed audit log, policy evaluator, approval gating with SLA timeouts, retry semantics, GitHub App webhook receiver. ([`backend/`](backend/README.md))
-- **Runner action (`fishhawk/runner`)** — published as `kuhlman-labs/fishhawk/runner@runner/vX.Y.Z`. Cosign-signed releases with SBOMs. ([`runner/`](runner/README.md))
-- **CLI (`fishhawk`)** — `validate`, `run start`, `run status`, `run open`. ([`cli/`](cli/README.md))
+- **Runner action (`fishhawk/runner`)** — runs the agent (Claude Code or Codex) on the customer's CI, captures the signed trace, and validates the plan against its schema. Published as `kuhlman-labs/fishhawk/runner@runner/vX.Y.Z`; cosign-signed releases with SBOMs. ([`runner/`](runner/README.md))
+- **CLI (`fishhawk`)** — `validate`, `run` (start/status/open), `plan`, `audit`, `doctor`. ([`cli/`](cli/README.md))
+- **MCP server (`fishhawk-mcp`)** — exposes run, plan, and audit state to Claude Code (and any MCP client) over the Model Context Protocol; the surface self-hosted runs are driven through. ([`backend/cmd/fishhawk-mcp/`](backend/cmd/fishhawk-mcp))
 - **Web UI** — plan review, approval, audit log per run, retry on failures. ([`frontend/`](frontend/README.md))
 - **Audit-log verifier** — standalone binary that re-verifies an exported chain offline. ([`verifier/`](verifier/README.md))
-- **Hosted infrastructure (Terraform)** — VPC, RDS, ECS Fargate, ALB, OIDC-based deploys. Two cost profiles: dev (~$15/mo, no NAT/no ALB) and prod (~$85/mo, full HA-eligible). ([`infra/terraform/`](infra/terraform/README.md))
+- **Hosted infrastructure** — Terraform on AWS (VPC, RDS, ECS Fargate, ALB, OIDC-based deploys; dev ~$15/mo and prod ~$85/mo profiles, [`infra/terraform/`](infra/terraform/README.md)) plus a Helm chart for Kubernetes ([`deploy/helm/fishhawk/`](deploy/helm/fishhawk), quickstart in [`docs/deploy/kubernetes.md`](docs/deploy/kubernetes.md)).
 - **CI/CD** — every push to `main` builds + signs the backend image; tagged releases auto-deploy via GitHub Actions OIDC.
 
-What's still ahead is the methodology commitment in [`docs/METHODOLOGY.md`](docs/METHODOLOGY.md): on Day 21 of the v0 build (~2026-05-20), Fishhawk starts shipping its *own* changes through Fishhawk. Until then, the workflow spec at [`.fishhawk/workflows.yaml`](.fishhawk/workflows.yaml) is a public commitment, not yet a running system. Day 21 is the gating event after which every PR carries a link to its workflow run and audit log.
+Fishhawk now ships its *own* changes through Fishhawk. Since Day 22 of the v0 build (2026-05-21), substantive changes flow through a workflow run defined by [`.fishhawk/workflows.yaml`](.fishhawk/workflows.yaml): a human approves the plan, constraints are enforced on the implementation, and the PR is opened by Fishhawk itself — stamped with its run and stage IDs (the *"Opened by Fishhawk for run …"* footer on recent PRs). This is the methodology commitment in [`docs/METHODOLOGY.md`](docs/METHODOLOGY.md), today held by convention rather than enforced by the product. The audit log behind each run is captured but not yet published as a public artifact — that step is still ahead.
 
 For the canonical scope and the technical realization, see [`docs/MVP_SPEC.md`](docs/MVP_SPEC.md) and [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
 
@@ -84,13 +85,13 @@ Per-component details live in each subdirectory's README:
 | Backend (`fishhawkd`) | [`backend/README.md`](backend/README.md) — `serve`, `migrate`, `token issue`, env-var reference |
 | Web UI | [`frontend/README.md`](frontend/README.md) — `pnpm dev`, route layout, OAuth wiring |
 | Runner action | [`runner/README.md`](runner/README.md) — used in GitHub Actions, not typically run locally |
-| CLI | [`cli/README.md`](cli/README.md) — `fishhawk validate`, `fishhawk run start/status/open` |
+| CLI | [`cli/README.md`](cli/README.md) — `fishhawk validate`, `run`, `plan`, `audit`, `doctor` |
 | Verifier | [`verifier/README.md`](verifier/README.md) — `fishhawk-verify` against an exported audit log |
 | Infrastructure | [`infra/terraform/README.md`](infra/terraform/README.md) — bootstrap, dev vs prod profiles, CI deploy flow |
 
 ## Following along
 
-Watch the repository. Substantive changes land as PRs against `main`; once Fishhawk is self-hosting, every PR will carry a link to its workflow run and audit log.
+Watch the repository. Substantive changes land as PRs against `main`, each opened by Fishhawk and stamped with its workflow run and stage IDs.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

The root README's Status section was stale on the project's most important current-state fact: it described **Day 21 self-hosting as a future "gating event,"** but that's now past (today is ~Day 41). Fishhawk has been shipping its own changes through Fishhawk since ~Day 22 (2026-05-21) — recent merged PRs (#933, #923, #922) carry the *"Opened by Fishhawk for run `<uuid>`, stage `<uuid>`"* footer.

Changes:

- **Methodology paragraph** rewritten to present reality: Fishhawk now ships its own changes through a workflow run (plan approved, constraints enforced, PR opened by Fishhawk with run/stage IDs). Stays honest — *by convention*, not yet product-enforced, and the audit log is captured but **not yet public** (the footer links point at a local stack).
- **"Following along"** updated from the conditional "once Fishhawk is self-hosting…" to present tense.
- **Component inventory refresh:**
  - Runner now runs **Claude Code or Codex** (agent-agnosticism, demonstrated — #926).
  - CLI surface grew: `validate`, `run`, `plan`, `audit`, `doctor` (was just `validate` / `run start/status/open`).
  - Added the **`fishhawk-mcp` MCP server** — the surface self-hosted runs are driven through.
  - Noted the **Helm/Kubernetes** deploy path alongside Terraform/ECS.

## Test plan

Docs-only.

- Verified every new/changed link target exists on disk: `deploy/helm/fishhawk`, `docs/deploy/kubernetes.md`, `backend/cmd/fishhawk-mcp`, `infra/terraform/README.md`, `cli/README.md`.
- CLI command list cross-checked against `cli/cmd/fishhawk/main.go` dispatch (`run`/`plan`/`audit`/`validate`/`runner`/`doctor`/`version`).
- Self-hosting claim cross-checked against the footer on recently merged PRs.

## Notes

Tagline already reads "the governed, auditable workflow for agent-driven software development" (merged in #936); this PR leaves it untouched.