### PR TITLE
Derive ci.yml schema-sync gate from scripts/sync-schemas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,17 +95,18 @@ jobs:
       - name: Schema sync (docs/spec ↔ embedded copies)
         if: steps.have-modules.outputs.yes == 'true'
         run: |
-          # Each schema has a canonical copy under docs/spec/ and an
-          # embedded copy under backend/internal/<pkg>/schemas/. CI
-          # fails if they drift; update both in the same PR.
-          diff -u docs/spec/workflow-v0.schema.json \
-                  backend/internal/spec/schemas/workflow-v0.schema.json
-          diff -u docs/spec/workflow-v0.schema.json \
-                  cli/internal/spec/schemas/workflow-v0.schema.json
-          diff -u docs/spec/plan-standard-v1.schema.json \
-                  backend/internal/plan/schemas/plan-standard-v1.schema.json
-          diff -u docs/spec/plan-standard-v1.schema.json \
-                  runner/internal/plan/schemas/plan-standard-v1.schema.json
+          # Each canonical schema/default under docs/spec/ is mirrored into
+          # one or more embedded copies vendored into the Go modules.
+          # scripts/sync-schemas is the single source of truth for those
+          # pairs; re-run it and fail if anything changed, so a newly added
+          # pair (e.g. operator-role, work-management) is covered here
+          # automatically without editing this gate. Update both sides in
+          # the same PR and run scripts/sync-schemas before committing.
+          scripts/sync-schemas
+          if ! git diff --exit-code; then
+            echo "::error::Embedded schema copies drifted from docs/spec/. Run scripts/sync-schemas and commit the result." >&2
+            exit 1
+          fi
 
       - name: Install golangci-lint
         if: steps.have-modules.outputs.yes == 'true'


### PR DESCRIPTION
## Summary

The `Schema sync` gate in `ci.yml` hardcoded the four original `docs/spec/` ↔ embedded diff pairs and did not glob, so it could not catch drift in the **operator-role** copies (#1025) or the **work-management** copies (#1005) that were added to `scripts/sync-schemas` after the gate was written. Both #1025 plan reviewers flagged this window.

Rather than just append the three operator-role pairs (which would leave the work-management pairs uncovered and re-open the same gap on the next pair), this takes the issue's suggested single-source-of-truth path: the gate now runs `scripts/sync-schemas` — which already routes every pair — then fails on a non-empty `git diff`. A committed embedded copy that drifts from its canonical is re-synced by the script and surfaces in the diff, failing the gate. **New pairs are covered automatically without editing this workflow.**

`.github/workflows/**` is human-led repo policy (all agent workflows forbid it), so this is applied as a direct PR rather than through a Fishhawk run — drafted by the agent, applied by the operator.

## Test plan

- `actionlint .github/workflows/ci.yml` — passes.
- **Positive (synced tree):** `scripts/sync-schemas` then `git diff --quiet` over `docs backend cli runner` → clean, gate green.
- **Negative (committed operator-role drift):** committed a one-byte change to `backend/internal/operatorrole/schemas/operator-role.schema.json` without updating the canonical, ran the gate logic → `git diff --exit-code` non-empty, gate fails. (Confirmed the earlier hardcoded list did **not** cover this file.)

## Notes

- Direction is symmetric to the old `diff -u`: drift in either the canonical or an embedded copy of any routed pair fails the gate, because `sync-schemas` regenerates embedded-from-canonical and any committed difference shows up in `git diff`.
- `scripts/sync-schemas` already emits a stderr warning for `clarification-request-v1.schema.json` (no routing case / no embedded copy) but exits 0 — pre-existing, unaffected by this change and out of scope.

Closes #1041

🤖 Generated with [Claude Code](https://claude.com/claude-code)