### PR TITLE
Zero-pad work-management ADR numbers via numbering.pad

### DIFF
--- a/backend/internal/server/workitems_test.go
+++ b/backend/internal/server/workitems_test.go
@@ -293,8 +293,8 @@ func TestFileWorkItem_NumberedType_AllocatesAndDispatches(t *testing.T) {
 	if fp.captured.Number != 36 {
 		t.Errorf("ProviderRequest.Number = %d, want 36", fp.captured.Number)
 	}
-	if fp.captured.Item.Title != "[ADR-36] Record the provider boundary" {
-		t.Errorf("title = %q, want ADR-36 rendered", fp.captured.Item.Title)
+	if fp.captured.Item.Title != "[ADR-036] Record the provider boundary" {
+		t.Errorf("title = %q, want ADR-036 rendered", fp.captured.Item.Title)
 	}
 }
 

--- a/backend/internal/workmgmt/apply.go
+++ b/backend/internal/workmgmt/apply.go
@@ -83,7 +83,11 @@ func Apply(req FilingRequest, conv Conventions) (WorkItem, int, error) {
 		return WorkItem{}, 0, err
 	}
 
-	title, err := renderTitle(itemType.TitleFormat, req.Summary, number, req.TitleVars)
+	pad := 0
+	if itemType.Numbering != nil {
+		pad = itemType.Numbering.Pad
+	}
+	title, err := renderTitle(itemType.TitleFormat, req.Summary, number, pad, req.TitleVars)
 	if err != nil {
 		return WorkItem{}, 0, err
 	}
@@ -157,14 +161,17 @@ func allocateNumber(itemType ItemType, existing []int) (int, error) {
 // any caller-supplied TitleVars into title_format. An empty title_format
 // yields the bare summary. Any placeholder left unresolved fails closed,
 // so a feature missing its {epic}/{n} vars is rejected rather than filed
-// with a literal `{epic}` in its title.
-func renderTitle(format, summary string, number int, vars map[string]string) (string, error) {
+// with a literal `{epic}` in its title. pad zero-pads the {number}
+// substitution to a minimum width; pad<=0 renders the bare integer (the
+// "%0*d" width-from-arg form is identical to "%d" when pad<=0), so types
+// that declare no numbering.pad are unchanged.
+func renderTitle(format, summary string, number, pad int, vars map[string]string) (string, error) {
 	if strings.TrimSpace(format) == "" {
 		return summary, nil
 	}
 	subs := map[string]string{"summary": summary}
 	if number > 0 {
-		subs["number"] = fmt.Sprintf("%d", number)
+		subs["number"] = fmt.Sprintf("%0*d", pad, number)
 	}
 	for k, v := range vars {
 		subs[k] = v

--- a/backend/internal/workmgmt/apply_test.go
+++ b/backend/internal/workmgmt/apply_test.go
@@ -61,7 +61,38 @@ func TestApply_ADRAllocatesNextNumberAndRendersPrefix(t *testing.T) {
 	if num != 36 {
 		t.Errorf("next ADR number = %d, want 36", num)
 	}
-	if want := "[ADR-36] use postgres"; item.Title != want {
+	// The shipped default sets numbering.pad: 3 (#1148), so the {number}
+	// substitution zero-pads to width 3 ([ADR-036], not the bare [ADR-36]).
+	if want := "[ADR-036] use postgres"; item.Title != want {
+		t.Errorf("title = %q, want %q", item.Title, want)
+	}
+}
+
+// TestApply_ADRZeroPadsViaDefault is the #1148 done-means: filing an adr
+// through the SHIPPED Default() conventions (numbering.pad: 3) with existing
+// numbers up to 40 renders the zero-padded [ADR-041] form — exactly what
+// fishhawk_file_issue produces. It pins the shipped default, not a hand-built
+// Pad:3 copy, exercising the default yaml -> Numbering.Pad -> renderTitle
+// %0*d chain end to end.
+func TestApply_ADRZeroPadsViaDefault(t *testing.T) {
+	conv := testConventions(t)
+	existing := make([]int, 0, 40)
+	for n := 1; n <= 40; n++ {
+		existing = append(existing, n)
+	}
+	item, num, err := Apply(FilingRequest{
+		Type:            "adr",
+		Summary:         "zero-pad adr numbers",
+		Body:            "## Context\n\n…\n",
+		ExistingNumbers: existing,
+	}, conv)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if num != 41 {
+		t.Errorf("next ADR number = %d, want 41", num)
+	}
+	if want := "[ADR-041] zero-pad adr numbers"; item.Title != want {
 		t.Errorf("title = %q, want %q", item.Title, want)
 	}
 }

--- a/backend/internal/workmgmt/conventions.go
+++ b/backend/internal/workmgmt/conventions.go
@@ -114,10 +114,13 @@ type DefaultFields struct {
 }
 
 // Numbering is a type's numbering rule. Scheme is the allocation scheme
-// (sequential in v0); Prefix is rendered into the title (e.g. ADR-).
+// (sequential in v0); Prefix is rendered into the title (e.g. ADR-); Pad is
+// the zero-pad minimum width for the {number} substitution (e.g. 3 -> 041),
+// 0/absent meaning no padding.
 type Numbering struct {
 	Scheme string `json:"scheme"`
 	Prefix string `json:"prefix,omitempty"`
+	Pad    int    `json:"pad,omitempty"`
 }
 
 // Default returns the shipped default work-management conventions, parsed

--- a/backend/internal/workmgmt/conventions_test.go
+++ b/backend/internal/workmgmt/conventions_test.go
@@ -57,6 +57,11 @@ func TestDefaultRoundTrip(t *testing.T) {
 	if adr.Numbering.Prefix != "ADR-" {
 		t.Errorf("types.adr.numbering.prefix = %q, want ADR-", adr.Numbering.Prefix)
 	}
+	// The shipped default sets numbering.pad: 3 so ADR titles render in the
+	// established zero-padded [ADR-NNN] series ([ADR-036], [ADR-041]) (#1148).
+	if adr.Numbering.Pad != 3 {
+		t.Errorf("types.adr.numbering.pad = %d, want 3 (zero-padded default, #1148)", adr.Numbering.Pad)
+	}
 	if d.Types["feature"].EpicLink != "required" {
 		t.Errorf("types.feature.epic_link = %q, want required", d.Types["feature"].EpicLink)
 	}

--- a/backend/internal/workmgmt/defaults/work-management-default.yaml
+++ b/backend/internal/workmgmt/defaults/work-management-default.yaml
@@ -127,4 +127,7 @@ types:
     numbering:
       scheme: sequential
       prefix: ADR-
+      # Zero-pad the rendered {number} to 3 digits so ADR titles match the
+      # established [ADR-NNN] series ([ADR-041], not [ADR-41]) (#1148).
+      pad: 3
     epic_link: none

--- a/backend/internal/workmgmt/schemas/work-management-v0.schema.json
+++ b/backend/internal/workmgmt/schemas/work-management-v0.schema.json
@@ -191,6 +191,12 @@
             "prefix": {
               "type": "string",
               "description": "Number prefix rendered into the title (e.g. ADR-)."
+            },
+            "pad": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 12,
+              "description": "Zero-pad the rendered {number} to this minimum width (e.g. 3 -> 041). 0/absent means no padding. Bounded 0..12 so a runaway pad cannot allocate an oversized title string; 12 exceeds any realistic numbering width."
             }
           }
         },

--- a/docs/spec/work-management-default.yaml
+++ b/docs/spec/work-management-default.yaml
@@ -127,4 +127,7 @@ types:
     numbering:
       scheme: sequential
       prefix: ADR-
+      # Zero-pad the rendered {number} to 3 digits so ADR titles match the
+      # established [ADR-NNN] series ([ADR-041], not [ADR-41]) (#1148).
+      pad: 3
     epic_link: none

--- a/docs/spec/work-management-v0.md
+++ b/docs/spec/work-management-v0.md
@@ -32,7 +32,7 @@ This is a **new canonical artifact**, NOT a block inside `.fishhawk/workflows.ya
 | `body_skeleton` | yes | non-empty string list | Ordered body section headings. Dual-audience: Feature = Summary/Proposal/Done-means/Notes/Relations; Bug = Summary/Observed/Proposal/Done-means/Notes/Relations; ADR = Context/Options/Recommendation/Decision/Consequences; Chore = Summary/Done-means. |
 | `default_labels` | no | unique label list | Labels applied before caller-supplied labels are merged. Each label is a bare token (`epic`, `adr`) or namespaced (`area:backend`, `type:feature`). |
 | `default_fields` | no | object | `status` (single-select Status value), `board_column`, and `complexity` (low/medium/high). |
-| `numbering` | conditional | object | `scheme` (`sequential`) + optional `prefix`. Required when the type is `adr` (semantic check). |
+| `numbering` | conditional | object | `scheme` (`sequential`) + optional `prefix` + optional `pad` (zero-pad width for the rendered `{number}`, bounded 0..12; e.g. `3` → `041`, `0`/absent → no padding). Required when the type is `adr` (semantic check). |
 | `epic_link` | no | enum `required` \| `optional` \| `none` | Whether items of this type link to a parent epic. |
 
 Every object level is `additionalProperties: false` — the surface is closed; new sections are additive schema changes within v0.

--- a/docs/spec/work-management-v0.schema.json
+++ b/docs/spec/work-management-v0.schema.json
@@ -191,6 +191,12 @@
             "prefix": {
               "type": "string",
               "description": "Number prefix rendered into the title (e.g. ADR-)."
+            },
+            "pad": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 12,
+              "description": "Zero-pad the rendered {number} to this minimum width (e.g. 3 -> 041). 0/absent means no padding. Bounded 0..12 so a runaway pad cannot allocate an oversized title string; 12 exceeds any realistic numbering width."
             }
           }
         },


### PR DESCRIPTION
## Summary

Operator hand-finish of #1148 after three loop attempts failed to wire the fix into the shipped default. Adds an optional `pad` knob to the work-management `numbering` rule and sets `pad: 3` on the shipped `adr` default, so `fishhawk_file_issue type=adr` renders `[ADR-041]` for the existing zero-padded ADR series instead of the bare `[ADR-41]`. The `pad` property is bounded `0-12` in both schema copies.

The `numbering.pad` mechanism (schema property, `Numbering.Pad` field, `renderTitle` `%0*d` threading) is reused from the third loop attempt (PR #1167, closed) — which was correct but never set `pad: 3` on the shipped default (it added an explanatory comment) and asserted `[ADR-041]` against a hand-built `Pad:3` copy rather than `Default()`. This PR completes it: wires `pad: 3` into both `default.yaml` copies via `scripts/sync-schemas`, pins the done-means against the shipped `Default()` in `apply_test.go`, and updates the coupled `conventions_test.go` and `workitems_test.go` assertions to the padded form.

## Test plan

- `go test ./internal/workmgmt/` — pass (incl. `TestApply_ADRZeroPadsViaDefault` asserting the shipped `Default()` renders `[ADR-041]` for existing 1..40, `TestApply_ADRAllocatesNextNumberAndRendersPrefix` → `[ADR-036]`, and `TestDefaultRoundTrip` → `pad: 3`).
- `go test ./internal/server/ -run TestFileWorkItem_NumberedType` — pass (`[ADR-036]` end-to-end through the filing endpoint).
- `check-jsonschema` validates the canonical default against the schema (`pad: 3` within `0-12`); `scripts/sync-schemas` shows no mirror drift; `golangci-lint` 0 issues on both packages.

## Notes

- Three prior loop attempts (`a1c8d66e` cat-B infra flake, `a4cfd41b` dropped the default edits + no-op fixup wedge, `5aaf89fa` comment-instead-of-`pad:3`). Findings filed separately.
- The coupled `backend/internal/server/workitems_test.go` (out of the original plan scope) is the assertion that made loop attempts avoid wiring the default — its mid-stage amendment timed out while `run_stage` blocked.

Closes #1148