### PR TITLE
Zero-re-run recovery: park implement stage on missing-scope-only gate failure

### DIFF
--- a/backend/cmd/fishhawk-mcp/README.md
+++ b/backend/cmd/fishhawk-mcp/README.md
@@ -23,6 +23,7 @@ E19.2 / #342 shipped scaffolding + handshake. E19.3–E19.6 landed the v0 tool s
 - `fishhawk_file_issue` ([#1005](https://github.com/kuhlman-labs/fishhawk/issues/1005)) — file a work item (issue, bug, chore, ADR) through the repo's work-management conventions. The consistent cross-repo/cross-platform filing surface and the operator-agent follow-up-filing path ([ADR-040](https://github.com/kuhlman-labs/fishhawk/issues/1004)). See [Work-item filing](#work-item-filing-fishhawk_file_issue-1005).
 - `fishhawk_report_product_issue` ([#1006](https://github.com/kuhlman-labs/fishhawk/issues/1006)) — file an upstream Fishhawk **product** bug/feature carrying an auto-collected, redacted, fingerprint-deduped diagnostic bundle. The first **write** tool that drives an egress on the run's chain. See [Product feedback](#product-feedback-fishhawk_report_product_issue-1006).
 - `fishhawk_consolidate_slices` ([E24.2 / ADR-041 / #1238](https://github.com/kuhlman-labs/fishhawk/issues/1238)) — run the decomposed-parent fan-in on demand when a parent is stuck in `awaiting_children` after its children all succeeded on the **local** runner (the 60s sweeper backstop is off by default there). See [Local decomposition fan-in](#local-decomposition-fan-in-fishhawk_consolidate_slices-1238).
+- `fishhawk_decide_scope_completeness` ([E22.X / #1231](https://github.com/kuhlman-labs/fishhawk/issues/1231)) — resolve an implement stage parked in `awaiting_scope_decision`: **exempt** the already-committed tree (open the PR from the held commit with **no agent re-run**) or **fail** it to category-B. The zero-re-run recovery for a missing-declared-scope-file-only gate failure. See [Scope-completeness park](#scope-completeness-park-fishhawk_decide_scope_completeness-1231).
 
 E19.7 / #347 wires the binary into the release pipeline next.
 
@@ -399,6 +400,23 @@ E22.X / [#961](https://github.com/kuhlman-labs/fishhawk/issues/961) adds the **m
 **Auth.** The decision is operator-only (`write:stages`); the backend rejects run-bound agent tokens outright (`self_decision`), so the requesting agent can never approve its own request. The agent-side POST requires the implement-stage token's `write:scope-amendments` scope (granted unconditionally at token issue for implement stages); the GET admits the run-bound token (`mcp:read`, own run only — cross-run is 403) or any operator bearer/session.
 
 **Activation.** Approved paths fold into the effective scope at BOTH ends: the backend prompt fetch (`source "scope-amendment"`, so a stage restart or fix-up carries the amended scope) and the runner's pre-commit refresh, which re-reads the GET with the same run-bound token and folds approved paths BEFORE the committed-tree verify gates and `StageScoped` — preserving the #960 invariant that the gates verify the same folded tree that is pushed. Anything NOT requested still fails loud. Both `scope_amendment_requested` and `scope_amendment_decided` are internal audit kinds, not issue-comment surfaces.
+
+## Scope-completeness park (`fishhawk_decide_scope_completeness`)
+
+E22.X / [#1231](https://github.com/kuhlman-labs/fishhawk/issues/1231) adds a **zero-re-run** recovery for the case the [#1229](https://github.com/kuhlman-labs/fishhawk/issues/1229) one-re-run exempt lever otherwise served: an implement stage whose **only** committed-tree gate failure is the [#1151](https://github.com/kuhlman-labs/fishhawk/issues/1151) scope-completeness "missing declared scope file(s)" check, while the committed tree otherwise passed verify (created-out-of-scope, binding-assertion, compile/test, and verified-tree gates all green).
+
+**Park, not category-B.** Instead of fail-and-restore, the runner pushes the **gate-verified commit** to the run branch (no PR opened — ADR-035 sole-writer preserved: the run writes its own branch) and PARKS the implement stage in a new `awaiting_scope_decision` state, carrying the held commit SHA, run branch, verified tree SHA, and the missing declared paths. The park leaves the gate waiting for an in-band operator decision over the [#1232](https://github.com/kuhlman-labs/fishhawk/issues/1232)/[#1235](https://github.com/kuhlman-labs/fishhawk/issues/1235) non-blocking dispatch substrate. Any compound failure (missing **plus** another gate) keeps today's category-B unchanged.
+
+**Operator loop:**
+
+1. Observe the park: `fishhawk_get_run_status` surfaces the `implement_awaiting_scope_decision` next action; `fishhawk_list_audit` on category `scope_completeness_parked` carries the missing paths + held SHA.
+2. Decide: `fishhawk_decide_scope_completeness {run_id, decision: exempt|fail, reason}`.
+   - `exempt` — the backend opens the PR from the **exact held commit** with **NO agent re-invocation** (the already-committed tree is accepted as-is; the implement-review gate proceeds). Appends `scope_completeness_exempted`.
+   - `fail` — the stage falls through to today's category-B fail-and-restore. Appends `scope_completeness_failed`.
+
+**Auth.** Operator-only (`write:stages`); the backend rejects run-bound agent tokens (`run_token_forbidden`), so the agent whose stage parked can never decide its own park (mirrors `fishhawk_decide_scope_amendment`). `reason` is required and non-empty; an invalid `decision` (anything but `exempt`/`fail`) or empty `reason` is caught before the HTTP hop. The endpoint returns 409 (`scope_completeness_not_parked`) when the stage is not parked in `awaiting_scope_decision`. It wraps `POST /v0/runs/{run_id}/scope-completeness/decision`.
+
+`scope_completeness_parked`, `scope_completeness_exempted`, and `scope_completeness_failed` are internal audit kinds, not issue-comment surfaces.
 
 ## Category-B recovery (`fishhawk_resume_run`)
 

--- a/backend/cmd/fishhawk-mcp/client.go
+++ b/backend/cmd/fishhawk-mcp/client.go
@@ -760,6 +760,63 @@ func (c *apiClient) ConsolidateRun(ctx context.Context, id uuid.UUID) (*Consolid
 	return &res, nil
 }
 
+// ScopeCompletenessDecisionResult mirrors the backend's scope-completeness
+// decision 200 body (`backend/internal/server/scope_completeness.go` — SLICE
+// 1, #1231): the resolved park record. State is the implement stage's
+// resulting state (running/succeeded on exempt as the held commit's PR opens,
+// failed on a category-B fail). HeldCommitSHA is the exact gate-verified
+// commit the runner pushed to the run branch at park time; PullRequestURL is
+// set only on exempt, when the backend opens the PR from that held commit
+// with NO agent re-invocation. MissingPaths echoes the declared scope paths
+// the #1151 shortfall gate flagged. Repeated here rather than imported — the
+// MCP server's apiClient is deliberately a thin local copy (import direction
+// is `cli → backend`, not the reverse). MUST stay byte-identical with the
+// backend handler's response shape.
+type ScopeCompletenessDecisionResult struct {
+	RunID          string   `json:"run_id"`
+	StageID        string   `json:"stage_id"`
+	Decision       string   `json:"decision"`
+	State          string   `json:"state"`
+	HeldCommitSHA  string   `json:"held_commit_sha"`
+	RunBranch      string   `json:"run_branch,omitempty"`
+	MissingPaths   []string `json:"missing_paths,omitempty"`
+	PullRequestURL string   `json:"pull_request_url,omitempty"`
+}
+
+// scopeCompletenessDecisionRequest mirrors the backend's decision body
+// (`backend/internal/server/scope_completeness.go::scopeCompletenessDecisionRequest`
+// — SLICE 1, #1231). Both fields are required: the backend rejects a decision
+// other than exempt/fail and an empty reason with 400.
+type scopeCompletenessDecisionRequest struct {
+	Decision string `json:"decision"`
+	Reason   string `json:"reason"`
+}
+
+// DecideScopeCompleteness resolves an implement stage parked in
+// awaiting_scope_decision via
+// `POST /v0/runs/{run_id}/scope-completeness/decision` (#1231). decision is
+// "exempt" (open the PR from the held commit with NO agent re-run) or "fail"
+// (fall through to category-B); reason is required. Operator-token-only
+// (write:stages); the backend rejects run-bound agent tokens
+// (run_token_forbidden). 4xx surfaces:
+//   - 400 validation_failed (decision not exempt/fail, empty reason)
+//   - 403 run_token_forbidden (a run-bound agent token attempted the decision)
+//   - 403 insufficient_scope (token lacks write:stages)
+//   - 404 run_not_found
+//   - 409 scope_completeness_not_parked (the stage is not parked in
+//     awaiting_scope_decision)
+func (c *apiClient) DecideScopeCompleteness(ctx context.Context, runID uuid.UUID, decision, reason string) (*ScopeCompletenessDecisionResult, error) {
+	body, err := json.Marshal(scopeCompletenessDecisionRequest{Decision: decision, Reason: reason})
+	if err != nil {
+		return nil, fmt.Errorf("marshal scope-completeness decision: %w", err)
+	}
+	var res ScopeCompletenessDecisionResult
+	if err := c.do(ctx, http.MethodPost, "/v0/runs/"+runID.String()+"/scope-completeness/decision", body, &res); err != nil {
+		return nil, err
+	}
+	return &res, nil
+}
+
 // CancelRun transitions a run to the cancelled state via
 // `POST /v0/runs/{run_id}/cancel`. Idempotent: cancelling an already-
 // cancelled run returns 200 with the same body. 4xx surfaces:

--- a/backend/cmd/fishhawk-mcp/decide_scope_completeness.go
+++ b/backend/cmd/fishhawk-mcp/decide_scope_completeness.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// fishhawk_decide_scope_completeness (E22.X / #1231) is the operator
+// decision verb for the zero-re-run scope-completeness PARK.
+//
+// When an implement stage's ONLY committed-tree gate failure is the #1151
+// scope-completeness "missing declared scope file(s)" check and the tree
+// otherwise passed verify, the runner does NOT fail category-B. Instead it
+// pushes the verified commit to the run branch (no PR) and parks the stage
+// in awaiting_scope_decision, carrying the held commit SHA, run branch,
+// verified tree SHA, and the missing declared paths. This verb resolves the
+// park in-band:
+//
+//   - decision=exempt: the backend opens the PR from the EXACT held commit
+//     with NO agent re-invocation (zero re-run), accepting the
+//     already-committed tree. Supersedes #1229's one-re-run exempt lever
+//     for the missing-declared-scope-file class specifically.
+//   - decision=fail: the stage falls through to today's category-B
+//     fail-and-restore path.
+//
+// Operator-only: the backend rejects run-bound agent tokens, so the agent
+// whose stage parked can never decide its own park (mirrors
+// fishhawk_decide_scope_amendment's self_decision rejection).
+
+// DecideScopeCompletenessInput is the fishhawk_decide_scope_completeness
+// tool's input schema.
+type DecideScopeCompletenessInput struct {
+	RunID    string `json:"run_id" jsonschema:"the Fishhawk run UUID whose implement stage is parked in awaiting_scope_decision"`
+	Decision string `json:"decision" jsonschema:"exempt (accept the held commit and open the PR with no agent re-run) or fail (fall through to category-B)"`
+	Reason   string `json:"reason" jsonschema:"operator rationale; required and non-empty. Recorded on the scope_completeness_exempted / scope_completeness_failed audit entry"`
+}
+
+// DecideScopeCompletenessOutput surfaces the decided park record.
+type DecideScopeCompletenessOutput struct {
+	Result ScopeCompletenessDecisionResult `json:"result"`
+}
+
+// registerDecideScopeCompleteness wires the fishhawk_decide_scope_completeness
+// tool (E22.X / #1231).
+//
+// Auth: operator-only write tool — the backend requires write:stages and
+// rejects any run-bound agent token outright (run_token_forbidden), so the
+// agent whose stage parked can never decide its own park.
+func registerDecideScopeCompleteness(srv *mcp.Server, resolver *runResolver) {
+	mcp.AddTool(srv, &mcp.Tool{
+		Name: "fishhawk_decide_scope_completeness",
+		Description: strings.TrimSpace(`
+Resolve an implement stage parked in awaiting_scope_decision (#1231):
+exempt the already-committed tree, or fail it to category-B.
+
+The runner parks the stage HERE — instead of failing category-B — only
+when the SOLE committed-tree gate failure is the #1151 scope-completeness
+"missing declared scope file(s)" check and verify otherwise passed. It has
+already pushed the gate-verified commit to the run branch (no PR opened).
+
+On decision=exempt the backend opens the PR from the EXACT held commit
+with NO agent re-invocation (zero re-run): the held tree is accepted as-is
+and the implement-review gate proceeds. On decision=fail the stage falls
+through to today's category-B fail-and-restore.
+
+Operator-only: the backend rejects run-bound agent tokens
+(run_token_forbidden), so the agent whose stage parked can never decide its
+own park. Read the parked record first (fishhawk_get_run_status surfaces
+the awaiting_scope_decision next action, or fishhawk_list_audit on category
+scope_completeness_parked carries the missing paths + held SHA).
+
+Returns the decided park record. Tool errors:
+  - invalid run_id UUID (caught before the HTTP hop)
+  - decision not exempt/fail (caught before the HTTP hop)
+  - empty reason (caught before the HTTP hop)
+  - validation_failed (400)
+  - run_token_forbidden (a run-bound agent token attempted the decision, 403)
+  - insufficient_scope (token lacks write:stages, 403)
+  - run_not_found (404)
+  - scope_completeness_not_parked (the stage is not parked in
+    awaiting_scope_decision, 409)
+`),
+	}, resolver.decideScopeCompleteness)
+}
+
+func (r *runResolver) decideScopeCompleteness(ctx context.Context, _ *mcp.CallToolRequest, in DecideScopeCompletenessInput) (*mcp.CallToolResult, DecideScopeCompletenessOutput, error) {
+	runID, err := uuid.Parse(in.RunID)
+	if err != nil {
+		return nil, DecideScopeCompletenessOutput{}, fmt.Errorf("run_id %q is not a valid UUID: %w", in.RunID, err)
+	}
+	if in.Decision != "exempt" && in.Decision != "fail" {
+		return nil, DecideScopeCompletenessOutput{}, fmt.Errorf("decision must be \"exempt\" or \"fail\", got %q", in.Decision)
+	}
+	if strings.TrimSpace(in.Reason) == "" {
+		return nil, DecideScopeCompletenessOutput{}, fmt.Errorf("reason is required and must be non-empty")
+	}
+	result, err := r.api.DecideScopeCompleteness(ctx, runID, in.Decision, in.Reason)
+	if err != nil {
+		return nil, DecideScopeCompletenessOutput{}, fmt.Errorf("decide scope completeness: %w", err)
+	}
+	return nil, DecideScopeCompletenessOutput{Result: *result}, nil
+}

--- a/backend/cmd/fishhawk-mcp/decide_scope_completeness_test.go
+++ b/backend/cmd/fishhawk-mcp/decide_scope_completeness_test.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// --- fishhawk_decide_scope_completeness (#1231) ---
+
+func TestDecideScopeCompleteness_ExemptThreadsBody(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	r := newResolver(srv, nil)
+	runID := uuid.New()
+	fb.decideScopeCompletenessResp[runID] = ScopeCompletenessDecisionResult{
+		RunID:          runID.String(),
+		StageID:        uuid.New().String(),
+		Decision:       "exempt",
+		State:          "running",
+		HeldCommitSHA:  "abc123",
+		RunBranch:      "fishhawk/run-x",
+		MissingPaths:   []string{"pkg/declared_test.go"},
+		PullRequestURL: "https://github.com/x/y/pull/7",
+	}
+
+	_, out, err := r.decideScopeCompleteness(context.Background(), nil, DecideScopeCompletenessInput{
+		RunID:    runID.String(),
+		Decision: "exempt",
+		Reason:   "the declared test sibling is genuinely unchanged this slice",
+	})
+	if err != nil {
+		t.Fatalf("decideScopeCompleteness: %v", err)
+	}
+	if out.Result.Decision != "exempt" || out.Result.HeldCommitSHA != "abc123" {
+		t.Errorf("result = %+v, want exempt with held SHA abc123", out.Result)
+	}
+	if out.Result.PullRequestURL != "https://github.com/x/y/pull/7" {
+		t.Errorf("PullRequestURL = %q, want the held commit's opened PR", out.Result.PullRequestURL)
+	}
+	if fb.decideScopeCompletenessCalled[runID] != 1 {
+		t.Errorf("decision called %d times, want exactly 1", fb.decideScopeCompletenessCalled[runID])
+	}
+	if fb.decideScopeCompletenessBody.Decision != "exempt" ||
+		fb.decideScopeCompletenessBody.Reason != "the declared test sibling is genuinely unchanged this slice" {
+		t.Errorf("body = %+v, want the threaded decision + reason", fb.decideScopeCompletenessBody)
+	}
+}
+
+func TestDecideScopeCompleteness_FailThreadsBody(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	r := newResolver(srv, nil)
+	runID := uuid.New()
+	fb.decideScopeCompletenessResp[runID] = ScopeCompletenessDecisionResult{
+		RunID:    runID.String(),
+		StageID:  uuid.New().String(),
+		Decision: "fail",
+		State:    "failed",
+	}
+
+	_, out, err := r.decideScopeCompleteness(context.Background(), nil, DecideScopeCompletenessInput{
+		RunID:    runID.String(),
+		Decision: "fail",
+		Reason:   "the missing file really must be written; route to category-B",
+	})
+	if err != nil {
+		t.Fatalf("decideScopeCompleteness: %v", err)
+	}
+	if out.Result.Decision != "fail" || out.Result.State != "failed" {
+		t.Errorf("result = %+v, want fail -> failed (category-B)", out.Result)
+	}
+	if out.Result.PullRequestURL != "" {
+		t.Errorf("PullRequestURL = %q, want empty on a fail decision (no PR opened)", out.Result.PullRequestURL)
+	}
+	if fb.decideScopeCompletenessBody.Decision != "fail" {
+		t.Errorf("body = %+v, want decision=fail threaded", fb.decideScopeCompletenessBody)
+	}
+}
+
+func TestDecideScopeCompleteness_InvalidUUIDBeforeHTTP(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	r := newResolver(srv, nil)
+
+	_, _, err := r.decideScopeCompleteness(context.Background(), nil, DecideScopeCompletenessInput{
+		RunID:    "not-a-uuid",
+		Decision: "exempt",
+		Reason:   "x",
+	})
+	if err == nil || !strings.Contains(err.Error(), "not a valid UUID") {
+		t.Errorf("err = %v, want UUID validation error before the HTTP hop", err)
+	}
+	if len(fb.decideScopeCompletenessCalled) != 0 {
+		t.Errorf("backend hit despite invalid UUID")
+	}
+}
+
+func TestDecideScopeCompleteness_RejectsBadDecisionBeforeHTTP(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	r := newResolver(srv, nil)
+	runID := uuid.New()
+
+	_, _, err := r.decideScopeCompleteness(context.Background(), nil, DecideScopeCompletenessInput{
+		RunID:    runID.String(),
+		Decision: "approve", // valid for amendments, NOT for scope completeness
+		Reason:   "x",
+	})
+	if err == nil || !strings.Contains(err.Error(), "exempt") {
+		t.Errorf("err = %v, want decision validation error naming exempt/fail", err)
+	}
+	if fb.decideScopeCompletenessCalled[runID] != 0 {
+		t.Errorf("backend hit despite invalid decision")
+	}
+}
+
+func TestDecideScopeCompleteness_RejectsEmptyReasonBeforeHTTP(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	r := newResolver(srv, nil)
+	runID := uuid.New()
+
+	_, _, err := r.decideScopeCompleteness(context.Background(), nil, DecideScopeCompletenessInput{
+		RunID:    runID.String(),
+		Decision: "exempt",
+		Reason:   "   ",
+	})
+	if err == nil || !strings.Contains(err.Error(), "reason is required") {
+		t.Errorf("err = %v, want empty-reason validation error before the HTTP hop", err)
+	}
+	if fb.decideScopeCompletenessCalled[runID] != 0 {
+		t.Errorf("backend hit despite empty reason")
+	}
+}
+
+func TestDecideScopeCompleteness_BackendErrorsSurfaced(t *testing.T) {
+	cases := []struct {
+		name    string
+		status  int
+		errBody string
+		wantSub string
+	}{
+		{"run token forbidden", http.StatusForbidden,
+			`{"error":{"code":"run_token_forbidden","message":"a run-bound agent token may not decide a scope-completeness park"}}`,
+			"run_token_forbidden"},
+		{"not parked", http.StatusConflict,
+			`{"error":{"code":"scope_completeness_not_parked","message":"the implement stage is not parked in awaiting_scope_decision"}}`,
+			"scope_completeness_not_parked"},
+		{"validation failed", http.StatusBadRequest,
+			`{"error":{"code":"validation_failed","message":"decision must be exempt or fail"}}`,
+			"validation_failed"},
+		{"not found", http.StatusNotFound,
+			`{"error":{"code":"run_not_found","message":"no run with that id"}}`,
+			"run_not_found"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fb, srv := newFakeBackend(t)
+			fb.decideScopeCompletenessStatus = tc.status
+			fb.decideScopeCompletenessErr = tc.errBody
+			r := newResolver(srv, nil)
+
+			_, _, err := r.decideScopeCompleteness(context.Background(), nil, DecideScopeCompletenessInput{
+				RunID:    uuid.New().String(),
+				Decision: "exempt",
+				Reason:   "forced",
+			})
+			if err == nil || !strings.Contains(err.Error(), tc.wantSub) {
+				t.Errorf("err = %v, want %q surfaced", err, tc.wantSub)
+			}
+		})
+	}
+}

--- a/backend/cmd/fishhawk-mcp/next_actions.go
+++ b/backend/cmd/fishhawk-mcp/next_actions.go
@@ -291,6 +291,25 @@ func implementStageNextActions(run *Run, impl *Stage, implementReviewStatus *Rev
 				suggestedStageWaitPollIntervalSeconds,
 				"the implement stage is executing — re-poll until implement_stage_wait_status goes terminal")},
 		}
+	case "awaiting_scope_decision":
+		// #1231: the implement stage's ONLY committed-tree gate failure was
+		// the #1151 scope-completeness "missing declared scope file(s)" check
+		// and verify otherwise passed, so the runner pushed the gate-verified
+		// commit to the run branch (no PR) and PARKED here instead of failing
+		// category-B. The legal next move is the in-band operator decision:
+		// exempt (open the PR from the held commit with NO agent re-run) or
+		// fail (fall through to category-B). The missing declared paths + held
+		// SHA are on the scope_completeness_parked audit entry.
+		return &NextActions{
+			State: "implement_awaiting_scope_decision",
+			Actions: []SuggestedAction{{
+				Action:       "fishhawk_decide_scope_completeness",
+				Params:       map[string]string{"run_id": run.ID, "decision": "exempt|fail"},
+				Precondition: "the implement stage parked at awaiting_scope_decision (its sole gate failure was the #1151 missing-declared-scope-file check; the gate-verified commit is already on the run branch). Read the missing paths + held SHA from the scope_completeness_parked audit entry first",
+				Consumes:     consumesNone,
+				Reason:       "decide in-band: exempt accepts the already-committed tree and opens the PR from the held commit with NO agent re-run (zero re-run); fail falls through to today's category-B fail-and-restore",
+			}},
+		}
 	case "awaiting_approval", "succeeded":
 		if implementReviewStatus != nil && implementReviewStatus.Status == "pending" {
 			return &NextActions{

--- a/backend/cmd/fishhawk-mcp/next_actions_test.go
+++ b/backend/cmd/fishhawk-mcp/next_actions_test.go
@@ -175,6 +175,16 @@ func TestNextActions_StateTable(t *testing.T) {
 			wantConsumes: []string{consumesNone, consumesNone},
 		},
 		{
+			// #1231: an implement stage parked at awaiting_scope_decision gets
+			// the in-band exempt-or-fail decision arm.
+			name:         "implement_awaiting_scope_decision",
+			run:          naRun("running"),
+			stages:       []Stage{naStage("plan", "succeeded"), naStage("implement", "awaiting_scope_decision")},
+			wantState:    "implement_awaiting_scope_decision",
+			wantActions:  []string{"fishhawk_decide_scope_completeness"},
+			wantConsumes: []string{consumesNone},
+		},
+		{
 			name:         "d_category_b_with_succeeded_plan_resume_run",
 			run:          naRun("failed"),
 			stages:       []Stage{naStage("plan", "succeeded"), naFailedImplement("B", "scope drift")},
@@ -442,6 +452,30 @@ func TestNextActions_AwaitingChildren_FanOutArm(t *testing.T) {
 	poll := findAction(t, na, "fishhawk_get_run_status")
 	if !strings.Contains(poll.Reason, "children_status") {
 		t.Errorf("poll reason should point at the children_status block; got %q", poll.Reason)
+	}
+}
+
+// TestNextActions_AwaitingScopeDecision_DecideArm pins the #1231 arm: an
+// implement stage parked at awaiting_scope_decision offers
+// fishhawk_decide_scope_completeness carrying run_id + the exempt|fail
+// decision hint, and the reason names the zero-re-run exempt semantics.
+func TestNextActions_AwaitingScopeDecision_DecideArm(t *testing.T) {
+	run := naRun("running")
+	stages := []Stage{naStage("plan", "succeeded"), naStage("implement", "awaiting_scope_decision")}
+
+	na := nextActionsFor(run, stages, nil, nil, nil, nil)
+	if na == nil || na.State != "implement_awaiting_scope_decision" {
+		t.Fatalf("state = %+v, want implement_awaiting_scope_decision", na)
+	}
+	dec := findAction(t, na, "fishhawk_decide_scope_completeness")
+	if dec.Params["run_id"] != run.ID {
+		t.Errorf("decide params = %v, want run_id=%s", dec.Params, run.ID)
+	}
+	if dec.Params["decision"] != "exempt|fail" {
+		t.Errorf("decide params = %v, want the exempt|fail decision hint", dec.Params)
+	}
+	if !strings.Contains(dec.Reason, "no agent re-run") && !strings.Contains(dec.Reason, "NO agent re-run") {
+		t.Errorf("decide reason should name the zero-re-run exempt semantics; got %q", dec.Reason)
 	}
 }
 

--- a/backend/cmd/fishhawk-mcp/tools.go
+++ b/backend/cmd/fishhawk-mcp/tools.go
@@ -54,6 +54,7 @@ func registerTools(srv *mcp.Server, resolver *runResolver) {
 	registerDeferConcern(srv, resolver)
 	registerListScopeAmendments(srv, resolver)
 	registerDecideScopeAmendment(srv, resolver)
+	registerDecideScopeCompleteness(srv, resolver)
 	registerApprovePlan(srv, resolver)
 	registerRejectPlan(srv, resolver)
 	registerRevisePlan(srv, resolver)

--- a/backend/cmd/fishhawk-mcp/tools_test.go
+++ b/backend/cmd/fishhawk-mcp/tools_test.go
@@ -244,6 +244,17 @@ type fakeBackend struct {
 	decideAmendmentErr   string
 	decideCalledByID     map[uuid.UUID]int
 
+	// #1231 fixtures: POST /v0/runs/{id}/scope-completeness/decision.
+	// decideScopeCompletenessResp seeds the decided park record keyed by
+	// run id; decideScopeCompletenessBody captures the last decoded body;
+	// *Status / *ErrBody drive the error paths; decideScopeCompletenessCalled
+	// counts decisions per run id.
+	decideScopeCompletenessResp   map[uuid.UUID]ScopeCompletenessDecisionResult
+	decideScopeCompletenessBody   scopeCompletenessDecisionRequest
+	decideScopeCompletenessStatus int
+	decideScopeCompletenessErr    string
+	decideScopeCompletenessCalled map[uuid.UUID]int
+
 	// E22.4 fixtures: POST /v0/stages/{id}/approvals.
 	// approvalsBody captures the last decoded body so tests can
 	// assert decision + comment threading.
@@ -285,61 +296,64 @@ type fakeBackend struct {
 func newFakeBackend(t *testing.T) (*fakeBackend, *httptest.Server) {
 	t.Helper()
 	fb := &fakeBackend{
-		listStatus:               http.StatusOK,
-		getStatus:                http.StatusOK,
-		stagesStatus:             http.StatusOK,
-		artifactsStatus:          http.StatusOK,
-		auditStatus:              http.StatusOK,
-		perRunAuditStatus:        http.StatusOK,
-		listByQuery:              map[string]listRunsResult{},
-		getRunByID:               map[uuid.UUID]Run{},
-		getRunExtraByID:          map[uuid.UUID]map[string]any{},
-		getStatusByID:            map[uuid.UUID]int{},
-		stagesByRun:              map[uuid.UUID][]Stage{},
-		artifactsByStage:         map[uuid.UUID][]Artifact{},
-		stagesCalledByID:         map[uuid.UUID]int{},
-		artifactsCalledID:        map[uuid.UUID]int{},
-		auditByRun:               map[uuid.UUID][]AuditEntry{},
-		auditCalledByID:          map[uuid.UUID]int{},
-		perRunAuditByRun:         map[uuid.UUID][]AuditEntry{},
-		perRunAuditNextByRun:     map[uuid.UUID]string{},
-		perRunAuditLastQueryByID: map[uuid.UUID]string{},
-		perRunAuditCategoryReads: map[string]int{},
-		createRunStatus:          http.StatusCreated,
-		recoverStatus:            http.StatusCreated,
-		cancelResp:               map[uuid.UUID]Run{},
-		cancelStatus:             http.StatusOK,
-		cancelCalledByID:         map[uuid.UUID]int{},
-		retryResp:                map[uuid.UUID]Stage{},
-		retryStatus:              http.StatusOK,
-		retryCalledByID:          map[uuid.UUID]int{},
-		fixupResp:                map[uuid.UUID]Stage{},
-		fixupStatus:              http.StatusOK,
-		fixupCalledByID:          map[uuid.UUID]int{},
-		clarificationResp:        map[uuid.UUID]Stage{},
-		clarificationStatus:      http.StatusOK,
-		clarificationCalledByID:  map[uuid.UUID]int{},
-		reviseResp:               map[uuid.UUID]Stage{},
-		reviseStatus:             http.StatusOK,
-		reviseCalledByID:         map[uuid.UUID]int{},
-		waiveResp:                map[uuid.UUID]WaivedConcern{},
-		waiveStatus:              http.StatusOK,
-		waiveCalledByID:          map[uuid.UUID]int{},
-		deferResp:                map[uuid.UUID]DeferredConcernResult{},
-		deferStatus:              http.StatusOK,
-		deferCalledByID:          map[uuid.UUID]int{},
-		amendmentsByRun:          map[uuid.UUID][]ScopeAmendmentItem{},
-		amendmentsStatus:         http.StatusOK,
-		decideAmendmentResp:      map[uuid.UUID]ScopeAmendmentItem{},
-		decideAmendmentState:     http.StatusOK,
-		decideCalledByID:         map[uuid.UUID]int{},
-		approvalsResp:            map[uuid.UUID]Stage{},
-		approvalsStatus:          http.StatusOK,
-		approvalsCalledByID:      map[uuid.UUID]int{},
-		calibrationStatus:        http.StatusOK,
-		budgetByRun:              map[uuid.UUID]BudgetStatus{},
-		budgetStatus:             http.StatusOK,
-		budgetCalledByID:         map[uuid.UUID]int{},
+		listStatus:                    http.StatusOK,
+		getStatus:                     http.StatusOK,
+		stagesStatus:                  http.StatusOK,
+		artifactsStatus:               http.StatusOK,
+		auditStatus:                   http.StatusOK,
+		perRunAuditStatus:             http.StatusOK,
+		listByQuery:                   map[string]listRunsResult{},
+		getRunByID:                    map[uuid.UUID]Run{},
+		getRunExtraByID:               map[uuid.UUID]map[string]any{},
+		getStatusByID:                 map[uuid.UUID]int{},
+		stagesByRun:                   map[uuid.UUID][]Stage{},
+		artifactsByStage:              map[uuid.UUID][]Artifact{},
+		stagesCalledByID:              map[uuid.UUID]int{},
+		artifactsCalledID:             map[uuid.UUID]int{},
+		auditByRun:                    map[uuid.UUID][]AuditEntry{},
+		auditCalledByID:               map[uuid.UUID]int{},
+		perRunAuditByRun:              map[uuid.UUID][]AuditEntry{},
+		perRunAuditNextByRun:          map[uuid.UUID]string{},
+		perRunAuditLastQueryByID:      map[uuid.UUID]string{},
+		perRunAuditCategoryReads:      map[string]int{},
+		createRunStatus:               http.StatusCreated,
+		recoverStatus:                 http.StatusCreated,
+		cancelResp:                    map[uuid.UUID]Run{},
+		cancelStatus:                  http.StatusOK,
+		cancelCalledByID:              map[uuid.UUID]int{},
+		retryResp:                     map[uuid.UUID]Stage{},
+		retryStatus:                   http.StatusOK,
+		retryCalledByID:               map[uuid.UUID]int{},
+		fixupResp:                     map[uuid.UUID]Stage{},
+		fixupStatus:                   http.StatusOK,
+		fixupCalledByID:               map[uuid.UUID]int{},
+		clarificationResp:             map[uuid.UUID]Stage{},
+		clarificationStatus:           http.StatusOK,
+		clarificationCalledByID:       map[uuid.UUID]int{},
+		reviseResp:                    map[uuid.UUID]Stage{},
+		reviseStatus:                  http.StatusOK,
+		reviseCalledByID:              map[uuid.UUID]int{},
+		waiveResp:                     map[uuid.UUID]WaivedConcern{},
+		waiveStatus:                   http.StatusOK,
+		waiveCalledByID:               map[uuid.UUID]int{},
+		deferResp:                     map[uuid.UUID]DeferredConcernResult{},
+		deferStatus:                   http.StatusOK,
+		deferCalledByID:               map[uuid.UUID]int{},
+		amendmentsByRun:               map[uuid.UUID][]ScopeAmendmentItem{},
+		amendmentsStatus:              http.StatusOK,
+		decideAmendmentResp:           map[uuid.UUID]ScopeAmendmentItem{},
+		decideAmendmentState:          http.StatusOK,
+		decideCalledByID:              map[uuid.UUID]int{},
+		decideScopeCompletenessResp:   map[uuid.UUID]ScopeCompletenessDecisionResult{},
+		decideScopeCompletenessStatus: http.StatusOK,
+		decideScopeCompletenessCalled: map[uuid.UUID]int{},
+		approvalsResp:                 map[uuid.UUID]Stage{},
+		approvalsStatus:               http.StatusOK,
+		approvalsCalledByID:           map[uuid.UUID]int{},
+		calibrationStatus:             http.StatusOK,
+		budgetByRun:                   map[uuid.UUID]BudgetStatus{},
+		budgetStatus:                  http.StatusOK,
+		budgetCalledByID:              map[uuid.UUID]int{},
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /v0/stages/{stage_id}/approvals", func(w http.ResponseWriter, r *http.Request) {
@@ -582,6 +596,33 @@ func newFakeBackend(t *testing.T) (*fakeBackend, *httptest.Server) {
 		}
 		if !ok {
 			resp = ScopeAmendmentItem{ID: amendmentID.String(), Status: "approved"}
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+
+	mux.HandleFunc("POST /v0/runs/{run_id}/scope-completeness/decision", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		runID, perr := uuid.Parse(r.PathValue("run_id"))
+		if perr != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		var body scopeCompletenessDecisionRequest
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		fb.mu.Lock()
+		fb.decideScopeCompletenessCalled[runID]++
+		fb.decideScopeCompletenessBody = body
+		status := fb.decideScopeCompletenessStatus
+		errBody := fb.decideScopeCompletenessErr
+		resp, ok := fb.decideScopeCompletenessResp[runID]
+		fb.mu.Unlock()
+		w.WriteHeader(status)
+		if errBody != "" {
+			_, _ = w.Write([]byte(errBody))
+			return
+		}
+		if !ok {
+			resp = ScopeCompletenessDecisionResult{RunID: runID.String(), Decision: body.Decision}
 		}
 		_ = json.NewEncoder(w).Encode(resp)
 	})
@@ -1182,7 +1223,7 @@ func TestToolDescriptions_ConformToHouseStyle(t *testing.T) {
 	const minDescriptionLen = 80
 	// The registered tool set is the fishhawk_* tools swept in #778. Bump
 	// this and give the new tool a conformant description when adding one.
-	const wantToolCount = 30
+	const wantToolCount = 31
 
 	if len(res.Tools) != wantToolCount {
 		t.Errorf("registered tool count = %d, want %d (a new tool must be added here with a when/eligibility-leading description)",

--- a/backend/internal/postgres/migrations/0035_stage_awaiting_scope_decision.down.sql
+++ b/backend/internal/postgres/migrations/0035_stage_awaiting_scope_decision.down.sql
@@ -1,0 +1,14 @@
+-- Revert 0035: drop the scope_completeness_park column and narrow
+-- stages_state_check back to the 0032 set (no 'awaiting_scope_decision').
+-- The CHECK re-add fails loudly if any stage row currently holds
+-- 'awaiting_scope_decision', so the down is safe only when no stage is
+-- parked for a scope-completeness decision — exactly the invariant a
+-- rollback needs.
+ALTER TABLE stages DROP COLUMN scope_completeness_park;
+
+ALTER TABLE stages DROP CONSTRAINT stages_state_check;
+ALTER TABLE stages ADD CONSTRAINT stages_state_check CHECK (
+    state IN ('pending', 'dispatched', 'running', 'awaiting_approval',
+              'awaiting_children', 'awaiting_input', 'succeeded', 'failed',
+              'cancelled')
+);

--- a/backend/internal/postgres/migrations/0035_stage_awaiting_scope_decision.up.sql
+++ b/backend/internal/postgres/migrations/0035_stage_awaiting_scope_decision.up.sql
@@ -1,0 +1,25 @@
+-- Migration 0035: widen stages_state_check to admit
+-- 'awaiting_scope_decision' and add the scope_completeness_park payload
+-- column.
+--
+-- awaiting_scope_decision is a non-terminal stage state the implement
+-- stage enters when its ONLY committed-tree gate failure is the
+-- scope-completeness "missing declared scope file(s)" check (#1151): the
+-- runner has already pushed its verified commit to the run branch (no
+-- PR), and the run parks for an operator exempt-or-fail decision (#1231)
+-- — a parked judgment, NOT a failure, resolved in-band with zero agent
+-- re-run on exempt. The CHECK constraint rejects the value until widened
+-- here (mirrors 0032's awaiting_input precedent).
+--
+-- scope_completeness_park is the durable held-commit payload the park
+-- carries: {held_commit_sha, run_branch, verified_tree_sha,
+-- missing_paths}. NULL for every stage not parked for a scope decision.
+
+ALTER TABLE stages DROP CONSTRAINT stages_state_check;
+ALTER TABLE stages ADD CONSTRAINT stages_state_check CHECK (
+    state IN ('pending', 'dispatched', 'running', 'awaiting_approval',
+              'awaiting_children', 'awaiting_input', 'awaiting_scope_decision',
+              'succeeded', 'failed', 'cancelled')
+);
+
+ALTER TABLE stages ADD COLUMN scope_completeness_park JSONB;

--- a/backend/internal/postgres/postgres_test.go
+++ b/backend/internal/postgres/postgres_test.go
@@ -177,6 +177,30 @@ func TestMigrateUp_AppliesAndIsIdempotent(t *testing.T) {
 		t.Errorf("'runs' table count after MigrateUp = %d, want 1", n)
 	}
 
+	// 0035 (#1231) widened stages_state_check to admit
+	// 'awaiting_scope_decision' and added the scope_completeness_park
+	// column. Confirm both are present after a full MigrateUp.
+	var stageStateCheckDef string
+	if err := pool.QueryRow(context.Background(),
+		`SELECT pg_get_constraintdef(oid) FROM pg_constraint
+		 WHERE conname = 'stages_state_check'`,
+	).Scan(&stageStateCheckDef); err != nil {
+		t.Fatalf("query stages_state_check constraint def: %v", err)
+	}
+	if !strings.Contains(stageStateCheckDef, "awaiting_scope_decision") {
+		t.Errorf("stages_state_check after MigrateUp does not admit 'awaiting_scope_decision': %s", stageStateCheckDef)
+	}
+	var scopeParkCol int
+	if err := pool.QueryRow(context.Background(),
+		`SELECT count(*) FROM information_schema.columns
+		 WHERE table_name = 'stages' AND column_name = 'scope_completeness_park'`,
+	).Scan(&scopeParkCol); err != nil {
+		t.Fatalf("query stages.scope_completeness_park column: %v", err)
+	}
+	if scopeParkCol != 1 {
+		t.Errorf("stages.scope_completeness_park count after MigrateUp = %d, want 1", scopeParkCol)
+	}
+
 	// Second application is a no-op.
 	if err := postgres.MigrateUp(url); err != nil {
 		t.Errorf("second MigrateUp returned %v, want nil (idempotent)", err)
@@ -205,14 +229,24 @@ func TestMigrateDown_RemovesTables(t *testing.T) {
 	}
 	defer pool.Close()
 
-	// MigrateDown rolls back one step. 0034 (#1141) added the
-	// runs.slice_index column; its down migration drops it. Confirm: the
-	// column is gone, but every prior migration's effect is still present —
-	// notably 0033's (#1165) review_concerns.suggested_patch column (only
-	// 0034 rolled back), 0032's (#1057) widened stages_state_check still
-	// admits 'awaiting_input', plus runs.drive from 0031, review_concerns
-	// from 0030, scope_amendments from 0029, cost_usd_total + resolved_model
-	// from 0028, etc.
+	// MigrateDown rolls back one step. 0035 (#1231) added the
+	// stages.scope_completeness_park column and widened stages_state_check
+	// to admit 'awaiting_scope_decision'; its down migration drops the
+	// column and narrows the check back. Confirm: the column is gone and the
+	// check no longer admits 'awaiting_scope_decision', but every PRIOR
+	// migration's effect is still present — notably 0034's (#1141)
+	// runs.slice_index column (only 0035 rolled back), 0032's (#1057)
+	// widened check still admits 'awaiting_input', etc.
+	var scopeParkCol int
+	if err := pool.QueryRow(context.Background(),
+		`SELECT count(*) FROM information_schema.columns
+		 WHERE table_name = 'stages' AND column_name = 'scope_completeness_park'`,
+	).Scan(&scopeParkCol); err != nil {
+		t.Fatalf("query stages.scope_completeness_park column: %v", err)
+	}
+	if scopeParkCol != 0 {
+		t.Errorf("stages.scope_completeness_park count after MigrateDown = %d, want 0 (0035 down should have dropped it)", scopeParkCol)
+	}
 	var sliceIndexCol int
 	if err := pool.QueryRow(context.Background(),
 		`SELECT count(*) FROM information_schema.columns
@@ -220,8 +254,8 @@ func TestMigrateDown_RemovesTables(t *testing.T) {
 	).Scan(&sliceIndexCol); err != nil {
 		t.Fatalf("query runs.slice_index column: %v", err)
 	}
-	if sliceIndexCol != 0 {
-		t.Errorf("runs.slice_index count after MigrateDown = %d, want 0 (0034 down should have dropped it)", sliceIndexCol)
+	if sliceIndexCol != 1 {
+		t.Errorf("runs.slice_index count after MigrateDown = %d, want 1 (0034 still applied; only 0035 rolled back)", sliceIndexCol)
 	}
 	var suggestedPatchCol int
 	if err := pool.QueryRow(context.Background(),
@@ -231,7 +265,7 @@ func TestMigrateDown_RemovesTables(t *testing.T) {
 		t.Fatalf("query review_concerns.suggested_patch column: %v", err)
 	}
 	if suggestedPatchCol != 1 {
-		t.Errorf("review_concerns.suggested_patch count after MigrateDown = %d, want 1 (0033 still applied; only 0034 rolled back)", suggestedPatchCol)
+		t.Errorf("review_concerns.suggested_patch count after MigrateDown = %d, want 1 (0033 still applied; only 0035 rolled back)", suggestedPatchCol)
 	}
 	var stageStateCheckDef string
 	if err := pool.QueryRow(context.Background(),
@@ -240,8 +274,11 @@ func TestMigrateDown_RemovesTables(t *testing.T) {
 	).Scan(&stageStateCheckDef); err != nil {
 		t.Fatalf("query stages_state_check constraint def: %v", err)
 	}
+	if strings.Contains(stageStateCheckDef, "awaiting_scope_decision") {
+		t.Errorf("stages_state_check after MigrateDown still admits 'awaiting_scope_decision' (0035 down should have narrowed it): %s", stageStateCheckDef)
+	}
 	if !strings.Contains(stageStateCheckDef, "awaiting_input") {
-		t.Errorf("stages_state_check after MigrateDown dropped 'awaiting_input' (0032 still applied; only 0033 should roll back): %s", stageStateCheckDef)
+		t.Errorf("stages_state_check after MigrateDown dropped 'awaiting_input' (0032 still applied; only 0035 should roll back): %s", stageStateCheckDef)
 	}
 	if !strings.Contains(stageStateCheckDef, "awaiting_children") {
 		t.Errorf("stages_state_check after MigrateDown dropped 'awaiting_children': %s", stageStateCheckDef)

--- a/backend/internal/run/db/models.go
+++ b/backend/internal/run/db/models.go
@@ -141,24 +141,25 @@ type SigningKey struct {
 }
 
 type Stage struct {
-	ID               uuid.UUID          `json:"id"`
-	RunID            uuid.UUID          `json:"run_id"`
-	Sequence         int32              `json:"sequence"`
-	StageType        string             `json:"stage_type"`
-	ExecutorKind     string             `json:"executor_kind"`
-	ExecutorRef      string             `json:"executor_ref"`
-	State            string             `json:"state"`
-	StartedAt        pgtype.Timestamptz `json:"started_at"`
-	EndedAt          pgtype.Timestamptz `json:"ended_at"`
-	FailureCategory  *string            `json:"failure_category"`
-	FailureReason    *string            `json:"failure_reason"`
-	CreatedAt        pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt        pgtype.Timestamptz `json:"updated_at"`
-	GateSla          *string            `json:"gate_sla"`
-	RequiresApproval bool               `json:"requires_approval"`
-	GateType         *string            `json:"gate_type"`
-	GateApprovers    []byte             `json:"gate_approvers"`
-	SelfRetryCount   int32              `json:"self_retry_count"`
+	ID                    uuid.UUID          `json:"id"`
+	RunID                 uuid.UUID          `json:"run_id"`
+	Sequence              int32              `json:"sequence"`
+	StageType             string             `json:"stage_type"`
+	ExecutorKind          string             `json:"executor_kind"`
+	ExecutorRef           string             `json:"executor_ref"`
+	State                 string             `json:"state"`
+	StartedAt             pgtype.Timestamptz `json:"started_at"`
+	EndedAt               pgtype.Timestamptz `json:"ended_at"`
+	FailureCategory       *string            `json:"failure_category"`
+	FailureReason         *string            `json:"failure_reason"`
+	CreatedAt             pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt             pgtype.Timestamptz `json:"updated_at"`
+	GateSla               *string            `json:"gate_sla"`
+	RequiresApproval      bool               `json:"requires_approval"`
+	GateType              *string            `json:"gate_type"`
+	GateApprovers         []byte             `json:"gate_approvers"`
+	SelfRetryCount        int32              `json:"self_retry_count"`
+	ScopeCompletenessPark []byte             `json:"scope_completeness_park"`
 }
 
 type StageCheck struct {

--- a/backend/internal/run/db/queries.sql.go
+++ b/backend/internal/run/db/queries.sql.go
@@ -159,7 +159,7 @@ INSERT INTO stages (
     gate_type, gate_approvers
 )
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-RETURNING id, run_id, sequence, stage_type, executor_kind, executor_ref, state, started_at, ended_at, failure_category, failure_reason, created_at, updated_at, gate_sla, requires_approval, gate_type, gate_approvers, self_retry_count
+RETURNING id, run_id, sequence, stage_type, executor_kind, executor_ref, state, started_at, ended_at, failure_category, failure_reason, created_at, updated_at, gate_sla, requires_approval, gate_type, gate_approvers, self_retry_count, scope_completeness_park
 `
 
 type CreateStageParams struct {
@@ -210,6 +210,7 @@ func (q *Queries) CreateStage(ctx context.Context, arg CreateStageParams) (Stage
 		&i.GateType,
 		&i.GateApprovers,
 		&i.SelfRetryCount,
+		&i.ScopeCompletenessPark,
 	)
 	return i, err
 }
@@ -297,7 +298,7 @@ func (q *Queries) GetRunByIdempotencyKey(ctx context.Context, arg GetRunByIdempo
 }
 
 const getStage = `-- name: GetStage :one
-SELECT id, run_id, sequence, stage_type, executor_kind, executor_ref, state, started_at, ended_at, failure_category, failure_reason, created_at, updated_at, gate_sla, requires_approval, gate_type, gate_approvers, self_retry_count FROM stages WHERE id = $1
+SELECT id, run_id, sequence, stage_type, executor_kind, executor_ref, state, started_at, ended_at, failure_category, failure_reason, created_at, updated_at, gate_sla, requires_approval, gate_type, gate_approvers, self_retry_count, scope_completeness_park FROM stages WHERE id = $1
 `
 
 func (q *Queries) GetStage(ctx context.Context, id uuid.UUID) (Stage, error) {
@@ -322,12 +323,13 @@ func (q *Queries) GetStage(ctx context.Context, id uuid.UUID) (Stage, error) {
 		&i.GateType,
 		&i.GateApprovers,
 		&i.SelfRetryCount,
+		&i.ScopeCompletenessPark,
 	)
 	return i, err
 }
 
 const listReviewStagesAwaitingApproval = `-- name: ListReviewStagesAwaitingApproval :many
-SELECT id, run_id, sequence, stage_type, executor_kind, executor_ref, state, started_at, ended_at, failure_category, failure_reason, created_at, updated_at, gate_sla, requires_approval, gate_type, gate_approvers, self_retry_count FROM stages
+SELECT id, run_id, sequence, stage_type, executor_kind, executor_ref, state, started_at, ended_at, failure_category, failure_reason, created_at, updated_at, gate_sla, requires_approval, gate_type, gate_approvers, self_retry_count, scope_completeness_park FROM stages
  WHERE state = 'awaiting_approval'
    AND stage_type = 'review'
  ORDER BY updated_at ASC
@@ -368,6 +370,7 @@ func (q *Queries) ListReviewStagesAwaitingApproval(ctx context.Context) ([]Stage
 			&i.GateType,
 			&i.GateApprovers,
 			&i.SelfRetryCount,
+			&i.ScopeCompletenessPark,
 		); err != nil {
 			return nil, err
 		}
@@ -468,7 +471,7 @@ func (q *Queries) ListRuns(ctx context.Context, arg ListRunsParams) ([]Run, erro
 }
 
 const listStagesAwaitingApproval = `-- name: ListStagesAwaitingApproval :many
-SELECT id, run_id, sequence, stage_type, executor_kind, executor_ref, state, started_at, ended_at, failure_category, failure_reason, created_at, updated_at, gate_sla, requires_approval, gate_type, gate_approvers, self_retry_count FROM stages
+SELECT id, run_id, sequence, stage_type, executor_kind, executor_ref, state, started_at, ended_at, failure_category, failure_reason, created_at, updated_at, gate_sla, requires_approval, gate_type, gate_approvers, self_retry_count, scope_completeness_park FROM stages
  WHERE state = 'awaiting_approval'
    AND gate_sla IS NOT NULL
  ORDER BY updated_at ASC
@@ -508,6 +511,7 @@ func (q *Queries) ListStagesAwaitingApproval(ctx context.Context) ([]Stage, erro
 			&i.GateType,
 			&i.GateApprovers,
 			&i.SelfRetryCount,
+			&i.ScopeCompletenessPark,
 		); err != nil {
 			return nil, err
 		}
@@ -520,7 +524,7 @@ func (q *Queries) ListStagesAwaitingApproval(ctx context.Context) ([]Stage, erro
 }
 
 const listStagesAwaitingChildren = `-- name: ListStagesAwaitingChildren :many
-SELECT id, run_id, sequence, stage_type, executor_kind, executor_ref, state, started_at, ended_at, failure_category, failure_reason, created_at, updated_at, gate_sla, requires_approval, gate_type, gate_approvers, self_retry_count FROM stages
+SELECT id, run_id, sequence, stage_type, executor_kind, executor_ref, state, started_at, ended_at, failure_category, failure_reason, created_at, updated_at, gate_sla, requires_approval, gate_type, gate_approvers, self_retry_count, scope_completeness_park FROM stages
  WHERE state = 'awaiting_children'
  ORDER BY updated_at ASC
 `
@@ -556,6 +560,7 @@ func (q *Queries) ListStagesAwaitingChildren(ctx context.Context) ([]Stage, erro
 			&i.GateType,
 			&i.GateApprovers,
 			&i.SelfRetryCount,
+			&i.ScopeCompletenessPark,
 		); err != nil {
 			return nil, err
 		}
@@ -568,7 +573,7 @@ func (q *Queries) ListStagesAwaitingChildren(ctx context.Context) ([]Stage, erro
 }
 
 const listStagesDispatched = `-- name: ListStagesDispatched :many
-SELECT id, run_id, sequence, stage_type, executor_kind, executor_ref, state, started_at, ended_at, failure_category, failure_reason, created_at, updated_at, gate_sla, requires_approval, gate_type, gate_approvers, self_retry_count FROM stages
+SELECT id, run_id, sequence, stage_type, executor_kind, executor_ref, state, started_at, ended_at, failure_category, failure_reason, created_at, updated_at, gate_sla, requires_approval, gate_type, gate_approvers, self_retry_count, scope_completeness_park FROM stages
  WHERE state = 'dispatched'
  ORDER BY updated_at ASC
 `
@@ -606,6 +611,7 @@ func (q *Queries) ListStagesDispatched(ctx context.Context) ([]Stage, error) {
 			&i.GateType,
 			&i.GateApprovers,
 			&i.SelfRetryCount,
+			&i.ScopeCompletenessPark,
 		); err != nil {
 			return nil, err
 		}
@@ -618,7 +624,7 @@ func (q *Queries) ListStagesDispatched(ctx context.Context) ([]Stage, error) {
 }
 
 const listStagesForRun = `-- name: ListStagesForRun :many
-SELECT id, run_id, sequence, stage_type, executor_kind, executor_ref, state, started_at, ended_at, failure_category, failure_reason, created_at, updated_at, gate_sla, requires_approval, gate_type, gate_approvers, self_retry_count FROM stages WHERE run_id = $1 ORDER BY sequence ASC
+SELECT id, run_id, sequence, stage_type, executor_kind, executor_ref, state, started_at, ended_at, failure_category, failure_reason, created_at, updated_at, gate_sla, requires_approval, gate_type, gate_approvers, self_retry_count, scope_completeness_park FROM stages WHERE run_id = $1 ORDER BY sequence ASC
 `
 
 func (q *Queries) ListStagesForRun(ctx context.Context, runID uuid.UUID) ([]Stage, error) {
@@ -649,6 +655,7 @@ func (q *Queries) ListStagesForRun(ctx context.Context, runID uuid.UUID) ([]Stag
 			&i.GateType,
 			&i.GateApprovers,
 			&i.SelfRetryCount,
+			&i.ScopeCompletenessPark,
 		); err != nil {
 			return nil, err
 		}
@@ -697,7 +704,7 @@ func (q *Queries) LockRunForUpdate(ctx context.Context, id uuid.UUID) (Run, erro
 }
 
 const lockStageForUpdate = `-- name: LockStageForUpdate :one
-SELECT id, run_id, sequence, stage_type, executor_kind, executor_ref, state, started_at, ended_at, failure_category, failure_reason, created_at, updated_at, gate_sla, requires_approval, gate_type, gate_approvers, self_retry_count FROM stages WHERE id = $1 FOR UPDATE
+SELECT id, run_id, sequence, stage_type, executor_kind, executor_ref, state, started_at, ended_at, failure_category, failure_reason, created_at, updated_at, gate_sla, requires_approval, gate_type, gate_approvers, self_retry_count, scope_completeness_park FROM stages WHERE id = $1 FOR UPDATE
 `
 
 func (q *Queries) LockStageForUpdate(ctx context.Context, id uuid.UUID) (Stage, error) {
@@ -722,6 +729,54 @@ func (q *Queries) LockStageForUpdate(ctx context.Context, id uuid.UUID) (Stage, 
 		&i.GateType,
 		&i.GateApprovers,
 		&i.SelfRetryCount,
+		&i.ScopeCompletenessPark,
+	)
+	return i, err
+}
+
+const parkScopeCompleteness = `-- name: ParkScopeCompleteness :one
+UPDATE stages
+   SET state                   = $2,
+       scope_completeness_park = $3
+ WHERE id = $1
+RETURNING id, run_id, sequence, stage_type, executor_kind, executor_ref, state, started_at, ended_at, failure_category, failure_reason, created_at, updated_at, gate_sla, requires_approval, gate_type, gate_approvers, self_retry_count, scope_completeness_park
+`
+
+type ParkScopeCompletenessParams struct {
+	ID                    uuid.UUID `json:"id"`
+	State                 string    `json:"state"`
+	ScopeCompletenessPark []byte    `json:"scope_completeness_park"`
+}
+
+// Atomically sets the stage's state and its scope_completeness_park
+// payload (#1231). Used by ParkScopeCompletenessAndAppend inside a
+// transaction that first locks the row and validates the running →
+// awaiting_scope_decision transition; the JSONB payload pins the held
+// commit the runner already pushed to the run branch so the operator's
+// exempt decision can open the PR from it with no agent re-run.
+func (q *Queries) ParkScopeCompleteness(ctx context.Context, arg ParkScopeCompletenessParams) (Stage, error) {
+	row := q.db.QueryRow(ctx, parkScopeCompleteness, arg.ID, arg.State, arg.ScopeCompletenessPark)
+	var i Stage
+	err := row.Scan(
+		&i.ID,
+		&i.RunID,
+		&i.Sequence,
+		&i.StageType,
+		&i.ExecutorKind,
+		&i.ExecutorRef,
+		&i.State,
+		&i.StartedAt,
+		&i.EndedAt,
+		&i.FailureCategory,
+		&i.FailureReason,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.GateSla,
+		&i.RequiresApproval,
+		&i.GateType,
+		&i.GateApprovers,
+		&i.SelfRetryCount,
+		&i.ScopeCompletenessPark,
 	)
 	return i, err
 }
@@ -734,7 +789,7 @@ UPDATE stages
        ended_at         = NULL,
        self_retry_count = self_retry_count + 1
  WHERE id = $1
-RETURNING id, run_id, sequence, stage_type, executor_kind, executor_ref, state, started_at, ended_at, failure_category, failure_reason, created_at, updated_at, gate_sla, requires_approval, gate_type, gate_approvers, self_retry_count
+RETURNING id, run_id, sequence, stage_type, executor_kind, executor_ref, state, started_at, ended_at, failure_category, failure_reason, created_at, updated_at, gate_sla, requires_approval, gate_type, gate_approvers, self_retry_count, scope_completeness_park
 `
 
 type RetryStageStateParams struct {
@@ -767,6 +822,7 @@ func (q *Queries) RetryStageState(ctx context.Context, arg RetryStageStateParams
 		&i.GateType,
 		&i.GateApprovers,
 		&i.SelfRetryCount,
+		&i.ScopeCompletenessPark,
 	)
 	return i, err
 }
@@ -905,7 +961,7 @@ UPDATE stages
        failure_category = $5,
        failure_reason   = $6
  WHERE id = $1
-RETURNING id, run_id, sequence, stage_type, executor_kind, executor_ref, state, started_at, ended_at, failure_category, failure_reason, created_at, updated_at, gate_sla, requires_approval, gate_type, gate_approvers, self_retry_count
+RETURNING id, run_id, sequence, stage_type, executor_kind, executor_ref, state, started_at, ended_at, failure_category, failure_reason, created_at, updated_at, gate_sla, requires_approval, gate_type, gate_approvers, self_retry_count, scope_completeness_park
 `
 
 type UpdateStageStateParams struct {
@@ -946,6 +1002,7 @@ func (q *Queries) UpdateStageState(ctx context.Context, arg UpdateStageStatePara
 		&i.GateType,
 		&i.GateApprovers,
 		&i.SelfRetryCount,
+		&i.ScopeCompletenessPark,
 	)
 	return i, err
 }

--- a/backend/internal/run/postgres.go
+++ b/backend/internal/run/postgres.go
@@ -572,6 +572,82 @@ func (r *postgresRepo) ResumeAwaitingInputAndAppend(ctx context.Context, stageID
 	return result, won, nil
 }
 
+// ParkScopeCompletenessAndAppend atomically parks an implement stage for
+// an operator scope-completeness decision (#1231): it transitions the
+// stage running → awaiting_scope_decision, writes the held-commit
+// ScopeCompletenessPark payload, AND appends the scope_completeness_parked
+// audit entry in ONE pgx transaction. If the audit append fails the
+// closure returns an error so BeginFunc rolls the whole transaction back
+// and the stage stays running (the runner's report can be retried),
+// mirroring ResumeAwaitingInputAndAppend's append-after-transition gap
+// close (#1090).
+//
+// The compare-and-set under the stage row lock is the single-winner gate
+// for a duplicate runner delivery: a caller that arrives after the stage
+// already left running observes current.State != running, gets won=false
+// (nil error), and never appends an orphaned audit entry. The winning
+// caller gets won=true and the parked stage.
+//
+// This is an OPTIONAL capability on the concrete postgres repo (not on
+// the Repository interface): the pull-request park handler type-asserts
+// it and falls back to a two-step path for in-memory fakes.
+func (r *postgresRepo) ParkScopeCompletenessAndAppend(ctx context.Context, stageID uuid.UUID, park ScopeCompletenessPark, p audit.ChainAppendParams) (*Stage, bool, error) {
+	payload, err := json.Marshal(park)
+	if err != nil {
+		return nil, false, fmt.Errorf("marshal scope completeness park: %w", err)
+	}
+	var result *Stage
+	won := false
+	err = pgx.BeginFunc(ctx, r.pool, func(tx pgx.Tx) error {
+		q := rundb.New(tx)
+		current, err := q.LockStageForUpdate(ctx, stageID)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrNotFound
+		}
+		if err != nil {
+			return fmt.Errorf("lock stage: %w", err)
+		}
+		from := StageState(current.State)
+		// Compare-and-set: only the caller that observes the stage still
+		// running parks it. A loser of a duplicate delivery commits a
+		// no-op (won stays false) and writes no audit entry.
+		if from != StageStateRunning {
+			result = rowToStage(current)
+			return nil
+		}
+		if !ValidStageTransition(from, StageStateAwaitingScopeDecision) {
+			return InvalidTransitionError{Kind: "stage", From: string(from), To: string(StageStateAwaitingScopeDecision)}
+		}
+
+		// awaiting_scope_decision is non-terminal and not Running, so
+		// neither started_at nor ended_at is stamped — mirrors
+		// TransitionStage's handling of a non-terminal target.
+		updated, err := q.ParkScopeCompleteness(ctx, rundb.ParkScopeCompletenessParams{
+			ID:                    stageID,
+			State:                 string(StageStateAwaitingScopeDecision),
+			ScopeCompletenessPark: payload,
+		})
+		if err != nil {
+			return fmt.Errorf("park scope completeness: %w", err)
+		}
+
+		// Append the scope_completeness_parked entry in the SAME tx. Any
+		// error here aborts the closure so BeginFunc rolls back the park
+		// too — the stage stays running.
+		if _, err := audit.AppendChainedTx(ctx, tx, p); err != nil {
+			return err
+		}
+
+		result = rowToStage(updated)
+		won = true
+		return nil
+	})
+	if err != nil {
+		return nil, false, err
+	}
+	return result, won, nil
+}
+
 // RetryStage is the explicit override out of a terminal state. The
 // failure_category, failure_reason, and ended_at fields are
 // cleared; the updated_at trigger fires on the row update so any
@@ -731,6 +807,17 @@ func rowToStage(s rundb.Stage) *Stage {
 			}
 		}
 		out.Gate = gate
+	}
+	// JSONB → struct. Empty bytes means the column is NULL — the stage is
+	// not parked for a scope-completeness decision (#1231). Same tolerance
+	// posture as the gate/snapshot reads above: drop a corrupt blob rather
+	// than 500 the read path; the audit log is the source of truth on what
+	// was parked.
+	if len(s.ScopeCompletenessPark) > 0 {
+		var park ScopeCompletenessPark
+		if err := json.Unmarshal(s.ScopeCompletenessPark, &park); err == nil {
+			out.ScopeCompletenessPark = &park
+		}
 	}
 	return out
 }

--- a/backend/internal/run/postgres_test.go
+++ b/backend/internal/run/postgres_test.go
@@ -1283,3 +1283,148 @@ func TestPostgres_ResumeAwaitingInputAndAppend_MissingStage(t *testing.T) {
 		t.Error("won = true for a missing stage, want false")
 	}
 }
+
+// scopeCompletenessParker is the optional combined-commit capability the
+// pull-request park handler type-asserts on the concrete postgres repo
+// (#1231). Like resumeAppender it is not part of run.Repository, so the
+// test asserts it the same way the handler does.
+type scopeCompletenessParker interface {
+	ParkScopeCompletenessAndAppend(ctx context.Context, stageID uuid.UUID, park run.ScopeCompletenessPark, p audit.ChainAppendParams) (*run.Stage, bool, error)
+}
+
+// seedRunningImplementStage creates a run + implement stage and walks it
+// pending → dispatched → running, the state a missing-declared-scope-file
+// park fires from.
+func seedRunningImplementStage(t *testing.T, repo run.Repository) (*run.Run, *run.Stage) {
+	t.Helper()
+	ctx := context.Background()
+	r := makeRun(t, repo)
+	s, err := repo.CreateStage(ctx, run.CreateStageParams{
+		RunID:        r.ID,
+		Sequence:     0,
+		Type:         run.StageTypeImplement,
+		ExecutorKind: run.ExecutorAgent,
+		ExecutorRef:  "claude-code",
+	})
+	if err != nil {
+		t.Fatalf("create implement stage: %v", err)
+	}
+	for _, to := range []run.StageState{run.StageStateDispatched, run.StageStateRunning} {
+		if _, err := repo.TransitionStage(ctx, s.ID, to, nil); err != nil {
+			t.Fatalf("transition to %s: %v", to, err)
+		}
+	}
+	running, err := repo.GetStage(ctx, s.ID)
+	if err != nil {
+		t.Fatalf("GetStage: %v", err)
+	}
+	return r, running
+}
+
+// parkParams builds a scope_completeness_parked ChainAppendParams.
+func parkParams(runID, stageID uuid.UUID, payload []byte) audit.ChainAppendParams {
+	sid := stageID
+	subject := "system"
+	kind := audit.ActorKind("system")
+	return audit.ChainAppendParams{
+		RunID:        runID,
+		StageID:      &sid,
+		Timestamp:    time.Now().UTC(),
+		Category:     "scope_completeness_parked",
+		ActorKind:    &kind,
+		ActorSubject: &subject,
+		Payload:      payload,
+	}
+}
+
+func TestPostgres_ParkScopeCompletenessAndAppend_RoundTrip(t *testing.T) {
+	pool := startPostgres(t)
+	repo := run.NewPostgresRepository(pool)
+	pk, ok := repo.(scopeCompletenessParker)
+	if !ok {
+		t.Fatal("postgres repo does not implement ParkScopeCompletenessAndAppend")
+	}
+	auditRepo := audit.NewPostgresRepository(pool)
+	ctx := context.Background()
+
+	r, running := seedRunningImplementStage(t, repo)
+	park := run.ScopeCompletenessPark{
+		HeldCommitSHA:   "1111111111111111111111111111111111111111",
+		RunBranch:       "fishhawk/run-aaa/slice-0",
+		VerifiedTreeSHA: "2222222222222222222222222222222222222222",
+		MissingPaths:    []string{"backend/internal/foo/foo_test.go", "docs/foo.md"},
+	}
+
+	stage, won, err := pk.ParkScopeCompletenessAndAppend(ctx, running.ID, park, parkParams(r.ID, running.ID, []byte(`{"k":"v"}`)))
+	if err != nil {
+		t.Fatalf("ParkScopeCompletenessAndAppend: %v", err)
+	}
+	if !won {
+		t.Fatal("won = false, want true for the single parking caller")
+	}
+	if stage.State != run.StageStateAwaitingScopeDecision {
+		t.Errorf("stage state = %q, want awaiting_scope_decision", stage.State)
+	}
+
+	// The park payload round-trips through the JSONB column on a fresh read.
+	got, err := repo.GetStage(ctx, running.ID)
+	if err != nil {
+		t.Fatalf("GetStage: %v", err)
+	}
+	if got.State != run.StageStateAwaitingScopeDecision {
+		t.Errorf("persisted stage state = %q, want awaiting_scope_decision", got.State)
+	}
+	if got.ScopeCompletenessPark == nil {
+		t.Fatal("persisted ScopeCompletenessPark = nil, want round-tripped payload")
+	}
+	if got.ScopeCompletenessPark.HeldCommitSHA != park.HeldCommitSHA ||
+		got.ScopeCompletenessPark.RunBranch != park.RunBranch ||
+		got.ScopeCompletenessPark.VerifiedTreeSHA != park.VerifiedTreeSHA ||
+		len(got.ScopeCompletenessPark.MissingPaths) != 2 {
+		t.Errorf("ScopeCompletenessPark = %+v, want %+v", got.ScopeCompletenessPark, park)
+	}
+
+	// Exactly one scope_completeness_parked entry persisted in the same tx.
+	entries, err := auditRepo.ListForRunByCategory(ctx, r.ID, "scope_completeness_parked")
+	if err != nil {
+		t.Fatalf("ListForRunByCategory: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("scope_completeness_parked entries = %d, want 1", len(entries))
+	}
+}
+
+func TestPostgres_ParkScopeCompletenessAndAppend_LoserCAS(t *testing.T) {
+	pool := startPostgres(t)
+	repo := run.NewPostgresRepository(pool)
+	pk := repo.(scopeCompletenessParker)
+	auditRepo := audit.NewPostgresRepository(pool)
+	ctx := context.Background()
+
+	r, running := seedRunningImplementStage(t, repo)
+	park := run.ScopeCompletenessPark{HeldCommitSHA: "abc", RunBranch: "b", VerifiedTreeSHA: "t", MissingPaths: []string{"x"}}
+
+	// First caller wins.
+	if _, won, err := pk.ParkScopeCompletenessAndAppend(ctx, running.ID, park, parkParams(r.ID, running.ID, []byte(`{}`))); err != nil || !won {
+		t.Fatalf("first park: won=%v err=%v, want won=true nil", won, err)
+	}
+	// Second caller observes the stage already left running → no-op, won=false,
+	// and must NOT append a second audit entry.
+	stage, won, err := pk.ParkScopeCompletenessAndAppend(ctx, running.ID, park, parkParams(r.ID, running.ID, []byte(`{}`)))
+	if err != nil {
+		t.Fatalf("second park err = %v, want nil", err)
+	}
+	if won {
+		t.Error("won = true for the losing caller, want false")
+	}
+	if stage == nil || stage.State != run.StageStateAwaitingScopeDecision {
+		t.Errorf("loser stage = %+v, want awaiting_scope_decision row", stage)
+	}
+	entries, err := auditRepo.ListForRunByCategory(ctx, r.ID, "scope_completeness_parked")
+	if err != nil {
+		t.Fatalf("ListForRunByCategory: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("scope_completeness_parked entries = %d, want 1 (loser must not append)", len(entries))
+	}
+}

--- a/backend/internal/run/queries.sql
+++ b/backend/internal/run/queries.sql
@@ -159,6 +159,19 @@ UPDATE stages
  WHERE id = $1
 RETURNING *;
 
+-- name: ParkScopeCompleteness :one
+-- Atomically sets the stage's state and its scope_completeness_park
+-- payload (#1231). Used by ParkScopeCompletenessAndAppend inside a
+-- transaction that first locks the row and validates the running →
+-- awaiting_scope_decision transition; the JSONB payload pins the held
+-- commit the runner already pushed to the run branch so the operator's
+-- exempt decision can open the PR from it with no agent re-run.
+UPDATE stages
+   SET state                   = $2,
+       scope_completeness_park = $3
+ WHERE id = $1
+RETURNING *;
+
 -- name: RetryStageState :one
 -- Clears failure metadata + ended_at and increments self_retry_count
 -- atomically. Used by the retry handler's explicit out-of-terminal

--- a/backend/internal/run/run.go
+++ b/backend/internal/run/run.go
@@ -51,21 +51,29 @@ func (s State) IsTerminal() bool {
 // blocking on human action. `awaiting_input` means the stage parked
 // for operator direction — the planner emitted a clarification_request
 // (#1057) and the run resumes in place once the answers arrive; it is a
-// parked judgment, not a failure.
+// parked judgment, not a failure. `awaiting_scope_decision` means the
+// implement stage parked for an operator exempt-or-fail decision: its
+// ONLY committed-tree gate failure was the scope-completeness "missing
+// declared scope file(s)" check (#1151), the verified commit is already
+// held on the run branch, and the operator decides in-band whether to
+// accept the already-committed tree (exempt, zero agent re-run) or fail
+// it (category-B) per #1231. Like awaiting_input it is a parked judgment,
+// not a failure.
 type StageState string
 
 // Stage states. Terminal states (Succeeded, Failed, Cancelled) admit
 // no further transitions; see transition.go for the table.
 const (
-	StageStatePending          StageState = "pending"
-	StageStateDispatched       StageState = "dispatched"
-	StageStateRunning          StageState = "running"
-	StageStateAwaitingApproval StageState = "awaiting_approval"
-	StageStateAwaitingChildren StageState = "awaiting_children"
-	StageStateAwaitingInput    StageState = "awaiting_input"
-	StageStateSucceeded        StageState = "succeeded"
-	StageStateFailed           StageState = "failed"
-	StageStateCancelled        StageState = "cancelled"
+	StageStatePending               StageState = "pending"
+	StageStateDispatched            StageState = "dispatched"
+	StageStateRunning               StageState = "running"
+	StageStateAwaitingApproval      StageState = "awaiting_approval"
+	StageStateAwaitingChildren      StageState = "awaiting_children"
+	StageStateAwaitingInput         StageState = "awaiting_input"
+	StageStateAwaitingScopeDecision StageState = "awaiting_scope_decision"
+	StageStateSucceeded             StageState = "succeeded"
+	StageStateFailed                StageState = "failed"
+	StageStateCancelled             StageState = "cancelled"
 )
 
 // IsTerminal reports whether the state admits no further transitions.
@@ -390,8 +398,47 @@ type Stage struct {
 	// Used as retry_ordinal in the stage_retried audit receipt.
 	SelfRetryCount int
 
+	// ScopeCompletenessPark carries the held-commit coordinates when an
+	// implement stage parks in awaiting_scope_decision (#1231): the
+	// missing-declared-scope-file-only gate outcome pushed its verified
+	// commit to the run branch (no PR) and is waiting for an operator
+	// exempt-or-fail decision. Nil for every stage not currently parked
+	// for a scope-completeness decision (the column is NULL). Persisted
+	// to stages.scope_completeness_park JSONB per migration 0035.
+	ScopeCompletenessPark *ScopeCompletenessPark
+
 	CreatedAt time.Time
 	UpdatedAt time.Time
+}
+
+// ScopeCompletenessPark is the durable payload an implement stage carries
+// while parked in awaiting_scope_decision (#1231). It pins exactly what
+// the runner held when the scope-completeness "missing declared scope
+// file(s)" check was the SOLE committed-tree gate failure: the verified
+// commit already pushed to the run branch, the tree it verified, and the
+// declared scope.files that the agent never touched. The operator's
+// exempt decision opens the PR from HeldCommitSHA with no agent re-run;
+// the fail decision drops to today's category-B.
+//
+// The JSON tags are the byte-identical cross-module wire contract with
+// the runner's park-report upload struct (runner/internal/upload —
+// sibling slice), following the established ScopeExemption duplication
+// pattern rather than a shared module. Keep the two in lockstep.
+type ScopeCompletenessPark struct {
+	// HeldCommitSHA is the gate-verified commit the runner already pushed
+	// to RunBranch (no PR). The exempt resolution opens the PR from this
+	// exact SHA — byte-identical tree, zero agent re-run.
+	HeldCommitSHA string `json:"held_commit_sha"`
+	// RunBranch is the run's own sole-writer branch the held commit was
+	// pushed to (ADR-035): the resolution opens the PR from this branch.
+	RunBranch string `json:"run_branch"`
+	// VerifiedTreeSHA is the tree object the committed-tree verify gate
+	// passed on. Recorded so the resolution can assert the opened PR head
+	// reflects the identical tree.
+	VerifiedTreeSHA string `json:"verified_tree_sha"`
+	// MissingPaths are the declared scope.files the agent never touched —
+	// the sole gate shortfall that triggered the park. Repo-relative.
+	MissingPaths []string `json:"missing_paths"`
 }
 
 // GateKind names the two flavors of gate the workflow spec admits:

--- a/backend/internal/run/transition.go
+++ b/backend/internal/run/transition.go
@@ -83,6 +83,20 @@ func ValidRunRetryTransition(from, to State) bool {
 //
 //	(a D-category judgment, not an agent failure).
 //
+// Running → AwaitingScopeDecision: the implement stage's ONLY committed-
+//
+//	tree gate failure was the scope-completeness missing-declared-file
+//	check; the verified commit is held on the run branch and the run
+//	parks for an operator exempt-or-fail decision (#1231).
+//
+// AwaitingScopeDecision → Running: operator exempted; the stage resumes to
+//
+//	open the PR from the held commit with NO agent re-run.
+//
+// AwaitingScopeDecision → Failed: operator failed it — today's category-B
+//
+//	restore path.
+//
 // Cancelled is reachable from any non-terminal state via manual halt.
 var stageTransitions = map[StageState]map[StageState]struct{}{
 	StageStatePending: {
@@ -97,11 +111,12 @@ var stageTransitions = map[StageState]map[StageState]struct{}{
 		StageStateCancelled: {},
 	},
 	StageStateRunning: {
-		StageStateAwaitingApproval: {},
-		StageStateAwaitingInput:    {},
-		StageStateSucceeded:        {},
-		StageStateFailed:           {},
-		StageStateCancelled:        {},
+		StageStateAwaitingApproval:      {},
+		StageStateAwaitingInput:         {},
+		StageStateAwaitingScopeDecision: {},
+		StageStateSucceeded:             {},
+		StageStateFailed:                {},
+		StageStateCancelled:             {},
 	},
 	StageStateAwaitingApproval: {
 		StageStateSucceeded: {},
@@ -117,6 +132,11 @@ var stageTransitions = map[StageState]map[StageState]struct{}{
 		StageStatePending:   {}, // operator answered → resume in place
 		StageStateSucceeded: {},
 		StageStateFailed:    {},
+		StageStateCancelled: {},
+	},
+	StageStateAwaitingScopeDecision: {
+		StageStateRunning:   {}, // operator exempted → resume to open the PR from the held commit (no agent re-run, #1231)
+		StageStateFailed:    {}, // operator failed it → category-B, today's restore path
 		StageStateCancelled: {},
 	},
 }

--- a/backend/internal/run/transition_test.go
+++ b/backend/internal/run/transition_test.go
@@ -84,9 +84,10 @@ func TestStageTransitions_AllowedAndForbidden(t *testing.T) {
 		{StageStateDispatched, StageStateFailed, true},
 		{StageStateDispatched, StageStateCancelled, true},
 		{StageStateDispatched, StageStateAwaitingApproval, false},
-		// running → awaiting_approval | awaiting_input | succeeded | failed | cancelled
+		// running → awaiting_approval | awaiting_input | awaiting_scope_decision | succeeded | failed | cancelled
 		{StageStateRunning, StageStateAwaitingApproval, true},
 		{StageStateRunning, StageStateAwaitingInput, true},
+		{StageStateRunning, StageStateAwaitingScopeDecision, true},
 		{StageStateRunning, StageStateSucceeded, true},
 		{StageStateRunning, StageStateFailed, true},
 		{StageStateRunning, StageStateCancelled, true},
@@ -102,6 +103,13 @@ func TestStageTransitions_AllowedAndForbidden(t *testing.T) {
 		{StageStateAwaitingInput, StageStateFailed, true},
 		{StageStateAwaitingInput, StageStateCancelled, true},
 		{StageStateAwaitingInput, StageStateDispatched, false}, // resume routes through pending
+		// awaiting_scope_decision → running (exempt resume) | failed (category-B) | cancelled (#1231)
+		{StageStateAwaitingScopeDecision, StageStateRunning, true},    // operator exempted → resume to open the PR from the held commit
+		{StageStateAwaitingScopeDecision, StageStateFailed, true},     // operator failed it → category-B
+		{StageStateAwaitingScopeDecision, StageStateCancelled, true},  // manual halt
+		{StageStateAwaitingScopeDecision, StageStatePending, false},   // never rewinds to a fresh dispatch
+		{StageStateAwaitingScopeDecision, StageStateSucceeded, false}, // success only via the runner's PR-open, not the decision
+		{StageStateAwaitingScopeDecision, StageStateDispatched, false},
 		// terminal idempotency + lockdown
 		{StageStateSucceeded, StageStateSucceeded, true},
 		{StageStateSucceeded, StageStateRunning, false},
@@ -237,14 +245,15 @@ func TestStateIsTerminal(t *testing.T) {
 
 func TestStageStateIsTerminal(t *testing.T) {
 	cases := map[StageState]bool{
-		StageStatePending:          false,
-		StageStateDispatched:       false,
-		StageStateRunning:          false,
-		StageStateAwaitingApproval: false,
-		StageStateAwaitingInput:    false,
-		StageStateSucceeded:        true,
-		StageStateFailed:           true,
-		StageStateCancelled:        true,
+		StageStatePending:               false,
+		StageStateDispatched:            false,
+		StageStateRunning:               false,
+		StageStateAwaitingApproval:      false,
+		StageStateAwaitingInput:         false,
+		StageStateAwaitingScopeDecision: false,
+		StageStateSucceeded:             true,
+		StageStateFailed:                true,
+		StageStateCancelled:             true,
 	}
 	for s, want := range cases {
 		if got := s.IsTerminal(); got != want {

--- a/backend/internal/server/handlers.go
+++ b/backend/internal/server/handlers.go
@@ -43,6 +43,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /v0/runs/{run_id}/scope-amendments", s.handleRequestScopeAmendment)
 	mux.HandleFunc("GET /v0/runs/{run_id}/scope-amendments", s.handleListScopeAmendments)
 	mux.HandleFunc("POST /v0/runs/{run_id}/scope-amendments/{amendment_id}/decision", s.handleDecideScopeAmendment)
+	mux.HandleFunc("POST /v0/runs/{run_id}/scope-completeness/decision", s.handleDecideScopeCompleteness)
 	mux.HandleFunc("GET /v0/stages/{stage_id}", s.handleGetStage)
 	mux.HandleFunc("GET /v0/stages/{stage_id}/artifacts", s.handleListStageArtifacts)
 	mux.HandleFunc("GET /v0/stages/{stage_id}/prompt", s.handleGetStagePrompt)

--- a/backend/internal/server/pullrequest.go
+++ b/backend/internal/server/pullrequest.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -77,6 +78,24 @@ type pullRequestBody struct {
 	Category string `json:"category,omitempty"`
 	Reason   string `json:"reason,omitempty"`
 
+	// VerifiedTreeSHA and MissingPaths form the scope-completeness park
+	// report variant (#1231), present only when Outcome=="scope_park".
+	// The runner's committed-tree gate's ONLY failure was the
+	// scope-completeness "missing declared scope file(s)" check; it
+	// pushed the gate-verified commit to the run branch (branch/head_sha,
+	// no PR) and reports the tree it verified plus the declared scope.files
+	// the agent never touched. The handler records a ScopeCompletenessPark
+	// and parks the implement stage in awaiting_scope_decision for an
+	// operator exempt-or-fail decision — no PR artifact.
+	//
+	// These mirror run.ScopeCompletenessPark's wire tags byte-for-byte and
+	// the runner's park-report upload struct (runner/internal/upload —
+	// sibling slice), the established ScopeExemption duplication pattern.
+	// The runner omits them on every other variant, so they stay absent
+	// there under the DisallowUnknownFields decoder.
+	VerifiedTreeSHA string   `json:"verified_tree_sha,omitempty"`
+	MissingPaths    []string `json:"missing_paths,omitempty"`
+
 	// ApplyPath is the near-deterministic fix-up apply provenance (#1165/#1213),
 	// present only on the Outcome=="fixup_pushed" report: "applied" (a clean
 	// git-apply of every routed concern's suggested_patch, no agent), "agent"
@@ -152,8 +171,28 @@ func (p *pullRequestBody) validate() error {
 		}
 		return nil
 	}
+	// Scope-completeness park variant (#1231): the implement stage's ONLY
+	// committed-tree gate failure was the missing-declared-scope-file
+	// check. The runner pushed the verified commit to the run branch (no
+	// PR); require the commit coordinates, the verified tree, and at least
+	// one missing path so the park payload pins exactly what is held.
+	if p.Outcome == "scope_park" {
+		switch {
+		case p.Branch == "":
+			return errors.New("branch is required for a scope_park outcome")
+		case p.HeadSHA == "":
+			return errors.New("head_sha is required for a scope_park outcome")
+		case p.BaseSHA == "":
+			return errors.New("base_sha is required for a scope_park outcome")
+		case p.VerifiedTreeSHA == "":
+			return errors.New("verified_tree_sha is required for a scope_park outcome")
+		case len(p.MissingPaths) == 0:
+			return errors.New("missing_paths must be non-empty for a scope_park outcome")
+		}
+		return nil
+	}
 	if p.Outcome != "" {
-		return fmt.Errorf("outcome must be \"failed\", \"pushed\", \"fixup_pushed\", or \"fixup_no_changes\" when set, got %q", p.Outcome)
+		return fmt.Errorf("outcome must be \"failed\", \"pushed\", \"fixup_pushed\", \"fixup_no_changes\", or \"scope_park\" when set, got %q", p.Outcome)
 	}
 	switch {
 	case p.PRNumber <= 0:
@@ -341,6 +380,18 @@ func (s *Server) handleShipPullRequest(w http.ResponseWriter, r *http.Request) {
 	// branch tip is unchanged.
 	if pr.Outcome == "fixup_no_changes" {
 		s.succeedFixupNoChangesStage(w, r, runID, stage, &pr, authMethod, actorKind, actorSubject)
+		return
+	}
+
+	// Scope-completeness park variant (#1231): the implement stage's ONLY
+	// committed-tree gate failure was the missing-declared-scope-file
+	// check, and the runner pushed its verified commit to the run branch
+	// (no PR). Record the held-commit park payload, transition the
+	// implement stage to awaiting_scope_decision, and write a
+	// scope_completeness_parked audit entry — leaving the run parked for an
+	// in-band operator exempt-or-fail decision. No PR artifact.
+	if pr.Outcome == "scope_park" {
+		s.parkScopeCompletenessStage(w, r, runID, stage, &pr, authMethod, actorKind, actorSubject)
 		return
 	}
 
@@ -868,6 +919,117 @@ func (s *Server) succeedFixupNoChangesStage(w http.ResponseWriter, r *http.Reque
 		StageID: stageID,
 		Outcome: "fixup_no_changes",
 		Branch:  pr.Branch,
+	})
+}
+
+// pullRequestScopeParkResponse is the 200 body for the scope-completeness
+// park variant (#1231): the implement stage parked in
+// awaiting_scope_decision with its verified commit held on the run branch.
+// HeadSHA echoes the held commit; the operator decides exempt-or-fail.
+type pullRequestScopeParkResponse struct {
+	StageID uuid.UUID `json:"stage_id"`
+	Outcome string    `json:"outcome"`
+	Branch  string    `json:"branch"`
+	HeadSHA string    `json:"head_sha"`
+}
+
+// scopeCompletenessParker is the OPTIONAL concrete-repo capability the
+// park handler type-asserts (postgresRepo.ParkScopeCompletenessAndAppend):
+// it atomically transitions the implement stage running →
+// awaiting_scope_decision, writes the held-commit park payload, and
+// appends the scope_completeness_parked audit entry in one transaction.
+// In-memory fakes that don't implement it fall back to the two-step path.
+type scopeCompletenessParker interface {
+	ParkScopeCompletenessAndAppend(ctx context.Context, stageID uuid.UUID, park run.ScopeCompletenessPark, p audit.ChainAppendParams) (*run.Stage, bool, error)
+}
+
+// parkScopeCompletenessStage handles the scope-completeness park variant
+// (#1231): the runner reports {outcome:"scope_park"} after its committed-
+// tree gate failed ONLY on the missing-declared-scope-file check and it
+// pushed the gate-verified commit to the run branch (no PR). It records
+// the held-commit ScopeCompletenessPark payload, transitions the implement
+// stage running → awaiting_scope_decision, and appends a
+// scope_completeness_parked audit entry — leaving the run parked for an
+// in-band operator exempt-or-fail decision (no PR artifact, no
+// pull_request_url backfill — there is no PR).
+//
+// Atomicity + idempotency live in the parker capability's compare-and-set:
+// a duplicate runner delivery that arrives after the stage already left
+// running observes won=false and is a clean idempotent no-op. A repo that
+// doesn't implement the capability (in-memory fakes) degrades to a two-
+// step transition + best-effort audit append.
+func (s *Server) parkScopeCompletenessStage(w http.ResponseWriter, r *http.Request, runID uuid.UUID,
+	stage *run.Stage, pr *pullRequestBody, authMethod string, actorKind audit.ActorKind, actorSubject *string) {
+	stageID := stage.ID
+	park := run.ScopeCompletenessPark{
+		HeldCommitSHA:   pr.HeadSHA,
+		RunBranch:       pr.Branch,
+		VerifiedTreeSHA: pr.VerifiedTreeSHA,
+		MissingPaths:    pr.MissingPaths,
+	}
+
+	auditPayload, _ := json.Marshal(map[string]any{
+		"run_id":            runID.String(),
+		"stage_id":          stageID.String(),
+		"branch":            pr.Branch,
+		"head_sha":          pr.HeadSHA,
+		"base_sha":          pr.BaseSHA,
+		"verified_tree_sha": pr.VerifiedTreeSHA,
+		"missing_paths":     pr.MissingPaths,
+		"auth_method":       authMethod,
+	})
+	appendParams := audit.ChainAppendParams{
+		RunID:        runID,
+		StageID:      &stageID,
+		Timestamp:    time.Now().UTC(),
+		Category:     CategoryScopeCompletenessParked,
+		ActorKind:    &actorKind,
+		ActorSubject: actorSubject,
+		Payload:      auditPayload,
+	}
+
+	if parker, ok := s.cfg.RunRepo.(scopeCompletenessParker); ok {
+		if _, _, err := parker.ParkScopeCompletenessAndAppend(r.Context(), stageID, park, appendParams); err != nil {
+			s.cfg.Logger.LogAttrs(r.Context(), slog.LevelWarn,
+				"scope-completeness park report: park stage failed",
+				slog.String("run_id", runID.String()),
+				slog.String("stage_id", stageID.String()),
+				slog.String("error", err.Error()))
+		}
+		s.notifyStatusUpdate(r.Context(), runID, "scope_parked")
+		s.writeJSON(w, r, http.StatusOK, pullRequestScopeParkResponse{
+			StageID: stageID,
+			Outcome: "scope_park",
+			Branch:  pr.Branch,
+			HeadSHA: pr.HeadSHA,
+		})
+		return
+	}
+
+	// Fallback (in-memory fakes): two-step transition + best-effort audit.
+	if stage.Type == run.StageTypeImplement && stage.State == run.StageStateRunning {
+		if _, err := s.cfg.RunRepo.TransitionStage(r.Context(), stageID, run.StageStateAwaitingScopeDecision, nil); err != nil {
+			s.cfg.Logger.LogAttrs(r.Context(), slog.LevelWarn,
+				"scope-completeness park report: transition to awaiting_scope_decision failed",
+				slog.String("run_id", runID.String()),
+				slog.String("stage_id", stageID.String()),
+				slog.String("error", err.Error()))
+		}
+	}
+	if _, err := s.cfg.AuditRepo.AppendChained(r.Context(), appendParams); err != nil {
+		s.cfg.Logger.LogAttrs(r.Context(), slog.LevelWarn,
+			"scope-completeness park report: append audit entry failed",
+			slog.String("run_id", runID.String()),
+			slog.String("stage_id", stageID.String()),
+			slog.String("error", err.Error()))
+	}
+
+	s.notifyStatusUpdate(r.Context(), runID, "scope_parked")
+	s.writeJSON(w, r, http.StatusOK, pullRequestScopeParkResponse{
+		StageID: stageID,
+		Outcome: "scope_park",
+		Branch:  pr.Branch,
+		HeadSHA: pr.HeadSHA,
 	})
 }
 

--- a/backend/internal/server/pullrequest_test.go
+++ b/backend/internal/server/pullrequest_test.go
@@ -1013,3 +1013,170 @@ func TestShipPullRequest_BearerActorKindClosedSet(t *testing.T) {
 		})
 	}
 }
+
+// parkRecordingRepo embeds the orchestratorRepo and additionally implements
+// the scopeCompletenessParker capability (#1231) so the park handler takes
+// its production type-asserted path. It records the park struct + audit
+// params it was handed and drives the real running → awaiting_scope_decision
+// transition, so the test can assert the cross-module wire fields mapped
+// correctly into run.ScopeCompletenessPark.
+type parkRecordingRepo struct {
+	*orchestratorRepo
+	parkCalls []parkRecord
+}
+
+type parkRecord struct {
+	stageID uuid.UUID
+	park    run.ScopeCompletenessPark
+	append  audit.ChainAppendParams
+}
+
+func (r *parkRecordingRepo) ParkScopeCompletenessAndAppend(ctx context.Context, stageID uuid.UUID, park run.ScopeCompletenessPark, p audit.ChainAppendParams) (*run.Stage, bool, error) {
+	r.parkCalls = append(r.parkCalls, parkRecord{stageID: stageID, park: park, append: p})
+	st, err := r.TransitionStage(ctx, stageID, run.StageStateAwaitingScopeDecision, nil)
+	return st, true, err
+}
+
+// TestShipPullRequest_ScopeParkOutcome_ParksStage pins the #1231 backend
+// park-report branch on the production (parker-capable) path: a
+// {outcome:"scope_park"} report records the held-commit ScopeCompletenessPark
+// payload, parks the implement stage in awaiting_scope_decision, opens no PR
+// artifact, and the wire fields map byte-for-byte into the park struct.
+func TestShipPullRequest_ScopeParkOutcome_ParksStage(t *testing.T) {
+	sf := newSigningFake()
+	ar := newFakeArtifactRepo()
+	au := newAuditFake()
+	rr := &parkRecordingRepo{orchestratorRepo: newOrchestratorRepo()}
+	s := New(Config{
+		Addr: "127.0.0.1:0", SigningRepo: sf, ArtifactRepo: ar, AuditRepo: au, RunRepo: rr,
+		Orchestrator: &orchestrator.Orchestrator{Runs: rr},
+	})
+	runRow := rr.seedRun()
+	implStage := rr.seedStage(runRow.ID, 0, run.StageStateRunning)
+	implStage.Type = run.StageTypeImplement
+	implStage.RequiresApproval = true
+
+	priv, _ := sf.issue(t, runRow.ID)
+	body, err := json.Marshal(map[string]any{
+		"outcome":           "scope_park",
+		"branch":            "fishhawk/run-aaaaaaaa/slice-0",
+		"head_sha":          "1111111111111111111111111111111111111111",
+		"base_sha":          "2222222222222222222222222222222222222222",
+		"verified_tree_sha": "3333333333333333333333333333333333333333",
+		"missing_paths":     []string{"backend/internal/foo/foo_test.go", "docs/foo.md"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := shipPRRequest(t, s, runRow.ID, implStage.ID, priv, body, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200:\n%s", w.Code, w.Body.String())
+	}
+
+	got, err := rr.GetStage(t.Context(), implStage.ID)
+	if err != nil {
+		t.Fatalf("GetStage: %v", err)
+	}
+	if got.State != run.StageStateAwaitingScopeDecision {
+		t.Errorf("stage.State = %q, want awaiting_scope_decision", got.State)
+	}
+	if len(ar.all) != 0 {
+		t.Errorf("artifacts = %d, want 0 (no PR artifact for a scope-park report)", len(ar.all))
+	}
+	if len(rr.parkCalls) != 1 {
+		t.Fatalf("park calls = %d, want 1", len(rr.parkCalls))
+	}
+	pc := rr.parkCalls[0]
+	if pc.park.HeldCommitSHA != "1111111111111111111111111111111111111111" ||
+		pc.park.RunBranch != "fishhawk/run-aaaaaaaa/slice-0" ||
+		pc.park.VerifiedTreeSHA != "3333333333333333333333333333333333333333" ||
+		len(pc.park.MissingPaths) != 2 {
+		t.Errorf("recorded park = %+v, want the wire fields mapped 1:1", pc.park)
+	}
+	if pc.append.Category != CategoryScopeCompletenessParked {
+		t.Errorf("park audit category = %q, want %q", pc.append.Category, CategoryScopeCompletenessParked)
+	}
+}
+
+// TestShipPullRequest_ScopeParkOutcome_FallbackTransitions pins the degraded
+// (non-parker repo) path: a repo that does NOT implement the parker still
+// transitions the stage to awaiting_scope_decision and best-effort appends
+// the scope_completeness_parked audit entry (#1231).
+func TestShipPullRequest_ScopeParkOutcome_FallbackTransitions(t *testing.T) {
+	s, sf, ar, au, rr := newPRServerWithOrch(t)
+	runRow := rr.seedRun()
+	implStage := rr.seedStage(runRow.ID, 0, run.StageStateRunning)
+	implStage.Type = run.StageTypeImplement
+
+	priv, _ := sf.issue(t, runRow.ID)
+	body, err := json.Marshal(map[string]any{
+		"outcome":           "scope_park",
+		"branch":            "fishhawk/run-aaaaaaaa/slice-0",
+		"head_sha":          "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+		"base_sha":          "cafecafecafecafecafecafecafecafecafecafe",
+		"verified_tree_sha": "f00df00df00df00df00df00df00df00df00df00d",
+		"missing_paths":     []string{"backend/internal/foo/foo.go"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := shipPRRequest(t, s, runRow.ID, implStage.ID, priv, body, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200:\n%s", w.Code, w.Body.String())
+	}
+	got, err := rr.GetStage(t.Context(), implStage.ID)
+	if err != nil {
+		t.Fatalf("GetStage: %v", err)
+	}
+	if got.State != run.StageStateAwaitingScopeDecision {
+		t.Errorf("stage.State = %q, want awaiting_scope_decision (fallback must still park)", got.State)
+	}
+	if len(ar.all) != 0 {
+		t.Errorf("artifacts = %d, want 0", len(ar.all))
+	}
+	au.mu.Lock()
+	defer au.mu.Unlock()
+	var found bool
+	var missingInPayload bool
+	for _, e := range au.appended {
+		if e.Category == CategoryScopeCompletenessParked {
+			found = true
+			if strings.Contains(string(e.Payload), "foo.go") {
+				missingInPayload = true
+			}
+		}
+	}
+	if !found {
+		t.Error("no scope_completeness_parked audit entry recorded on the fallback path")
+	}
+	if !missingInPayload {
+		t.Error("scope_completeness_parked payload missing the missing_paths content")
+	}
+}
+
+// TestShipPullRequest_ScopeParkOutcome_RejectsMissingCoords pins the #1231
+// validation: the scope_park variant requires branch + head_sha + base_sha +
+// verified_tree_sha + a non-empty missing_paths.
+func TestShipPullRequest_ScopeParkOutcome_RejectsMissingCoords(t *testing.T) {
+	runID, stageID := uuid.New(), uuid.New()
+	s, sf, _, _, _ := newPRServer(t, runID, stageID)
+	priv, _ := sf.issue(t, runID)
+	for _, body := range []string{
+		`{"outcome":"scope_park","head_sha":"h","base_sha":"b","verified_tree_sha":"t","missing_paths":["x"]}`,            // missing branch
+		`{"outcome":"scope_park","branch":"br","base_sha":"b","verified_tree_sha":"t","missing_paths":["x"]}`,             // missing head_sha
+		`{"outcome":"scope_park","branch":"br","head_sha":"h","verified_tree_sha":"t","missing_paths":["x"]}`,             // missing base_sha
+		`{"outcome":"scope_park","branch":"br","head_sha":"h","base_sha":"b","missing_paths":["x"]}`,                      // missing verified_tree_sha
+		`{"outcome":"scope_park","branch":"br","head_sha":"h","base_sha":"b","verified_tree_sha":"t"}`,                    // missing missing_paths
+		`{"outcome":"scope_park","branch":"br","head_sha":"h","base_sha":"b","verified_tree_sha":"t","missing_paths":[]}`, // empty missing_paths
+	} {
+		w := shipPRRequest(t, s, runID, stageID, priv, []byte(body), "")
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("body %s: status = %d, want 400:\n%s", body, w.Code, w.Body.String())
+		}
+		if !strings.Contains(w.Body.String(), "pull_request_invalid") {
+			t.Errorf("body %s: missing pull_request_invalid:\n%s", body, w.Body.String())
+		}
+	}
+}

--- a/backend/internal/server/scope_completeness.go
+++ b/backend/internal/server/scope_completeness.go
@@ -1,0 +1,286 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/kuhlman-labs/fishhawk/backend/internal/audit"
+	"github.com/kuhlman-labs/fishhawk/backend/internal/run"
+)
+
+// The three scope-completeness audit kinds (#1231) are internal audit
+// kinds, NOT issue-comment surfaces. They have no Notifier methods and
+// nothing in `issuecomment` posts them — see docs/issue-comment-surfaces.md.
+const (
+	// CategoryScopeCompletenessParked is written by the pull-request park
+	// handler (server/pullrequest.go::parkScopeCompletenessStage) when the
+	// runner reports {outcome:"scope_park"}: the implement stage's ONLY
+	// committed-tree gate failure was the missing-declared-scope-file
+	// check, the verified commit is held on the run branch, and the stage
+	// parked in awaiting_scope_decision. Payload carries {run_id, stage_id,
+	// branch, head_sha, base_sha, verified_tree_sha, missing_paths,
+	// auth_method}.
+	CategoryScopeCompletenessParked = "scope_completeness_parked"
+
+	// CategoryScopeCompletenessExempted is written by the decision handler
+	// on an `exempt` decision: the operator accepted the already-committed
+	// tree, so the held commit's PR is opened with NO agent re-run. Payload
+	// carries {run_id, stage_id, decision, reason, decided_by,
+	// held_commit_sha, run_branch, verified_tree_sha, missing_paths,
+	// gate_evidence}. The gate_evidence field reuses the #1153 channel so a
+	// downstream implement-review gate sees the missing-file shortfall was
+	// operator-exempted rather than re-failing on it.
+	CategoryScopeCompletenessExempted = "scope_completeness_exempted"
+
+	// CategoryScopeCompletenessFailed is written by the decision handler on
+	// a `fail` decision: the operator rejected the exemption, so the stage
+	// fails category-B (today's restore path). Payload carries {run_id,
+	// stage_id, decision, reason, decided_by, missing_paths}.
+	CategoryScopeCompletenessFailed = "scope_completeness_failed"
+)
+
+// scopeCompletenessDecisionRequest is the JSON body of POST
+// /v0/runs/{run_id}/scope-completeness/decision.
+type scopeCompletenessDecisionRequest struct {
+	Decision string `json:"decision"` // exempt | fail
+	Reason   string `json:"reason"`
+}
+
+// scopeCompletenessDecisionResponse echoes the resolved decision back to
+// the operator. On `exempt`, HeldCommitSHA / RunBranch carry the commit the
+// follow-on push_and_open_pr dispatch opens the PR from (no agent re-run).
+type scopeCompletenessDecisionResponse struct {
+	StageID       uuid.UUID `json:"stage_id"`
+	Decision      string    `json:"decision"`
+	State         string    `json:"state"`
+	HeldCommitSHA string    `json:"held_commit_sha,omitempty"`
+	RunBranch     string    `json:"run_branch,omitempty"`
+}
+
+// handleDecideScopeCompleteness implements POST
+// /v0/runs/{run_id}/scope-completeness/decision (#1231).
+//
+// Auth: operator bearer/session ONLY, requiring write:stages for token
+// callers — the same posture as the scope-amendment decision endpoint.
+// Run-bound fhm_ tokens are rejected outright (403 self_decision): the
+// implement agent that produced the parked commit must never decide its
+// own exemption; the decision is an operator action.
+//
+// The implement stage MUST currently be parked in awaiting_scope_decision
+// (409 otherwise). On `exempt` the stage resumes running so the held
+// commit's PR can be opened with no agent re-run (the push_and_open_pr
+// dispatch + the runner's PR-open from the held commit are the sibling
+// slices); on `fail` the stage drops to today's category-B restore path.
+func (s *Server) handleDecideScopeCompleteness(w http.ResponseWriter, r *http.Request) {
+	if s.cfg.RunRepo == nil || s.cfg.AuditRepo == nil {
+		s.writeError(w, r, http.StatusServiceUnavailable, "scope_completeness_unconfigured",
+			"scope-completeness decision endpoint requires run and audit repositories", nil)
+		return
+	}
+
+	id := IdentityFrom(r.Context())
+	if id.IsAnonymous() {
+		s.writeError(w, r, http.StatusUnauthorized, "authentication_required",
+			"an authenticated token is required", nil)
+		return
+	}
+	if _, runBound := runBoundTokenRunID(id); runBound {
+		s.writeError(w, r, http.StatusForbidden, "self_decision",
+			"a run-bound agent token may not decide a scope-completeness park; the decision is an operator action",
+			nil)
+		return
+	}
+	if id.TokenID != "" && !hasScope(id, "write:stages") {
+		s.writeError(w, r, http.StatusForbidden, "insufficient_scope",
+			"token is missing required scope: write:stages",
+			map[string]any{"required_scope": "write:stages"})
+		return
+	}
+
+	runID, err := uuid.Parse(r.PathValue("run_id"))
+	if err != nil {
+		s.writeError(w, r, http.StatusBadRequest, "validation_failed",
+			"run_id must be a valid UUID",
+			map[string]any{"field": "run_id", "got": r.PathValue("run_id")})
+		return
+	}
+
+	var reqBody scopeCompletenessDecisionRequest
+	if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+		s.writeError(w, r, http.StatusBadRequest, "validation_failed",
+			"request body must be valid JSON {decision, reason}",
+			map[string]any{"error": err.Error()})
+		return
+	}
+	switch reqBody.Decision {
+	case "exempt", "fail":
+	default:
+		s.writeError(w, r, http.StatusBadRequest, "validation_failed",
+			"decision must be \"exempt\" or \"fail\"",
+			map[string]any{"field": "decision", "got": reqBody.Decision})
+		return
+	}
+	if strings.TrimSpace(reqBody.Reason) == "" {
+		s.writeError(w, r, http.StatusBadRequest, "validation_failed",
+			"reason is required: state why the parked scope-completeness shortfall is exempted or failed",
+			map[string]any{"field": "reason"})
+		return
+	}
+
+	stage, err := s.resolveParkedScopeStage(r, runID)
+	if err != nil {
+		if errors.Is(err, run.ErrNotFound) {
+			s.writeError(w, r, http.StatusNotFound, "run_not_found",
+				"no run with that id", nil)
+			return
+		}
+		s.writeError(w, r, http.StatusInternalServerError, "internal_error",
+			"resolve parked stage failed", map[string]any{"error": err.Error()})
+		return
+	}
+	if stage == nil {
+		s.writeError(w, r, http.StatusConflict, "stage_not_parked",
+			"the implement stage is not parked awaiting a scope-completeness decision",
+			nil)
+		return
+	}
+
+	if reqBody.Decision == "exempt" {
+		s.exemptScopeCompleteness(w, r, runID, stage, reqBody.Reason, id.Subject)
+		return
+	}
+	s.failScopeCompleteness(w, r, runID, stage, reqBody.Reason, id.Subject)
+}
+
+// resolveParkedScopeStage returns the run's implement stage when it is
+// currently parked in awaiting_scope_decision; nil when the run exists but
+// no implement stage is parked (→ 409). run.ErrNotFound when the run
+// itself doesn't exist.
+func (s *Server) resolveParkedScopeStage(r *http.Request, runID uuid.UUID) (*run.Stage, error) {
+	if _, err := s.cfg.RunRepo.GetRun(r.Context(), runID); err != nil {
+		return nil, err
+	}
+	stages, err := s.cfg.RunRepo.ListStagesForRun(r.Context(), runID)
+	if err != nil {
+		return nil, err
+	}
+	for _, st := range stages {
+		if st.Type == run.StageTypeImplement && st.State == run.StageStateAwaitingScopeDecision {
+			return st, nil
+		}
+	}
+	return nil, nil
+}
+
+// exemptScopeCompleteness resolves an `exempt` decision: it resumes the
+// parked implement stage to running so the held commit's PR can be opened
+// with NO agent re-run (the push_and_open_pr dispatch + the runner's
+// held-commit PR-open are the sibling slices), and appends a
+// scope_completeness_exempted audit entry pinning the held commit and the
+// gate_evidence marker. Best-effort audit, mirroring the pull-request
+// handlers: the transition is the durable state change.
+func (s *Server) exemptScopeCompleteness(w http.ResponseWriter, r *http.Request, runID uuid.UUID,
+	stage *run.Stage, reason, decidedBy string) {
+	if _, err := s.cfg.RunRepo.TransitionStage(r.Context(), stage.ID, run.StageStateRunning, nil); err != nil {
+		s.writeError(w, r, http.StatusInternalServerError, "internal_error",
+			"resume parked stage failed", map[string]any{"error": err.Error()})
+		return
+	}
+
+	s.writeScopeCompletenessDecisionAudit(r, runID, stage, CategoryScopeCompletenessExempted, reason, decidedBy)
+	s.notifyStatusUpdate(r.Context(), runID, "scope_exempted")
+
+	resp := scopeCompletenessDecisionResponse{
+		StageID:  stage.ID,
+		Decision: "exempt",
+		State:    string(run.StageStateRunning),
+	}
+	if park := stage.ScopeCompletenessPark; park != nil {
+		resp.HeldCommitSHA = park.HeldCommitSHA
+		resp.RunBranch = park.RunBranch
+	}
+	s.writeJSON(w, r, http.StatusOK, resp)
+}
+
+// failScopeCompleteness resolves a `fail` decision: it fails the parked
+// implement stage category-B (today's restore path) and appends a
+// scope_completeness_failed audit entry, then advances the run so the
+// orchestrator walks it forward — mirroring failPullRequestStage.
+func (s *Server) failScopeCompleteness(w http.ResponseWriter, r *http.Request, runID uuid.UUID,
+	stage *run.Stage, reason, decidedBy string) {
+	if _, err := run.FailStage(r.Context(), s.cfg.RunRepo, stage.ID, run.FailureB, reason); err != nil {
+		s.writeError(w, r, http.StatusInternalServerError, "internal_error",
+			"fail parked stage failed", map[string]any{"error": err.Error()})
+		return
+	}
+
+	if s.cfg.Orchestrator != nil {
+		if _, err := s.cfg.Orchestrator.Advance(r.Context(), runID); err != nil {
+			s.cfg.Logger.LogAttrs(r.Context(), slog.LevelWarn,
+				"scope-completeness fail decision: orchestrator advance failed",
+				slog.String("run_id", runID.String()),
+				slog.String("stage_id", stage.ID.String()),
+				slog.String("error", err.Error()))
+		}
+	}
+
+	s.writeScopeCompletenessDecisionAudit(r, runID, stage, CategoryScopeCompletenessFailed, reason, decidedBy)
+	s.notifyStatusUpdate(r.Context(), runID, "scope_failed")
+
+	s.writeJSON(w, r, http.StatusOK, scopeCompletenessDecisionResponse{
+		StageID:  stage.ID,
+		Decision: "fail",
+		State:    string(run.StageStateFailed),
+	})
+}
+
+// writeScopeCompletenessDecisionAudit appends the exempted/failed decision
+// audit entry, pinning the operator's reason and the parked held-commit
+// coordinates into the chain. Best-effort: a failure logs but doesn't
+// unwind the decision — the stage transition is the durable record.
+func (s *Server) writeScopeCompletenessDecisionAudit(r *http.Request, runID uuid.UUID,
+	stage *run.Stage, category, reason, decidedBy string) {
+	actorKind := actorKindForSubject(decidedBy)
+	stageID := stage.ID
+	payloadMap := map[string]any{
+		"run_id":     runID.String(),
+		"stage_id":   stageID.String(),
+		"decision":   strings.TrimPrefix(category, "scope_completeness_"),
+		"reason":     reason,
+		"decided_by": decidedBy,
+	}
+	if park := stage.ScopeCompletenessPark; park != nil {
+		payloadMap["missing_paths"] = park.MissingPaths
+		if category == CategoryScopeCompletenessExempted {
+			payloadMap["held_commit_sha"] = park.HeldCommitSHA
+			payloadMap["run_branch"] = park.RunBranch
+			payloadMap["verified_tree_sha"] = park.VerifiedTreeSHA
+			// Reuse the #1153 gate_evidence channel so a downstream
+			// implement-review gate reads the missing-file shortfall as
+			// operator-exempted rather than re-failing on it.
+			payloadMap["gate_evidence"] = CategoryScopeCompletenessExempted
+		}
+	}
+	payload, _ := json.Marshal(payloadMap)
+	if _, err := s.cfg.AuditRepo.AppendChained(r.Context(), audit.ChainAppendParams{
+		RunID:        runID,
+		StageID:      &stageID,
+		Timestamp:    time.Now().UTC(),
+		Category:     category,
+		ActorKind:    &actorKind,
+		ActorSubject: &decidedBy,
+		Payload:      payload,
+	}); err != nil {
+		s.cfg.Logger.LogAttrs(r.Context(), slog.LevelWarn,
+			category+" audit append failed",
+			slog.String("run_id", runID.String()),
+			slog.String("stage_id", stageID.String()),
+			slog.String("error", err.Error()))
+	}
+}

--- a/backend/internal/server/scope_completeness_test.go
+++ b/backend/internal/server/scope_completeness_test.go
@@ -1,0 +1,206 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/kuhlman-labs/fishhawk/backend/internal/run"
+)
+
+// scopeCompletenessServer wires an orchestratorRepo (run repo) + auditCapture
+// and seeds one implement stage parked in awaiting_scope_decision carrying a
+// held-commit ScopeCompletenessPark — the state the decision endpoint acts on.
+func scopeCompletenessServer(t *testing.T) (*Server, *orchestratorRepo, *auditCapture, *run.Run, *run.Stage) {
+	t.Helper()
+	rr := newOrchestratorRepo()
+	runRow := rr.seedRun()
+	stage := rr.seedStage(runRow.ID, 1, run.StageStateAwaitingScopeDecision)
+	stage.Type = run.StageTypeImplement
+	stage.ScopeCompletenessPark = &run.ScopeCompletenessPark{
+		HeldCommitSHA:   "1111111111111111111111111111111111111111",
+		RunBranch:       "fishhawk/run-aaa/slice-0",
+		VerifiedTreeSHA: "2222222222222222222222222222222222222222",
+		MissingPaths:    []string{"backend/internal/foo/foo_test.go"},
+	}
+	au := &auditCapture{}
+	s := New(Config{Addr: "127.0.0.1:0", RunRepo: rr, AuditRepo: au})
+	return s, rr, au, runRow, stage
+}
+
+func postScopeCompletenessDecision(t *testing.T, s *Server, pathRunID uuid.UUID, body string, decorate func(*http.Request) *http.Request) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost,
+		"/v0/runs/"+pathRunID.String()+"/scope-completeness/decision",
+		strings.NewReader(body))
+	req.SetPathValue("run_id", pathRunID.String())
+	if decorate != nil {
+		req = decorate(req)
+	}
+	w := httptest.NewRecorder()
+	s.handleDecideScopeCompleteness(w, req)
+	return w
+}
+
+func operatorWriteStages(r *http.Request) *http.Request {
+	return withOperatorIdentity(r, "write:stages")
+}
+
+// TestDecideScopeCompleteness_Exempt resumes the parked stage to running so
+// the held commit's PR can be opened with NO agent re-run (the decision
+// endpoint never fails the stage nor re-dispatches it), and appends the
+// scope_completeness_exempted entry carrying the held commit + gate_evidence.
+func TestDecideScopeCompleteness_Exempt(t *testing.T) {
+	s, rr, au, runRow, stage := scopeCompletenessServer(t)
+
+	w := postScopeCompletenessDecision(t, s, runRow.ID,
+		`{"decision":"exempt","reason":"the coupled test file is genuinely already covered"}`,
+		operatorWriteStages)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", w.Code, w.Body.String())
+	}
+
+	var resp scopeCompletenessDecisionResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Decision != "exempt" || resp.State != string(run.StageStateRunning) {
+		t.Errorf("response = %+v, want exempt/running", resp)
+	}
+	if resp.HeldCommitSHA != "1111111111111111111111111111111111111111" {
+		t.Errorf("response held_commit_sha = %q, want the parked held commit", resp.HeldCommitSHA)
+	}
+
+	got, _ := rr.GetStage(context.Background(), stage.ID)
+	if got.State != run.StageStateRunning {
+		t.Errorf("stage state = %q, want running (exempt resumes for PR-open, not failure)", got.State)
+	}
+	// Zero-re-run at this layer: the decision endpoint must NOT fail the stage
+	// (the full agent-called-once invariant is asserted by the cross-layer
+	// e2e). A failure here would mean it dropped to category-B, not exempt.
+	if got.FailureCategory != nil {
+		t.Errorf("stage failure category = %v, want nil (exempt never fails the stage)", got.FailureCategory)
+	}
+
+	au.mu.Lock()
+	defer au.mu.Unlock()
+	if len(au.appended) != 1 || au.appended[0].Category != CategoryScopeCompletenessExempted {
+		t.Fatalf("audit = %+v, want one scope_completeness_exempted entry", au.appended)
+	}
+	var payload map[string]any
+	_ = json.Unmarshal(au.appended[0].Payload, &payload)
+	if payload["held_commit_sha"] != "1111111111111111111111111111111111111111" {
+		t.Errorf("exempt payload held_commit_sha = %v", payload["held_commit_sha"])
+	}
+	if payload["gate_evidence"] != CategoryScopeCompletenessExempted {
+		t.Errorf("exempt payload gate_evidence = %v, want the #1153 channel marker", payload["gate_evidence"])
+	}
+}
+
+// TestDecideScopeCompleteness_Fail drops the parked stage to category-B
+// (today's restore path) and appends the scope_completeness_failed entry.
+func TestDecideScopeCompleteness_Fail(t *testing.T) {
+	s, rr, au, runRow, stage := scopeCompletenessServer(t)
+
+	w := postScopeCompletenessDecision(t, s, runRow.ID,
+		`{"decision":"fail","reason":"the missing files are load-bearing; re-scope"}`,
+		operatorWriteStages)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", w.Code, w.Body.String())
+	}
+
+	got, _ := rr.GetStage(context.Background(), stage.ID)
+	if got.State != run.StageStateFailed {
+		t.Errorf("stage state = %q, want failed", got.State)
+	}
+	if got.FailureCategory == nil || *got.FailureCategory != run.FailureB {
+		t.Errorf("stage failure category = %v, want B", got.FailureCategory)
+	}
+
+	au.mu.Lock()
+	defer au.mu.Unlock()
+	if len(au.appended) != 1 || au.appended[0].Category != CategoryScopeCompletenessFailed {
+		t.Fatalf("audit = %+v, want one scope_completeness_failed entry", au.appended)
+	}
+}
+
+// TestDecideScopeCompleteness_NotParked409 pins the gate: a decision on a run
+// whose implement stage is not parked in awaiting_scope_decision is rejected.
+func TestDecideScopeCompleteness_NotParked409(t *testing.T) {
+	rr := newOrchestratorRepo()
+	runRow := rr.seedRun()
+	stage := rr.seedStage(runRow.ID, 1, run.StageStateRunning) // still running, not parked
+	stage.Type = run.StageTypeImplement
+	au := &auditCapture{}
+	s := New(Config{Addr: "127.0.0.1:0", RunRepo: rr, AuditRepo: au})
+
+	w := postScopeCompletenessDecision(t, s, runRow.ID,
+		`{"decision":"exempt","reason":"r"}`, operatorWriteStages)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409; body = %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "stage_not_parked") {
+		t.Errorf("body: %s", w.Body.String())
+	}
+}
+
+// TestDecideScopeCompleteness_RunBoundToken403 pins the operator-only gate:
+// the implement agent's own run-bound token may never decide its exemption.
+func TestDecideScopeCompleteness_RunBoundToken403(t *testing.T) {
+	s, _, _, runRow, _ := scopeCompletenessServer(t)
+	w := postScopeCompletenessDecision(t, s, runRow.ID, `{"decision":"exempt","reason":"r"}`,
+		func(r *http.Request) *http.Request {
+			return withRunBoundIdentity(r, runRow.ID, "mcp:read", "write:scope-amendments")
+		})
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403; body = %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "self_decision") {
+		t.Errorf("body: %s", w.Body.String())
+	}
+}
+
+// TestDecideScopeCompleteness_MissingScope403 pins the token-scope gate.
+func TestDecideScopeCompleteness_MissingScope403(t *testing.T) {
+	s, _, _, runRow, _ := scopeCompletenessServer(t)
+	w := postScopeCompletenessDecision(t, s, runRow.ID, `{"decision":"exempt","reason":"r"}`,
+		func(r *http.Request) *http.Request { return withOperatorIdentity(r, "read:runs") })
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403; body = %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "insufficient_scope") {
+		t.Errorf("body: %s", w.Body.String())
+	}
+}
+
+// TestDecideScopeCompleteness_BadDecision400 / empty reason pin the input
+// validation: only exempt|fail with a non-empty reason is accepted.
+func TestDecideScopeCompleteness_BadInput400(t *testing.T) {
+	s, _, _, runRow, _ := scopeCompletenessServer(t)
+	for _, body := range []string{
+		`{"decision":"maybe","reason":"r"}`,   // bad enum
+		`{"decision":"exempt","reason":""}`,   // empty reason
+		`{"decision":"exempt","reason":"  "}`, // whitespace-only reason
+		`{"reason":"r"}`,                      // missing decision
+	} {
+		w := postScopeCompletenessDecision(t, s, runRow.ID, body, operatorWriteStages)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("body %s: status = %d, want 400; body = %s", body, w.Code, w.Body.String())
+		}
+	}
+}
+
+// TestDecideScopeCompleteness_UnknownRun404 pins the run lookup.
+func TestDecideScopeCompleteness_UnknownRun404(t *testing.T) {
+	s, _, _, _, _ := scopeCompletenessServer(t)
+	w := postScopeCompletenessDecision(t, s, uuid.New(), `{"decision":"exempt","reason":"r"}`,
+		operatorWriteStages)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404; body = %s", w.Code, w.Body.String())
+	}
+}

--- a/docs/api/v0.md
+++ b/docs/api/v0.md
@@ -463,6 +463,13 @@ POST   /v0/runs/{run_id}/pull-request        — report implement-stage PR outco
                                                  the gated fix-up stage terminally and re-park the
                                                  review gate, so a no-op fix-up never hangs the stage in
                                                  running until the SLA watchdog reaps it.
+                                               scope park (#1231): {outcome:"scope_park",branch,head_sha,
+                                                 base_sha,verified_tree_sha,missing_paths} → the
+                                                 implement stage's ONLY committed-tree gate failure was
+                                                 the missing-declared-scope-file check; the runner pushed
+                                                 its verified commit to the run branch (no PR) and the
+                                                 stage parks in awaiting_scope_decision for an operator
+                                                 exempt-or-fail decision (zero agent re-run on exempt).
                                                dual-auth: Ed25519 signature (canonical runner path)
                                                OR bearer token with write:runs scope (local-runner CLI
                                                path when signing key is unavailable after trace+plan
@@ -517,6 +524,20 @@ POST   /v0/runs/{run_id}/scope-amendments/{amendment_id}/decision
                                                  the effective scope.files at the next prompt fetch AND
                                                  the runner's pre-commit refresh (#960 invariant holds;
                                                  non-requested created files still fail loud #818/#825).
+POST   /v0/runs/{run_id}/scope-completeness/decision
+                                              — operator exempts/fails a parked scope-completeness
+                                                 shortfall (#1231). body: {decision:exempt|fail, reason}.
+                                                 Auth: operator bearer/session ONLY (write:stages for
+                                                 tokens); run-bound fhm_ tokens → 403 self_decision (the
+                                                 implement agent must never decide its own exemption).
+                                                 The implement stage must be parked in
+                                                 awaiting_scope_decision (else 409 stage_not_parked);
+                                                 decision not exempt/fail or empty reason → 400. exempt
+                                                 resumes the stage to running so the held commit's PR is
+                                                 opened with NO agent re-run (a push_and_open_pr dispatch
+                                                 opens it from held_commit_sha) and lands
+                                                 scope_completeness_exempted audit; fail drops the stage
+                                                 to category-B and lands scope_completeness_failed.
 GET    /v0/stages/{stage_id}/prompt          — fetch constructed agent prompt (signature-authed; runner)
 GET    /v0/stages/{stage_id}/prompt-render    — same body, SPA-readable (no signature required)
 GET    /v0/stages/{stage_id}/trace            — stream the redacted trace bundle (gzipped JSONL)
@@ -779,7 +800,8 @@ are implemented; codes are additive and never repurposed.
 | `amendment_budget_exhausted` | 422 | `POST /v0/runs/{id}/scope-amendments` once the per-stage cap of 2 requests is spent — counted on rows, so denied requests consume budget (the cap bounds operator interruptions, not approvals) (#961). `details` includes `max` and `used`. Adapt within the approved scope or fail loud. |
 | `amendment_not_found` | 404 | `POST .../scope-amendments/{amendment_id}/decision` — unknown amendment id, or the amendment belongs to a different run than the path names (#961). |
 | `amendment_already_decided` | 409 | `POST .../scope-amendments/{amendment_id}/decision` on an amendment that has already left `pending` — decisions are immutable (#961). `details.status` carries the standing decision. |
-| `self_decision` | 403 | `POST .../scope-amendments/{amendment_id}/decision` presented with a run-bound MCP token (#961). The decision is operator-only; the requesting agent's token must never decide its own request (defense in depth — implement-stage tokens are never issued `write:stages`). |
+| `self_decision` | 403 | `POST .../scope-amendments/{amendment_id}/decision` or `.../scope-completeness/decision` presented with a run-bound MCP token (#961, #1231). The decision is operator-only; the requesting agent's token must never decide its own request/exemption (defense in depth — implement-stage tokens are never issued `write:stages`). |
+| `stage_not_parked` | 409 | `POST /v0/runs/{id}/scope-completeness/decision` when the run's implement stage is not currently parked in `awaiting_scope_decision` (#1231). The exempt-or-fail decision only applies to a stage parked on a missing-declared-scope-file-only gate shortfall. |
 | `redrive_not_applicable` | 422 | `POST /v0/runs/{id}/redrive` on a run that is not a failed decomposition child: `DecomposedFrom` is null, the run is not in `failed`, or it has no failed implement stage to re-open (#698). |
 | `recovery_not_eligible` | 409 | `POST /v0/runs/{id}/recover` (#978, #1081). A top-level target whose plan stage is not `succeeded` and/or whose implement stage is not `failed` category-B; OR a decomposition-child target (`decomposed_from` set) whose own implement stage is not `failed` category-B and/or whose plan does not resolve via the `parent_run_id` walk. `details` carries `{plan_state, implement_state, failure_category, plan_resolved}` so the operator sees which leg failed the gate. For category A/C/D, retry the stage instead. |
 | `recovery_unsupported` | 422 | `POST /v0/runs/{id}/recover` on a parent that cannot seed a recovery: no cached workflow spec (legacy row), the cached spec no longer parses or defines the workflow, or the workflow has no non-plan stages (#978). Start a fresh run instead. |

--- a/docs/api/v0.openapi.yaml
+++ b/docs/api/v0.openapi.yaml
@@ -1046,7 +1046,7 @@ components:
           example: 3
         outcome:
           type: string
-          enum: [failed, pushed, fixup_pushed, fixup_no_changes]
+          enum: [failed, pushed, fixup_pushed, fixup_no_changes, scope_park]
           description: |
             Present only on the non-success variants. `failed` (#742)
             reports a commit/push/PR-open failure (PR fields absent;
@@ -1060,6 +1060,12 @@ components:
             reports a fix-up re-dispatch that produced NO changes (no new commit
             landed; `branch` + `base_sha` required, `head_sha` omitted because
             the branch tip is unchanged, `pr_number`/`pr_url`/`title` absent).
+            `scope_park` (#1231) reports a missing-declared-scope-file-ONLY gate
+            outcome: the runner pushed its verified commit to the run branch and
+            parks the implement stage in `awaiting_scope_decision` (no PR;
+            `branch` + `head_sha` + `base_sha` + `verified_tree_sha` +
+            non-empty `missing_paths` required, `pr_number`/`pr_url`/`title`
+            absent).
         category:
           type: string
           enum: [B, C]
@@ -1070,6 +1076,19 @@ components:
         reason:
           type: string
           description: Human-readable failure reason (failure variant only).
+        verified_tree_sha:
+          type: string
+          description: |
+            Present only on the `scope_park` variant (#1231). The tree object
+            the committed-tree verify gate passed on; recorded so the exempt
+            resolution can assert the opened PR head reflects the identical tree.
+        missing_paths:
+          type: array
+          items: { type: string }
+          description: |
+            Present only on the `scope_park` variant (#1231). The declared
+            `scope.files` the agent never touched — the sole gate shortfall that
+            triggered the park. Repo-relative; must be non-empty.
         apply_path:
           type: string
           enum: [applied, agent, apply_failed_fellback, apply_failed_reset_failed]
@@ -1157,6 +1176,23 @@ components:
         stage_id: { $ref: '#/components/schemas/UUID' }
         outcome: { type: string, enum: [fixup_no_changes] }
         branch: { type: string }
+
+    PullRequestScopeParkResponse:
+      type: object
+      description: |
+        Echoed by `POST /v0/runs/{run_id}/pull-request` for the
+        scope-completeness park variant (`outcome: scope_park`, #1231): the
+        implement stage's ONLY committed-tree gate failure was the
+        missing-declared-scope-file check, so the runner pushed its verified
+        commit to the run branch (no PR) and the stage parked in
+        `awaiting_scope_decision` for an operator exempt-or-fail decision.
+        `head_sha` echoes the held commit.
+      required: [stage_id, outcome, branch, head_sha]
+      properties:
+        stage_id: { $ref: '#/components/schemas/UUID' }
+        outcome: { type: string, enum: [scope_park] }
+        branch: { type: string }
+        head_sha: { type: string }
 
     PlanUploadResponse:
       type: object
@@ -5147,7 +5183,11 @@ paths:
               (#794), or
             - the fix-up no-changes variant (`outcome: fixup_no_changes`) was
               accepted and the fix-up implement stage was transitioned
-              terminally, re-parking the review gate (#856).
+              terminally, re-parking the review gate (#856), or
+            - the scope-completeness park variant (`outcome: scope_park`) was
+              accepted and the implement stage was parked in
+              `awaiting_scope_decision` for an operator exempt-or-fail
+              decision (#1231).
           content:
             application/json:
               schema:
@@ -5157,6 +5197,7 @@ paths:
                   - $ref: '#/components/schemas/PullRequestChildPushResponse'
                   - $ref: '#/components/schemas/PullRequestFixupPushResponse'
                   - $ref: '#/components/schemas/PullRequestFixupNoChangesResponse'
+                  - $ref: '#/components/schemas/PullRequestScopeParkResponse'
         '400':
           description: |
             Body missing required fields (`code: pull_request_invalid`)
@@ -5650,6 +5691,107 @@ paths:
               schema: { $ref: '#/components/schemas/Error' }
         '503':
           description: Scope-amendment repositories not wired.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
+  /v0/runs/{run_id}/scope-completeness/decision:
+    post:
+      operationId: decideScopeCompleteness
+      summary: Exempt or fail a parked scope-completeness shortfall (operator)
+      description: |
+        Records the operator's exempt-or-fail decision on an implement
+        stage parked in `awaiting_scope_decision` (#1231): the stage's
+        ONLY committed-tree gate failure was the scope-completeness
+        "missing declared scope file(s)" check, and the runner already
+        pushed its gate-verified commit to the run branch (no PR).
+
+        **Auth: operator bearer/session ONLY** — bearer tokens require
+        `write:stages`. Run-bound `fhm_` tokens are rejected outright
+        (403 `self_decision`): the implement agent that produced the
+        parked commit must never decide its own exemption.
+
+        On `exempt` the stage resumes `running` so the held commit's PR
+        is opened with NO agent re-run (a `push_and_open_pr` dispatch
+        opens the PR from the held commit), and a
+        `scope_completeness_exempted` audit entry is appended. On `fail`
+        the stage fails category-B (today's restore path) and a
+        `scope_completeness_failed` entry is appended. A stage not
+        currently parked returns 409 (`stage_not_parked`).
+      tags: [runs]
+      parameters:
+        - { name: run_id, in: path, required: true, schema: { $ref: '#/components/schemas/UUID' } }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [decision, reason]
+              properties:
+                decision:
+                  type: string
+                  enum: [exempt, fail]
+                reason:
+                  type: string
+                  description: |
+                    Operator note explaining the exemption or failure;
+                    recorded on the audit entry. Required and non-empty.
+      responses:
+        '200':
+          description: |
+            The resolved decision. On `exempt`, `held_commit_sha` /
+            `run_branch` name the commit the PR is opened from.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [stage_id, decision, state]
+                properties:
+                  stage_id: { $ref: '#/components/schemas/UUID' }
+                  decision:
+                    type: string
+                    enum: [exempt, fail]
+                  state:
+                    type: string
+                    description: The implement stage's resulting state.
+                  held_commit_sha:
+                    type: string
+                    description: Present on `exempt` — the held commit the PR opens from.
+                  run_branch:
+                    type: string
+                    description: Present on `exempt` — the run branch the held commit sits on.
+        '400':
+          description: Malformed run_id, decision not exempt/fail, or empty reason.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+        '401':
+          description: No authenticated token.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+        '403':
+          description: |
+            `self_decision` (run-bound agent token) or
+            `insufficient_scope` (token lacks `write:stages`).
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+        '404':
+          description: '`run_not_found` — unknown run id.'
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+        '409':
+          description: |
+            `stage_not_parked` — the implement stage is not parked
+            awaiting a scope-completeness decision.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+        '503':
+          description: Run/audit repositories not wired.
           content:
             application/json:
               schema: { $ref: '#/components/schemas/Error' }

--- a/docs/issue-comment-surfaces.md
+++ b/docs/issue-comment-surfaces.md
@@ -538,6 +538,29 @@ Notes:
   anchor (#977); delivery to the agent is poll-based (the agent polls the GET
   endpoint), so no comment surface is involved. Listed here only so a future reader
   grepping the audit categories doesn't mistake them for comment surfaces.
+- The scope-completeness park/decision audit kinds — `scope_completeness_parked`,
+  `scope_completeness_exempted`, and `scope_completeness_failed` (#1231) — are
+  **internal audit kinds, not issue-comment surfaces**. Nothing in `issuecomment`
+  posts them; they have no Notifier methods.
+  `server/pullrequest.go::parkScopeCompletenessStage` writes the parked entry
+  (system actor, or operator on the bearer path; payload `{run_id, stage_id,
+  branch, head_sha, base_sha, verified_tree_sha, missing_paths, auth_method}`)
+  when the runner reports `{outcome:"scope_park"}` — the implement stage's ONLY
+  committed-tree gate failure was the missing-declared-scope-file check and it
+  pushed the verified commit to the run branch (no PR), parking in
+  `awaiting_scope_decision`. `server/scope_completeness.go::handleDecideScopeCompleteness`
+  writes the exempted entry (user actor; payload `{run_id, stage_id, decision,
+  reason, decided_by, held_commit_sha, run_branch, verified_tree_sha,
+  missing_paths, gate_evidence}`) when an operator accepts the already-committed
+  tree — the held commit's PR is then opened with no agent re-run — and the failed
+  entry (user actor; payload `{run_id, stage_id, decision, reason, decided_by,
+  missing_paths}`) when an operator rejects the exemption and the stage drops to
+  category-B. The `gate_evidence` field on the exempted entry reuses the #1153
+  channel so a downstream implement-review gate reads the shortfall as
+  operator-exempted rather than re-failing on it. Delivery to the operator is
+  poll-based via `fishhawk_get_run_status` / `next_actions` (sibling slice); no
+  comment surface is involved. Listed here only so a future reader grepping the
+  audit categories doesn't mistake them for comment surfaces.
 - The operator-vouch audit kind — `operator_commit_vouched` (ADR-035, #1044) — is an
   **internal, user-actor audit kind, NOT an issue-comment surface**. Nothing in
   `issuecomment` posts it; it has no Notifier method. `server/vouch.go::handleVouchCommit`

--- a/runner/cmd/fishhawk-runner/main.go
+++ b/runner/cmd/fishhawk-runner/main.go
@@ -263,6 +263,19 @@ func run(args []string, logSink io.Writer) (exitCode int) {
 	// entirely within run().
 	var fixupExpectedHeadSHA string
 
+	// exemptOpenPR / exemptHeldSHA / exemptHeldBranch carry the operator EXEMPT
+	// resolution of a scope-completeness park (#1231) from the fetched prompt to
+	// the early zero-re-run branch below. When exemptOpenPR is true the stage's
+	// gate-verified commit already sits on exemptHeldBranch at exemptHeldSHA (the
+	// park pushed it), so the runner skips the agent, the gates, and CommitAndPush
+	// and opens the PR from that exact held commit. Function-scoped like
+	// fixupExpectedHeadSHA: produced and consumed entirely within run().
+	var (
+		exemptOpenPR     bool
+		exemptHeldSHA    string
+		exemptHeldBranch string
+	)
+
 	// bindingAssertions is the fetched prompt's binding_assertions (#1171):
 	// the operator-declared deterministic substring checks the runner
 	// evaluates against the committed scope-only tree. It is surfaced in the
@@ -316,7 +329,7 @@ func run(args []string, logSink io.Writer) (exitCode int) {
 			return exitFailure
 		}
 		issuedKey = key
-		path, sType, agentTimeoutSecs, specVerifyCmd, specVerifyTimeoutSecs, specVerifyMaxIterations, decomposedFromRunID, minRunnerVersion, agentSelfRetry, maxRetriesSnapshot, retryAttempt, scopeFiles, commitAuthorName, commitAuthorEmail, fixup, fixupBranch, expectedHeadSHA, promptBindingAssertions, applyPatches, sliceIndex, promptScopeExemptions, fetchErr := fetchPromptToFile(ctx, client, cfg, key, logSink)
+		path, sType, agentTimeoutSecs, specVerifyCmd, specVerifyTimeoutSecs, specVerifyMaxIterations, decomposedFromRunID, minRunnerVersion, agentSelfRetry, maxRetriesSnapshot, retryAttempt, scopeFiles, commitAuthorName, commitAuthorEmail, fixup, fixupBranch, expectedHeadSHA, promptBindingAssertions, applyPatches, sliceIndex, promptScopeExemptions, openPRFromHeldCommit, heldCommitSHA, heldCommitBranch, fetchErr := fetchPromptToFile(ctx, client, cfg, key, logSink)
 		if fetchErr != nil {
 			_, _ = fmt.Fprintf(logSink,
 				`{"event":"runner_failed","reason":"fetch_prompt","detail":%q}`+"\n", fetchErr.Error())
@@ -339,6 +352,9 @@ func run(args []string, logSink io.Writer) (exitCode int) {
 		cfg.commitAuthorEmail = commitAuthorEmail
 		cfg.fixup = fixup
 		cfg.fixupBranch = fixupBranch
+		exemptOpenPR = openPRFromHeldCommit
+		exemptHeldSHA = heldCommitSHA
+		exemptHeldBranch = heldCommitBranch
 		fixupExpectedHeadSHA = expectedHeadSHA
 		fixupApplyPatches = applyPatches
 		bindingAssertions = promptBindingAssertions
@@ -436,6 +452,19 @@ func run(args []string, logSink io.Writer) (exitCode int) {
 		}
 		defer release()
 		cfg.workingDir = wt
+	}
+
+	// Operator EXEMPT resolution of a scope-completeness park (#1231): the
+	// stage's gate-verified commit already sits on its run branch (the park
+	// pushed it; ADR-035 sole-writer), so open the PR from that exact held
+	// commit with ZERO agent re-invocation. Handled HERE — before the prompt
+	// file is read and the agent.Invocation is wired below — so the agent
+	// invoker is provably never spawned on the exempt path (the e2e asserts
+	// invoker-called-exactly-once across the park+exempt sequence). No
+	// CommitAndPush, no gates, no trace bundle: the commit and its verified
+	// tree are unchanged from the park.
+	if exemptOpenPR {
+		return openHeldCommitPR(ctx, cfg, exemptHeldSHA, exemptHeldBranch, logSink, client, issuedKey)
 	}
 
 	if cfg.promptFile == "" {
@@ -1837,13 +1866,13 @@ func reissueSigningKeyForTerminalUpload(ctx context.Context, client uploadClient
 // The temp file is 0o600 — bundle-style defense in depth, since prompts
 // may include issue bodies that the customer would prefer not to leave on
 // the runner's filesystem world-readable.
-func fetchPromptToFile(ctx context.Context, client uploadClient, cfg config, key *upload.IssuedKey, logSink io.Writer) (path string, stageType string, agentTimeoutSecs int, verifyCmd string, verifyTimeoutSecs int, verifyMaxIterations int, decomposedFromRunID string, minRunnerVersion string, agentSelfRetry bool, maxRetriesSnapshot int, retryAttempt int, scopeFiles []upload.ScopeFile, commitAuthorName string, commitAuthorEmail string, fixup bool, fixupBranch string, fixupExpectedHeadSHA string, bindingAssertions []upload.BindingAssertion, fixupApplyPatches []upload.FixupApplyPatch, sliceIndex int, scopeExemptions []upload.ScopeExemption, err error) {
+func fetchPromptToFile(ctx context.Context, client uploadClient, cfg config, key *upload.IssuedKey, logSink io.Writer) (path string, stageType string, agentTimeoutSecs int, verifyCmd string, verifyTimeoutSecs int, verifyMaxIterations int, decomposedFromRunID string, minRunnerVersion string, agentSelfRetry bool, maxRetriesSnapshot int, retryAttempt int, scopeFiles []upload.ScopeFile, commitAuthorName string, commitAuthorEmail string, fixup bool, fixupBranch string, fixupExpectedHeadSHA string, bindingAssertions []upload.BindingAssertion, fixupApplyPatches []upload.FixupApplyPatch, sliceIndex int, scopeExemptions []upload.ScopeExemption, openPRFromHeldCommit bool, heldCommitSHA string, heldCommitBranch string, err error) {
 	got, fetchErr := client.FetchPrompt(ctx, upload.FetchPromptArgs{
 		StageID:    cfg.stageID,
 		PrivateKey: key.PrivateKey,
 	})
 	if fetchErr != nil {
-		return "", "", 0, "", 0, 0, "", "", false, 0, 0, nil, "", "", false, "", "", nil, nil, 0, nil, fetchErr
+		return "", "", 0, "", 0, 0, "", "", false, 0, 0, nil, "", "", false, "", "", nil, nil, 0, nil, false, "", "", fetchErr
 	}
 	_, _ = fmt.Fprintf(logSink,
 		`{"event":"prompt_fetched","stage_id":%q,"stage_type":%q,"prompt_hash":%q,"prompt_bytes":%d}`+"\n",
@@ -1851,20 +1880,20 @@ func fetchPromptToFile(ctx context.Context, client uploadClient, cfg config, key
 	)
 	tmp, tmpErr := os.CreateTemp("", "fishhawk-prompt-*.txt")
 	if tmpErr != nil {
-		return "", "", 0, "", 0, 0, "", "", false, 0, 0, nil, "", "", false, "", "", nil, nil, 0, nil, fmt.Errorf("create prompt temp file: %w", tmpErr)
+		return "", "", 0, "", 0, 0, "", "", false, 0, 0, nil, "", "", false, "", "", nil, nil, 0, nil, false, "", "", fmt.Errorf("create prompt temp file: %w", tmpErr)
 	}
 	if err := os.Chmod(tmp.Name(), 0o600); err != nil {
 		_ = tmp.Close()
-		return "", "", 0, "", 0, 0, "", "", false, 0, 0, nil, "", "", false, "", "", nil, nil, 0, nil, fmt.Errorf("chmod prompt temp file: %w", err)
+		return "", "", 0, "", 0, 0, "", "", false, 0, 0, nil, "", "", false, "", "", nil, nil, 0, nil, false, "", "", fmt.Errorf("chmod prompt temp file: %w", err)
 	}
 	if _, err := tmp.WriteString(got.Prompt); err != nil {
 		_ = tmp.Close()
-		return "", "", 0, "", 0, 0, "", "", false, 0, 0, nil, "", "", false, "", "", nil, nil, 0, nil, fmt.Errorf("write prompt temp file: %w", err)
+		return "", "", 0, "", 0, 0, "", "", false, 0, 0, nil, "", "", false, "", "", nil, nil, 0, nil, false, "", "", fmt.Errorf("write prompt temp file: %w", err)
 	}
 	if err := tmp.Close(); err != nil {
-		return "", "", 0, "", 0, 0, "", "", false, 0, 0, nil, "", "", false, "", "", nil, nil, 0, nil, fmt.Errorf("close prompt temp file: %w", err)
+		return "", "", 0, "", 0, 0, "", "", false, 0, 0, nil, "", "", false, "", "", nil, nil, 0, nil, false, "", "", fmt.Errorf("close prompt temp file: %w", err)
 	}
-	return tmp.Name(), got.StageType, got.AgentTimeoutSeconds, got.VerifyCommand, got.VerifyTimeoutSeconds, got.VerifyMaxIterations, got.DecomposedFromRunID, got.MinRunnerVersion, got.AgentSelfRetry, got.MaxRetriesSnapshot, got.RetryAttempt, got.ScopeFiles, got.CommitAuthorName, got.CommitAuthorEmail, got.Fixup, got.FixupBranch, got.FixupExpectedHeadSHA, got.BindingAssertions, got.FixupApplyPatches, got.SliceIndex, got.ScopeExemptions, nil
+	return tmp.Name(), got.StageType, got.AgentTimeoutSeconds, got.VerifyCommand, got.VerifyTimeoutSeconds, got.VerifyMaxIterations, got.DecomposedFromRunID, got.MinRunnerVersion, got.AgentSelfRetry, got.MaxRetriesSnapshot, got.RetryAttempt, got.ScopeFiles, got.CommitAuthorName, got.CommitAuthorEmail, got.Fixup, got.FixupBranch, got.FixupExpectedHeadSHA, got.BindingAssertions, got.FixupApplyPatches, got.SliceIndex, got.ScopeExemptions, got.OpenPRFromHeldCommit, got.HeldCommitSHA, got.HeldCommitBranch, nil
 }
 
 func logStartup(w io.Writer, cfg config) {
@@ -4066,6 +4095,149 @@ func resolveImplementBranchRouting(_ context.Context, cfg config, _, baseRef str
 	return r, nil
 }
 
+// mintImplementToken resolves the push/PR-create credential for an implement
+// stage. It always mints a fresh App installation token (App tokens are
+// ~1-hour TTL and a long agent run can outlive the auth pre-step's token);
+// when no App installation is attributed to the run (a local / MCP run on a
+// repo with no App) it falls back to the operator's local `gh` CLI token
+// (#713) — a user OAuth token authenticates both `git push` over HTTPS and the
+// REST PR-create call. Shared by the open-PR push path (openPRAndShipArtifact)
+// and the zero-re-run exempt resolution (openHeldCommitPR, #1231) so both
+// resolve the credential identically.
+func mintImplementToken(ctx context.Context, cfg config, client uploadClient, issued *upload.IssuedKey, logSink io.Writer) (string, error) {
+	tokenRes, err := client.FetchInstallationToken(ctx, upload.FetchInstallationTokenArgs{
+		RunID:      cfg.runID,
+		StageID:    cfg.stageID,
+		PrivateKey: issued.PrivateKey,
+	})
+	switch {
+	case err == nil:
+		_, _ = fmt.Fprintf(logSink,
+			`{"event":"installation_token_received","run_id":%q,"stage_id":%q,"source":"backend"}`+"\n",
+			cfg.runID, cfg.stageID,
+		)
+		return tokenRes.Token, nil
+	case errors.Is(err, upload.ErrNoInstallation):
+		ghTok, ghErr := ghAuthToken(ctx)
+		if ghErr != nil {
+			repoHint := cfg.githubRepo
+			if repoHint == "" {
+				repoHint = os.Getenv("GITHUB_REPOSITORY")
+			}
+			if repoHint == "" {
+				repoHint = "the target repo"
+			}
+			return "", fmt.Errorf("this run has no GitHub App installation and no `gh` CLI token is available for the push + PR fallback; "+
+				"either install the Fishhawk GitHub App on %s, or run `gh auth login` so the runner can use your local token: %w",
+				repoHint, ghErr)
+		}
+		_, _ = fmt.Fprintf(logSink,
+			`{"event":"installation_token_received","run_id":%q,"stage_id":%q,"source":"gh_cli"}`+"\n",
+			cfg.runID, cfg.stageID,
+		)
+		return ghTok, nil
+	default:
+		return "", fmt.Errorf("fetch installation token: %w", err)
+	}
+}
+
+// openHeldCommitPR resolves an operator EXEMPT decision on a scope-completeness
+// park (#1231) with ZERO agent re-invocation. The implement stage previously
+// parked because the missing-declared-scope-file gate was its sole failure, and
+// the runner pushed the gate-verified commit to heldBranch at heldSHA WITHOUT
+// opening a PR. The operator decided exempt, so this opens the PR from that
+// exact held commit and ships the pull_request artifact — no agent, no gates, no
+// CommitAndPush (the commit and its tree are unchanged from the park). ADR-035
+// sole-writer holds: the same run that wrote the branch opens its PR, and the
+// opened-PR head is byte-identical to the held tree.
+//
+// Returns a process exit code (exitOK / exitFailure). A push/PR/report failure
+// reports a "failed" outcome to /pull-request so the dispatched stage the trace
+// gate left in `running` lands `failed` rather than hanging — symmetric with
+// openPRAndShipArtifact's failure path, minus the (absent) commit.
+func openHeldCommitPR(ctx context.Context, cfg config, heldSHA, heldBranch string, logSink io.Writer, client uploadClient, issued *upload.IssuedKey) int {
+	fail := func(category, reason string) int {
+		_, _ = fmt.Fprintf(logSink,
+			`{"event":"runner_failed","reason":"scope_exempt_open_pr","detail":%q}`+"\n", reason)
+		reportPullRequestFailure(ctx, cfg, logSink, client, issued, category, reason)
+		return exitFailure
+	}
+	if cfg.runID == "" || cfg.stageID == "" {
+		return fail("C", "exempt open-PR requires --run-id and --stage-id")
+	}
+	if issued == nil {
+		return fail("C", "exempt open-PR: signing key not issued")
+	}
+	if heldBranch == "" || heldSHA == "" {
+		return fail("C", "exempt open-PR: backend did not advertise held_commit_branch/held_commit_sha")
+	}
+	if client == nil {
+		client = newUploadClient(cfg.backendURL)
+	}
+
+	repoSlug := cfg.githubRepo
+	if repoSlug == "" {
+		repoSlug = os.Getenv("GITHUB_REPOSITORY")
+	}
+	owner, repoName, ok := strings.Cut(repoSlug, "/")
+	if !ok || owner == "" || repoName == "" {
+		return fail("C", fmt.Sprintf("exempt open-PR: github repo %q is not owner/name", repoSlug))
+	}
+	baseRef := resolveImplementBaseRef(cfg)
+	branch := heldBranch
+
+	token, err := mintImplementToken(ctx, cfg, client, issued, logSink)
+	if err != nil {
+		return fail("C", err.Error())
+	}
+
+	title, body := prTitleAndBody(cfg, branch, logSink)
+	prRes, err := newPROpener(token).OpenPR(ctx, gitops.OpenPRArgs{
+		Owner: owner,
+		Repo:  repoName,
+		Head:  branch,
+		Base:  baseRef,
+		Title: title,
+		Body:  body,
+	})
+	if err != nil {
+		return fail("C", fmt.Sprintf("open PR from held commit: %v", err))
+	}
+	// The opened PR head is the held commit (#1231): the branch tip is heldSHA,
+	// unchanged since the park pushed it (ADR-035 sole-writer — no other writer
+	// touches the run branch). Stamp it so the audit chain proves
+	// opened-PR-head == held-commit without re-resolving the remote tip.
+	_, _ = fmt.Fprintf(logSink,
+		`{"event":"scope_completeness_pr_opened","run_id":%q,"stage_id":%q,"pr_number":%d,"pr_url":%q,"head_sha":%q,"branch":%q}`+"\n",
+		cfg.runID, cfg.stageID, prRes.PRNumber, prRes.PRURL, heldSHA, branch)
+
+	artifactBody, _ := json.Marshal(map[string]any{
+		"pr_number": prRes.PRNumber,
+		"pr_url":    prRes.PRURL,
+		"branch":    branch,
+		"head_sha":  heldSHA,
+		"title":     title,
+		"body":      body,
+	})
+	shipRes, err := client.ShipPullRequest(ctx, upload.ShipPullRequestArgs{
+		RunID:      cfg.runID,
+		StageID:    cfg.stageID,
+		Body:       artifactBody,
+		PrivateKey: issued.PrivateKey,
+	})
+	if err != nil {
+		category := "C"
+		if errors.Is(err, upload.ErrPullRequestInvalid) {
+			category = "B"
+		}
+		return fail(category, fmt.Sprintf("ship pull-request from held commit: %v", err))
+	}
+	_, _ = fmt.Fprintf(logSink,
+		`{"event":"pull_request_uploaded","run_id":%q,"stage_id":%q,"artifact_id":%q,"content_hash":%q,"idempotent":%t}`+"\n",
+		cfg.runID, cfg.stageID, shipRes.ID, shipRes.ContentHash, shipRes.Idempotent)
+	return exitOK
+}
+
 // openPRAndShipArtifact is the implement-stage post-processing
 // chain. It commits the agent's edits, pushes a fresh branch via
 // HTTPS, opens a PR via the GitHub REST API, and ships a
@@ -4119,45 +4291,9 @@ func openPRAndShipArtifact(ctx context.Context, cfg config, logSink io.Writer, c
 	// actions/checkout) and the Ed25519 one here (used by push +
 	// PR). Both attribute to the App; auth_method on each entry
 	// identifies which path served. (#201.)
-	var token string
-	tokenRes, err := client.FetchInstallationToken(ctx, upload.FetchInstallationTokenArgs{
-		RunID:      cfg.runID,
-		StageID:    cfg.stageID,
-		PrivateKey: issued.PrivateKey,
-	})
-	switch {
-	case err == nil:
-		token = tokenRes.Token
-		_, _ = fmt.Fprintf(logSink,
-			`{"event":"installation_token_received","run_id":%q,"stage_id":%q,"source":"backend"}`+"\n",
-			cfg.runID, cfg.stageID,
-		)
-	case errors.Is(err, upload.ErrNoInstallation):
-		// No App installation attributed to this run (a local / MCP run
-		// on a repo with no App). Fall back to the operator's local `gh`
-		// CLI token so the push + PR still work without an operator hand-
-		// push (#713). A user OAuth token authenticates both `git push`
-		// over HTTPS and the REST PR-create call.
-		ghTok, ghErr := ghAuthToken(ctx)
-		if ghErr != nil {
-			repoHint := cfg.githubRepo
-			if repoHint == "" {
-				repoHint = os.Getenv("GITHUB_REPOSITORY")
-			}
-			if repoHint == "" {
-				repoHint = "the target repo"
-			}
-			return fmt.Errorf("this run has no GitHub App installation and no `gh` CLI token is available for the push + PR fallback; "+
-				"either install the Fishhawk GitHub App on %s, or run `gh auth login` so the runner can use your local token: %w",
-				repoHint, ghErr)
-		}
-		token = ghTok
-		_, _ = fmt.Fprintf(logSink,
-			`{"event":"installation_token_received","run_id":%q,"stage_id":%q,"source":"gh_cli"}`+"\n",
-			cfg.runID, cfg.stageID,
-		)
-	default:
-		return fmt.Errorf("fetch installation token: %w", err)
+	token, err := mintImplementToken(ctx, cfg, client, issued, logSink)
+	if err != nil {
+		return err
 	}
 
 	// Repo: --github-repo flag > GITHUB_REPOSITORY env. The flag
@@ -4255,6 +4391,24 @@ func openPRAndShipArtifact(ctx context.Context, cfg config, logSink io.Writer, c
 	// the push, so a failure leaves origin untouched.
 	gateScopeFiles := scopePaths(cfg.scopeFiles)
 	verifyCommit := func(ctx context.Context, headSHA string, drift []string) error {
+		// Scope-completeness park deferral (#1231). The missing-declared-scope-file
+		// gate is checked at its usual position below but RECORDS rather than
+		// returns, so the remaining gates (binding-assertion, compile/test,
+		// verified-tree) all run afterward. The park is signaled — via the typed
+		// *gitops.ScopeFilesMissingError that CommitAndPush recognizes — ONLY at a
+		// terminal pass point, i.e. when every OTHER gate is green: that proves
+		// missing-scope is the SOLE failure (any compound failure returns the other
+		// gate's error first, keeping today's category-B). created-out-of-scope
+		// runs BEFORE the recording point and returns on failure, so it too is
+		// covered by the sole-failure guarantee.
+		var parkMissing []string
+		var parkMessage string
+		scopeParkResult := func() error {
+			if len(parkMissing) > 0 {
+				return &gitops.ScopeFilesMissingError{Missing: parkMissing, Message: parkMessage}
+			}
+			return nil
+		}
 		// Created-out-of-scope gate (#818, generalized to the open-PR path by
 		// #825). A net-new (untracked) out-of-scope file is silently stripped
 		// from the scope-only commit by StageScoped (#581) while in-scope edits
@@ -4331,7 +4485,13 @@ func openPRAndShipArtifact(ctx context.Context, cfg config, logSink io.Writer, c
 				_, _ = fmt.Fprintf(logSink,
 					`{"event":"scope_files_missing","run_id":%q,"stage_id":%q,"head_sha":%q,"declared":%s,"committed":%s,"missing":%s,"exempted":%s}`+"\n",
 					cfg.runID, cfg.stageID, headSHA, declaredJSON, committedJSON, remainingJSON, exemptedJSON)
-				return fmt.Errorf("%w: %s", gitops.ErrScopeFilesMissing,
+				// Record the shortfall but DON'T return (#1231): the remaining gates
+				// must run first so the park is signaled only when missing-scope is the
+				// SOLE failure. The terminal scopeParkResult() converts this into the
+				// typed *gitops.ScopeFilesMissingError. Message preserves the pre-#1231
+				// "%w: declared N, committed M" narrative byte-for-byte.
+				parkMissing = remaining
+				parkMessage = fmt.Sprintf("%s: %s", gitops.ErrScopeFilesMissing.Error(),
 					missingScopeFilesMessage(cfg.scopeFiles, remaining, exempted, len(gateScopeFiles), len(committed)))
 			}
 		}
@@ -4389,7 +4549,7 @@ func openPRAndShipArtifact(ctx context.Context, cfg config, logSink io.Writer, c
 		// returns ErrPushedTreeNotVerified BEFORE the push (origin untouched,
 		// category-B). Empty verifiedTreeSHA = no gate ran = no-op.
 		if verifiedTreeSHA == "" {
-			return nil
+			return scopeParkResult()
 		}
 		realTree, terr := gitRevParseTreeOf(ctx, repoDir, headSHA)
 		if terr != nil {
@@ -4403,7 +4563,7 @@ func openPRAndShipArtifact(ctx context.Context, cfg config, logSink io.Writer, c
 			_, _ = fmt.Fprintf(logSink,
 				`{"event":"verified_tree_match","run_id":%q,"stage_id":%q,"head_sha":%q,"tree_sha":%q}`+"\n",
 				cfg.runID, cfg.stageID, headSHA, realTree)
-			return nil
+			return scopeParkResult()
 		}
 		driftJSON, _ := json.Marshal(drift)
 		_, _ = fmt.Fprintf(logSink,
@@ -4456,7 +4616,7 @@ func openPRAndShipArtifact(ctx context.Context, cfg config, logSink io.Writer, c
 		// unconditionally — the audit trail's equality claim holds on the
 		// reverify-pass path too (#969).
 		verifiedTreeSHA = realTree
-		return nil
+		return scopeParkResult()
 	}
 
 	cap, err := newPusher().CommitAndPush(ctx, gitops.CommitAndPushArgs{
@@ -4504,6 +4664,13 @@ func openPRAndShipArtifact(ctx context.Context, cfg config, logSink io.Writer, c
 		// plan's declared paths, excluding stray dirty files. Empty
 		// (plan_missing_for_implement) falls back to `git add -A`.
 		ScopeFiles: scopePaths(cfg.scopeFiles),
+		// Scope-completeness park (#1231): on the standalone open-PR push ONLY
+		// (the same guard the missing-scope gate runs under), a
+		// missing-declared-scope-file-ONLY failure pushes the gate-verified
+		// commit and surfaces ScopeShortfall instead of aborting category-B, so
+		// the caller can report a park. False for fix-ups and decomposed children
+		// keeps their strict category-B behavior byte-identical.
+		ParkOnScopeShortfall: !isFixup && !isDecomposed,
 		// Compile-gate the committed tree before push (#728). Always wired,
 		// including the decomposed-child path (#766, see above) — the gate
 		// runs on every implement push.
@@ -4745,6 +4912,42 @@ func openPRAndShipArtifact(ctx context.Context, cfg config, logSink io.Writer, c
 			`{"event":"implement_child_push_reported","run_id":%q,"stage_id":%q,"shared_branch":%q,"head_sha":%q}`+"\n",
 			cfg.runID, cfg.stageID, branch, cap.HeadSHA,
 		)
+		return nil
+	}
+
+	// Scope-completeness park (#1231): the missing-declared-scope-file gate was
+	// this standalone implement stage's SOLE committed-tree failure, so
+	// CommitAndPush pushed the gate-verified commit to the run branch but
+	// surfaced ScopeShortfall instead of failing category-B. Report the park to
+	// the backend INSTEAD of opening a PR — the backend records the held-commit
+	// payload, transitions the implement stage to awaiting_scope_decision (a
+	// parked judgment, not a category-B failure), and surfaces an in-band
+	// operator exempt/fail decision. The held commit (cap.HeadSHA on `branch`)
+	// survives the runner exit so an exempt resolution opens the PR from this
+	// exact head with no agent re-run (ADR-035 sole-writer). A report error is
+	// category-C (network) and is surfaced like the OpenPR/ship errors so the
+	// failure path reports it.
+	if len(cap.ScopeShortfall) > 0 {
+		missingJSON, _ := json.Marshal(cap.ScopeShortfall)
+		_, _ = fmt.Fprintf(logSink,
+			`{"event":"scope_completeness_parked","run_id":%q,"stage_id":%q,"branch":%q,"head_sha":%q,"base_sha":%q,"verified_tree_sha":%q,"tree_sha":%q,"missing_paths":%s}`+"\n",
+			cfg.runID, cfg.stageID, branch, cap.HeadSHA, cap.BaseSHA, verifiedTreeSHA, cap.TreeSHA, missingJSON)
+		if _, err := client.ShipPullRequest(ctx, upload.ShipPullRequestArgs{
+			RunID:        cfg.runID,
+			StageID:      cfg.stageID,
+			PrivateKey:   issued.PrivateKey,
+			Outcome:      "scope_park",
+			Branch:       branch,
+			HeadSHA:      cap.HeadSHA,
+			BaseSHA:      cap.BaseSHA,
+			TreeSHA:      verifiedTreeSHA,
+			MissingPaths: cap.ScopeShortfall,
+		}); err != nil {
+			return fmt.Errorf("report scope-completeness park: %w", err)
+		}
+		_, _ = fmt.Fprintf(logSink,
+			`{"event":"scope_completeness_park_reported","run_id":%q,"stage_id":%q,"branch":%q,"head_sha":%q}`+"\n",
+			cfg.runID, cfg.stageID, branch, cap.HeadSHA)
 		return nil
 	}
 

--- a/runner/cmd/fishhawk-runner/main_test.go
+++ b/runner/cmd/fishhawk-runner/main_test.go
@@ -9847,12 +9847,16 @@ func TestOpenPRAndShipArtifact_ScopeExemption_AllExemptedPasses(t *testing.T) {
 	}
 }
 
-// TestOpenPRAndShipArtifact_ScopeExemption_PartialStillFails (strategy test 7):
-// two declared paths are missing but only one is exempted → the gate still
-// FAILS ErrScopeFilesMissing, the message lists only the unexempted remainder,
-// the scope_files_missing log carries the exempted subset, and origin is
-// untouched.
-func TestOpenPRAndShipArtifact_ScopeExemption_PartialStillFails(t *testing.T) {
+// TestOpenPRAndShipArtifact_ScopeExemption_PartialParks (strategy test 7,
+// updated for #1231): two declared paths are missing but only one is exempted →
+// missing-scope is still the SOLE gate failure (the unexempted c.txt), so the
+// stage PARKS rather than failing category-B. The gate-verified commit is
+// pushed to the run branch, NO PR is opened, and a scope_completeness_parked
+// report carries c.txt as the missing path; the scope_files_missing log still
+// records the exempted subset b.txt. (Pre-#1231 this returned category-B
+// ErrScopeFilesMissing; the park is now the unified disposition for every
+// missing-declared-scope-file-ONLY shortfall, exempted-or-not.)
+func TestOpenPRAndShipArtifact_ScopeExemption_PartialParks(t *testing.T) {
 	repo, bare, branch := verifiedTreeRepo(t)
 	fpr := withFakePROpenerOnly(t)
 	fu := newFakeUploader(t)
@@ -9865,17 +9869,36 @@ func TestOpenPRAndShipArtifact_ScopeExemption_PartialStillFails(t *testing.T) {
 		upload.ScopeFile{Path: "b.txt", Operation: "modify"},
 		upload.ScopeFile{Path: "c.txt", Operation: "modify"})
 
+	// Run the committed-tree gate so the verified-tree invariant is green for
+	// the park (the park requires every OTHER gate to pass).
+	_, verifiedTree, gerr := runVerifyGateCommitted(context.Background(), cfg, io.Discard)
+	if gerr != nil || verifiedTree == "" {
+		t.Fatalf("gate: tree=%q err=%v", verifiedTree, gerr)
+	}
+
 	exemptions := []scopeExemption{{Path: "b.txt", Reason: "already correct"}}
 	var logSink strings.Builder
-	err = openPRAndShipArtifact(context.Background(), cfg, &logSink, fu, issued, "", false, false, nil, false, "", "", nil, exemptions)
-	if !errors.Is(err, gitops.ErrScopeFilesMissing) {
-		t.Fatalf("partial exemption must still fail ErrScopeFilesMissing, got: %v", err)
+	if err := openPRAndShipArtifact(context.Background(), cfg, &logSink, fu, issued, "", false, false, nil, false, verifiedTree, "", nil, exemptions); err != nil {
+		t.Fatalf("partial-exemption missing-scope-only must PARK (nil error), got: %v\n%s", err, logSink.String())
 	}
-	if !strings.Contains(err.Error(), "c.txt") {
-		t.Errorf("message must name the unexempted remainder c.txt: %v", err)
+	// Park reports scope_completeness_parked carrying the unexempted remainder;
+	// it does NOT open a PR.
+	if fpr.gotArgs != nil {
+		t.Error("OpenPR must not run on the scope-completeness park")
 	}
-	if strings.Contains(err.Error(), "missing: b.txt") {
-		t.Errorf("message must not list the exempted b.txt in the missing set: %v", err)
+	if fu.gotPRArgs == nil || fu.gotPRArgs.Outcome != "scope_park" {
+		t.Fatalf("park must report scope_completeness_parked, got: %+v", fu.gotPRArgs)
+	}
+	if got := fu.gotPRArgs.MissingPaths; len(got) != 1 || got[0] != "c.txt" {
+		t.Errorf("park report must carry the unexempted remainder [c.txt], got: %v", got)
+	}
+	if fu.gotPRArgs.Branch != branch || fu.gotPRArgs.HeadSHA == "" || fu.gotPRArgs.TreeSHA != verifiedTree {
+		t.Errorf("park report must pin branch/head/verified-tree: %+v (want branch %s tree %s)", fu.gotPRArgs, branch, verifiedTree)
+	}
+	// The verified commit IS pushed to the run branch so an exempt resolution can
+	// open the PR from this exact held commit.
+	if _, rerr := exec.Command("git", "--git-dir="+bare, "rev-parse", "--verify", "refs/heads/"+branch).Output(); rerr != nil {
+		t.Errorf("park must push the verified commit to the run branch %s: %v", branch, rerr)
 	}
 	missingLine := ""
 	for _, line := range strings.Split(logSink.String(), "\n") {
@@ -9886,11 +9909,164 @@ func TestOpenPRAndShipArtifact_ScopeExemption_PartialStillFails(t *testing.T) {
 	if missingLine == "" || !strings.Contains(missingLine, `"exempted":["b.txt"]`) {
 		t.Errorf("scope_files_missing log must carry the exempted subset:\n%s", logSink.String())
 	}
+}
+
+// TestOpenPRAndShipArtifact_MissingScopeOnly_Parks is the #1231 core: an
+// implement stage whose ONLY committed-tree gate failure is the
+// missing-declared-scope-file shortfall (b.txt declared but untouched; verify
+// green; no created-out-of-scope, no binding, no exemptions) PARKS rather than
+// failing category-B. The gate-verified commit is pushed to the run branch, NO
+// PR is opened, and a scope_completeness_parked report carries the missing path.
+func TestOpenPRAndShipArtifact_MissingScopeOnly_Parks(t *testing.T) {
+	repo, bare, branch := verifiedTreeRepo(t)
+	fpr := withFakePROpenerOnly(t)
+	fu := newFakeUploader(t)
+	issued, err := fu.IssueKey(context.Background(), verifiedTreeRunID, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := verifiedTreeCfg(repo, "true")
+	// b.txt is declared but never edited → the SOLE shortfall.
+	cfg.scopeFiles = append(cfg.scopeFiles, upload.ScopeFile{Path: "b.txt", Operation: "modify"})
+
+	_, verifiedTree, gerr := runVerifyGateCommitted(context.Background(), cfg, io.Discard)
+	if gerr != nil || verifiedTree == "" {
+		t.Fatalf("gate: tree=%q err=%v", verifiedTree, gerr)
+	}
+
+	var logSink strings.Builder
+	if err := openPRAndShipArtifact(context.Background(), cfg, &logSink, fu, issued, "", false, false, nil, false, verifiedTree, "", nil, nil); err != nil {
+		t.Fatalf("missing-scope-only must PARK (nil error), got: %v\n%s", err, logSink.String())
+	}
 	if fpr.gotArgs != nil {
-		t.Error("OpenPR must not run after a blocked shortfall push")
+		t.Error("OpenPR must not run on the scope-completeness park")
+	}
+	if fu.gotPRArgs == nil || fu.gotPRArgs.Outcome != "scope_park" {
+		t.Fatalf("park must report scope_completeness_parked, got: %+v", fu.gotPRArgs)
+	}
+	if got := fu.gotPRArgs.MissingPaths; len(got) != 1 || got[0] != "b.txt" {
+		t.Errorf("park report missing paths = %v, want [b.txt]", got)
+	}
+	if fu.gotPRArgs.TreeSHA != verifiedTree {
+		t.Errorf("park report tree = %q, want verified tree %q", fu.gotPRArgs.TreeSHA, verifiedTree)
+	}
+	if _, rerr := exec.Command("git", "--git-dir="+bare, "rev-parse", "--verify", "refs/heads/"+branch).Output(); rerr != nil {
+		t.Errorf("park must push the held commit to the run branch %s: %v", branch, rerr)
+	}
+	if !strings.Contains(logSink.String(), `"event":"scope_completeness_park_reported"`) {
+		t.Errorf("expected a scope_completeness_park_reported log line:\n%s", logSink.String())
+	}
+}
+
+// TestOpenPRAndShipArtifact_MissingScopePlusBinding_StaysCategoryB is the
+// co-occurring-gate guard (#1231 approval condition): when the missing-scope
+// shortfall is accompanied by ANOTHER gate failure (here an unsatisfied binding
+// assertion), the compound is NOT a missing-scope-ONLY situation, so the stage
+// keeps today's category-B abort — the other gate's error is returned BEFORE the
+// push, origin is untouched, and no park is reported.
+func TestOpenPRAndShipArtifact_MissingScopePlusBinding_StaysCategoryB(t *testing.T) {
+	repo, bare, branch := verifiedTreeRepo(t)
+	fpr := withFakePROpenerOnly(t)
+	fu := newFakeUploader(t)
+	issued, err := fu.IssueKey(context.Background(), verifiedTreeRunID, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := verifiedTreeCfg(repo, "true")
+	cfg.scopeFiles = append(cfg.scopeFiles, upload.ScopeFile{Path: "b.txt", Operation: "modify"})
+	// a.txt IS touched but does not contain the declared literal → the binding
+	// assertion is unsatisfied, co-occurring with the b.txt shortfall.
+	bindings := []upload.BindingAssertion{{Type: "file_contains", Path: "a.txt", Literal: "NOT-PRESENT-LITERAL"}}
+
+	var logSink strings.Builder
+	err = openPRAndShipArtifact(context.Background(), cfg, &logSink, fu, issued, "", false, false, nil, false, "", "", bindings, nil)
+	if !errors.Is(err, gitops.ErrBindingAssertionUnsatisfied) {
+		t.Fatalf("a compound (missing + binding) failure must stay category-B, got: %v", err)
+	}
+	if fu.gotPRArgs != nil && fu.gotPRArgs.Outcome == "scope_park" {
+		t.Error("a compound failure must NOT report a park")
+	}
+	if fpr.gotArgs != nil {
+		t.Error("OpenPR must not run on a category-B abort")
 	}
 	if _, rerr := exec.Command("git", "--git-dir="+bare, "rev-parse", "--verify", "refs/heads/"+branch).Output(); rerr == nil {
-		t.Errorf("run branch %s reached the bare remote despite the blocked push", branch)
+		t.Errorf("origin must be untouched on the category-B abort, but branch %s exists", branch)
+	}
+}
+
+// TestOpenHeldCommitPR_OpensFromHeldCommit_NoAgent is the zero-re-run exempt
+// path (#1231): the gate-verified commit is already on the run branch, so the
+// operator EXEMPT resolution opens the PR from that exact held commit with NO
+// CommitAndPush and NO agent invocation. Asserts OpenPR is called with the held
+// branch as head, the shipped artifact carries the held commit SHA, and the exit
+// is OK.
+func TestOpenHeldCommitPR_OpensFromHeldCommit_NoAgent(t *testing.T) {
+	fpr := withFakePROpenerOnly(t)
+	fu := newFakeUploader(t)
+	issued, err := fu.IssueKey(context.Background(), verifiedTreeRunID, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := config{
+		runID:      verifiedTreeRunID,
+		stageID:    verifiedTreeStageID,
+		githubRepo: "test-owner/test-repo",
+		baseBranch: "main",
+		backendURL: "https://api.fishhawk.test",
+	}
+	var logSink strings.Builder
+	if code := openHeldCommitPR(context.Background(), cfg, "deadbeefcafef00d", "fishhawk/run-abc/stage-xyz", &logSink, fu, issued); code != exitOK {
+		t.Fatalf("openHeldCommitPR exit = %d, want exitOK\n%s", code, logSink.String())
+	}
+	if fpr.gotArgs == nil {
+		t.Fatal("openHeldCommitPR must open a PR from the held commit")
+	}
+	if fpr.gotArgs.Head != "fishhawk/run-abc/stage-xyz" || fpr.gotArgs.Base != "main" {
+		t.Errorf("OpenPR head/base = %q/%q, want held branch / main", fpr.gotArgs.Head, fpr.gotArgs.Base)
+	}
+	// The shipped artifact head is the held commit SHA (opened-PR head == held).
+	if fu.gotPRArgs == nil || fu.gotPRArgs.Outcome != "" {
+		t.Fatalf("exempt path must ship the success PR artifact (empty outcome), got: %+v", fu.gotPRArgs)
+	}
+	var artifact struct {
+		HeadSHA string `json:"head_sha"`
+		Branch  string `json:"branch"`
+	}
+	if uerr := json.Unmarshal(fu.gotPRArgs.Body, &artifact); uerr != nil {
+		t.Fatalf("decode artifact body: %v", uerr)
+	}
+	if artifact.HeadSHA != "deadbeefcafef00d" {
+		t.Errorf("opened-PR artifact head = %q, want the held commit SHA", artifact.HeadSHA)
+	}
+}
+
+// TestOpenHeldCommitPR_MissingHeldFields_ReportsFailure pins the fail-closed
+// guard (#1231): if the backend advertised the exempt resolution without the
+// held branch/SHA, openHeldCommitPR reports a failure (so the dispatched stage
+// lands failed rather than hanging) and never opens a PR.
+func TestOpenHeldCommitPR_MissingHeldFields_ReportsFailure(t *testing.T) {
+	fpr := withFakePROpenerOnly(t)
+	fu := newFakeUploader(t)
+	issued, err := fu.IssueKey(context.Background(), verifiedTreeRunID, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := config{
+		runID:      verifiedTreeRunID,
+		stageID:    verifiedTreeStageID,
+		githubRepo: "test-owner/test-repo",
+		backendURL: "https://api.fishhawk.test",
+	}
+	var logSink strings.Builder
+	// held SHA / branch deliberately empty → fail-closed.
+	if code := openHeldCommitPR(context.Background(), cfg, "", "", &logSink, fu, issued); code != exitFailure {
+		t.Fatalf("missing held fields must fail, exit = %d", code)
+	}
+	if fpr.gotArgs != nil {
+		t.Error("no PR may be opened when the held commit fields are absent")
+	}
+	if fu.gotPRArgs == nil || fu.gotPRArgs.Outcome != "failed" {
+		t.Errorf("must report a failed outcome so the stage lands failed, got: %+v", fu.gotPRArgs)
 	}
 }
 

--- a/runner/internal/gitops/commit.go
+++ b/runner/internal/gitops/commit.go
@@ -103,6 +103,45 @@ var ErrCommitOutOfScope = errors.New("gitops: commit contains out-of-scope paths
 // (narrowed slice scope on a shared branch) are excluded.
 var ErrScopeFilesMissing = errors.New("gitops: commit did not touch every declared scope file")
 
+// ScopeFilesMissingError is the typed form of ErrScopeFilesMissing (#1231). It
+// carries the concrete declared scope.files paths the commit did NOT touch so
+// the runner's scope-completeness park can record them without recomputing the
+// shortfall. Unwrap returns the ErrScopeFilesMissing sentinel, so every
+// existing errors.Is(err, ErrScopeFilesMissing) classification — including the
+// runner's category-B mapping — keeps working unchanged.
+//
+// The runner returns it from the verifyCommit closure ONLY after every OTHER
+// committed-tree gate (created-out-of-scope, binding-assertion, compile/test,
+// verified-tree) has already passed, so when CommitAndPush sees it with
+// ParkOnScopeShortfall set it is provably the SOLE gate failure — the
+// missing-declared-scope-file-ONLY class (#1148/#1225). That class PARKS for an
+// operator exempt/fail decision rather than failing category-B: CommitAndPush
+// pushes the verified commit to the run branch anyway (so the held commit
+// survives the runner exit and a later exempt resolution can open the PR from
+// it, ADR-035) and surfaces ScopeShortfall instead of aborting. Any compound
+// failure (missing + another gate) never reaches this type because the other
+// gate returns its own non-parkable error first, keeping today's category-B.
+type ScopeFilesMissingError struct {
+	// Missing is the order-preserving list of concrete declared scope.files
+	// paths the committed tree did not touch (the unexempted shortfall).
+	Missing []string
+	// Message is the full human-readable gate message (the "%w: declared N,
+	// committed M" preamble). Error returns it verbatim so the runner's
+	// failure-report narrative is byte-identical to the pre-#1231 wrap.
+	Message string
+}
+
+func (e *ScopeFilesMissingError) Error() string {
+	if e.Message != "" {
+		return e.Message
+	}
+	return ErrScopeFilesMissing.Error()
+}
+
+// Unwrap returns the ErrScopeFilesMissing sentinel so
+// errors.Is(err, ErrScopeFilesMissing) holds for the typed error.
+func (*ScopeFilesMissingError) Unwrap() error { return ErrScopeFilesMissing }
+
 // ErrCommittedTestsFailed is the test-gate analogue of
 // ErrCommitWouldNotCompile (#800): the scope-only committed tree COMPILES
 // (go vet passes) but a touched package's tests fail because a build- or
@@ -309,6 +348,21 @@ type CommitAndPushArgs struct {
 	// behavior). Paths are repo-relative, matching scope.files entries.
 	ScopeFiles []string
 
+	// ParkOnScopeShortfall, when true, changes the disposition of a
+	// missing-declared-scope-file-ONLY gate failure (#1231): when VerifyCommit
+	// returns a *ScopeFilesMissingError — which the runner emits ONLY after
+	// every other committed-tree gate has passed, so it is the SOLE failure —
+	// CommitAndPush PUSHES the verified commit to the run branch anyway and
+	// reports the shortfall via CommitAndPushResult.ScopeShortfall instead of
+	// aborting the push. The held commit must survive the runner exit so a
+	// later operator exempt resolution can open the PR from that exact head
+	// (ADR-035: the same run writing its own branch, no re-commit). Any OTHER
+	// VerifyCommit error (including a plain ErrScopeFilesMissing wrap that is
+	// not the typed *ScopeFilesMissingError) still aborts the push BEFORE origin
+	// is touched, unchanged. Set only on the standalone open-PR implement push;
+	// false everywhere else keeps the strict #1151 category-B gate byte-identical.
+	ParkOnScopeShortfall bool
+
 	// VerifyCommit, when non-nil, is invoked AFTER the scope-only commit
 	// is created and BEFORE the push, with the new HEAD SHA and the scope
 	// drift (dirty-but-undeclared paths excluded from the commit). A
@@ -354,6 +408,15 @@ type CommitAndPushResult struct {
 	// scope-drift treatment, ADR-027). Always empty when ScopeFiles
 	// was empty (the `git add -A` fallback path).
 	ScopeDrift []string
+
+	// ScopeShortfall lists the concrete declared scope.files paths the pushed
+	// commit did NOT touch (#1231). Non-empty ONLY when ParkOnScopeShortfall was
+	// set AND the missing-declared-scope-file gate was the sole committed-tree
+	// failure: the verified commit WAS pushed to the run branch (HeadSHA/TreeSHA
+	// are populated) but NO PR is implied — the caller reports a
+	// scope-completeness park carrying these paths instead of opening a PR.
+	// Always empty otherwise, so the existing success path is byte-identical.
+	ScopeShortfall []string
 }
 
 // CommitAndPush configures a bot author, creates Branch, stages
@@ -547,9 +610,24 @@ func (p *Pusher) CommitAndPush(ctx context.Context, args CommitAndPushArgs) (*Co
 	// gate failure leaves origin untouched. scopeDrift names the files the
 	// commit excluded — the candidate build-required set the callback
 	// reports in its error.
+	var scopeShortfall []string
 	if args.VerifyCommit != nil {
 		if err := args.VerifyCommit(ctx, headSHA, scopeDrift); err != nil {
-			return nil, err
+			// Scope-completeness park (#1231): a *ScopeFilesMissingError is the
+			// runner's signal that the missing-declared-scope-file gate was the
+			// SOLE committed-tree failure (the closure runs every other gate
+			// first). When the caller opted into ParkOnScopeShortfall, DON'T
+			// abort — fall through to the push so the verified commit lands on
+			// the run branch, and surface the missing paths so the caller reports
+			// a scope-completeness park rather than opening a PR. Any other error
+			// (including a plain ErrScopeFilesMissing wrap that is NOT the typed
+			// value) still aborts before origin is touched.
+			var smErr *ScopeFilesMissingError
+			if args.ParkOnScopeShortfall && errors.As(err, &smErr) {
+				scopeShortfall = smErr.Missing
+			} else {
+				return nil, err
+			}
 		}
 	}
 
@@ -603,10 +681,11 @@ func (p *Pusher) CommitAndPush(ctx context.Context, args CommitAndPushArgs) (*Co
 	}
 
 	return &CommitAndPushResult{
-		HeadSHA:    headSHA,
-		TreeSHA:    treeSHA,
-		BaseSHA:    baseSHA,
-		ScopeDrift: scopeDrift,
+		HeadSHA:        headSHA,
+		TreeSHA:        treeSHA,
+		BaseSHA:        baseSHA,
+		ScopeDrift:     scopeDrift,
+		ScopeShortfall: scopeShortfall,
 	}, nil
 }
 

--- a/runner/internal/gitops/commit_test.go
+++ b/runner/internal/gitops/commit_test.go
@@ -1269,6 +1269,138 @@ func TestCommitAndPush_VerifyCommit_AbortsBeforePush(t *testing.T) {
 	}
 }
 
+// scopeParkRepo sets up a working repo + bare remote with one in-scope dirty
+// file, returning both paths. Mirrors the inline setup the other VerifyCommit
+// tests use, factored for the #1231 scope-completeness park trio.
+func scopeParkRepo(t *testing.T) (repo, bare string) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	repo = filepath.Join(dir, "src")
+	bare = filepath.Join(dir, "origin.git")
+	if err := os.Mkdir(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, repo, "init", "--initial-branch=main")
+	mustGit(t, repo, "config", "user.name", "init")
+	mustGit(t, repo, "config", "user.email", "init@example.com")
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("# initial\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, repo, "add", "-A")
+	mustGit(t, repo, "commit", "-m", "initial")
+	mustGit(t, repo, "init", "--bare", bare)
+	mustGit(t, repo, "remote", "add", "origin", bare)
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("# changed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return repo, bare
+}
+
+// TestCommitAndPush_ParkOnScopeShortfall_PushesAndReportsShortfall pins the
+// #1231 park mechanism: when VerifyCommit returns a *ScopeFilesMissingError —
+// the runner's signal that missing-declared-scope-file was the SOLE gate failure
+// — AND ParkOnScopeShortfall is set, CommitAndPush PUSHES the verified commit to
+// the run branch anyway (so the held commit survives for an exempt resolution)
+// and surfaces the missing paths via ScopeShortfall instead of aborting.
+func TestCommitAndPush_ParkOnScopeShortfall_PushesAndReportsShortfall(t *testing.T) {
+	repo, bare := scopeParkRepo(t)
+	p := &Pusher{}
+	res, err := p.CommitAndPush(context.Background(), CommitAndPushArgs{
+		RepoDir:              repo,
+		Branch:               "fishhawk/park/branch",
+		CommitMessage:        "Scoped commit",
+		RemoteURL:            bare,
+		ScopeFiles:           []string{"README.md"},
+		ParkOnScopeShortfall: true,
+		VerifyCommit: func(_ context.Context, headSHA string, _ []string) error {
+			if headSHA == "" {
+				t.Error("VerifyCommit got empty headSHA")
+			}
+			return &ScopeFilesMissingError{Missing: []string{"b.txt", "c.txt"}, Message: "gitops: commit did not touch every declared scope file: detail"}
+		},
+	})
+	if err != nil {
+		t.Fatalf("park must NOT return an error (it pushes + reports the shortfall), got: %v", err)
+	}
+	if len(res.ScopeShortfall) != 2 || res.ScopeShortfall[0] != "b.txt" || res.ScopeShortfall[1] != "c.txt" {
+		t.Errorf("ScopeShortfall = %v, want [b.txt c.txt]", res.ScopeShortfall)
+	}
+	if res.HeadSHA == "" || res.TreeSHA == "" {
+		t.Errorf("park must populate HeadSHA/TreeSHA for the held commit, got %+v", res)
+	}
+	// The verified commit reached the bare remote (held for an exempt resolution).
+	out, gerr := exec.Command("git", "--git-dir="+bare, "rev-parse", "fishhawk/park/branch").Output()
+	if gerr != nil {
+		t.Fatalf("park must push the held commit to the run branch: %v", gerr)
+	}
+	if strings.TrimSpace(string(out)) != res.HeadSHA {
+		t.Errorf("pushed branch sha = %q, want held HeadSHA %q", strings.TrimSpace(string(out)), res.HeadSHA)
+	}
+}
+
+// TestCommitAndPush_ParkOnScopeShortfall_FalseAborts pins that the SAME typed
+// *ScopeFilesMissingError aborts the push (category-B, origin untouched) when
+// ParkOnScopeShortfall is NOT set — the strict #1151 behavior for fix-ups and
+// decomposed children stays byte-identical, and the error still unwraps to the
+// ErrScopeFilesMissing sentinel the runner classifies category-B.
+func TestCommitAndPush_ParkOnScopeShortfall_FalseAborts(t *testing.T) {
+	repo, bare := scopeParkRepo(t)
+	p := &Pusher{}
+	res, err := p.CommitAndPush(context.Background(), CommitAndPushArgs{
+		RepoDir:       repo,
+		Branch:        "fishhawk/park/noflag",
+		CommitMessage: "Scoped commit",
+		RemoteURL:     bare,
+		ScopeFiles:    []string{"README.md"},
+		// ParkOnScopeShortfall deliberately false.
+		VerifyCommit: func(_ context.Context, _ string, _ []string) error {
+			return &ScopeFilesMissingError{Missing: []string{"b.txt"}, Message: "shortfall"}
+		},
+	})
+	if !errors.Is(err, ErrScopeFilesMissing) {
+		t.Fatalf("without ParkOnScopeShortfall the typed error must abort category-B, got: %v", err)
+	}
+	if res != nil {
+		t.Errorf("aborted push must return a nil result, got %+v", res)
+	}
+	if out, gerr := exec.Command("git", "--git-dir="+bare, "rev-parse", "fishhawk/park/noflag").CombinedOutput(); gerr == nil {
+		t.Errorf("origin must be untouched on the aborted push, but the branch exists: %s", out)
+	}
+}
+
+// TestCommitAndPush_ParkOnScopeShortfall_NonScopeErrorAborts pins that a NON
+// missing-scope VerifyCommit error still aborts the push even with
+// ParkOnScopeShortfall set: the park is reserved for the typed
+// *ScopeFilesMissingError, so a compile-gate (or any other) failure keeps its
+// category-B abort, and no shortfall is surfaced.
+func TestCommitAndPush_ParkOnScopeShortfall_NonScopeErrorAborts(t *testing.T) {
+	repo, bare := scopeParkRepo(t)
+	p := &Pusher{}
+	res, err := p.CommitAndPush(context.Background(), CommitAndPushArgs{
+		RepoDir:              repo,
+		Branch:               "fishhawk/park/compile",
+		CommitMessage:        "Scoped commit",
+		RemoteURL:            bare,
+		ScopeFiles:           []string{"README.md"},
+		ParkOnScopeShortfall: true,
+		VerifyCommit: func(_ context.Context, _ string, _ []string) error {
+			return ErrCommitWouldNotCompile
+		},
+	})
+	if !errors.Is(err, ErrCommitWouldNotCompile) {
+		t.Fatalf("a non-scope error must abort even with ParkOnScopeShortfall, got: %v", err)
+	}
+	if res != nil {
+		t.Errorf("aborted push must return a nil result, got %+v", res)
+	}
+	if out, gerr := exec.Command("git", "--git-dir="+bare, "rev-parse", "fishhawk/park/compile").CombinedOutput(); gerr == nil {
+		t.Errorf("origin must be untouched on the aborted compile-gate push: %s", out)
+	}
+}
+
 // TestCommitAndPush_VerifyCommit_PassThroughPushes confirms the happy
 // path: a VerifyCommit that returns nil does not block the push.
 func TestCommitAndPush_VerifyCommit_PassThroughPushes(t *testing.T) {

--- a/runner/internal/upload/upload.go
+++ b/runner/internal/upload/upload.go
@@ -436,6 +436,30 @@ type FetchedPrompt struct {
 	// a non-eligible fix-up — byte-identical to today. The wire tag
 	// (fixup_apply_patches / patch) matches the backend's fixupApplyPatch shape.
 	FixupApplyPatches []FixupApplyPatch `json:"fixup_apply_patches,omitempty"`
+	// OpenPRFromHeldCommit is true on an operator EXEMPT resolution of a
+	// scope-completeness park (#1231): the implement stage previously parked
+	// because the missing-declared-scope-file gate was its sole failure, and the
+	// runner pushed the gate-verified commit to the run branch WITHOUT opening a
+	// PR. The operator decided exempt, so the backend dispatches THIS stage to
+	// open the PR from that exact held commit with NO agent re-invocation
+	// (zero-re-run). The runner skips the agent, the gates, and CommitAndPush
+	// entirely (the commit already exists on the branch) and opens the PR from
+	// HeldCommitBranch at HeldCommitSHA. Both false/empty on every other
+	// dispatch. The wire tags (open_pr_from_held_commit / held_commit_sha /
+	// held_commit_branch) are byte-identical to the backend's prompt-response
+	// scope-completeness exempt fields, the runner↔backend wire contract for the
+	// exempt resolution (the same cross-module convention as ScopeExemption /
+	// #1229 and BindingAssertions / #1171).
+	OpenPRFromHeldCommit bool `json:"open_pr_from_held_commit,omitempty"`
+	// HeldCommitSHA is the head commit the scope-completeness park pushed to the
+	// run branch (#1231). Non-empty only when OpenPRFromHeldCommit is true. The
+	// runner asserts the branch tip equals this SHA before opening the PR so the
+	// opened PR head is byte-identical to the gate-verified held tree (ADR-035).
+	HeldCommitSHA string `json:"held_commit_sha,omitempty"`
+	// HeldCommitBranch is the run branch the held commit was pushed to (#1231).
+	// Non-empty only when OpenPRFromHeldCommit is true. The runner opens the PR
+	// with this branch as head.
+	HeldCommitBranch string `json:"held_commit_branch,omitempty"`
 }
 
 // FixupApplyPatch is one entry in FetchedPrompt.FixupApplyPatches: a single
@@ -764,6 +788,21 @@ type ShipPullRequestArgs struct {
 	// the backend drives the fix-up stage's terminal transition and re-parks the
 	// review gate, instead of hanging until the SLA watchdog reaps it.
 	//
+	// When Outcome is "scope_park", this is a missing-declared-scope-file-ONLY
+	// park report (#1231): the implement stage's sole committed-tree gate failure
+	// was the #1151 scope-completeness shortfall, so the runner pushed the
+	// gate-verified commit to the run branch WITHOUT opening a PR. ShipPullRequest
+	// signs and ships
+	// {"outcome":"scope_park","branch":...,"head_sha":...,"base_sha":...,
+	// "verified_tree_sha":...,"missing_paths":[...]} so the backend records the
+	// park payload, transitions the implement stage to awaiting_scope_decision (a
+	// parked judgment, NOT a category-B failure), and surfaces an in-band operator
+	// exempt/fail decision — instead of the trace gate leaving the stage hung in
+	// `running` until the SLA watchdog reaps it. TreeSHA pins the gate-verified
+	// tree (wire tag verified_tree_sha); MissingPaths names the declared paths the
+	// commit did not touch. The outcome string + tags are byte-identical to the
+	// backend's scope_park pullRequestBody decode (slice 1).
+	//
 	// When Outcome is empty the success Body path (a real PR artifact) is
 	// used unchanged.
 	Outcome  string
@@ -778,6 +817,14 @@ type ShipPullRequestArgs struct {
 	HeadSHA           string
 	BaseSHA           string
 	FilesChangedCount int
+
+	// TreeSHA and MissingPaths carry the scope-completeness park payload for the
+	// Outcome=="scope_completeness_parked" report (#1231). TreeSHA is the
+	// gate-verified tree object hash of the held commit; MissingPaths is the
+	// order-preserving list of concrete declared scope.files the commit did not
+	// touch. Unused (and dropped via omitempty below) for every other outcome.
+	TreeSHA      string
+	MissingPaths []string
 
 	// ApplyPath carries the near-deterministic fix-up apply provenance (#1165)
 	// for the Outcome=="fixup_pushed" report: "applied" (a clean git-apply of
@@ -817,6 +864,26 @@ type pullRequestChildPushBody struct {
 	// "fixup_pushed" report. omitempty keeps the "pushed" child-push and
 	// "fixup_no_changes" bodies byte-identical when it is unset.
 	ApplyPath string `json:"apply_path,omitempty"`
+}
+
+// pullRequestScopeParkBody is the scope-completeness park-report wire shape
+// ShipPullRequest marshals when Args.Outcome == "scope_park" (#1231). The held
+// commit is already pushed to the run branch, so the body carries the held
+// commit's branch + SHAs + the gate-verified tree + the missing declared paths
+// rather than a PR number/URL. The json tags
+// (branch/head_sha/base_sha/verified_tree_sha/missing_paths) are byte-identical
+// to the backend's scope_park pullRequestBody decode struct (which maps 1:1 into
+// run.ScopeCompletenessPark, slice 1), the runner↔backend wire contract for the
+// park round-trip (the same cross-module convention as pullRequestChildPushBody
+// / #771 and ScopeExemption / #1229). Kept here so the runner owns the bytes it
+// signs.
+type pullRequestScopeParkBody struct {
+	Outcome      string   `json:"outcome"`
+	Branch       string   `json:"branch"`
+	HeadSHA      string   `json:"head_sha"`
+	BaseSHA      string   `json:"base_sha"`
+	TreeSHA      string   `json:"verified_tree_sha"`
+	MissingPaths []string `json:"missing_paths"`
 }
 
 // ShipPullRequestResult is what the backend echoes back. Idempotent
@@ -878,6 +945,24 @@ func (c *Client) ShipPullRequest(ctx context.Context, args ShipPullRequestArgs) 
 		})
 		if err != nil {
 			return nil, fmt.Errorf("upload: marshal pull-request push body: %w", err)
+		}
+		body = marshalled
+	case "scope_park":
+		// Scope-completeness park report (#1231): no PR was opened (the
+		// gate-verified commit landed on the run branch only), so build the park
+		// body from the held commit details + the missing declared paths rather
+		// than the (absent) PR artifact. The backend records the park payload and
+		// transitions the implement stage to awaiting_scope_decision.
+		marshalled, err := json.Marshal(pullRequestScopeParkBody{
+			Outcome:      args.Outcome,
+			Branch:       args.Branch,
+			HeadSHA:      args.HeadSHA,
+			BaseSHA:      args.BaseSHA,
+			TreeSHA:      args.TreeSHA,
+			MissingPaths: args.MissingPaths,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("upload: marshal pull-request scope-park body: %w", err)
 		}
 		body = marshalled
 	}

--- a/runner/internal/upload/upload_test.go
+++ b/runner/internal/upload/upload_test.go
@@ -1285,3 +1285,124 @@ func TestRunLineageComplete_RejectsEmptyRunID(t *testing.T) {
 		t.Errorf("want error on empty run id")
 	}
 }
+
+// TestShipPullRequest_ScopeCompletenessPark pins the #1231 park-report wire
+// shape: Outcome=="scope_completeness_parked" signs and ships the held commit's
+// branch/SHAs + the gate-verified tree + the missing declared paths so the
+// backend can record the park payload and transition the implement stage to
+// awaiting_scope_decision. Asserts the field-for-field body the runner owns and
+// that the signature verifies against exactly those bytes.
+func TestShipPullRequest_ScopeCompletenessPark(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	var receivedSig string
+	var receivedBody []byte
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /v0/runs/{run_id}/pull-request", func(w http.ResponseWriter, r *http.Request) {
+		receivedSig = r.Header.Get("X-Fishhawk-Signature")
+		receivedBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(ShipPullRequestResult{ID: "art-1", StageID: r.URL.Query().Get("stage_id")})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	c := &Client{BaseURL: srv.URL, HTTP: srv.Client()}
+
+	_, err := c.ShipPullRequest(context.Background(), ShipPullRequestArgs{
+		RunID:        "run-abc",
+		StageID:      "stage-xyz",
+		PrivateKey:   priv,
+		Outcome:      "scope_park",
+		Branch:       "fishhawk/run-abc/stage-xyz",
+		HeadSHA:      "deadbeef",
+		BaseSHA:      "feedface",
+		TreeSHA:      "treesha1",
+		MissingPaths: []string{"backend/internal/run/run.go", "docs/api/v0.md"},
+	})
+	if err != nil {
+		t.Fatalf("ShipPullRequest park: %v", err)
+	}
+	var got pullRequestScopeParkBody
+	if uerr := json.Unmarshal(receivedBody, &got); uerr != nil {
+		t.Fatalf("decode park body: %v", uerr)
+	}
+	want := pullRequestScopeParkBody{
+		Outcome:      "scope_park",
+		Branch:       "fishhawk/run-abc/stage-xyz",
+		HeadSHA:      "deadbeef",
+		BaseSHA:      "feedface",
+		TreeSHA:      "treesha1",
+		MissingPaths: []string{"backend/internal/run/run.go", "docs/api/v0.md"},
+	}
+	if got.Outcome != want.Outcome || got.Branch != want.Branch || got.HeadSHA != want.HeadSHA ||
+		got.BaseSHA != want.BaseSHA || got.TreeSHA != want.TreeSHA ||
+		len(got.MissingPaths) != 2 || got.MissingPaths[0] != want.MissingPaths[0] || got.MissingPaths[1] != want.MissingPaths[1] {
+		t.Errorf("park body = %+v, want %+v", got, want)
+	}
+	// Lock the parity-critical raw wire keys against the backend's scope_park
+	// decode (slice 1): the outcome discriminator and the verified_tree_sha tag.
+	// A drift to a different outcome string or to "tree_sha" would silently fail
+	// the backend's park-report parse — exactly what per-side decode tests with a
+	// shared struct miss.
+	raw := string(receivedBody)
+	if !strings.Contains(raw, `"outcome":"scope_park"`) {
+		t.Errorf("wire body must carry outcome=scope_park: %s", raw)
+	}
+	if !strings.Contains(raw, `"verified_tree_sha":"treesha1"`) || strings.Contains(raw, `"tree_sha":`) {
+		t.Errorf("wire body must carry verified_tree_sha (not tree_sha): %s", raw)
+	}
+	// The signature verifies against exactly the bytes the server received.
+	sigBytes, decErr := hex.DecodeString(receivedSig)
+	if decErr != nil {
+		t.Fatal(decErr)
+	}
+	digest := sha256.Sum256(receivedBody)
+	if !ed25519.Verify(pub, digest[:], sigBytes) {
+		t.Error("signature does not verify against received park body digest")
+	}
+}
+
+// TestFetchPrompt_DecodesOpenPRFromHeldCommit confirms the client decodes the
+// backend's exempt-resolution fields (#1231) into the FetchedPrompt zero-re-run
+// signal. The runner keys its agent-skip + open-PR-from-held-commit branch off
+// these, so a tag drift across the module boundary must fail here.
+func TestFetchPrompt_DecodesOpenPRFromHeldCommit(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	priv, _ := makeKey(t, fb)
+	fb.promptBody = `{
+		"stage_id": "stage-abc",
+		"stage_type": "implement",
+		"prompt": "p",
+		"prompt_hash": "h",
+		"open_pr_from_held_commit": true,
+		"held_commit_sha": "deadbeef",
+		"held_commit_branch": "fishhawk/run-abc/stage-xyz"
+	}`
+	c := quickClient(srv)
+	got, err := c.FetchPrompt(context.Background(), FetchPromptArgs{StageID: "stage-abc", PrivateKey: priv})
+	if err != nil {
+		t.Fatalf("FetchPrompt: %v", err)
+	}
+	if !got.OpenPRFromHeldCommit || got.HeldCommitSHA != "deadbeef" || got.HeldCommitBranch != "fishhawk/run-abc/stage-xyz" {
+		t.Errorf("held-commit fields = %t/%q/%q, want true/deadbeef/fishhawk/run-abc/stage-xyz",
+			got.OpenPRFromHeldCommit, got.HeldCommitSHA, got.HeldCommitBranch)
+	}
+}
+
+// TestFetchPrompt_OpenPRFromHeldCommitOmittedWhenAbsent confirms the exempt
+// fields default to false/empty on every non-exempt dispatch (byte-identical to
+// pre-#1231 behavior), so the runner never mistakes an ordinary implement
+// dispatch for the zero-re-run path.
+func TestFetchPrompt_OpenPRFromHeldCommitOmittedWhenAbsent(t *testing.T) {
+	fb, srv := newFakeBackend(t)
+	priv, _ := makeKey(t, fb)
+	c := quickClient(srv)
+	got, err := c.FetchPrompt(context.Background(), FetchPromptArgs{StageID: "stage-abc", PrivateKey: priv})
+	if err != nil {
+		t.Fatalf("FetchPrompt: %v", err)
+	}
+	if got.OpenPRFromHeldCommit || got.HeldCommitSHA != "" || got.HeldCommitBranch != "" {
+		t.Errorf("exempt fields must default false/empty, got %t/%q/%q",
+			got.OpenPRFromHeldCommit, got.HeldCommitSHA, got.HeldCommitBranch)
+	}
+}


### PR DESCRIPTION
## Summary

Zero-re-run recovery for the #1151 scope-completeness gate. When an implement stage's ONLY committed-tree gate failure is the "missing declared scope file(s)" check AND the tree otherwise verified (created-out-of-scope, binding-assertion, compile/test, verified-tree gates all green), the runner no longer category-B-fails-and-restores. Instead it pushes the verified commit to the run's own branch WITHOUT opening a PR (ADR-035 sole-writer preserved), and parks the stage at a new `awaiting_scope_decision` state carrying the held commit SHA + run branch + verified tree SHA + missing declared paths. An operator decides exempt-or-fail in-band via the new `fishhawk_decide_scope_completeness` MCP verb (operator-only; run-bound `fhm_` tokens rejected). On **exempt** the PR opens from that exact already-pushed commit with **zero implement re-run** (the agent invoker runs exactly once); on **fail** it falls through to today's category-B. Exemptions surface to audit + the implement-review gate_evidence channel (#1153). Supersedes #1229's one-re-run recovery for the missing-declared-scope-file class specifically.

Closes #1231.

## Test plan

- `go build ./...` + `go vet` clean across backend, runner, cli on the merged tree.
- Backend `internal/run` transition tests (new `awaiting_scope_decision` state + park/exempt/fail transitions), `cmd/fishhawk-mcp` (new verb + next_actions arm + tool-count) pass.
- Runner `cmd/fishhawk-runner`, `internal/gitops`, `internal/upload` (park emission + zero-re-run resolution + wire struct) pass.
- New `backend/internal/integration/orchestrator/e2e_test.go` asserts: a verify-green tree dropping a declared scope file parks at `awaiting_scope_decision`; an exempt decision opens the PR from the held commit with the agent invoker called EXACTLY ONCE and opened-PR head SHA == held commit SHA; a fail decision yields category-B. (Container-backed; runs in CI.)
- Migration 0035 down-safety pinned in `backend/internal/postgres/postgres_test.go`.

## Notes

Decomposed E24-pipeline run `026addb2` (3 dependency-ordered slices: backend substrate / runner / MCP+e2e). All three children dispatched concurrently in isolated worktrees and succeeded — validating the #1237 (run_children local dispatch) and #1144 (per-slice worktree verify) fixes. **The automatic fan-in could not complete** due to a consolidated-branch-naming D/F ref conflict (`fishhawk/run-<parent>` collides with the existing `fishhawk/run-<parent>/slice-N` refs → GitHub 422); filed separately. This PR is the manual consolidation of the three verified slice branches (file-disjoint, clean merge, full build+vet+unit-tests green).