### PR TITLE
[E22.X] Operator exempt_scope_files lever on resume_run + resume-reason injection (#1229)

### DIFF
--- a/backend/cmd/fishhawk-mcp/client.go
+++ b/backend/cmd/fishhawk-mcp/client.go
@@ -780,22 +780,35 @@ type RecoverScopePath struct {
 	Operation string `json:"operation,omitempty"`
 }
 
+// RecoverExemptPath is one operator-justified-unchanged path on a recovery
+// request (#1229): a DECLARED scope.files path the runner's #1151 shortfall
+// gate subtracts. The inverse of RecoverScopePath — it carries a required
+// {path, reason} and subtracts from the gate rather than widening scope.
+// Exported (like RecoverScopePath) so the MCP tool's input schema can reuse
+// the same shape the wire body carries.
+type RecoverExemptPath struct {
+	Path   string `json:"path"`
+	Reason string `json:"reason"`
+}
+
 // recoverRunRequest mirrors `server/recover.go::recoverRunRequest`.
 type recoverRunRequest struct {
-	AddScopeFiles  []RecoverScopePath `json:"add_scope_files,omitempty"`
-	Reason         string             `json:"reason,omitempty"`
-	BudgetOverride bool               `json:"budget_override,omitempty"`
+	AddScopeFiles    []RecoverScopePath  `json:"add_scope_files,omitempty"`
+	ExemptScopeFiles []RecoverExemptPath `json:"exempt_scope_files,omitempty"`
+	Reason           string              `json:"reason,omitempty"`
+	BudgetOverride   bool                `json:"budget_override,omitempty"`
 }
 
 // RecoverRunParams bundles the inputs to RecoverRun. IdempotencyKey
 // travels in the HTTP header per the backend's E8.2 contract, same
 // keyspace as StartRun.
 type RecoverRunParams struct {
-	ParentRunID    uuid.UUID
-	AddScopeFiles  []RecoverScopePath
-	Reason         string
-	BudgetOverride bool
-	IdempotencyKey string
+	ParentRunID      uuid.UUID
+	AddScopeFiles    []RecoverScopePath
+	ExemptScopeFiles []RecoverExemptPath
+	Reason           string
+	BudgetOverride   bool
+	IdempotencyKey   string
 }
 
 // RecoverRun mints a category-B recovery run via
@@ -808,9 +821,10 @@ type RecoverRunParams struct {
 //   - 422 recovery_unsupported (no cached workflow spec)
 func (c *apiClient) RecoverRun(ctx context.Context, p RecoverRunParams) (*Run, bool, error) {
 	body, err := json.Marshal(recoverRunRequest{
-		AddScopeFiles:  p.AddScopeFiles,
-		Reason:         p.Reason,
-		BudgetOverride: p.BudgetOverride,
+		AddScopeFiles:    p.AddScopeFiles,
+		ExemptScopeFiles: p.ExemptScopeFiles,
+		Reason:           p.Reason,
+		BudgetOverride:   p.BudgetOverride,
 	})
 	if err != nil {
 		return nil, false, fmt.Errorf("marshal recover_run: %w", err)

--- a/backend/cmd/fishhawk-mcp/resume_run.go
+++ b/backend/cmd/fishhawk-mcp/resume_run.go
@@ -19,7 +19,14 @@ type ResumeRunInput struct {
 	// AddScopeFiles are operator-named paths folded into the recovery
 	// run's effective scope as a pre-approved scope amendment.
 	AddScopeFiles []RecoverScopePath `json:"add_scope_files,omitempty" jsonschema:"paths to fold into the recovery run's effective scope; each entry is {path, operation} with operation 'modify' (default) or 'create' for net-new files the #818 gate would otherwise fail"`
-	Reason        string             `json:"reason,omitempty" jsonschema:"why the recovery (and each added path) is needed; recorded on the amendment row and the plan_reused_from audit entry"`
+	// ExemptScopeFiles are operator-justified-unchanged paths — the inverse
+	// of AddScopeFiles. Each marks a DECLARED scope.files path the runner's
+	// #1151 shortfall gate should subtract, so a category-B run that failed
+	// SOLELY on a declared-but-unchanged file recovers in ONE resume call
+	// with no replan. Unlike AddScopeFiles, an exemption does NOT widen
+	// scope (no amendment row) — it subtracts from the gate.
+	ExemptScopeFiles []RecoverExemptPath `json:"exempt_scope_files,omitempty" jsonschema:"DECLARED scope.files paths to mark operator-justified-unchanged so the runner's shortfall gate subtracts them; each entry is {path, reason} and both are required. The inverse of add_scope_files: it subtracts from the gate, it does NOT widen scope"`
+	Reason           string              `json:"reason,omitempty" jsonschema:"why the recovery (and each added path) is needed; recorded on the amendment row and the plan_reused_from audit entry, and injected into the recovery agent's binding conditions"`
 	// BudgetOverride forces the recovery past a blocking periodic cost
 	// budget that is over its limit for the current period.
 	BudgetOverride bool   `json:"budget_override,omitempty" jsonschema:"force the recovery past a blocking periodic cost budget that is over its limit; ignored when no blocking budget is over"`
@@ -87,11 +94,12 @@ func (r *runResolver) resumeRun(ctx context.Context, _ *mcp.CallToolRequest, in 
 	}
 
 	created, idempotent, err := r.api.RecoverRun(ctx, RecoverRunParams{
-		ParentRunID:    parentID,
-		AddScopeFiles:  in.AddScopeFiles,
-		Reason:         in.Reason,
-		BudgetOverride: in.BudgetOverride,
-		IdempotencyKey: in.IdempotencyKey,
+		ParentRunID:      parentID,
+		AddScopeFiles:    in.AddScopeFiles,
+		ExemptScopeFiles: in.ExemptScopeFiles,
+		Reason:           in.Reason,
+		BudgetOverride:   in.BudgetOverride,
+		IdempotencyKey:   in.IdempotencyKey,
 	})
 	if err != nil {
 		// Map the backend's gate codes onto operator-actionable tool

--- a/backend/cmd/fishhawk-mcp/resume_run_test.go
+++ b/backend/cmd/fishhawk-mcp/resume_run_test.go
@@ -52,6 +52,31 @@ func TestResumeRun_HappyPath_PostsBodyReturnsRun(t *testing.T) {
 	}
 }
 
+// TestResumeRun_ExemptScopeFiles_RoundTrips pins the #1229 exempt_scope_files
+// lever: the MCP input's ExemptScopeFiles reaches the backend recover request
+// body byte-for-byte (path + reason), alongside add_scope_files.
+func TestResumeRun_ExemptScopeFiles_RoundTrips(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	r := newResolver(srv, nil)
+
+	parentID := uuid.New()
+	_, _, err := r.resumeRun(context.Background(), nil, ResumeRunInput{
+		ParentRunID: parentID.String(),
+		ExemptScopeFiles: []RecoverExemptPath{
+			{Path: "backend/internal/server/handlers.go", Reason: "no change needed on this slice"},
+		},
+		Reason: "recover with the declared file left unchanged",
+	})
+	if err != nil {
+		t.Fatalf("resumeRun: %v", err)
+	}
+	if len(fb.recoverBody.ExemptScopeFiles) != 1 ||
+		fb.recoverBody.ExemptScopeFiles[0].Path != "backend/internal/server/handlers.go" ||
+		fb.recoverBody.ExemptScopeFiles[0].Reason != "no change needed on this slice" {
+		t.Errorf("backend got ExemptScopeFiles = %+v", fb.recoverBody.ExemptScopeFiles)
+	}
+}
+
 func TestResumeRun_InvalidUUID_FailsLocally(t *testing.T) {
 	_, srv := newFakeBackend(t)
 	r := newResolver(srv, nil)

--- a/backend/internal/integration/orchestrator/e2e_test.go
+++ b/backend/internal/integration/orchestrator/e2e_test.go
@@ -1383,6 +1383,10 @@ func TestDecomposition_E2E_CategoryBChildRecoverInPlace(t *testing.T) {
 		ScopeAmendmentRepo: scopeRepo,
 		APITokenRepo:       apiRepo,
 		Orchestrator:       o,
+		// A real (never-called) client satisfies the prompt-render handler's
+		// issueGetter guard; the recovery run carries no InstallationID, so no
+		// GitHub request is made when its implement prompt is rendered (#1229).
+		GitHub: githubclient.New(nil),
 	})
 	httpSrv := httptest.NewServer(srv.Handler())
 	t.Cleanup(httpSrv.Close)
@@ -1460,9 +1464,15 @@ func TestDecomposition_E2E_CategoryBChildRecoverInPlace(t *testing.T) {
 		t.Fatalf("Issue token: %v", err)
 	}
 	const recoveredFile = "backend/internal/server/recover.go"
+	// x.go is the plan's declared scope.files path (decomposedPlanContent);
+	// exempt it so the runner gate would subtract it (#1229).
+	const exemptedFile = "x.go"
+	const exemptReason = "declared but unchanged on this recovery slice"
+	const resumeReason = "fold the dropped file and re-drive the child in place"
 	recoverBody, _ := json.Marshal(map[string]any{
-		"add_scope_files": []map[string]string{{"path": recoveredFile, "operation": "modify"}},
-		"reason":          "fold the dropped file and re-drive the child in place",
+		"add_scope_files":    []map[string]string{{"path": recoveredFile, "operation": "modify"}},
+		"exempt_scope_files": []map[string]string{{"path": exemptedFile, "reason": exemptReason}},
+		"reason":             resumeReason,
 	})
 	req, _ := http.NewRequestWithContext(ctx, http.MethodPost,
 		fmt.Sprintf("%s/v0/runs/%s/recover", httpSrv.URL, failing.ID), bytes.NewReader(recoverBody))
@@ -1542,13 +1552,55 @@ func TestDecomposition_E2E_CategoryBChildRecoverInPlace(t *testing.T) {
 		t.Fatalf("plan_reused_from entries = %d, want 1", len(reused))
 	}
 	var reusedPayload struct {
-		Source string `json:"source"`
+		Source        string `json:"source"`
+		ExemptedPaths []struct {
+			Path   string `json:"path"`
+			Reason string `json:"reason"`
+		} `json:"exempted_paths"`
 	}
 	if err := json.Unmarshal(reused[0].Payload, &reusedPayload); err != nil {
 		t.Fatalf("decode plan_reused_from payload: %v", err)
 	}
 	if reusedPayload.Source != "decomposition_child_recovery" {
 		t.Errorf("plan_reused_from source = %q, want decomposition_child_recovery", reusedPayload.Source)
+	}
+	// (#1229) The operator's exempt_scope_files persisted on the provenance.
+	if len(reusedPayload.ExemptedPaths) != 1 ||
+		reusedPayload.ExemptedPaths[0].Path != exemptedFile ||
+		reusedPayload.ExemptedPaths[0].Reason != exemptReason {
+		t.Errorf("plan_reused_from exempted_paths = %+v, want the one operator exemption", reusedPayload.ExemptedPaths)
+	}
+
+	// (#1229) Cross-boundary delivery: the re-driven child's implement
+	// prompt-response carries scope_exemptions AND the resume reason renders
+	// into the binding conditions (Part D) — the seam no per-layer unit covers.
+	promptReq, _ := http.NewRequestWithContext(ctx, http.MethodGet,
+		fmt.Sprintf("%s/v0/stages/%s/prompt-render", httpSrv.URL, reImpl.ID), nil)
+	promptResp, err := http.DefaultClient.Do(promptReq)
+	if err != nil {
+		t.Fatalf("prompt-render request: %v", err)
+	}
+	defer func() { _ = promptResp.Body.Close() }()
+	if promptResp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(promptResp.Body)
+		t.Fatalf("prompt-render status = %d, want 200: %s", promptResp.StatusCode, b)
+	}
+	var prompt struct {
+		Prompt          string `json:"prompt"`
+		ScopeExemptions []struct {
+			Path   string `json:"path"`
+			Reason string `json:"reason"`
+		} `json:"scope_exemptions"`
+	}
+	if err := json.NewDecoder(promptResp.Body).Decode(&prompt); err != nil {
+		t.Fatalf("decode prompt-render: %v", err)
+	}
+	if len(prompt.ScopeExemptions) != 1 || prompt.ScopeExemptions[0].Path != exemptedFile ||
+		prompt.ScopeExemptions[0].Reason != exemptReason {
+		t.Errorf("prompt scope_exemptions = %+v, want the one operator exemption (cross-boundary delivery broke)", prompt.ScopeExemptions)
+	}
+	if !strings.Contains(prompt.Prompt, resumeReason) {
+		t.Errorf("implement prompt missing the Part D resume reason %q (reason→binding-conditions broke)", resumeReason)
 	}
 
 	// (e) The re-driven child succeeds; the sweeper then resolves the parent's

--- a/backend/internal/server/prompt.go
+++ b/backend/internal/server/prompt.go
@@ -136,6 +136,35 @@ type promptResponse struct {
 	// down the unchanged agent fix-up path. Omitted on a normal implement
 	// dispatch and on a non-eligible fix-up — byte-identical to today.
 	FixupApplyPatches []fixupApplyPatch `json:"fixup_apply_patches,omitempty"`
+	// ScopeExemptions is the operator's exempt_scope_files list (#1229) echoed
+	// on a recovery run's implement stage so the runner's #1151 MissingScopeFiles
+	// shortfall gate subtracts each operator-justified-unchanged declared path —
+	// the inverse of add_scope_files (it subtracts from the gate, it does not
+	// widen scope). Resolved from the run's OWN plan_reused_from audit entry, so
+	// it is empty/omitted on every non-recovery run — byte-identical to today.
+	//
+	// CROSS-MODULE WIRE CONTRACT: the json tags (scope_exemptions/path/reason)
+	// MUST stay byte-identical to the runner's upload.FetchedPrompt.ScopeExemptions
+	// decoder (runner/internal/upload/upload.go), the counterpart of this field —
+	// the same independent-struct-by-tag convention as BindingAssertions (#1171)
+	// and add_scope_files (#824). A tag drift here breaks the runner gate silently.
+	ScopeExemptions []scopeExemption `json:"scope_exemptions,omitempty"`
+}
+
+// scopeExemption is one operator scope exemption: a DECLARED scope.files path
+// marked operator-justified-unchanged so the runner's #1151 shortfall gate
+// subtracts it (#1229). {path, reason}, both required at the recover endpoint.
+//
+// CROSS-MODULE WIRE CONTRACT: the json tags (path/reason) MUST stay
+// byte-identical to the runner's upload.ScopeExemption decoder
+// (runner/internal/upload/upload.go), the counterpart of this struct. Same
+// independent-struct-by-tag convention as bindingAssertion (#1171) and the
+// add_scope_files (#824) cross-module pair. This single server-package type
+// is shared by recoverRunRequest.ExemptScopeFiles (the request + validation),
+// the plan_reused_from exempted_paths persistence, and this response field.
+type scopeExemption struct {
+	Path   string `json:"path"`
+	Reason string `json:"reason"`
 }
 
 // fixupApplyPatch is one entry in promptResponse.FixupApplyPatches: a single
@@ -619,6 +648,7 @@ func (s *Server) handleGetStagePrompt(w http.ResponseWriter, r *http.Request) {
 	// the audit log captures the gap.
 	var scopeFiles []scopeFile
 	var bindingAssertions []bindingAssertion
+	var scopeExemptions []scopeExemption
 	var fixup bool
 	var fixupBranch string
 	var fixupExpectedHeadSHA string
@@ -658,6 +688,13 @@ func (s *Server) handleGetStagePrompt(w http.ResponseWriter, r *http.Request) {
 		}
 		trigger.ScopeConstraint = s.resolveDecomposedScopeConstraint(r.Context(), runRow, approvedPlan)
 		trigger.ApprovalConditions = s.resolveApprovalConditions(r.Context(), runRow)
+		// Part D (#1229): a recovery run's resume_run reason rides the existing
+		// #558 binding-conditions channel so the operator's steer at recovery
+		// reaches the agent. No-op (byte-identical conditions) on every
+		// non-recovery run — loadRecoveryResumeReason returns nil without a
+		// plan_reused_from entry.
+		trigger.ApprovalConditions = appendRecoveryResumeReason(
+			trigger.ApprovalConditions, s.loadRecoveryResumeReason(r.Context(), runRow.ID))
 		// Binding-assertion declaration (#1171): echo the operator's declared
 		// assertions on the implement prompt-response so the runner can decode
 		// and evaluate them post-implement (slice 2). Only when an approved
@@ -667,6 +704,11 @@ func (s *Server) handleGetStagePrompt(w http.ResponseWriter, r *http.Request) {
 		// add_scope_files / ApprovalConditions.
 		if approvedPlan != nil {
 			bindingAssertions = s.resolveApprovalBindingAssertions(r.Context(), runRow)
+			// Operator scope exemptions (#1229): echo the recovery run's
+			// exempt_scope_files so the runner's #1151 shortfall gate subtracts
+			// each operator-justified-unchanged declared path. Read from the
+			// run's OWN plan_reused_from entry — nil on every non-recovery run.
+			scopeExemptions = s.resolveRecoveryScopeExemptions(r.Context(), runRow.ID)
 		}
 		// Fold the authoritative add_scope_files paths a reviewer named at
 		// approval time into the effective scope set (#824). This structured
@@ -791,6 +833,7 @@ func (s *Server) handleGetStagePrompt(w http.ResponseWriter, r *http.Request) {
 		RetryAttempt:         runRow.RetryAttempt,
 		ScopeFiles:           scopeFiles,
 		BindingAssertions:    bindingAssertions,
+		ScopeExemptions:      scopeExemptions,
 		CommitAuthorName:     commitAuthorName,
 		CommitAuthorEmail:    commitAuthorEmail,
 		Fixup:                fixup,
@@ -880,6 +923,7 @@ func (s *Server) handleGetStagePromptRender(w http.ResponseWriter, r *http.Reque
 	// the audit log captures the gap.
 	var scopeFiles []scopeFile
 	var bindingAssertions []bindingAssertion
+	var scopeExemptions []scopeExemption
 	var fixup bool
 	var fixupBranch string
 	var fixupExpectedHeadSHA string
@@ -919,6 +963,13 @@ func (s *Server) handleGetStagePromptRender(w http.ResponseWriter, r *http.Reque
 		}
 		trigger.ScopeConstraint = s.resolveDecomposedScopeConstraint(r.Context(), runRow, approvedPlan)
 		trigger.ApprovalConditions = s.resolveApprovalConditions(r.Context(), runRow)
+		// Part D (#1229): a recovery run's resume_run reason rides the existing
+		// #558 binding-conditions channel so the operator's steer at recovery
+		// reaches the agent. No-op (byte-identical conditions) on every
+		// non-recovery run — loadRecoveryResumeReason returns nil without a
+		// plan_reused_from entry.
+		trigger.ApprovalConditions = appendRecoveryResumeReason(
+			trigger.ApprovalConditions, s.loadRecoveryResumeReason(r.Context(), runRow.ID))
 		// Binding-assertion declaration (#1171): echo the operator's declared
 		// assertions on the implement prompt-response so the runner can decode
 		// and evaluate them post-implement (slice 2). Only when an approved
@@ -928,6 +979,11 @@ func (s *Server) handleGetStagePromptRender(w http.ResponseWriter, r *http.Reque
 		// add_scope_files / ApprovalConditions.
 		if approvedPlan != nil {
 			bindingAssertions = s.resolveApprovalBindingAssertions(r.Context(), runRow)
+			// Operator scope exemptions (#1229): echo the recovery run's
+			// exempt_scope_files so the runner's #1151 shortfall gate subtracts
+			// each operator-justified-unchanged declared path. Read from the
+			// run's OWN plan_reused_from entry — nil on every non-recovery run.
+			scopeExemptions = s.resolveRecoveryScopeExemptions(r.Context(), runRow.ID)
 		}
 		// Fold the authoritative add_scope_files paths a reviewer named at
 		// approval time into the effective scope set (#824). This structured
@@ -1043,6 +1099,7 @@ func (s *Server) handleGetStagePromptRender(w http.ResponseWriter, r *http.Reque
 		RetryAttempt:         runRow.RetryAttempt,
 		ScopeFiles:           scopeFiles,
 		BindingAssertions:    bindingAssertions,
+		ScopeExemptions:      scopeExemptions,
 		CommitAuthorName:     commitAuthorName,
 		CommitAuthorEmail:    commitAuthorEmail,
 		Fixup:                fixup,
@@ -2523,6 +2580,108 @@ func (s *Server) resolveApprovalConditions(ctx context.Context, runRow *run.Run)
 		)
 	}
 	return cond
+}
+
+// resolveRecoveryScopeExemptions returns the operator scope exemptions for an
+// implement-stage prompt, read from the run's OWN plan_reused_from audit entry
+// (#1229). A recovery run — the new-child mint OR the in-place re-driven
+// decomposition child (same id) — records exempted_paths on its own
+// plan_reused_from entry, so NO fan-out parent fallback is needed (unlike
+// resolveApprovalConditions): the exemptions belong to the run executing the
+// implement stage. Returns nil on every non-recovery run (no plan_reused_from),
+// keeping the response byte-identical to today. Best-effort: WARN-logs and
+// returns nil on any error.
+func (s *Server) resolveRecoveryScopeExemptions(ctx context.Context, runID uuid.UUID) []scopeExemption {
+	if s.cfg.AuditRepo == nil {
+		return nil
+	}
+	entries, err := s.cfg.AuditRepo.ListForRunByCategory(ctx, runID, CategoryPlanReusedFrom)
+	if err != nil {
+		s.cfg.Logger.LogAttrs(ctx, slog.LevelWarn, "prompt: list plan_reused_from for scope exemptions failed",
+			slog.String("run_id", runID.String()),
+			slog.String("error", err.Error()),
+		)
+		return nil
+	}
+	for i := len(entries) - 1; i >= 0; i-- {
+		var payload struct {
+			ExemptedPaths []scopeExemption `json:"exempted_paths"`
+		}
+		if err := json.Unmarshal(entries[i].Payload, &payload); err != nil {
+			continue
+		}
+		if len(payload.ExemptedPaths) > 0 {
+			s.cfg.Logger.LogAttrs(ctx, slog.LevelInfo,
+				"prompt: loaded operator scope exemptions into implement prompt-response",
+				slog.String("run_id", runID.String()),
+				slog.Int("count", len(payload.ExemptedPaths)),
+			)
+			return payload.ExemptedPaths
+		}
+	}
+	return nil
+}
+
+// loadRecoveryResumeReason returns the operator's resume_run reason recorded on
+// the run's OWN plan_reused_from audit entry (#1229, Part D), capped at 4000
+// bytes. nil when no plan_reused_from entry exists (every non-recovery run) or
+// its reason is empty/whitespace — so normal prompts are byte-identical.
+// Best-effort: WARN-logs and returns nil on any error. The caller appends this
+// to trigger.ApprovalConditions so the recovery directive rides the existing
+// #558 binding-conditions channel, mirroring approve_plan note delivery.
+func (s *Server) loadRecoveryResumeReason(ctx context.Context, runID uuid.UUID) *string {
+	if s.cfg.AuditRepo == nil {
+		return nil
+	}
+	entries, err := s.cfg.AuditRepo.ListForRunByCategory(ctx, runID, CategoryPlanReusedFrom)
+	if err != nil {
+		s.cfg.Logger.LogAttrs(ctx, slog.LevelWarn, "prompt: list plan_reused_from for resume reason failed",
+			slog.String("run_id", runID.String()),
+			slog.String("error", err.Error()),
+		)
+		return nil
+	}
+	for i := len(entries) - 1; i >= 0; i-- {
+		var payload struct {
+			Reason string `json:"reason"`
+		}
+		if err := json.Unmarshal(entries[i].Payload, &payload); err != nil {
+			continue
+		}
+		if strings.TrimSpace(payload.Reason) != "" {
+			c := payload.Reason
+			const maxConditionBytes = 4000
+			if len(c) > maxConditionBytes {
+				c = c[:maxConditionBytes] + "...[truncated]"
+			}
+			s.cfg.Logger.LogAttrs(ctx, slog.LevelInfo,
+				"prompt: loaded recovery resume reason into implement prompt conditions",
+				slog.String("run_id", runID.String()),
+				slog.Int("reason_bytes", len(payload.Reason)),
+			)
+			return &c
+		}
+	}
+	return nil
+}
+
+// appendRecoveryResumeReason folds the recovery run's resume_run reason
+// (#1229, Part D) into the implement prompt's binding conditions so the
+// operator's steer at recovery reaches the agent through the existing #558
+// "Approval conditions" channel. The reason is appended under a labeled
+// marker so the agent can tell it apart from inherited approve-with-conditions
+// text. When recoveryReason is nil the conditions are returned unchanged
+// (every non-recovery run), keeping normal prompts byte-identical.
+func appendRecoveryResumeReason(conditions, recoveryReason *string) *string {
+	if recoveryReason == nil {
+		return conditions
+	}
+	labeled := "Recovery directive (resume_run reason): " + *recoveryReason
+	if conditions == nil {
+		return &labeled
+	}
+	combined := *conditions + "\n\n" + labeled
+	return &combined
 }
 
 // loadApprovalAddScopeFiles scans the run's approval_submitted audit entries

--- a/backend/internal/server/prompt_test.go
+++ b/backend/internal/server/prompt_test.go
@@ -3637,6 +3637,237 @@ func makeApproveWithCommentEntry(runID uuid.UUID, comment string) *audit.Entry {
 	return &audit.Entry{ID: uuid.New(), Category: "approval_submitted", RunID: &rid, Payload: payload}
 }
 
+// makePlanReusedFromEntry builds a plan_reused_from audit entry carrying the
+// #1229 exempted_paths + resume reason — the durable record the recovery
+// prompt builder reads back.
+func makePlanReusedFromEntry(runID uuid.UUID, exempted []scopeExemption, reason string) *audit.Entry {
+	payload, _ := json.Marshal(map[string]any{
+		"parent_run_id":           uuid.New().String(),
+		"parent_failure_category": "B",
+		"source":                  "operator_recovery",
+		"exempted_paths":          exempted,
+		"reason":                  reason,
+	})
+	rid := runID
+	return &audit.Entry{ID: uuid.New(), Category: CategoryPlanReusedFrom, RunID: &rid, Payload: payload}
+}
+
+func TestResolveRecoveryScopeExemptions(t *testing.T) {
+	runID := uuid.New()
+	want := []scopeExemption{{Path: "backend/a.go", Reason: "unchanged on this slice"}}
+
+	t.Run("returns the run's exempted_paths", func(t *testing.T) {
+		s := newFeedbackServer(t, nil, map[uuid.UUID][]*audit.Entry{
+			runID: {makePlanReusedFromEntry(runID, want, "recover")},
+		})
+		got := s.resolveRecoveryScopeExemptions(context.Background(), runID)
+		if len(got) != 1 || got[0] != want[0] {
+			t.Errorf("got %+v, want %+v", got, want)
+		}
+	})
+
+	t.Run("absent plan_reused_from returns nil", func(t *testing.T) {
+		s := newFeedbackServer(t, nil, nil)
+		if got := s.resolveRecoveryScopeExemptions(context.Background(), runID); got != nil {
+			t.Errorf("got %+v, want nil (no plan_reused_from)", got)
+		}
+	})
+
+	t.Run("plan_reused_from with no exemptions returns nil", func(t *testing.T) {
+		s := newFeedbackServer(t, nil, map[uuid.UUID][]*audit.Entry{
+			runID: {makePlanReusedFromEntry(runID, nil, "recover")},
+		})
+		if got := s.resolveRecoveryScopeExemptions(context.Background(), runID); got != nil {
+			t.Errorf("got %+v, want nil (no exempted_paths)", got)
+		}
+	})
+}
+
+func TestLoadRecoveryResumeReason(t *testing.T) {
+	runID := uuid.New()
+
+	t.Run("returns the resume reason", func(t *testing.T) {
+		s := newFeedbackServer(t, nil, map[uuid.UUID][]*audit.Entry{
+			runID: {makePlanReusedFromEntry(runID, nil, "steer the recovery here")},
+		})
+		got := s.loadRecoveryResumeReason(context.Background(), runID)
+		if got == nil || *got != "steer the recovery here" {
+			t.Errorf("got %v, want the resume reason", got)
+		}
+	})
+
+	t.Run("absent plan_reused_from returns nil", func(t *testing.T) {
+		s := newFeedbackServer(t, nil, nil)
+		if got := s.loadRecoveryResumeReason(context.Background(), runID); got != nil {
+			t.Errorf("got %q, want nil", *got)
+		}
+	})
+
+	t.Run("empty/whitespace reason returns nil", func(t *testing.T) {
+		s := newFeedbackServer(t, nil, map[uuid.UUID][]*audit.Entry{
+			runID: {makePlanReusedFromEntry(runID, nil, "   ")},
+		})
+		if got := s.loadRecoveryResumeReason(context.Background(), runID); got != nil {
+			t.Errorf("got %q, want nil (whitespace reason)", *got)
+		}
+	})
+}
+
+func TestAppendRecoveryResumeReason(t *testing.T) {
+	conditions := "Inherited approve-with-conditions text."
+	reason := "Recover with the declared file unchanged."
+
+	t.Run("nil reason leaves conditions unchanged", func(t *testing.T) {
+		got := appendRecoveryResumeReason(&conditions, nil)
+		if got != &conditions {
+			t.Errorf("got %v, want the original conditions pointer unchanged", got)
+		}
+	})
+
+	t.Run("nil conditions yields the labeled reason", func(t *testing.T) {
+		got := appendRecoveryResumeReason(nil, &reason)
+		if got == nil || *got != "Recovery directive (resume_run reason): "+reason {
+			t.Errorf("got %v, want the labeled reason", got)
+		}
+	})
+
+	t.Run("both combine conditions then reason", func(t *testing.T) {
+		got := appendRecoveryResumeReason(&conditions, &reason)
+		want := conditions + "\n\nRecovery directive (resume_run reason): " + reason
+		if got == nil || *got != want {
+			t.Errorf("got %v, want %q", got, want)
+		}
+	})
+}
+
+// TestGetStagePrompt_Implement_RecoveryScopeExemptionsAndReason crosses the
+// plan_reused_from audit → implement prompt-response path (#1229) on BOTH
+// build paths (the signed /prompt and the SPA /prompt-render): the recovery
+// run's exempt_scope_files surface in resp.ScopeExemptions and the resume
+// reason renders into the binding "Approval conditions" block (Part D). A
+// control run with no plan_reused_from leaves both empty/absent.
+func TestGetStagePrompt_Implement_RecoveryScopeExemptionsAndReason(t *testing.T) {
+	const exemptPath = "backend/internal/server/handlers.go"
+	const resumeReason = "Recover leaving the declared file unchanged on this slice."
+
+	buildServer := func(t *testing.T, withReuse bool) (*Server, *promptRunRepo, *signingFake, uuid.UUID, uuid.UUID) {
+		t.Helper()
+		rr := newPromptRunRepo()
+		sf := newSigningFake()
+		art := newFakeArtifactRepo()
+
+		runID := uuid.New()
+		planStageID := uuid.New()
+		implStageID := uuid.New()
+
+		p := &plan.Plan{
+			PlanVersion:  "standard_v1",
+			Summary:      "recoverable plan",
+			Verification: plan.Verification{TestStrategy: "ts", RollbackPlan: "rb"},
+			Scope: plan.Scope{
+				Files: []plan.ScopeFile{{Path: exemptPath, Operation: plan.FileOpModify}},
+			},
+		}
+		planBytes, err := json.Marshal(p)
+		if err != nil {
+			t.Fatalf("marshal plan: %v", err)
+		}
+		sv := "standard_v1"
+		if _, err := art.Create(context.Background(), artifact.CreateParams{
+			StageID:       planStageID,
+			Kind:          artifact.KindPlan,
+			SchemaVersion: &sv,
+			Content:       planBytes,
+		}); err != nil {
+			t.Fatalf("seed plan artifact: %v", err)
+		}
+
+		rr.stagesByRunID = map[uuid.UUID][]*run.Stage{
+			runID: {
+				{ID: planStageID, RunID: runID, Type: run.StageTypePlan},
+				{ID: implStageID, RunID: runID, Type: run.StageTypeImplement},
+			},
+		}
+		rr.getRuns[runID] = &run.Run{ID: runID, Repo: "o/r", WorkflowID: "feature_change"}
+		rr.getStages[implStageID] = &run.Stage{ID: implStageID, RunID: runID, Type: run.StageTypeImplement}
+
+		auditByRun := map[uuid.UUID][]*audit.Entry{}
+		if withReuse {
+			auditByRun[runID] = []*audit.Entry{
+				makePlanReusedFromEntry(runID,
+					[]scopeExemption{{Path: exemptPath, Reason: "declared but unchanged"}}, resumeReason),
+			}
+		}
+
+		s := New(Config{
+			Addr:         "127.0.0.1:0",
+			RunRepo:      rr,
+			SigningRepo:  sf,
+			ArtifactRepo: art,
+			AuditRepo:    &feedbackAuditRepo{byRunID: auditByRun},
+		})
+		s.promptIssueGetterOverride = &stubIssueGetter{}
+		return s, rr, sf, runID, implStageID
+	}
+
+	decode := func(t *testing.T, w *httptest.ResponseRecorder) promptResponse {
+		t.Helper()
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200:\n%s", w.Code, w.Body.String())
+		}
+		var resp promptResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode prompt: %v", err)
+		}
+		return resp
+	}
+
+	renderRequest := func(t *testing.T, s *Server, stageID uuid.UUID) *httptest.ResponseRecorder {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodGet,
+			fmt.Sprintf("/v0/stages/%s/prompt-render", stageID), nil)
+		w := httptest.NewRecorder()
+		s.Handler().ServeHTTP(w, req)
+		return w
+	}
+
+	t.Run("recovery run carries exemptions + reason on /prompt", func(t *testing.T) {
+		s, _, sf, runID, implStageID := buildServer(t, true)
+		priv, _ := sf.issue(t, runID)
+		resp := decode(t, promptRequest(t, s, runID, implStageID, priv, ""))
+		if len(resp.ScopeExemptions) != 1 || resp.ScopeExemptions[0].Path != exemptPath ||
+			resp.ScopeExemptions[0].Reason != "declared but unchanged" {
+			t.Errorf("ScopeExemptions = %+v, want the one operator exemption", resp.ScopeExemptions)
+		}
+		if !strings.Contains(resp.Prompt, resumeReason) {
+			t.Errorf("prompt missing the Part D resume reason %q\n---\n%s", resumeReason, resp.Prompt)
+		}
+	})
+
+	t.Run("recovery run carries exemptions + reason on /prompt-render", func(t *testing.T) {
+		s, _, _, _, implStageID := buildServer(t, true)
+		resp := decode(t, renderRequest(t, s, implStageID))
+		if len(resp.ScopeExemptions) != 1 || resp.ScopeExemptions[0].Path != exemptPath {
+			t.Errorf("ScopeExemptions = %+v, want the one operator exemption", resp.ScopeExemptions)
+		}
+		if !strings.Contains(resp.Prompt, resumeReason) {
+			t.Errorf("prompt-render missing the Part D resume reason %q\n---\n%s", resumeReason, resp.Prompt)
+		}
+	})
+
+	t.Run("non-recovery run has empty ScopeExemptions + no reason", func(t *testing.T) {
+		s, _, sf, runID, implStageID := buildServer(t, false)
+		priv, _ := sf.issue(t, runID)
+		resp := decode(t, promptRequest(t, s, runID, implStageID, priv, ""))
+		if len(resp.ScopeExemptions) != 0 {
+			t.Errorf("ScopeExemptions = %+v, want empty (no plan_reused_from)", resp.ScopeExemptions)
+		}
+		if strings.Contains(resp.Prompt, resumeReason) {
+			t.Errorf("non-recovery prompt unexpectedly contains the resume reason\n---\n%s", resp.Prompt)
+		}
+	})
+}
+
 // TestGetStagePrompt_ApprovalConditions_DecompositionFallback is the
 // integration test for #677: it crosses the audit-load -> handler ->
 // rendered-prompt-text path and asserts the parent plan-gate's binding

--- a/backend/internal/server/recover.go
+++ b/backend/internal/server/recover.go
@@ -23,7 +23,8 @@ import (
 // CategoryPlanReusedFrom is the audit-log category for the provenance
 // entry the recovery handler appends on the NEW run (E22.X / #978).
 // Payload carries {parent_run_id, parent_failure_category, added_paths,
-// source, reason}. Internal audit kind — NOT an issue-comment surface.
+// exempted_paths, source, reason}. Internal audit kind — NOT an
+// issue-comment surface.
 const CategoryPlanReusedFrom = "plan_reused_from"
 
 // recoverRunRequest is the JSON body of POST /v0/runs/{run_id}/recover.
@@ -34,8 +35,17 @@ type recoverRunRequest struct {
 	// recovery run's effective scope via a pre-approved #961 scope
 	// amendment row. Operation defaults to modify when omitted.
 	AddScopeFiles []scopeamendment.PathEntry `json:"add_scope_files,omitempty"`
+	// ExemptScopeFiles are the operator-justified-unchanged DECLARED
+	// scope.files paths the runner's #1151 shortfall gate subtracts
+	// (#1229) — the inverse of AddScopeFiles. Each {path, reason} is
+	// validated (clean repo-relative path + non-empty reason) and
+	// persisted on the plan_reused_from provenance as exempted_paths; it
+	// does NOT mint a scope-amendment row (it subtracts from the gate, it
+	// does not widen scope). scopeExemption is defined in prompt.go.
+	ExemptScopeFiles []scopeExemption `json:"exempt_scope_files,omitempty"`
 	// Reason rides on both the amendment row and the plan_reused_from
-	// provenance entry.
+	// provenance entry, and is injected into the recovery agent's binding
+	// conditions (Part D, #1229).
 	Reason string `json:"reason,omitempty"`
 	// BudgetOverride forces the recovery past a blocking periodic
 	// budget that is over its limit, mirroring POST /v0/runs (#688).
@@ -118,6 +128,18 @@ func (s *Server) handleRecoverRun(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Validate + normalize the operator's exempt_scope_files up front (#1229).
+	// Each path must be clean repo-relative AND carry a non-empty reason — a
+	// 400 on either failure, before the run is minted. Exemptions do NOT mint
+	// a scope-amendment row; they ride the plan_reused_from provenance and the
+	// runner subtracts them from the #1151 shortfall gate.
+	exemptPaths, err := validateExemptScopeFiles(req.ExemptScopeFiles)
+	if err != nil {
+		s.writeError(w, r, http.StatusBadRequest, "validation_failed",
+			err.Error(), map[string]any{"field": "exempt_scope_files"})
+		return
+	}
+
 	parent, err := s.cfg.RunRepo.GetRun(r.Context(), parentID)
 	if err != nil {
 		if errors.Is(err, run.ErrNotFound) {
@@ -140,7 +162,7 @@ func (s *Server) handleRecoverRun(w http.ResponseWriter, r *http.Request) {
 	// a second DecomposedFrom row would double-count in
 	// childcompletion.resolveParent's consolidation counters.
 	if parent.DecomposedFrom != nil {
-		s.handleRecoverDecompositionChild(w, r, parent, amendPaths, req.Reason)
+		s.handleRecoverDecompositionChild(w, r, parent, amendPaths, exemptPaths, req.Reason)
 		return
 	}
 
@@ -325,7 +347,7 @@ func (s *Server) handleRecoverRun(w http.ResponseWriter, r *http.Request) {
 	// child's ParentRunID and the approved amendment row are the
 	// durable records; a failed append warn-logs rather than
 	// unwinding the created run.
-	s.writePlanReusedFromAudit(r, child.ID, parent.ID.String(), "operator_recovery", amendPaths, req.Reason, id.Subject)
+	s.writePlanReusedFromAudit(r, child.ID, parent.ID.String(), "operator_recovery", amendPaths, exemptPaths, req.Reason, id.Subject)
 
 	s.writeJSON(w, r, http.StatusCreated, toRunResponse(child))
 }
@@ -397,7 +419,7 @@ func (s *Server) createApprovedScopeAmendment(ctx context.Context, runID, stageI
 // the identical contract. (Runner-side fhm_ tokens carry only mcp:read
 // and so can't clear write:runs to reach this branch in practice — but
 // the authz posture must be consistent by construction, not by accident.)
-func (s *Server) handleRecoverDecompositionChild(w http.ResponseWriter, r *http.Request, child *run.Run, amendPaths []scopeamendment.PathEntry, reason string) {
+func (s *Server) handleRecoverDecompositionChild(w http.ResponseWriter, r *http.Request, child *run.Run, amendPaths []scopeamendment.PathEntry, exemptPaths []scopeExemption, reason string) {
 	id := IdentityFrom(r.Context())
 	if strings.HasPrefix(id.Subject, "mcp:run:") {
 		s.writeError(w, r, http.StatusForbidden, "agent_token_forbidden",
@@ -495,7 +517,7 @@ func (s *Server) handleRecoverDecompositionChild(w http.ResponseWriter, r *http.
 	// the approved amendment row and the re-driven stage are the durable
 	// records.
 	s.writePlanReusedFromAudit(r, child.ID, child.DecomposedFrom.String(),
-		"decomposition_child_recovery", amendPaths, reason, id.Subject)
+		"decomposition_child_recovery", amendPaths, exemptPaths, reason, id.Subject)
 
 	// Un-terminal-ing the run let Advance act (it no-ops on terminal
 	// runs); walk the re-opened pending implement stage → dispatched.
@@ -520,17 +542,49 @@ func (s *Server) handleRecoverDecompositionChild(w http.ResponseWriter, r *http.
 	s.writeJSON(w, r, http.StatusCreated, toRunResponse(updated))
 }
 
+// validateExemptScopeFiles normalizes and validates the operator's
+// exempt_scope_files (#1229). Each entry must name a clean repo-relative path
+// (non-empty after trim; not absolute; no ".." traversal — the same
+// containment contract isRepoRelativePath enforces for the #1151 shortfall
+// gate) AND carry a non-empty reason. Returns the trimmed entries or an error
+// describing the first bad entry; nil input yields nil with no error (an
+// exemption-less recovery is valid).
+func validateExemptScopeFiles(in []scopeExemption) ([]scopeExemption, error) {
+	if len(in) == 0 {
+		return nil, nil
+	}
+	out := make([]scopeExemption, 0, len(in))
+	for _, e := range in {
+		p := strings.TrimSpace(e.Path)
+		if p == "" {
+			return nil, errors.New("exempt_scope_files entries must name a non-empty repo-relative path")
+		}
+		if !isRepoRelativePath(p) {
+			return nil, fmt.Errorf("exempt_scope_files path %q must be repo-relative (no leading '/' or '..')", p)
+		}
+		reason := strings.TrimSpace(e.Reason)
+		if reason == "" {
+			return nil, fmt.Errorf("exempt_scope_files path %q must carry a non-empty reason", p)
+		}
+		out = append(out, scopeExemption{Path: p, Reason: reason})
+	}
+	return out, nil
+}
+
 // writePlanReusedFromAudit appends the plan_reused_from chain entry on
 // the recovery run (childID). source distinguishes the new-child mint
 // (operator_recovery) from the in-place decomposition re-drive
 // (decomposition_child_recovery); parentRunID is the run whose approved
-// plan was reused.
-func (s *Server) writePlanReusedFromAudit(r *http.Request, childID uuid.UUID, parentRunID, source string, addedPaths []scopeamendment.PathEntry, reason, subject string) {
+// plan was reused. exemptedPaths records the operator's exempt_scope_files
+// (#1229) — the durable record the prompt builder reads back to deliver
+// scope_exemptions to the runner gate.
+func (s *Server) writePlanReusedFromAudit(r *http.Request, childID uuid.UUID, parentRunID, source string, addedPaths []scopeamendment.PathEntry, exemptedPaths []scopeExemption, reason, subject string) {
 	actorKind := audit.ActorUser
 	payload, _ := json.Marshal(map[string]any{
 		"parent_run_id":           parentRunID,
 		"parent_failure_category": string(run.FailureB),
 		"added_paths":             addedPaths,
+		"exempted_paths":          exemptedPaths,
 		"source":                  source,
 		"reason":                  reason,
 	})

--- a/backend/internal/server/recover_test.go
+++ b/backend/internal/server/recover_test.go
@@ -630,6 +630,154 @@ func TestRecoverRun_DecompositionChildInPlace(t *testing.T) {
 	}
 }
 
+// decodeExemptedPaths reads the run's plan_reused_from exempted_paths from the
+// recorded audit appends.
+func decodeExemptedPaths(t *testing.T, au *recoverAuditRepo, runID uuid.UUID) []scopeExemption {
+	t.Helper()
+	for i := range au.appended {
+		if au.appended[i].Category != CategoryPlanReusedFrom || au.appended[i].RunID != runID {
+			continue
+		}
+		var payload struct {
+			ExemptedPaths []scopeExemption `json:"exempted_paths"`
+		}
+		if err := json.Unmarshal(au.appended[i].Payload, &payload); err != nil {
+			t.Fatalf("decode plan_reused_from payload: %v", err)
+		}
+		return payload.ExemptedPaths
+	}
+	t.Fatalf("no plan_reused_from audit entry for run %s", runID)
+	return nil
+}
+
+// TestRecoverRun_ExemptScopeFiles_NewChild pins the #1229 lever on the
+// new-child mint branch: exempt_scope_files is validated, persisted as
+// exempted_paths on the child's plan_reused_from provenance, and (critically)
+// does NOT mint a scope-amendment row (it subtracts from the runner gate, it
+// does not widen scope).
+func TestRecoverRun_ExemptScopeFiles_NewChild(t *testing.T) {
+	s, rr, sa, au := newRecoverServer(t)
+	parent, _, _ := seedRecoverableParent(rr, run.StageStateFailed, failureCat(run.FailureB))
+
+	w := postRecover(t, s, parent.ID.String(),
+		`{"exempt_scope_files":[{"path":"backend/internal/server/handlers.go","reason":"no change needed on this slice"}],"reason":"recover, leaving the declared file unchanged"}`, nil)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201:\n%s", w.Code, w.Body.String())
+	}
+	var resp runResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	// Exemptions never mint a scope-amendment row.
+	amendments, err := sa.ListByRun(context.Background(), resp.ID)
+	if err != nil {
+		t.Fatalf("list amendments: %v", err)
+	}
+	if len(amendments) != 0 {
+		t.Errorf("amendments = %d, want 0 (an exemption subtracts from the gate, it does not widen scope)", len(amendments))
+	}
+
+	exempted := decodeExemptedPaths(t, au, resp.ID)
+	if len(exempted) != 1 || exempted[0].Path != "backend/internal/server/handlers.go" ||
+		exempted[0].Reason != "no change needed on this slice" {
+		t.Errorf("exempted_paths = %+v, want the one operator exemption", exempted)
+	}
+}
+
+// TestRecoverRun_ExemptScopeFiles_DecompositionChild pins the #1229 lever on
+// the in-place decomposition-child re-drive branch: exempted_paths are
+// persisted on the re-opened child's plan_reused_from, again with no amendment
+// row.
+func TestRecoverRun_ExemptScopeFiles_DecompositionChild(t *testing.T) {
+	s, rr, sa, au, art := newDecompositionRecoverServer(t)
+	child, _ := seedRecoverableDecompositionChild(t, rr, art, failureCat(run.FailureB))
+
+	w := postRecover(t, s, child.ID.String(),
+		`{"exempt_scope_files":[{"path":"backend/internal/server/handlers.go","reason":"declared but unchanged on this slice"}],"reason":"re-drive in place, file unchanged"}`, nil)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201:\n%s", w.Code, w.Body.String())
+	}
+
+	amendments, err := sa.ListByRun(context.Background(), child.ID)
+	if err != nil {
+		t.Fatalf("list amendments: %v", err)
+	}
+	if len(amendments) != 0 {
+		t.Errorf("amendments = %d, want 0 (exemptions subtract, they do not widen scope)", len(amendments))
+	}
+
+	exempted := decodeExemptedPaths(t, au, child.ID)
+	if len(exempted) != 1 || exempted[0].Path != "backend/internal/server/handlers.go" ||
+		exempted[0].Reason != "declared but unchanged on this slice" {
+		t.Errorf("exempted_paths = %+v, want the one operator exemption", exempted)
+	}
+}
+
+// TestRecoverRun_ExemptScopeFiles_FailModes asserts BOTH validation fail-modes
+// (bad repo-relative path; empty/whitespace reason) return 400
+// validation_failed field=exempt_scope_files on BOTH recover branches (the
+// new-child mint AND the in-place decomposition re-drive), and that the failure
+// mints/re-drives nothing — validation runs before the run is touched.
+func TestRecoverRun_ExemptScopeFiles_FailModes(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"absolute path", `{"exempt_scope_files":[{"path":"/etc/passwd","reason":"r"}]}`},
+		{"dotdot path", `{"exempt_scope_files":[{"path":"../escape.go","reason":"r"}]}`},
+		{"empty path", `{"exempt_scope_files":[{"path":"  ","reason":"r"}]}`},
+		{"empty reason", `{"exempt_scope_files":[{"path":"backend/a.go","reason":""}]}`},
+		{"whitespace reason", `{"exempt_scope_files":[{"path":"backend/a.go","reason":"   "}]}`},
+	}
+
+	t.Run("new-child branch", func(t *testing.T) {
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				s, rr, _, _ := newRecoverServer(t)
+				parent, _, _ := seedRecoverableParent(rr, run.StageStateFailed, failureCat(run.FailureB))
+				w := postRecover(t, s, parent.ID.String(), tc.body, nil)
+				if w.Code != http.StatusBadRequest {
+					t.Fatalf("status = %d, want 400:\n%s", w.Code, w.Body.String())
+				}
+				assertErrorCode(t, w, "validation_failed")
+				assertErrorField(t, w, "exempt_scope_files")
+				assertNoRunMinted(t, rr)
+			})
+		}
+	})
+
+	t.Run("decomposition-child branch", func(t *testing.T) {
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				s, rr, _, _, art := newDecompositionRecoverServer(t)
+				child, implStage := seedRecoverableDecompositionChild(t, rr, art, failureCat(run.FailureB))
+				w := postRecover(t, s, child.ID.String(), tc.body, nil)
+				if w.Code != http.StatusBadRequest {
+					t.Fatalf("status = %d, want 400:\n%s", w.Code, w.Body.String())
+				}
+				assertErrorCode(t, w, "validation_failed")
+				assertErrorField(t, w, "exempt_scope_files")
+				// The child was NOT re-driven — validation precedes RedriveChild.
+				reopened, err := rr.GetRun(context.Background(), child.ID)
+				if err != nil {
+					t.Fatalf("get child: %v", err)
+				}
+				if reopened.State != run.StateFailed {
+					t.Errorf("child state = %q, want failed (validation must precede the re-drive)", reopened.State)
+				}
+				stage, err := rr.GetStage(context.Background(), implStage.ID)
+				if err != nil {
+					t.Fatalf("get implement stage: %v", err)
+				}
+				if stage.State != run.StageStateFailed {
+					t.Errorf("implement stage state = %q, want failed (no re-drive on validation failure)", stage.State)
+				}
+			})
+		}
+	})
+}
+
 // TestRecoverRun_DecompositionChildNoAmendment confirms the branch
 // recovers with an empty body (no add_scope_files) — the amendment is
 // optional; the re-drive against the parent-walked plan is the point.
@@ -1204,5 +1352,24 @@ func assertErrorCode(t *testing.T, w *httptest.ResponseRecorder, want string) {
 	}
 	if env.Error.Code != want {
 		t.Errorf("error code = %q, want %q\n%s", env.Error.Code, want, w.Body.String())
+	}
+}
+
+// assertErrorField decodes the error envelope and asserts the details.field
+// value — the precise field name a validation_failed names.
+func assertErrorField(t *testing.T, w *httptest.ResponseRecorder, want string) {
+	t.Helper()
+	var env struct {
+		Error struct {
+			Details struct {
+				Field string `json:"field"`
+			} `json:"details"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode error envelope: %v\n%s", err, w.Body.String())
+	}
+	if env.Error.Details.Field != want {
+		t.Errorf("error details.field = %q, want %q\n%s", env.Error.Details.Field, want, w.Body.String())
 	}
 }

--- a/docs/api/v0.md
+++ b/docs/api/v0.md
@@ -122,7 +122,8 @@ POST   /v0/runs/{run_id}/recover             — category-B recovery (#978). Tar
                                                  parent_run_id walk. Re-opens implement failed→pending,
                                                  run failed→running, then hands to the orchestrator.
                                                body (all optional): {add_scope_files?: [{path,
-                                                 operation?: modify|create}], reason?, budget_override?}
+                                                 operation?: modify|create}], exempt_scope_files?:
+                                                 [{path, reason}], reason?, budget_override?}
                                                Ineligible → 409 recovery_not_eligible with
                                                  {plan_state, implement_state, failure_category,
                                                  plan_resolved}.
@@ -134,11 +135,24 @@ POST   /v0/runs/{run_id}/recover             — category-B recovery (#978). Tar
                                                  net-new-file gates. The fold no-ops when the reused
                                                  plan declares an empty scope.files (the git add -A
                                                  guard) — documented edge, not a refusal.
+                                               exempt_scope_files (#1229) is the INVERSE of
+                                                 add_scope_files: each {path, reason} marks a DECLARED
+                                                 scope.files path operator-justified-unchanged so the
+                                                 runner's MissingScopeFiles shortfall gate subtracts it
+                                                 — it does NOT mint an amendment row (subtracts from the
+                                                 gate, does not widen scope). Each path must be clean
+                                                 repo-relative AND carry a non-empty reason; either
+                                                 failure → 400 validation_failed field=exempt_scope_files.
+                                                 Recorded as exempted_paths on plan_reused_from and
+                                                 delivered to the runner via the implement prompt's
+                                                 scope_exemptions field.
                                                retry_attempt carried UNCHANGED (never consumes the
                                                  on_ci_failure cap); provenance = parent_run_id plus
                                                  a plan_reused_from audit entry on the child (source
                                                  operator_recovery, or decomposition_child_recovery
-                                                 for an in-place re-drive).
+                                                 for an in-place re-drive; payload adds exempted_paths,
+                                                 and reason is injected into the recovery agent's
+                                                 binding conditions, Part D).
                                                Idempotency-Key shares the (repo, key) keyspace with
                                                  POST /v0/runs — replay returns the existing run, 200,
                                                  honored BEFORE the budget gate (replay is not new
@@ -630,6 +644,16 @@ Fishhawk-attributed commit (#581). Dirty-but-undeclared paths are excluded
 commit, matching the spec's flag-only scope-drift treatment. When `scope_files`
 is absent (no approved plan, i.e. `plan_missing_for_implement`) the runner
 falls back to `git add -A`.
+
+On a recovery run the same prompt response additionally carries
+`scope_exemptions` — the operator's `exempt_scope_files` (#1229), each a
+`{path, reason}` marking a DECLARED `scope.files` path
+operator-justified-unchanged. The runner subtracts these from its
+`MissingScopeFiles` shortfall gate, so a category-B run that failed SOLELY on a
+declared-but-unchanged file recovers without a replan. It is the inverse of
+`add_scope_files`: it subtracts from the gate, it does not widen scope (no
+amendment row). Resolved from the run's own `plan_reused_from` provenance;
+absent on every non-recovery run.
 
 ### App bot commit identity
 

--- a/docs/api/v0.openapi.yaml
+++ b/docs/api/v0.openapi.yaml
@@ -2184,12 +2184,28 @@ paths:
         `git add -A` guard) — category-B failures presuppose a
         declared scope, so this is a documented edge, not a refusal.
 
+        **Scope exemptions.** Optional `exempt_scope_files` is the
+        inverse of `add_scope_files` (#1229): each `{path, reason}` marks
+        a DECLARED `scope.files` path operator-justified-unchanged so the
+        runner's `MissingScopeFiles` shortfall gate subtracts it — a
+        category-B run that failed SOLELY on a declared-but-unchanged file
+        recovers in one call with no replan. Unlike `add_scope_files`, an
+        exemption does NOT mint a scope-amendment row (it subtracts from
+        the gate, it does not widen scope). Each path must be clean
+        repo-relative AND carry a non-empty reason; either failure is
+        refused 400 `validation_failed` with `field=exempt_scope_files`.
+        Exemptions are recorded as `exempted_paths` on the
+        `plan_reused_from` provenance and delivered to the runner via the
+        implement prompt's `scope_exemptions` field.
+
         **Provenance.** A `plan_reused_from` audit entry is appended
         on the child with
-        `{parent_run_id, parent_failure_category, added_paths, source,
-        reason}`; `source` is `operator_recovery` for a top-level
-        target and `decomposition_child_recovery` for an in-place
-        child re-drive. The approved amendment row is the second surface.
+        `{parent_run_id, parent_failure_category, added_paths,
+        exempted_paths, source, reason}`; `source` is `operator_recovery`
+        for a top-level target and `decomposition_child_recovery` for an
+        in-place child re-drive. The approved amendment row is the second
+        surface. The `reason` is additionally injected into the recovery
+        agent's binding conditions (Part D, #1229).
 
         No `workflow_dispatch` is fired — identical to `POST /v0/runs`:
         local-runner runs sit pending for the local loop to drive. The
@@ -2250,12 +2266,35 @@ paths:
                         type: string
                         enum: [modify, create]
                         default: modify
+                exempt_scope_files:
+                  type: array
+                  description: |
+                    DECLARED `scope.files` paths to mark
+                    operator-justified-unchanged so the runner's shortfall
+                    gate subtracts them (#1229) — the inverse of
+                    `add_scope_files`: it subtracts from the gate, it does
+                    NOT widen scope (no amendment row). Each entry requires
+                    a clean repo-relative `path` AND a non-empty `reason`;
+                    either failure is refused 400 `validation_failed` with
+                    `field=exempt_scope_files`.
+                  items:
+                    type: object
+                    additionalProperties: false
+                    required: [path, reason]
+                    properties:
+                      path:
+                        type: string
+                        example: backend/internal/server/handlers.go
+                      reason:
+                        type: string
+                        example: the declared file needs no change on this slice
                 reason:
                   type: string
                   description: |
                     Why the recovery (and each added path) is needed;
                     recorded on the amendment row and the
-                    `plan_reused_from` audit entry.
+                    `plan_reused_from` audit entry, and injected into the
+                    recovery agent's binding conditions (Part D).
                 budget_override:
                   type: boolean
                   description: |
@@ -3162,6 +3201,27 @@ paths:
                           type: string
                           enum: [create, modify, delete]
                           description: Per-file intent from the standard_v1 plan scope.files entry.
+                  scope_exemptions:
+                    type: array
+                    description: |
+                      Operator `exempt_scope_files` for a recovery run
+                      (#1229), echoed on the implement stage so the runner's
+                      `MissingScopeFiles` shortfall gate subtracts each
+                      operator-justified-unchanged declared path — the inverse
+                      of `add_scope_files` (it subtracts from the gate, it does
+                      not widen scope). Resolved from the run's own
+                      `plan_reused_from` provenance; absent on every
+                      non-recovery run.
+                    items:
+                      type: object
+                      required: [path, reason]
+                      properties:
+                        path:
+                          type: string
+                          description: Repo-relative declared scope.files path marked operator-justified-unchanged.
+                        reason:
+                          type: string
+                          description: Operator justification for leaving the declared path unchanged.
                   commit_author_name:
                     type: string
                     description: |
@@ -3310,6 +3370,27 @@ paths:
                           type: string
                           enum: [create, modify, delete]
                           description: Per-file intent from the standard_v1 plan scope.files entry.
+                  scope_exemptions:
+                    type: array
+                    description: |
+                      Operator `exempt_scope_files` for a recovery run
+                      (#1229), echoed on the implement stage so the runner's
+                      `MissingScopeFiles` shortfall gate subtracts each
+                      operator-justified-unchanged declared path — the inverse
+                      of `add_scope_files` (it subtracts from the gate, it does
+                      not widen scope). Resolved from the run's own
+                      `plan_reused_from` provenance; absent on every
+                      non-recovery run.
+                    items:
+                      type: object
+                      required: [path, reason]
+                      properties:
+                        path:
+                          type: string
+                          description: Repo-relative declared scope.files path marked operator-justified-unchanged.
+                        reason:
+                          type: string
+                          description: Operator justification for leaving the declared path unchanged.
                   commit_author_name:
                     type: string
                     description: GitHub App bot account's git author name (`<app-slug>[bot]`), resolved backend-side (#722). Absent when unresolvable; the runner falls back to its default.

--- a/runner/cmd/fishhawk-runner/main.go
+++ b/runner/cmd/fishhawk-runner/main.go
@@ -284,6 +284,18 @@ func run(args []string, logSink io.Writer) (exitCode int) {
 	// Function-scoped like fixupExpectedHeadSHA: produced and consumed in run().
 	var fixupApplyPatches []upload.FixupApplyPatch
 
+	// operatorExemptions is the operator-declared exempt_scope_files set (#1229)
+	// delivered via the prompt-response scope_exemptions field. Declared up here
+	// (alongside bindingAssertions) because it is set from the prompt at fetch
+	// time below, BEFORE the agent loop's var block. It is set ONCE and is NEVER
+	// cleared by loadScopeExemptions — unlike validatedExemptions (the agent's
+	// consumable #1153 sidecar self-exemptions), so an operator exemption
+	// survives the base-rebase re-invoke reset. Merged with validatedExemptions
+	// (mergeExemptions) at each openPRAndShipArtifact gate call so the #1151
+	// shortfall subtracts the agent∪operator union. Empty on every non-recovery
+	// run, keeping the strict gate byte-identical.
+	var operatorExemptions []scopeExemption
+
 	// If --fetch-prompt is set and no --prompt-file was supplied,
 	// pull the constructed prompt from the backend and write it to
 	// a temp file. Sets cfg.promptFile so the rest of the path is
@@ -304,7 +316,7 @@ func run(args []string, logSink io.Writer) (exitCode int) {
 			return exitFailure
 		}
 		issuedKey = key
-		path, sType, agentTimeoutSecs, specVerifyCmd, specVerifyTimeoutSecs, specVerifyMaxIterations, decomposedFromRunID, minRunnerVersion, agentSelfRetry, maxRetriesSnapshot, retryAttempt, scopeFiles, commitAuthorName, commitAuthorEmail, fixup, fixupBranch, expectedHeadSHA, promptBindingAssertions, applyPatches, sliceIndex, fetchErr := fetchPromptToFile(ctx, client, cfg, key, logSink)
+		path, sType, agentTimeoutSecs, specVerifyCmd, specVerifyTimeoutSecs, specVerifyMaxIterations, decomposedFromRunID, minRunnerVersion, agentSelfRetry, maxRetriesSnapshot, retryAttempt, scopeFiles, commitAuthorName, commitAuthorEmail, fixup, fixupBranch, expectedHeadSHA, promptBindingAssertions, applyPatches, sliceIndex, promptScopeExemptions, fetchErr := fetchPromptToFile(ctx, client, cfg, key, logSink)
 		if fetchErr != nil {
 			_, _ = fmt.Fprintf(logSink,
 				`{"event":"runner_failed","reason":"fetch_prompt","detail":%q}`+"\n", fetchErr.Error())
@@ -330,6 +342,14 @@ func run(args []string, logSink io.Writer) (exitCode int) {
 		fixupExpectedHeadSHA = expectedHeadSHA
 		fixupApplyPatches = applyPatches
 		bindingAssertions = promptBindingAssertions
+		// Operator scope exemptions (#1229) arrive in the prompt-response, NOT
+		// the consumable #1153 sidecar, so they are captured ONCE here and held
+		// in operatorExemptions for the whole stage. They MUST survive the
+		// base-rebase re-invoke reset (run() ~line 1522) that reloads the
+		// agent's self-exemptions from the swept sidecar — hence a separate var
+		// re-merged at each openPRAndShipArtifact gate call, never cleared by
+		// loadScopeExemptions.
+		operatorExemptions = toScopeExemptions(promptScopeExemptions)
 		stageType = sType
 		// Hand the resolved scope.files to the out-of-process CLI
 		// auto-PR path (#581) the same way the PR description is
@@ -1184,8 +1204,16 @@ func run(args []string, logSink io.Writer) (exitCode int) {
 	// children). loadScopeExemptions consumes (deletes) the sidecar.
 	if res.OK && stageType == "implement" && !cfg.noPR && cfg.decomposedFromRunID == "" && !cfg.fixup {
 		validatedExemptions = loadScopeExemptions(cfg, scopePaths(cfg.scopeFiles), logSink)
-		if len(validatedExemptions) > 0 {
-			res.Events = append(res.Events, scopeFilesExemptedEvent(cfg, validatedExemptions))
+		// Surface BOTH the agent's self-exemptions (#1153) and the operator's
+		// exempt_scope_files exemptions (#1229) through the single
+		// scope_files_exempted event so gate_evidence/the review see the full
+		// agent∪operator set the gate will subtract. operatorExemptions came
+		// from the prompt at fetch time. Emitted EXACTLY ONCE here (binding
+		// condition 1) — the gate site never re-emits, and the base-rebase
+		// re-invoke reuses the already-shipped event.
+		emitExemptions := mergeExemptions(validatedExemptions, operatorExemptions)
+		if len(emitExemptions) > 0 {
+			res.Events = append(res.Events, scopeFilesExemptedEvent(cfg, emitExemptions))
 		}
 	}
 
@@ -1483,7 +1511,7 @@ func run(args []string, logSink io.Writer) (exitCode int) {
 		// category-B (we shipped the wrong shape); everything else
 		// is category-C (network, git, GitHub API).
 		if res.OK && stageType == "implement" {
-			prErr := openPRAndShipArtifact(ctx, cfg, logSink, client, issuedKey, preAgentRef, preAgentDetached, preAgentCaptured, preAgentDirty, preAgentDirtyCaptured, verifiedTreeSHA, applyPath, bindingAssertions, validatedExemptions)
+			prErr := openPRAndShipArtifact(ctx, cfg, logSink, client, issuedKey, preAgentRef, preAgentDetached, preAgentCaptured, preAgentDirty, preAgentDirtyCaptured, verifiedTreeSHA, applyPath, bindingAssertions, mergeExemptions(validatedExemptions, operatorExemptions))
 			// Bounded base-rebase-conflict re-invoke (#989): a stash-reapply
 			// conflict means the base moved under the agent (a sibling's
 			// shared-branch commit, or an advanced origin/<base>) — often a
@@ -1521,7 +1549,13 @@ func run(args []string, logSink io.Writer) (exitCode int) {
 					if willOpenPR {
 						validatedExemptions = loadScopeExemptions(cfg, scopePaths(cfg.scopeFiles), logSink)
 					}
-					prErr = openPRAndShipArtifact(ctx, cfg, logSink, client, issuedKey, preAgentRef, preAgentDetached, preAgentCaptured, preAgentDirty, preAgentDirtyCaptured, verifiedTreeSHA, applyPath, bindingAssertions, validatedExemptions)
+					// Re-merge operatorExemptions (#1229): the line above reset
+					// validatedExemptions to whatever the re-invoked agent wrote to
+					// the swept sidecar (nil if it justified nothing), but the
+					// operator's exempt_scope_files exemptions came from the prompt
+					// and MUST persist across the re-invoke. mergeExemptions unions
+					// them so the second gate call still subtracts the operator set.
+					prErr = openPRAndShipArtifact(ctx, cfg, logSink, client, issuedKey, preAgentRef, preAgentDetached, preAgentCaptured, preAgentDirty, preAgentDirtyCaptured, verifiedTreeSHA, applyPath, bindingAssertions, mergeExemptions(validatedExemptions, operatorExemptions))
 				} else {
 					// Re-invoke infra exhaustion (or checkout failure): log and
 					// fall through to the unchanged category-B failure path
@@ -1803,13 +1837,13 @@ func reissueSigningKeyForTerminalUpload(ctx context.Context, client uploadClient
 // The temp file is 0o600 — bundle-style defense in depth, since prompts
 // may include issue bodies that the customer would prefer not to leave on
 // the runner's filesystem world-readable.
-func fetchPromptToFile(ctx context.Context, client uploadClient, cfg config, key *upload.IssuedKey, logSink io.Writer) (path string, stageType string, agentTimeoutSecs int, verifyCmd string, verifyTimeoutSecs int, verifyMaxIterations int, decomposedFromRunID string, minRunnerVersion string, agentSelfRetry bool, maxRetriesSnapshot int, retryAttempt int, scopeFiles []upload.ScopeFile, commitAuthorName string, commitAuthorEmail string, fixup bool, fixupBranch string, fixupExpectedHeadSHA string, bindingAssertions []upload.BindingAssertion, fixupApplyPatches []upload.FixupApplyPatch, sliceIndex int, err error) {
+func fetchPromptToFile(ctx context.Context, client uploadClient, cfg config, key *upload.IssuedKey, logSink io.Writer) (path string, stageType string, agentTimeoutSecs int, verifyCmd string, verifyTimeoutSecs int, verifyMaxIterations int, decomposedFromRunID string, minRunnerVersion string, agentSelfRetry bool, maxRetriesSnapshot int, retryAttempt int, scopeFiles []upload.ScopeFile, commitAuthorName string, commitAuthorEmail string, fixup bool, fixupBranch string, fixupExpectedHeadSHA string, bindingAssertions []upload.BindingAssertion, fixupApplyPatches []upload.FixupApplyPatch, sliceIndex int, scopeExemptions []upload.ScopeExemption, err error) {
 	got, fetchErr := client.FetchPrompt(ctx, upload.FetchPromptArgs{
 		StageID:    cfg.stageID,
 		PrivateKey: key.PrivateKey,
 	})
 	if fetchErr != nil {
-		return "", "", 0, "", 0, 0, "", "", false, 0, 0, nil, "", "", false, "", "", nil, nil, 0, fetchErr
+		return "", "", 0, "", 0, 0, "", "", false, 0, 0, nil, "", "", false, "", "", nil, nil, 0, nil, fetchErr
 	}
 	_, _ = fmt.Fprintf(logSink,
 		`{"event":"prompt_fetched","stage_id":%q,"stage_type":%q,"prompt_hash":%q,"prompt_bytes":%d}`+"\n",
@@ -1817,20 +1851,20 @@ func fetchPromptToFile(ctx context.Context, client uploadClient, cfg config, key
 	)
 	tmp, tmpErr := os.CreateTemp("", "fishhawk-prompt-*.txt")
 	if tmpErr != nil {
-		return "", "", 0, "", 0, 0, "", "", false, 0, 0, nil, "", "", false, "", "", nil, nil, 0, fmt.Errorf("create prompt temp file: %w", tmpErr)
+		return "", "", 0, "", 0, 0, "", "", false, 0, 0, nil, "", "", false, "", "", nil, nil, 0, nil, fmt.Errorf("create prompt temp file: %w", tmpErr)
 	}
 	if err := os.Chmod(tmp.Name(), 0o600); err != nil {
 		_ = tmp.Close()
-		return "", "", 0, "", 0, 0, "", "", false, 0, 0, nil, "", "", false, "", "", nil, nil, 0, fmt.Errorf("chmod prompt temp file: %w", err)
+		return "", "", 0, "", 0, 0, "", "", false, 0, 0, nil, "", "", false, "", "", nil, nil, 0, nil, fmt.Errorf("chmod prompt temp file: %w", err)
 	}
 	if _, err := tmp.WriteString(got.Prompt); err != nil {
 		_ = tmp.Close()
-		return "", "", 0, "", 0, 0, "", "", false, 0, 0, nil, "", "", false, "", "", nil, nil, 0, fmt.Errorf("write prompt temp file: %w", err)
+		return "", "", 0, "", 0, 0, "", "", false, 0, 0, nil, "", "", false, "", "", nil, nil, 0, nil, fmt.Errorf("write prompt temp file: %w", err)
 	}
 	if err := tmp.Close(); err != nil {
-		return "", "", 0, "", 0, 0, "", "", false, 0, 0, nil, "", "", false, "", "", nil, nil, 0, fmt.Errorf("close prompt temp file: %w", err)
+		return "", "", 0, "", 0, 0, "", "", false, 0, 0, nil, "", "", false, "", "", nil, nil, 0, nil, fmt.Errorf("close prompt temp file: %w", err)
 	}
-	return tmp.Name(), got.StageType, got.AgentTimeoutSeconds, got.VerifyCommand, got.VerifyTimeoutSeconds, got.VerifyMaxIterations, got.DecomposedFromRunID, got.MinRunnerVersion, got.AgentSelfRetry, got.MaxRetriesSnapshot, got.RetryAttempt, got.ScopeFiles, got.CommitAuthorName, got.CommitAuthorEmail, got.Fixup, got.FixupBranch, got.FixupExpectedHeadSHA, got.BindingAssertions, got.FixupApplyPatches, got.SliceIndex, nil
+	return tmp.Name(), got.StageType, got.AgentTimeoutSeconds, got.VerifyCommand, got.VerifyTimeoutSeconds, got.VerifyMaxIterations, got.DecomposedFromRunID, got.MinRunnerVersion, got.AgentSelfRetry, got.MaxRetriesSnapshot, got.RetryAttempt, got.ScopeFiles, got.CommitAuthorName, got.CommitAuthorEmail, got.Fixup, got.FixupBranch, got.FixupExpectedHeadSHA, got.BindingAssertions, got.FixupApplyPatches, got.SliceIndex, got.ScopeExemptions, nil
 }
 
 func logStartup(w io.Writer, cfg config) {
@@ -5185,6 +5219,52 @@ func partitionExemptedMissing(missing []string, exemptions []scopeExemption) (ex
 		}
 	}
 	return exempted, remaining
+}
+
+// toScopeExemptions maps the prompt-response wire type (upload.ScopeExemption)
+// to the runner's internal scopeExemption (#1229). The operator's
+// exempt_scope_files exemptions arrive on the implement prompt rather than the
+// agent's #1153 sidecar; this is the single conversion at the fetch site. nil
+// in (no exemptions delivered) returns nil — the strict gate default.
+func toScopeExemptions(in []upload.ScopeExemption) []scopeExemption {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]scopeExemption, 0, len(in))
+	for _, e := range in {
+		out = append(out, scopeExemption{Path: e.Path, Reason: e.Reason})
+	}
+	return out
+}
+
+// mergeExemptions unions two scope-exemption sets by Path (#1229),
+// deduplicating so the agent's self-exemptions (#1153) and the operator's
+// exempt_scope_files exemptions both subtract from the #1151 shortfall without
+// double-counting. The first occurrence of a path wins (`a` before `b`), which
+// only affects the surfaced reason — partitionExemptedMissing keys on Path
+// alone. Order-preserving: all of `a`, then `b`'s new paths. Returns nil when
+// both are empty so the strict gate stays byte-identical.
+func mergeExemptions(a, b []scopeExemption) []scopeExemption {
+	if len(a) == 0 && len(b) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(a)+len(b))
+	out := make([]scopeExemption, 0, len(a)+len(b))
+	for _, e := range a {
+		if seen[e.Path] {
+			continue
+		}
+		seen[e.Path] = true
+		out = append(out, e)
+	}
+	for _, e := range b {
+		if seen[e.Path] {
+			continue
+		}
+		seen[e.Path] = true
+		out = append(out, e)
+	}
+	return out
 }
 
 // scopeFilesExemptedEvent builds the scope_files_exempted trace event (#1153)

--- a/runner/cmd/fishhawk-runner/main_test.go
+++ b/runner/cmd/fishhawk-runner/main_test.go
@@ -10862,6 +10862,131 @@ func TestPartitionExemptedMissing(t *testing.T) {
 	}
 }
 
+// TestToScopeExemptions covers the prompt-wire → internal mapping (#1229): a
+// populated upload.ScopeExemption slice maps path/reason 1:1, and a nil/empty
+// input returns nil (the strict gate default — no operator exemptions
+// delivered).
+func TestToScopeExemptions(t *testing.T) {
+	if got := toScopeExemptions(nil); got != nil {
+		t.Errorf("nil input: got %v, want nil", got)
+	}
+	if got := toScopeExemptions([]upload.ScopeExemption{}); got != nil {
+		t.Errorf("empty input: got %v, want nil", got)
+	}
+	got := toScopeExemptions([]upload.ScopeExemption{
+		{Path: "a.go", Reason: "operator-justified unchanged"},
+		{Path: "b.go", Reason: "interface unchanged"},
+	})
+	want := []scopeExemption{
+		{Path: "a.go", Reason: "operator-justified unchanged"},
+		{Path: "b.go", Reason: "interface unchanged"},
+	}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("toScopeExemptions = %+v, want %+v", got, want)
+	}
+}
+
+// TestMergeExemptions covers the agent∪operator union (#1229): the merge
+// deduplicates by Path (the first occurrence's reason wins), preserves order
+// (all of a, then b's new paths), and returns nil when both sets are empty so
+// the strict gate stays byte-identical.
+func TestMergeExemptions(t *testing.T) {
+	if got := mergeExemptions(nil, nil); got != nil {
+		t.Errorf("both-empty: got %v, want nil", got)
+	}
+
+	// Union of agent self-exemptions and operator exemptions, no overlap.
+	self := []scopeExemption{{Path: "self.go", Reason: "agent left unchanged"}}
+	op := []scopeExemption{{Path: "op.go", Reason: "operator-justified"}}
+	got := mergeExemptions(self, op)
+	if len(got) != 2 || got[0].Path != "self.go" || got[1].Path != "op.go" {
+		t.Fatalf("union: got %+v, want [self.go op.go]", got)
+	}
+
+	// Overlapping path is deduplicated; the first (a) occurrence's reason wins.
+	gotDup := mergeExemptions(
+		[]scopeExemption{{Path: "x.go", Reason: "agent reason"}},
+		[]scopeExemption{{Path: "x.go", Reason: "operator reason"}, {Path: "y.go", Reason: "op only"}},
+	)
+	if len(gotDup) != 2 {
+		t.Fatalf("dedup: got %+v, want 2 entries", gotDup)
+	}
+	if gotDup[0].Path != "x.go" || gotDup[0].Reason != "agent reason" {
+		t.Errorf("dedup: first-occurrence reason must win, got %+v", gotDup[0])
+	}
+	if gotDup[1].Path != "y.go" {
+		t.Errorf("dedup: b's new path must follow, got %+v", gotDup[1])
+	}
+}
+
+// TestOperatorExemption_GateSubtraction covers the #1229 operator path through
+// the gate's subtraction (mirroring the #1153 self-exemption assertions):
+// an operator-exempted missing path is subtracted (gate passes), while an
+// un-exempted missing path still fails (remainder non-empty). Operator
+// exemptions reach the gate as the b-side of mergeExemptions with no agent
+// self-exemptions (the common recovery case).
+func TestOperatorExemption_GateSubtraction(t *testing.T) {
+	op := []scopeExemption{{Path: "op.go", Reason: "operator-justified unchanged"}}
+	combined := mergeExemptions(nil, op)
+
+	// Operator-exempted missing path subtracted → gate passes.
+	exempted, remaining := partitionExemptedMissing([]string{"op.go"}, combined)
+	if len(remaining) != 0 || len(exempted) != 1 || exempted[0] != "op.go" {
+		t.Errorf("operator-exempted: exempted=%v remaining=%v", exempted, remaining)
+	}
+
+	// An un-exempted missing path still fails the gate.
+	exempted, remaining = partitionExemptedMissing([]string{"op.go", "other.go"}, combined)
+	if len(remaining) != 1 || remaining[0] != "other.go" || len(exempted) != 1 || exempted[0] != "op.go" {
+		t.Errorf("partial: exempted=%v remaining=%v", exempted, remaining)
+	}
+}
+
+// TestReinvokePersistence_OperatorExemptionSurvivesSidecarReset is the
+// CRITICAL #1229 re-invoke-persistence case. It models run()'s base-rebase
+// re-invoke: the FIRST gate call sees both the agent's in-band self-exemption
+// and the operator's prompt-delivered exemption; the re-invoke then resets
+// validatedExemptions to nil (the re-invoked agent justified nothing, so the
+// swept sidecar reload returns nil) while operatorExemptions — held in a
+// SEPARATE var, never cleared — persists. On the SECOND gate call the operator
+// exemption still subtracts, but the stale self-exemption does NOT.
+func TestReinvokePersistence_OperatorExemptionSurvivesSidecarReset(t *testing.T) {
+	cfg := exemptCfg()
+	dir := t.TempDir()
+	orig := scopeJustificationDir
+	scopeJustificationDir = dir
+	t.Cleanup(func() { scopeJustificationDir = orig })
+
+	operatorExemptions := []scopeExemption{{Path: "op.go", Reason: "operator-justified unchanged"}}
+
+	// Attempt 1: agent self-exempted self.go in-band; operator exempted op.go.
+	validatedExemptions := []scopeExemption{{Path: "self.go", Reason: "agent left unchanged"}}
+	combined1 := mergeExemptions(validatedExemptions, operatorExemptions)
+	_, remaining1 := partitionExemptedMissing([]string{"op.go", "self.go"}, combined1)
+	if len(remaining1) != 0 {
+		t.Fatalf("attempt 1: both exempted, want empty remainder, got %v", remaining1)
+	}
+
+	// Base-rebase re-invoke: the second agent justified nothing, so there is no
+	// sidecar and the real loadScopeExemptions reload resets validatedExemptions
+	// to nil. operatorExemptions is held in a SEPARATE var and is NOT cleared.
+	var logSink strings.Builder
+	validatedExemptions = loadScopeExemptions(cfg, []string{"self.go", "op.go"}, &logSink)
+	if validatedExemptions != nil {
+		t.Fatalf("re-invoke reset: absent sidecar must yield nil, got %v", validatedExemptions)
+	}
+	combined2 := mergeExemptions(validatedExemptions, operatorExemptions)
+	exempted2, remaining2 := partitionExemptedMissing([]string{"op.go", "self.go"}, combined2)
+	// Operator exemption survives the reset and still subtracts.
+	if len(exempted2) != 1 || exempted2[0] != "op.go" {
+		t.Errorf("attempt 2: operator exemption must survive the reset, exempted=%v", exempted2)
+	}
+	// The stale self-exemption does NOT survive — it failed to re-justify.
+	if len(remaining2) != 1 || remaining2[0] != "self.go" {
+		t.Errorf("attempt 2: stale self-exemption must NOT survive, remaining=%v", remaining2)
+	}
+}
+
 // TestSweepStaleScopeJustification covers the pre-invoke freshness sweep
 // (binding condition / strategy test 8): a pre-existing keyed sidecar is removed
 // and scope_justification_swept logged; an absent one is a silent no-op.

--- a/runner/internal/upload/upload.go
+++ b/runner/internal/upload/upload.go
@@ -376,6 +376,23 @@ type FetchedPrompt struct {
 	// round-trips approve-request → audit payload → prompt-response →
 	// this decoder unchanged.
 	BindingAssertions []BindingAssertion `json:"binding_assertions,omitempty"`
+	// ScopeExemptions is the operator-declared exempt_scope_files list
+	// (#1229), echoed by the backend on implement stages only when the run's
+	// recovery (resume_run exempt_scope_files) recorded operator-justified
+	// exemptions on its plan_reused_from provenance. Each entry marks a
+	// declared scope.files path the operator justified as unchanged, so the
+	// runner SUBTRACTS it from the #1151 scope-completeness shortfall exactly
+	// like a #1153 agent self-exemption — it does NOT widen scope (no
+	// scope-amendment row). Empty (the byte-identical default) on every
+	// non-recovery run — the gate is the strict #1151 default. The json tags
+	// (scope_exemptions/path/reason) are byte-identical to the backend's
+	// promptResponse.ScopeExemptions / scopeExemption prompt-response struct,
+	// the runner↔backend wire contract for the exemption round-trip (the same
+	// cross-module convention as BindingAssertions/#1171 and add_scope_files/
+	// #824). CRITICAL: these arrive in the prompt, not the consumable #1153
+	// sidecar, so the runner holds them in a separate var that survives the
+	// base-rebase re-invoke reset.
+	ScopeExemptions []ScopeExemption `json:"scope_exemptions,omitempty"`
 	// CommitAuthorName / CommitAuthorEmail are the GitHub App bot
 	// account's git commit identity, resolved backend-side from the App
 	// (slug + bot user-id) so App-backed commits attribute to the App's
@@ -451,6 +468,20 @@ type BindingAssertion struct {
 	Type    string `json:"type"`
 	Path    string `json:"path"`
 	Literal string `json:"literal"`
+}
+
+// ScopeExemption is one entry in FetchedPrompt.ScopeExemptions: an
+// operator-justified declared-scope.files path the runner subtracts from the
+// #1151 scope-completeness shortfall (#1229). The json tags (path/reason) are
+// byte-identical to the backend's scopeExemption struct, the runner↔backend
+// wire contract for the exempt_scope_files round-trip (approve-request →
+// plan_reused_from audit payload → prompt-response → this decoder). This
+// mirrors the BindingAssertion (#1171) and ScopeFile (#824) cross-module
+// convention: each module defines its own struct agreeing by json tag, so a
+// tag drift surfaces in review against this documented counterpart.
+type ScopeExemption struct {
+	Path   string `json:"path"`
+	Reason string `json:"reason"`
 }
 
 // FetchPrompt calls GET /v0/stages/{stage_id}/prompt with an

--- a/runner/internal/upload/upload_test.go
+++ b/runner/internal/upload/upload_test.go
@@ -672,6 +672,63 @@ func TestFetchPrompt_BindingAssertionsOmittedWhenAbsent(t *testing.T) {
 	}
 }
 
+// TestFetchPrompt_DecodesScopeExemptions confirms the client decodes the
+// backend's scope_exemptions response field (#1229) into
+// FetchedPrompt.ScopeExemptions, preserving path/reason order.
+func TestFetchPrompt_DecodesScopeExemptions(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	priv, _ := makeKey(t, fb)
+	fb.promptBody = `{
+		"stage_id": "stage-abc",
+		"stage_type": "implement",
+		"prompt": "p",
+		"prompt_hash": "h",
+		"scope_exemptions": [
+			{"path": "backend/internal/server/recover.go", "reason": "interface unchanged, no edit needed"},
+			{"path": "docs/api/v0.md", "reason": "prose already current"}
+		]
+	}`
+	c := quickClient(srv)
+
+	got, err := c.FetchPrompt(context.Background(), FetchPromptArgs{
+		StageID:    "stage-abc",
+		PrivateKey: priv,
+	})
+	if err != nil {
+		t.Fatalf("FetchPrompt: %v", err)
+	}
+	if len(got.ScopeExemptions) != 2 {
+		t.Fatalf("ScopeExemptions len = %d, want 2: %+v", len(got.ScopeExemptions), got.ScopeExemptions)
+	}
+	if got.ScopeExemptions[0] != (ScopeExemption{Path: "backend/internal/server/recover.go", Reason: "interface unchanged, no edit needed"}) {
+		t.Errorf("ScopeExemptions[0] = %+v", got.ScopeExemptions[0])
+	}
+	if got.ScopeExemptions[1] != (ScopeExemption{Path: "docs/api/v0.md", Reason: "prose already current"}) {
+		t.Errorf("ScopeExemptions[1] = %+v", got.ScopeExemptions[1])
+	}
+}
+
+// TestFetchPrompt_ScopeExemptionsOmittedWhenAbsent confirms ScopeExemptions
+// decodes to nil when the backend omits the field (every non-recovery run), so
+// the runner's scope-completeness gate keeps the strict #1151 default —
+// byte-identical to behavior before #1229.
+func TestFetchPrompt_ScopeExemptionsOmittedWhenAbsent(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	priv, _ := makeKey(t, fb)
+	c := quickClient(srv)
+
+	got, err := c.FetchPrompt(context.Background(), FetchPromptArgs{
+		StageID:    "stage-abc",
+		PrivateKey: priv,
+	})
+	if err != nil {
+		t.Fatalf("FetchPrompt: %v", err)
+	}
+	if got.ScopeExemptions != nil {
+		t.Errorf("ScopeExemptions = %+v, want nil when absent", got.ScopeExemptions)
+	}
+}
+
 // TestBindingAssertions_BackendEmitRunnerDecodeRoundTrip pins the backend
 // prompt-response binding_assertions JSON serialization against this package's
 // FetchedPrompt decoder (#1171 approval condition 1), the binding-assertion


### PR DESCRIPTION
## Summary

Operator `exempt_scope_files` lever on `fishhawk_resume_run` / `POST /v0/runs/{id}/recover` (Part B) + inject the resume reason into the recovery agent's binding conditions (Part D) — the B/D split of #1225. `exempt_scope_files` is the inverse of `add_scope_files`: it marks a declared `scope.files` path as operator-justified-unchanged so a category-B run that failed solely on a declared-but-unchanged file recovers in ONE resume call (no replan). The runner subtracts operator exemptions from the #1151 shortfall exactly like #1153 agent self-exemptions, surfaced via the existing `scope_files_exempted` channel, and they persist across the base-rebase re-invoke reset (held in a separate var). Part D appends the resume reason to the recovery agent's binding conditions (mirroring approve_plan #558).

## Test plan

Decomposed run `9b4e5654` (#1229) into two file-disjoint slices, both implemented + verified (each child's implement gate ran `scripts/test verify`):
- **slice-0 (backend)** `fishhawk/run-9b4e5654/slice-0`: MCP input, recover handler validation (bad-path→400, empty-reason→400 on both recover branches), plan_reused_from persistence, `scope_exemptions` prompt delivery, Part D reason→binding-conditions, docs (openapi+companion), e2e.
- **slice-1 (runner)** `fishhawk/run-9b4e5654/slice-1`: `FetchedPrompt.ScopeExemptions` decode into a separate `operatorExemptions` var, agent∪operator subtraction from the #1151 gate, re-invoke-reset persistence test.

Verified on the consolidated tree: the cross-module `scope_exemptions`/`path`/`reason` json-tag seam matches byte-for-byte (backend `prompt.go` ↔ runner `upload.go`), and both modules build. CI runs the full suite.

## Notes

**Manually consolidated** from the two pushed slice branches because the local-runner decomposition pipeline could not auto-consolidate: `fishhawk_run_children` couldn't dispatch the local children (**#1237**) and the E24.2 fan-in never triggered after they completed (**#1238**) — both filed during this dogfood run. The slices are file-disjoint (backend vs runner) so the merge is clean; this consolidated diff did not pass the heterogeneous agent review (the per-child reviews were parked pending the never-fired fan-in), so it was operator-reviewed (seam + build verified) + CI-gated. Closes #1229. Companion to #1225 (Part A, merged), #1151, #1153.

🤖 Generated with [Claude Code](https://claude.com/claude-code)