### PR TITLE
Planner-recommended implement model — slices 0+1 (data contracts + resolution spine)

### DIFF
--- a/backend/cmd/fishhawkd/serve.go
+++ b/backend/cmd/fishhawkd/serve.go
@@ -436,6 +436,18 @@ func runServe(args []string, logSink io.Writer) int {
 			"single run (E24.6 / #1146). The per-workflow decomposition.max_parallel knob overrides "+
 			"it when set. 0 (the default) = unlimited. This resolves and surfaces the cap; concurrency "+
 			"enforcement that consumes it lands in E24.3 (#1143)")
+	implementModelDefault := fs.String("implement-model-default",
+		envOr("FISHHAWKD_IMPLEMENT_MODEL_DEFAULT", ""),
+		"deployment default implement model — the lowest rung of the implement-model resolution "+
+			"ladder (#1013). Empty (the default) means no deployment default: with no spec executor.model, "+
+			"no plan model_recommendation, and no operator override, the resolved model is empty and the "+
+			"runner spawns the implement agent on the adapter's built-in default exactly as today")
+	implementAllowedModels := fs.String("implement-allowed-models",
+		envOr("FISHHAWKD_IMPLEMENT_ALLOWED_MODELS", ""),
+		"per-adapter allowed-model policy the approval gate validates the RESOLVED implement model "+
+			"against (#1013). Format: `adapter=model1,model2;adapter2=model3`, e.g. "+
+			"`claudecode=claude-opus-4-8,claude-sonnet-4-6;codex=gpt-5.5`. Empty (the default) or an "+
+			"adapter with no configured set fails OPEN — any model accepted, byte-identical to today")
 	budgetTimezone := fs.String("budget-timezone",
 		envOr("FISHHAWKD_BUDGET_TIMEZONE", "UTC"),
 		"IANA timezone (e.g. America/New_York) the advisory periodic-budget evaluator (#688) "+
@@ -478,7 +490,7 @@ func runServe(args []string, logSink io.Writer) int {
 		slog.Duration("cap", reviewBudget.Cap),
 		slog.String("ref", "#747"))
 
-	cfg := server.Config{Addr: *addr, StartNonce: *startNonce, Logger: logger, ExternalURL: *externalURL, SpendAlertMultiple: *spendAlertMultiple, BudgetLocation: budgetLocation, ReviewBudget: reviewBudget, MaxParallelChildren: *maxParallelChildren}
+	cfg := server.Config{Addr: *addr, StartNonce: *startNonce, Logger: logger, ExternalURL: *externalURL, SpendAlertMultiple: *spendAlertMultiple, BudgetLocation: budgetLocation, ReviewBudget: reviewBudget, MaxParallelChildren: *maxParallelChildren, ImplementModelDefault: *implementModelDefault, ImplementAllowedModels: server.ParseAllowedModels(*implementAllowedModels)}
 
 	// Plan-review agent wiring. Resolved by a pure helper so the selection seam
 	// (which adapters the flags configure) is unit-testable without booting a

--- a/backend/cmd/fishhawkd/serve_test.go
+++ b/backend/cmd/fishhawkd/serve_test.go
@@ -28,6 +28,65 @@ func resolveMaxParallelChildren(t *testing.T, args []string) int {
 	return *v
 }
 
+// resolveImplementModelConfig mirrors runServe's --implement-model-default and
+// --implement-allowed-models flag wiring (#1013) so the env > flag resolution
+// and the ParseAllowedModels handoff are unit-testable without booting the
+// server. Same shape as the live fs.String(... envOr(...) ...) calls.
+func resolveImplementModelConfig(t *testing.T, args []string) (string, server.AllowedModels) {
+	t.Helper()
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	deflt := fs.String("implement-model-default",
+		envOr("FISHHAWKD_IMPLEMENT_MODEL_DEFAULT", ""), "test")
+	allowed := fs.String("implement-allowed-models",
+		envOr("FISHHAWKD_IMPLEMENT_ALLOWED_MODELS", ""), "test")
+	if err := fs.Parse(args); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	return *deflt, server.ParseAllowedModels(*allowed)
+}
+
+// TestResolveImplementModelConfig covers the implement-model deployment config
+// resolution (#1013): the default model env/flag and the per-adapter
+// allowed-model policy parse, plus the empty/fail-open default.
+func TestResolveImplementModelConfig(t *testing.T) {
+	t.Run("unset yields empty default and fail-open policy", func(t *testing.T) {
+		t.Setenv("FISHHAWKD_IMPLEMENT_MODEL_DEFAULT", "")
+		t.Setenv("FISHHAWKD_IMPLEMENT_ALLOWED_MODELS", "")
+		deflt, policy := resolveImplementModelConfig(t, nil)
+		if deflt != "" {
+			t.Errorf("default = %q, want empty", deflt)
+		}
+		if !policy.IsAllowed("claudecode", "anything") {
+			t.Error("empty policy must fail open")
+		}
+	})
+	t.Run("env values parse into default and policy", func(t *testing.T) {
+		t.Setenv("FISHHAWKD_IMPLEMENT_MODEL_DEFAULT", "claude-sonnet-4-6")
+		t.Setenv("FISHHAWKD_IMPLEMENT_ALLOWED_MODELS", "claudecode=claude-opus-4-8;codex=gpt-5.5")
+		deflt, policy := resolveImplementModelConfig(t, nil)
+		if deflt != "claude-sonnet-4-6" {
+			t.Errorf("default = %q, want claude-sonnet-4-6", deflt)
+		}
+		if !policy.IsAllowed("claudecode", "claude-opus-4-8") {
+			t.Error("claudecode opus should be allowed")
+		}
+		if policy.IsAllowed("claudecode", "gpt-5.5") {
+			t.Error("claudecode should reject a codex-only model")
+		}
+		if !policy.IsAllowed("codex", "gpt-5.5") {
+			t.Error("codex gpt-5.5 should be allowed")
+		}
+	})
+	t.Run("flag arg wins over env for the default", func(t *testing.T) {
+		t.Setenv("FISHHAWKD_IMPLEMENT_MODEL_DEFAULT", "claude-sonnet-4-6")
+		deflt, _ := resolveImplementModelConfig(t, []string{"--implement-model-default", "claude-opus-4-8"})
+		if deflt != "claude-opus-4-8" {
+			t.Errorf("default = %q, want claude-opus-4-8 (flag wins)", deflt)
+		}
+	})
+}
+
 // TestResolveMaxParallelChildren covers the FISHHAWKD_MAX_PARALLEL_CHILDREN
 // resolution branches: the default applies when unset, the env value wins
 // over the default, an explicit env 0 is honored as the unlimited semantic

--- a/backend/internal/plan/plan.go
+++ b/backend/internal/plan/plan.go
@@ -35,7 +35,39 @@ type Plan struct {
 	PredictedRuntimeMinutes    int               `json:"predicted_runtime_minutes"`
 	PredictedRuntimeConfidence RuntimeConfidence `json:"predicted_runtime_confidence"`
 	Decomposition              *Decomposition    `json:"decomposition,omitempty"`
+	// ModelRecommendation is the agent's optional complexity-informed
+	// recommendation for which model executes the implement stage (#1013).
+	// Advisory: the operator ratifies or overrides it at the plan gate, and
+	// the resolved model is validated against the deployment's per-adapter
+	// allowed-model set. Nil means no recommendation — the implement-model
+	// resolver falls through to the spec executor.model, then the
+	// deployment default.
+	ModelRecommendation *ModelRecommendation `json:"model_recommendation,omitempty"`
 }
+
+// ModelRecommendation is the agent's optional recommendation for the
+// implement-stage model, keyed to its complexity assessment (#1013). It
+// is one rung of the implement-model resolution ladder (deployment
+// default < spec executor.model < plan model_recommendation < operator
+// gate decision); the operator ratifies or overrides it at the approval
+// gate. JSON tags mirror the model-recommendation $def in the schema.
+type ModelRecommendation struct {
+	ImplementModel     string     `json:"implement_model"`
+	Rationale          string     `json:"rationale"`
+	ComplexityAssessed Complexity `json:"complexity_assessed"`
+}
+
+// Complexity is the agent's assessment of a change's complexity, drawn
+// from a closed set. It informs the model recommendation and is stamped
+// onto calibration history.
+type Complexity string
+
+// Complexity levels per the schema.
+const (
+	ComplexityLow    Complexity = "low"
+	ComplexityMedium Complexity = "medium"
+	ComplexityHigh   Complexity = "high"
+)
 
 // KindClarificationRequest is the top-level discriminator value carried
 // by a clarification_request artifact. A plan artifact has no "kind"
@@ -99,6 +131,11 @@ type SubPlanSummary struct {
 	Scope                      *Scope            `json:"scope,omitempty"`
 	PredictedRuntimeMinutes    int               `json:"predicted_runtime_minutes"`
 	PredictedRuntimeConfidence RuntimeConfidence `json:"predicted_runtime_confidence"`
+	// ModelRecommendation is this sub-plan's optional per-child model
+	// recommendation (#1013). When set, the decomposition child minted for
+	// this sub-plan resolves it through the same chokepoint as a top-level
+	// recommendation. Nil means the child has no per-slice recommendation.
+	ModelRecommendation *ModelRecommendation `json:"model_recommendation,omitempty"`
 }
 
 // Decomposition holds the rationale and sub-plan summaries when

--- a/backend/internal/plan/plan_test.go
+++ b/backend/internal/plan/plan_test.go
@@ -409,6 +409,130 @@ func TestParse_SubPlanWithoutScope_StillValidates(t *testing.T) {
 	}
 }
 
+// --- model_recommendation (#1013) ---
+
+// TestParse_ModelRecommendation_RoundTrips covers the additive top-level
+// model_recommendation: a plan carrying it validates and decodes all three
+// fields into the typed Plan.ModelRecommendation.
+func TestParse_ModelRecommendation_RoundTrips(t *testing.T) {
+	m := planfixture.Valid(func(m map[string]any) {
+		m["model_recommendation"] = map[string]any{
+			"implement_model":     "claude-opus-4-8",
+			"rationale":           "cross-layer change with non-trivial seams",
+			"complexity_assessed": "high",
+		}
+	})
+	p, err := plan.Parse(marshalFixture(t, m))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if p.ModelRecommendation == nil {
+		t.Fatal("ModelRecommendation should be non-nil")
+	}
+	if got, want := p.ModelRecommendation.ImplementModel, "claude-opus-4-8"; got != want {
+		t.Errorf("ImplementModel = %q, want %q", got, want)
+	}
+	if got, want := p.ModelRecommendation.Rationale, "cross-layer change with non-trivial seams"; got != want {
+		t.Errorf("Rationale = %q, want %q", got, want)
+	}
+	if got, want := p.ModelRecommendation.ComplexityAssessed, plan.ComplexityHigh; got != want {
+		t.Errorf("ComplexityAssessed = %q, want %q", got, want)
+	}
+}
+
+// TestParse_WithoutModelRecommendation_StillValidates confirms the field is
+// additive-optional: the minimal valid plan (no recommendation) parses and the
+// typed field is nil. Failure here would indicate an accidental required
+// promotion.
+func TestParse_WithoutModelRecommendation_StillValidates(t *testing.T) {
+	p, err := plan.Parse(marshalFixture(t, planfixture.Valid()))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if p.ModelRecommendation != nil {
+		t.Errorf("ModelRecommendation = %+v, want nil (field omitted)", p.ModelRecommendation)
+	}
+}
+
+// TestParse_SubPlanModelRecommendation_RoundTrips covers the per-child
+// recommendation: a sub-plan carrying model_recommendation decodes into the
+// typed SubPlanSummary.ModelRecommendation, while a sibling without it decodes
+// to nil (additive-optional, per-slice).
+func TestParse_SubPlanModelRecommendation_RoundTrips(t *testing.T) {
+	m := planfixture.Valid(func(m map[string]any) {
+		m["decomposition"] = map[string]any{
+			"rationale": "split by layer",
+			"sub_plans": []any{
+				map[string]any{
+					"title": "Part A", "scope_hint": "first slice",
+					"predicted_runtime_minutes": 10, "predicted_runtime_confidence": "high",
+					"model_recommendation": map[string]any{
+						"implement_model":     "claude-sonnet-4-6",
+						"rationale":           "mechanical slice",
+						"complexity_assessed": "low",
+					},
+				},
+				map[string]any{
+					"title": "Part B", "scope_hint": "second slice",
+					"predicted_runtime_minutes": 15, "predicted_runtime_confidence": "medium",
+				},
+			},
+		}
+	})
+	p, err := plan.Parse(marshalFixture(t, m))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	subs := p.Decomposition.SubPlans
+	if subs[0].ModelRecommendation == nil {
+		t.Fatal("sub_plans[0].ModelRecommendation should be non-nil")
+	}
+	if got, want := subs[0].ModelRecommendation.ImplementModel, "claude-sonnet-4-6"; got != want {
+		t.Errorf("sub_plans[0].ModelRecommendation.ImplementModel = %q, want %q", got, want)
+	}
+	if got, want := subs[0].ModelRecommendation.ComplexityAssessed, plan.ComplexityLow; got != want {
+		t.Errorf("sub_plans[0].ModelRecommendation.ComplexityAssessed = %q, want %q", got, want)
+	}
+	if subs[1].ModelRecommendation != nil {
+		t.Errorf("sub_plans[1].ModelRecommendation = %+v, want nil (field omitted)", subs[1].ModelRecommendation)
+	}
+}
+
+// TestParse_ModelRecommendation_BadComplexity_IsSchemaError locks the closed
+// complexity_assessed enum: an out-of-set value is rejected structurally.
+func TestParse_ModelRecommendation_BadComplexity_IsSchemaError(t *testing.T) {
+	m := planfixture.Valid(func(m map[string]any) {
+		m["model_recommendation"] = map[string]any{
+			"implement_model":     "claude-opus-4-8",
+			"rationale":           "x",
+			"complexity_assessed": "extreme",
+		}
+	})
+	_, err := plan.Parse(marshalFixture(t, m))
+	var se *plan.SchemaError
+	if !errors.As(err, &se) {
+		t.Fatalf("err = %v, want *SchemaError", err)
+	}
+}
+
+// TestParse_ModelRecommendation_MissingImplementModel_IsSchemaError confirms
+// the three fields are required WHEN the object is present (additive at the
+// top level, complete within): a recommendation without its load-bearing
+// implement_model is rejected.
+func TestParse_ModelRecommendation_MissingImplementModel_IsSchemaError(t *testing.T) {
+	m := planfixture.Valid(func(m map[string]any) {
+		m["model_recommendation"] = map[string]any{
+			"rationale":           "x",
+			"complexity_assessed": "low",
+		}
+	})
+	_, err := plan.Parse(marshalFixture(t, m))
+	var se *plan.SchemaError
+	if !errors.As(err, &se) {
+		t.Fatalf("err = %v, want *SchemaError", err)
+	}
+}
+
 // --- decomposition semantic errors ---
 
 func TestParse_DecompositionDuplicateTitles_IsSemanticError(t *testing.T) {
@@ -831,13 +955,16 @@ func TestValidateClarificationRequest_SchemaViolations(t *testing.T) {
 	}
 }
 
-// TestPlanSchemaFrozen locks the parent-plan invariant: slice 1 must NOT
-// mutate the frozen plan-standard-v1 schema. The embedded copy's sha256 is
-// pinned; any byte change (here or via a drifted docs/spec sync) fails this
-// test deliberately. A standard_v1 plan must also still validate unchanged
-// through the plan-only Validate entry point.
+// TestPlanSchemaFrozen pins the embedded plan-standard-v1 schema's sha256
+// as a drift guard: any byte change (an unintended edit, or a docs/spec
+// sync that did not land in the embedded copy) fails this test deliberately.
+// The hash is re-pinned only for a sanctioned additive-optional change within
+// standard_v1.x — most recently the #1013 model_recommendation field. A
+// standard_v1 plan that omits the new optional fields must still validate
+// unchanged through the plan-only Validate entry point (asserted below),
+// which is the proof the change did not break the schema in place.
 func TestPlanSchemaFrozen(t *testing.T) {
-	const wantHash = "56f840126fde20d8051a9551af9d2528d7d7c32e4f5b6de4ba7216486d0aa555"
+	const wantHash = "38b5362c45f4a84189500edecfea3e0616a3dd7b2468cb42acacd6da8c678933"
 	b, err := os.ReadFile("schemas/plan-standard-v1.schema.json")
 	if err != nil {
 		t.Fatalf("read embedded plan schema: %v", err)

--- a/backend/internal/plan/schemas/plan-standard-v1.schema.json
+++ b/backend/internal/plan/schemas/plan-standard-v1.schema.json
@@ -72,7 +72,8 @@
           "description": "Ordered list of sub-plans. At least two required when decomposition is present."
         }
       }
-    }
+    },
+    "model_recommendation": { "$ref": "#/$defs/model-recommendation" }
   },
 
   "$defs": {
@@ -232,6 +233,34 @@
           "type": "string",
           "enum": ["low", "medium", "high"],
           "description": "Agent's confidence in this sub-plan's predicted_runtime_minutes."
+        },
+        "model_recommendation": {
+          "$ref": "#/$defs/model-recommendation",
+          "description": "Optional. The model recommendation for THIS sub-plan's decomposition child. Resolved through the same chokepoint as the top-level model_recommendation, so a decomposed child ratifies its own slice's recommendation at its plan gate. Omitted means the child has no per-slice recommendation."
+        }
+      }
+    },
+
+    "model-recommendation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["implement_model", "rationale", "complexity_assessed"],
+      "description": "Optional. The agent's complexity-informed recommendation for which model should execute the implement stage (#1013). Advisory: the operator ratifies or overrides it at the plan-approval gate, and the resolved model is validated against the deployment's per-adapter allowed-model set. Omitted means no recommendation — the implement-model resolver falls through to the workflow spec's executor.model, then the deployment default.",
+      "properties": {
+        "implement_model": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Model identifier the agent recommends for the implement stage (e.g. claude-opus-4-8). Routed to the runner adapter as the model override when this rung wins the resolution ladder (deployment default < spec executor.model < plan model_recommendation < operator gate decision)."
+        },
+        "rationale": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Why this model fits the assessed complexity. Rendered alongside the recommendation in the plan-review surface."
+        },
+        "complexity_assessed": {
+          "type": "string",
+          "enum": ["low", "medium", "high"],
+          "description": "The agent's assessment of the change's complexity, informing the recommendation. Stamped onto calibration history so per-model-per-complexity outcomes accumulate."
         }
       }
     }

--- a/backend/internal/server/modelpolicy.go
+++ b/backend/internal/server/modelpolicy.go
@@ -1,0 +1,368 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"sort"
+	"strings"
+
+	"github.com/google/uuid"
+	"gopkg.in/yaml.v3"
+
+	"github.com/kuhlman-labs/fishhawk/backend/internal/artifact"
+	"github.com/kuhlman-labs/fishhawk/backend/internal/run"
+)
+
+// ModelSource names which rung of the implement-model resolution ladder
+// supplied the resolved model. It is carried alongside the resolved value
+// (ResolvedModel) so calibration history can attribute a runtime observation
+// to the rung that chose the model — operator overrides vs planner
+// recommendations vs the deployment default.
+type ModelSource string
+
+// The implement-model ladder rungs, lowest precedence to highest. ModelSourceNone
+// is the sentinel for an all-empty ladder: no rung supplied a model, so the
+// runner spawns the implement agent on the adapter's built-in default exactly as
+// today (no --model argument).
+const (
+	ModelSourceNone     ModelSource = ""
+	ModelSourceDefault  ModelSource = "default"
+	ModelSourceSpec     ModelSource = "spec"
+	ModelSourcePlan     ModelSource = "plan"
+	ModelSourceOperator ModelSource = "operator"
+)
+
+// ResolvedModel is the source-tagged outcome of the implement-model ladder.
+// Value is the resolved model id (empty == "use the adapter default spawn",
+// today's behavior); Source names the winning rung.
+type ResolvedModel struct {
+	Value  string      `json:"model"`
+	Source ModelSource `json:"model_source"`
+}
+
+// resolveImplementModel applies the 4-rung implement-model ladder, lowest to
+// highest precedence:
+//
+//	deployment default  <  spec.executor.model  <  plan.model_recommendation.implement_model  <  operator gate decision
+//
+// The highest non-empty rung wins and its name is returned as the source. An
+// all-empty ladder returns {Value: "", Source: ModelSourceNone}: the caller
+// then carries no model, and the runner spawns the implement agent identically
+// to today (byte-for-byte, no --model argument). The function is pure — it does
+// no IO and is the single chokepoint both the prompt/calibration paths (this
+// slice) and the approval gate (the operator-gate slice) resolve through, so a
+// child run resolves its sub_plan recommendation the same way a top-level run
+// resolves its plan recommendation.
+func resolveImplementModel(deflt, spec, plan, operator string) ResolvedModel {
+	switch {
+	case operator != "":
+		return ResolvedModel{Value: operator, Source: ModelSourceOperator}
+	case plan != "":
+		return ResolvedModel{Value: plan, Source: ModelSourcePlan}
+	case spec != "":
+		return ResolvedModel{Value: spec, Source: ModelSourceSpec}
+	case deflt != "":
+		return ResolvedModel{Value: deflt, Source: ModelSourceDefault}
+	default:
+		return ResolvedModel{Value: "", Source: ModelSourceNone}
+	}
+}
+
+// AllowedModels is the per-adapter allowed-model policy sourced from deployment
+// config (ParseAllowedModels). It maps an adapter name (claudecode | codex |
+// anthropic) to the set of model ids the operator permits for that adapter.
+//
+// An adapter with no configured set — or an empty whole policy — FAILS OPEN:
+// IsAllowed returns true for any model, byte-identical to today's behavior
+// where no allow-list exists. The allow-list only ever tightens, never widens,
+// once configured.
+type AllowedModels map[string]map[string]bool
+
+// IsAllowed reports whether model is permitted for adapter under this policy.
+// It fails OPEN — returns true — when:
+//   - model is empty (the resolved value is empty == today's default spawn),
+//   - the adapter has no configured allow-set, or
+//   - the adapter's allow-set is empty.
+//
+// Only a non-empty allow-set that omits the model rejects it. This is the
+// gate-time validation primitive the approval slice calls against the RESOLVED
+// model regardless of which rung supplied it.
+func (a AllowedModels) IsAllowed(adapter, model string) bool {
+	if model == "" {
+		return true
+	}
+	set, ok := a[adapter]
+	if !ok || len(set) == 0 {
+		return true
+	}
+	return set[model]
+}
+
+// ParseAllowedModels parses the per-adapter allowed-model deployment config.
+// The format is a semicolon-separated list of `adapter=model1,model2` groups:
+//
+//	claudecode=claude-opus-4-8,claude-sonnet-4-6;codex=gpt-5.5
+//
+// Whitespace around adapters and models is trimmed; empty groups and empty
+// model entries are skipped. An empty/blank input yields an empty policy, which
+// fails open for every adapter (today's behavior). Parsing never errors —
+// malformed groups (no '=' or an empty adapter) are skipped so a typo degrades
+// to fail-open rather than failing the boot.
+func ParseAllowedModels(raw string) AllowedModels {
+	out := AllowedModels{}
+	for _, group := range strings.Split(raw, ";") {
+		group = strings.TrimSpace(group)
+		if group == "" {
+			continue
+		}
+		eq := strings.IndexByte(group, '=')
+		if eq <= 0 {
+			continue
+		}
+		adapter := strings.TrimSpace(group[:eq])
+		if adapter == "" {
+			continue
+		}
+		set := out[adapter]
+		if set == nil {
+			set = map[string]bool{}
+		}
+		for _, m := range strings.Split(group[eq+1:], ",") {
+			m = strings.TrimSpace(m)
+			if m == "" {
+				continue
+			}
+			set[m] = true
+		}
+		if len(set) > 0 {
+			out[adapter] = set
+		}
+	}
+	if len(out) == 0 {
+		return AllowedModels{}
+	}
+	return out
+}
+
+// resolveImplementModelForRun resolves the implement-model ladder for a run
+// through the pure resolveImplementModel chokepoint, reading each rung without
+// a static dependency on the schema/struct slice that owns the plan
+// model_recommendation and spec executor.model fields (those live in a sibling
+// decomposition slice). Rungs are read defensively from the data the run
+// already carries:
+//
+//   - default:  the deployment-configured default implement model (cfg).
+//   - spec:     executor.model on the run's workflow spec implement stage,
+//     read from the raw spec bytes (specImplementExecutorModel).
+//   - plan:     model_recommendation.implement_model on the run's approved
+//     standard_v1 plan artifact, read from the raw artifact bytes
+//     (planImplementModelRecommendation).
+//   - operator: the approval gate's persisted resolution. When the gate has
+//     recorded a model_resolved audit entry (the operator-gate slice), its
+//     source-tagged value is authoritative and returned verbatim — the gate
+//     already evaluated the full ladder including any operator override.
+//
+// When no gate resolution exists yet (pre-approval, or a deployment without the
+// gate writer), the function falls back to resolving {default, spec, plan} with
+// an empty operator rung. An empty result (ModelSourceNone) means today's spawn.
+func (s *Server) resolveImplementModelForRun(ctx context.Context, runRow *run.Run) ResolvedModel {
+	if rm, ok := s.gateResolvedModel(ctx, runRow.ID); ok {
+		return rm
+	}
+	deflt := s.cfg.ImplementModelDefault
+	specModel := specImplementExecutorModel(runRow.WorkflowSpec, runRow.WorkflowID)
+	planModel := s.planImplementModelRecommendation(ctx, runRow.ID)
+	return resolveImplementModel(deflt, specModel, planModel, "")
+}
+
+// resolvedImplementModelForRunID is the by-id convenience over
+// resolveImplementModelForRun used by the calibration-stamp path (trace.go),
+// which holds a run id rather than the loaded run. Loads the run and resolves;
+// returns the empty ResolvedModel (ModelSourceNone) when the RunRepo is
+// unconfigured or the load fails, so a stamp degrades to "default spawn" rather
+// than unwinding the best-effort trace handler.
+func (s *Server) resolvedImplementModelForRunID(ctx context.Context, runID uuid.UUID) ResolvedModel {
+	if s.cfg.RunRepo == nil {
+		return ResolvedModel{Source: ModelSourceNone}
+	}
+	runRow, err := s.cfg.RunRepo.GetRun(ctx, runID)
+	if err != nil {
+		return ResolvedModel{Source: ModelSourceNone}
+	}
+	return s.resolveImplementModelForRun(ctx, runRow)
+}
+
+// gateResolvedModel returns the most-recent model_resolved audit entry's
+// source-tagged resolution for the run, if any. The model_resolved kind is
+// emitted ONLY by the approval gate (the operator-gate slice) — this slice
+// never emits it, keeping its surface sweep clean — so reading it here is the
+// read-only bridge that carries the gate's authoritative resolution (including
+// an operator override) into the prompt and calibration paths. Returns
+// ok=false when the AuditRepo is unconfigured, the lookup fails, or no
+// model_resolved entry exists for the run, so the caller falls back to the
+// visible-rung computation.
+//
+// WIRE CONTRACT: the model_resolved payload MUST carry the {model, model_source}
+// keys (ResolvedModel's json tags). The gate writer (sibling slice) emits that
+// shape; a drift degrades this read to ok=false (fall back), never a panic.
+func (s *Server) gateResolvedModel(ctx context.Context, runID uuid.UUID) (ResolvedModel, bool) {
+	if s.cfg.AuditRepo == nil {
+		return ResolvedModel{}, false
+	}
+	entries, err := s.cfg.AuditRepo.ListForRunByCategory(ctx, runID, "model_resolved")
+	if err != nil || len(entries) == 0 {
+		return ResolvedModel{}, false
+	}
+	// Newest wins: ListForRunByCategory returns ascending by sequence, so sort
+	// by the monotonic Sequence descending defensively rather than assume an
+	// order.
+	sort.SliceStable(entries, func(i, j int) bool {
+		return entries[i].Sequence > entries[j].Sequence
+	})
+	var rm ResolvedModel
+	if err := json.Unmarshal(entries[0].Payload, &rm); err != nil {
+		return ResolvedModel{}, false
+	}
+	if rm.Value == "" {
+		// A recorded empty resolution is a valid "use the default spawn"
+		// decision; surface it so the caller does not re-derive a non-empty
+		// rung the gate deliberately left empty.
+		return ResolvedModel{Value: "", Source: ModelSourceNone}, true
+	}
+	return rm, true
+}
+
+// planImplementModelRecommendation reads model_recommendation.implement_model
+// from the run's most-recent approved standard_v1 plan artifact. It decodes the
+// raw artifact bytes into a local probe struct so this slice carries no static
+// dependency on the plan struct field (owned by a sibling schema slice). Returns
+// "" when the AuditRepo/ArtifactRepo are unconfigured, no plan artifact exists,
+// the decode fails, or the field is absent — every path degrades to "no plan
+// recommendation".
+func (s *Server) planImplementModelRecommendation(ctx context.Context, runID uuid.UUID) string {
+	if s.cfg.ArtifactRepo == nil || s.cfg.RunRepo == nil {
+		return ""
+	}
+	content := s.latestPlanArtifactContent(ctx, runID)
+	if len(content) == 0 {
+		return ""
+	}
+	return planModelRecommendationFromBytes(content)
+}
+
+// latestPlanArtifactContent returns the raw bytes of the run's most-recent
+// kind=plan, schema_version=standard_v1 artifact, or nil. It mirrors
+// tryLoadPlanForRun's selection but returns bytes (not a decoded *plan.Plan) so
+// the model_recommendation can be read without the sibling-owned struct field.
+func (s *Server) latestPlanArtifactContent(ctx context.Context, runID uuid.UUID) []byte {
+	stages, err := s.cfg.RunRepo.ListStagesForRun(ctx, runID)
+	if err != nil {
+		return nil
+	}
+	var planStageID uuid.UUID
+	for _, st := range stages {
+		if st.Type == run.StageTypePlan {
+			planStageID = st.ID
+			break
+		}
+	}
+	if planStageID == uuid.Nil {
+		return nil
+	}
+	arts, err := s.cfg.ArtifactRepo.ListForStage(ctx, planStageID)
+	if err != nil {
+		return nil
+	}
+	var picked *artifact.Artifact
+	for _, a := range arts {
+		if a.Kind != artifact.KindPlan {
+			continue
+		}
+		if a.SchemaVersion == nil || *a.SchemaVersion != "standard_v1" {
+			continue
+		}
+		if picked == nil || a.CreatedAt.After(picked.CreatedAt) {
+			picked = a
+		}
+	}
+	if picked == nil {
+		return nil
+	}
+	return picked.Content
+}
+
+// planModelRecommendationFromBytes decodes model_recommendation.implement_model
+// from standard_v1 plan artifact JSON via a local probe, returning "" when the
+// JSON is malformed or the field is absent. Kept pure (bytes in, string out) so
+// it is unit-testable and free of any sibling-slice struct dependency.
+func planModelRecommendationFromBytes(content []byte) string {
+	var probe struct {
+		ModelRecommendation *struct {
+			ImplementModel string `json:"implement_model"`
+		} `json:"model_recommendation"`
+	}
+	if err := json.Unmarshal(content, &probe); err != nil {
+		return ""
+	}
+	if probe.ModelRecommendation == nil {
+		return ""
+	}
+	return strings.TrimSpace(probe.ModelRecommendation.ImplementModel)
+}
+
+// specImplementExecutorModel reads executor.model on the implement stage of the
+// given workflow from raw workflow-spec bytes via a local YAML probe, returning
+// "" when the spec is empty, malformed, or declares no executor.model. Decoding
+// from bytes (rather than the parsed spec.Stage) keeps this slice free of a
+// static dependency on the spec.Executor.Model field (owned by a sibling schema
+// slice). The probe mirrors resolveVerifyConfig's stage lookup: prefer a stage
+// whose id == "implement", else the first stage whose type == "implement".
+func specImplementExecutorModel(specBytes []byte, workflowID string) string {
+	if len(specBytes) == 0 {
+		return ""
+	}
+	var probe struct {
+		Workflows map[string]struct {
+			Stages []struct {
+				ID       string `yaml:"id"`
+				Type     string `yaml:"type"`
+				Executor struct {
+					Model string `yaml:"model"`
+				} `yaml:"executor"`
+			} `yaml:"stages"`
+		} `yaml:"workflows"`
+	}
+	if err := yaml.Unmarshal(specBytes, &probe); err != nil {
+		return ""
+	}
+	wf, ok := probe.Workflows[workflowID]
+	if !ok {
+		return ""
+	}
+	for _, st := range wf.Stages {
+		if st.ID == "implement" {
+			return strings.TrimSpace(st.Executor.Model)
+		}
+	}
+	for _, st := range wf.Stages {
+		if st.Type == "implement" {
+			return strings.TrimSpace(st.Executor.Model)
+		}
+	}
+	return ""
+}
+
+// logModelResolution emits a debug line when a non-default model is resolved,
+// aiding operator visibility without a new audit surface. Best-effort, no-op on
+// a nil logger.
+func (s *Server) logModelResolution(ctx context.Context, runID uuid.UUID, rm ResolvedModel) {
+	if s.cfg.Logger == nil || rm.Value == "" {
+		return
+	}
+	s.cfg.Logger.LogAttrs(ctx, slog.LevelDebug, "server: resolved implement model",
+		slog.String("run_id", runID.String()),
+		slog.String("model", rm.Value),
+		slog.String("model_source", string(rm.Source)),
+	)
+}

--- a/backend/internal/server/modelpolicy_test.go
+++ b/backend/internal/server/modelpolicy_test.go
@@ -1,0 +1,341 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/kuhlman-labs/fishhawk/backend/internal/audit"
+)
+
+// gateAuditFake returns canned model_resolved entries (or an error) so the
+// gateResolvedModel defensive branches are unit-testable.
+type gateAuditFake struct {
+	audit.BaseFake
+	entries []*audit.Entry
+	err     error
+}
+
+func (f *gateAuditFake) ListForRunByCategory(_ context.Context, _ uuid.UUID, category string) ([]*audit.Entry, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	if category != "model_resolved" {
+		return nil, nil
+	}
+	return f.entries, nil
+}
+
+func entry(seq int64, payload string) *audit.Entry {
+	return &audit.Entry{Sequence: seq, Payload: []byte(payload)}
+}
+
+func TestGateResolvedModel(t *testing.T) {
+	ctx := context.Background()
+	runID := uuid.New()
+
+	t.Run("nil AuditRepo returns not-ok", func(t *testing.T) {
+		s := New(Config{})
+		if _, ok := s.gateResolvedModel(ctx, runID); ok {
+			t.Fatal("expected not-ok with a nil AuditRepo")
+		}
+	})
+	t.Run("list error returns not-ok", func(t *testing.T) {
+		s := New(Config{AuditRepo: &gateAuditFake{err: errors.New("boom")}})
+		if _, ok := s.gateResolvedModel(ctx, runID); ok {
+			t.Fatal("expected not-ok on a list error")
+		}
+	})
+	t.Run("no entries returns not-ok", func(t *testing.T) {
+		s := New(Config{AuditRepo: &gateAuditFake{}})
+		if _, ok := s.gateResolvedModel(ctx, runID); ok {
+			t.Fatal("expected not-ok with no model_resolved entries")
+		}
+	})
+	t.Run("malformed payload returns not-ok", func(t *testing.T) {
+		s := New(Config{AuditRepo: &gateAuditFake{entries: []*audit.Entry{entry(1, "{not json")}}})
+		if _, ok := s.gateResolvedModel(ctx, runID); ok {
+			t.Fatal("expected not-ok on a malformed payload")
+		}
+	})
+	t.Run("valid entry returns the source-tagged resolution", func(t *testing.T) {
+		s := New(Config{AuditRepo: &gateAuditFake{entries: []*audit.Entry{
+			entry(1, `{"model":"claude-opus-4-8","model_source":"operator"}`),
+		}}})
+		rm, ok := s.gateResolvedModel(ctx, runID)
+		if !ok || rm.Value != "claude-opus-4-8" || rm.Source != ModelSourceOperator {
+			t.Fatalf("got {%q,%q} ok=%v, want {claude-opus-4-8,operator} ok=true", rm.Value, rm.Source, ok)
+		}
+	})
+	t.Run("newest entry by sequence wins", func(t *testing.T) {
+		s := New(Config{AuditRepo: &gateAuditFake{entries: []*audit.Entry{
+			entry(1, `{"model":"old-model","model_source":"plan"}`),
+			entry(5, `{"model":"new-model","model_source":"operator"}`),
+			entry(3, `{"model":"mid-model","model_source":"spec"}`),
+		}}})
+		rm, ok := s.gateResolvedModel(ctx, runID)
+		if !ok || rm.Value != "new-model" || rm.Source != ModelSourceOperator {
+			t.Fatalf("got {%q,%q}, want the highest-sequence {new-model,operator}", rm.Value, rm.Source)
+		}
+	})
+	t.Run("recorded empty resolution returns none/ok (deliberate default spawn)", func(t *testing.T) {
+		s := New(Config{AuditRepo: &gateAuditFake{entries: []*audit.Entry{
+			entry(1, `{"model":"","model_source":""}`),
+		}}})
+		rm, ok := s.gateResolvedModel(ctx, runID)
+		if !ok || rm.Value != "" || rm.Source != ModelSourceNone {
+			t.Fatalf("got {%q,%q} ok=%v, want {\"\",none} ok=true", rm.Value, rm.Source, ok)
+		}
+	})
+}
+
+// TestResolvedImplementModelForRunID_NilRunRepo covers the by-id stamp helper's
+// fail-soft branch: a nil RunRepo yields the empty (none) ResolvedModel rather
+// than panicking the best-effort trace handler.
+func TestResolvedImplementModelForRunID_NilRunRepo(t *testing.T) {
+	s := New(Config{})
+	rm := s.resolvedImplementModelForRunID(context.Background(), uuid.New())
+	if rm.Value != "" || rm.Source != ModelSourceNone {
+		t.Fatalf("got {%q,%q}, want {\"\",none}", rm.Value, rm.Source)
+	}
+}
+
+func TestResolveImplementModel_LadderPrecedence(t *testing.T) {
+	tests := []struct {
+		name                        string
+		deflt, spec, plan, operator string
+		wantValue                   string
+		wantSource                  ModelSource
+	}{
+		{
+			name:  "operator wins over all lower rungs",
+			deflt: "d", spec: "s", plan: "p", operator: "o",
+			wantValue: "o", wantSource: ModelSourceOperator,
+		},
+		{
+			name:  "plan wins when no operator",
+			deflt: "d", spec: "s", plan: "p", operator: "",
+			wantValue: "p", wantSource: ModelSourcePlan,
+		},
+		{
+			name:  "spec wins when no operator or plan",
+			deflt: "d", spec: "s", plan: "", operator: "",
+			wantValue: "s", wantSource: ModelSourceSpec,
+		},
+		{
+			name:  "default wins when it is the only rung",
+			deflt: "d", spec: "", plan: "", operator: "",
+			wantValue: "d", wantSource: ModelSourceDefault,
+		},
+		{
+			name:  "all empty yields none (today's spawn)",
+			deflt: "", spec: "", plan: "", operator: "",
+			wantValue: "", wantSource: ModelSourceNone,
+		},
+		{
+			name:  "higher empty rung skipped, lower non-empty wins",
+			deflt: "d", spec: "", plan: "p", operator: "",
+			wantValue: "p", wantSource: ModelSourcePlan,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveImplementModel(tt.deflt, tt.spec, tt.plan, tt.operator)
+			if got.Value != tt.wantValue || got.Source != tt.wantSource {
+				t.Fatalf("resolveImplementModel(%q,%q,%q,%q) = {%q,%q}, want {%q,%q}",
+					tt.deflt, tt.spec, tt.plan, tt.operator,
+					got.Value, got.Source, tt.wantValue, tt.wantSource)
+			}
+		})
+	}
+}
+
+func TestAllowedModels_IsAllowed(t *testing.T) {
+	policy := AllowedModels{
+		"claudecode": {"claude-opus-4-8": true, "claude-sonnet-4-6": true},
+		"codex":      {"gpt-5.5": true},
+		"empty":      {}, // configured but empty set
+	}
+	tests := []struct {
+		name           string
+		adapter, model string
+		want           bool
+	}{
+		{"empty model always allowed (today's default spawn)", "claudecode", "", true},
+		{"configured model in set is allowed", "claudecode", "claude-opus-4-8", true},
+		{"configured model NOT in set is rejected", "claudecode", "gpt-5.5", false},
+		{"unknown adapter fails open", "anthropic", "anything", true},
+		{"adapter with empty set fails open", "empty", "anything", true},
+		{"codex model in set allowed", "codex", "gpt-5.5", true},
+		{"codex model not in set rejected", "codex", "gpt-4", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := policy.IsAllowed(tt.adapter, tt.model); got != tt.want {
+				t.Fatalf("IsAllowed(%q,%q) = %v, want %v", tt.adapter, tt.model, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAllowedModels_NilPolicyFailsOpen(t *testing.T) {
+	var policy AllowedModels // nil
+	if !policy.IsAllowed("claudecode", "any-model") {
+		t.Fatal("a nil policy must fail open for any model")
+	}
+	if !policy.IsAllowed("claudecode", "") {
+		t.Fatal("a nil policy must allow the empty model")
+	}
+}
+
+func TestParseAllowedModels(t *testing.T) {
+	t.Run("single adapter", func(t *testing.T) {
+		got := ParseAllowedModels("claudecode=claude-opus-4-8,claude-sonnet-4-6")
+		if !got.IsAllowed("claudecode", "claude-opus-4-8") || !got.IsAllowed("claudecode", "claude-sonnet-4-6") {
+			t.Fatalf("expected both models allowed, got %#v", got)
+		}
+		if got.IsAllowed("claudecode", "gpt-5.5") {
+			t.Fatal("a model outside the configured set must be rejected")
+		}
+	})
+	t.Run("multi adapter with whitespace", func(t *testing.T) {
+		got := ParseAllowedModels(" claudecode = claude-opus-4-8 ; codex = gpt-5.5 ")
+		if !got.IsAllowed("claudecode", "claude-opus-4-8") {
+			t.Fatal("trimmed claudecode model should be allowed")
+		}
+		if !got.IsAllowed("codex", "gpt-5.5") {
+			t.Fatal("trimmed codex model should be allowed")
+		}
+	})
+	t.Run("malformed groups skipped, degrade to fail-open", func(t *testing.T) {
+		got := ParseAllowedModels(";=novalueadapter;noequalssign;=;claudecode=claude-opus-4-8")
+		if len(got) != 1 {
+			t.Fatalf("expected only the one well-formed group, got %#v", got)
+		}
+		if !got.IsAllowed("claudecode", "claude-opus-4-8") {
+			t.Fatal("the well-formed group should still parse")
+		}
+		// A skipped/garbage adapter fails open.
+		if !got.IsAllowed("noequalssign", "x") {
+			t.Fatal("an unparsed adapter must fail open")
+		}
+	})
+	t.Run("empty input yields empty fail-open policy", func(t *testing.T) {
+		got := ParseAllowedModels("")
+		if len(got) != 0 {
+			t.Fatalf("empty input must yield an empty policy, got %#v", got)
+		}
+		if !got.IsAllowed("claudecode", "anything") {
+			t.Fatal("an empty policy must fail open")
+		}
+	})
+	t.Run("adapter with no models is dropped", func(t *testing.T) {
+		got := ParseAllowedModels("claudecode=")
+		if len(got) != 0 {
+			t.Fatalf("an adapter with no models must be dropped, got %#v", got)
+		}
+	})
+}
+
+func TestPlanModelRecommendationFromBytes(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "present",
+			content: `{"model_recommendation":{"implement_model":"claude-opus-4-8","rationale":"hard","complexity_assessed":"high"}}`,
+			want:    "claude-opus-4-8",
+		},
+		{
+			name:    "trimmed",
+			content: `{"model_recommendation":{"implement_model":"  claude-opus-4-8  "}}`,
+			want:    "claude-opus-4-8",
+		},
+		{
+			name:    "object present but field absent",
+			content: `{"model_recommendation":{"rationale":"x"}}`,
+			want:    "",
+		},
+		{
+			name:    "no model_recommendation",
+			content: `{"summary":"x"}`,
+			want:    "",
+		},
+		{
+			name:    "malformed json degrades to empty",
+			content: `{not json`,
+			want:    "",
+		},
+		{
+			name:    "empty bytes",
+			content: ``,
+			want:    "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := planModelRecommendationFromBytes([]byte(tt.content)); got != tt.want {
+				t.Fatalf("planModelRecommendationFromBytes() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSpecImplementExecutorModel(t *testing.T) {
+	specByID := []byte(`
+workflows:
+  feature_change:
+    stages:
+      - id: plan
+        type: plan
+        executor:
+          agent: planner
+      - id: implement
+        type: implement
+        executor:
+          agent: claudecode
+          model: claude-opus-4-8
+`)
+	specByType := []byte(`
+workflows:
+  feature_change:
+    stages:
+      - id: impl-stage
+        type: implement
+        executor:
+          model: gpt-5.5
+`)
+	specNoModel := []byte(`
+workflows:
+  feature_change:
+    stages:
+      - id: implement
+        type: implement
+        executor:
+          agent: claudecode
+`)
+	tests := []struct {
+		name       string
+		spec       []byte
+		workflowID string
+		want       string
+	}{
+		{"matched by stage id", specByID, "feature_change", "claude-opus-4-8"},
+		{"matched by stage type when id differs", specByType, "feature_change", "gpt-5.5"},
+		{"implement stage declares no model", specNoModel, "feature_change", ""},
+		{"unknown workflow id", specByID, "nonexistent", ""},
+		{"empty spec bytes", nil, "feature_change", ""},
+		{"malformed yaml degrades to empty", []byte("\t\tnot: [valid"), "feature_change", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := specImplementExecutorModel(tt.spec, tt.workflowID); got != tt.want {
+				t.Fatalf("specImplementExecutorModel() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/backend/internal/server/prompt.go
+++ b/backend/internal/server/prompt.go
@@ -150,6 +150,21 @@ type promptResponse struct {
 	// the same independent-struct-by-tag convention as BindingAssertions (#1171)
 	// and add_scope_files (#824). A tag drift here breaks the runner gate silently.
 	ScopeExemptions []scopeExemption `json:"scope_exemptions,omitempty"`
+	// ImplementModel is the backend-resolved implement model id (#1013),
+	// carried on an implement-stage prompt so the runner pins the agent spawn
+	// to it (`--model <ImplementModel>`). Resolved through the
+	// implement-model ladder (resolveImplementModelForRun): operator gate
+	// decision > plan model_recommendation.implement_model > spec
+	// executor.model > deployment default. EMPTY/omitted (the common case)
+	// means no rung supplied a model, and the runner spawns the agent on the
+	// adapter's built-in default exactly as today, byte-for-byte.
+	//
+	// CROSS-MODULE WIRE CONTRACT: the json tag (`implement_model`) MUST stay
+	// byte-identical to the runner's upload.FetchedPrompt.ImplementModel
+	// decoder (runner/internal/upload/upload.go) — the same independent-struct-
+	// by-tag convention as ScopeExemptions/BindingAssertions. A tag drift here
+	// silently drops the model and the runner falls back to today's spawn.
+	ImplementModel string `json:"implement_model,omitempty"`
 }
 
 // scopeExemption is one operator scope exemption: a DECLARED scope.files path
@@ -852,6 +867,11 @@ func (s *Server) handleGetStagePrompt(w http.ResponseWriter, r *http.Request) {
 			resp.SliceIndex = *runRow.SliceIndex
 		}
 	}
+	if stage.Type == run.StageTypeImplement {
+		rm := s.resolveImplementModelForRun(r.Context(), runRow)
+		resp.ImplementModel = rm.Value
+		s.logModelResolution(r.Context(), runRow.ID, rm)
+	}
 	s.writeJSON(w, r, http.StatusOK, resp)
 }
 
@@ -1117,6 +1137,10 @@ func (s *Server) handleGetStagePromptRender(w http.ResponseWriter, r *http.Reque
 		if runRow.SliceIndex != nil {
 			resp.SliceIndex = *runRow.SliceIndex
 		}
+	}
+	if stage.Type == run.StageTypeImplement {
+		rm := s.resolveImplementModelForRun(r.Context(), runRow)
+		resp.ImplementModel = rm.Value
 	}
 	s.writeJSON(w, r, http.StatusOK, resp)
 }

--- a/backend/internal/server/prompt_test.go
+++ b/backend/internal/server/prompt_test.go
@@ -350,6 +350,94 @@ func TestGetStagePrompt_HappyPath_ImplementWithIssue(t *testing.T) {
 	}
 }
 
+// TestGetStagePrompt_Implement_CarriesResolvedModel asserts the implement-model
+// producer side (#1013): a resolved model (here from the spec executor.model
+// rung) is carried on the prompt response under the byte-identical
+// `implement_model` json tag the runner decoder reads.
+func TestGetStagePrompt_Implement_CarriesResolvedModel(t *testing.T) {
+	s, rr, sf, gh := newPromptServer(t)
+	runID := uuid.New()
+	stageID := uuid.New()
+	priv, _ := sf.issue(t, runID)
+
+	installation := int64(99)
+	triggerRef := "issue:42"
+	rr.runRow = &run.Run{
+		ID:             runID,
+		Repo:           "kuhlman-labs/example",
+		WorkflowID:     "feature_change",
+		TriggerSource:  run.TriggerGitHubIssue,
+		TriggerRef:     &triggerRef,
+		InstallationID: &installation,
+		WorkflowSpec: []byte("workflows:\n" +
+			"  feature_change:\n" +
+			"    stages:\n" +
+			"      - id: implement\n" +
+			"        type: implement\n" +
+			"        executor:\n" +
+			"          agent: claudecode\n" +
+			"          model: claude-opus-4-8\n"),
+	}
+	rr.stage = &run.Stage{ID: stageID, RunID: runID, Type: run.StageTypeImplement}
+	gh.issue = &githubclient.Issue{Number: 42, Title: "Add foo", Body: "b", State: "open"}
+
+	w := promptRequest(t, s, runID, stageID, priv, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200:\n%s", w.Code, w.Body.String())
+	}
+	var resp promptResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.ImplementModel != "claude-opus-4-8" {
+		t.Fatalf("ImplementModel = %q, want claude-opus-4-8", resp.ImplementModel)
+	}
+	// Pin the wire tag byte-identical to the runner decoder.
+	if !contains(w.Body.String(), `"implement_model":"claude-opus-4-8"`) {
+		t.Fatalf("response missing the implement_model json tag:\n%s", w.Body.String())
+	}
+}
+
+// TestGetStagePrompt_Implement_EmptyModelOmitted asserts the byte-identical
+// today's-spawn path (#1013): with no spec executor.model, no plan
+// recommendation, no deployment default and no operator override, the resolved
+// model is empty and the implement_model key is OMITTED from the response.
+func TestGetStagePrompt_Implement_EmptyModelOmitted(t *testing.T) {
+	s, rr, sf, gh := newPromptServer(t)
+	runID := uuid.New()
+	stageID := uuid.New()
+	priv, _ := sf.issue(t, runID)
+
+	installation := int64(99)
+	triggerRef := "issue:42"
+	rr.runRow = &run.Run{
+		ID:             runID,
+		Repo:           "kuhlman-labs/example",
+		WorkflowID:     "feature_change",
+		TriggerSource:  run.TriggerGitHubIssue,
+		TriggerRef:     &triggerRef,
+		InstallationID: &installation,
+		// No WorkflowSpec executor.model, no plan artifact, no default.
+	}
+	rr.stage = &run.Stage{ID: stageID, RunID: runID, Type: run.StageTypeImplement}
+	gh.issue = &githubclient.Issue{Number: 42, Title: "Add foo", Body: "b", State: "open"}
+
+	w := promptRequest(t, s, runID, stageID, priv, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200:\n%s", w.Code, w.Body.String())
+	}
+	var resp promptResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.ImplementModel != "" {
+		t.Fatalf("ImplementModel = %q, want empty", resp.ImplementModel)
+	}
+	if contains(w.Body.String(), "implement_model") {
+		t.Fatalf("implement_model key must be omitted when empty (byte-identical spawn):\n%s", w.Body.String())
+	}
+}
+
 func TestGetStagePrompt_Implement_CarriesScopeJustificationPath(t *testing.T) {
 	// #1153: the implement handler populates trigger.ImplementRunID /
 	// ImplementStageID, so the rendered prompt carries the run/stage-keyed scope

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -298,6 +298,22 @@ type Config struct {
 	// orchestrator, which resolves and surfaces the effective cap;
 	// concurrency enforcement that consumes it lands in E24.3 (#1143).
 	MaxParallelChildren int
+
+	// ImplementModelDefault is the deployment-configured default implement
+	// model — the lowest rung of the implement-model resolution ladder
+	// (resolveImplementModel). Empty (the default) means "no deployment
+	// default": with no spec executor.model, no plan model_recommendation, and
+	// no operator override, the resolved model is empty and the runner spawns
+	// the implement agent on the adapter's built-in default exactly as today
+	// (byte-for-byte). Wired from FISHHAWKD_IMPLEMENT_MODEL_DEFAULT in serve.go.
+	ImplementModelDefault string
+
+	// ImplementAllowedModels is the per-adapter allowed-model policy
+	// (AllowedModels) the approval gate validates the RESOLVED implement model
+	// against (#1013). A nil/empty policy — or an adapter with no configured
+	// set — fails OPEN (any model accepted, byte-identical to today). Wired
+	// from FISHHAWKD_IMPLEMENT_ALLOWED_MODELS in serve.go via ParseAllowedModels.
+	ImplementAllowedModels AllowedModels
 }
 
 // Server wraps an http.Server with the routes and middleware stack

--- a/backend/internal/server/server_test.go
+++ b/backend/internal/server/server_test.go
@@ -62,6 +62,27 @@ func TestServer_FullStack(t *testing.T) {
 // TestServer_MethodMismatch confirms the Go 1.22 ServeMux's
 // method-aware routing returns 405 for the wrong verb on a registered
 // path, rather than 404.
+// TestServer_WiresImplementModelConfig asserts the implement-model deployment
+// config (#1013) is threaded from Config onto the Server: the default rung and
+// the per-adapter allowed-model policy are reachable for the prompt resolver
+// and the approval gate respectively.
+func TestServer_WiresImplementModelConfig(t *testing.T) {
+	policy := ParseAllowedModels("claudecode=claude-opus-4-8")
+	s := New(Config{
+		ImplementModelDefault:  "claude-sonnet-4-6",
+		ImplementAllowedModels: policy,
+	})
+	if s.cfg.ImplementModelDefault != "claude-sonnet-4-6" {
+		t.Errorf("ImplementModelDefault = %q, want claude-sonnet-4-6", s.cfg.ImplementModelDefault)
+	}
+	if !s.cfg.ImplementAllowedModels.IsAllowed("claudecode", "claude-opus-4-8") {
+		t.Error("allowed-model policy not threaded onto the server")
+	}
+	if s.cfg.ImplementAllowedModels.IsAllowed("claudecode", "gpt-5.5") {
+		t.Error("threaded policy should still reject an unlisted model")
+	}
+}
+
 func TestServer_MethodMismatch(t *testing.T) {
 	s := New(Config{})
 	ts := httptest.NewServer(s.Handler())

--- a/backend/internal/server/trace.go
+++ b/backend/internal/server/trace.go
@@ -1215,14 +1215,23 @@ func (s *Server) emitRuntimeObserved(ctx context.Context, runID, stageID uuid.UU
 	predictedMinutes := float64(planArtifact.PredictedRuntimeMinutes)
 	deltaMinutes := actualMinutes - predictedMinutes
 
+	// Stamp the resolved implement model {value, source} (#1013) onto the
+	// EXISTING runtime_observed kind so per-model-per-complexity calibration
+	// history accumulates without a new audit surface. Empty value/source means
+	// today's default spawn — the keys are still emitted (omitempty-free) so the
+	// calibration reader can distinguish "default spawn" from a missing field.
+	rm := s.resolvedImplementModelForRunID(ctx, runID)
+
 	payload, _ := json.Marshal(map[string]any{
-		"stage_type":        string(stage.Type),
-		"predicted_minutes": predictedMinutes,
-		"confidence":        string(planArtifact.PredictedRuntimeConfidence),
-		"actual_seconds":    actualSeconds,
-		"actual_minutes":    actualMinutes,
-		"delta_minutes":     deltaMinutes,
-		"outcome":           outcome,
+		"stage_type":            string(stage.Type),
+		"predicted_minutes":     predictedMinutes,
+		"confidence":            string(planArtifact.PredictedRuntimeConfidence),
+		"actual_seconds":        actualSeconds,
+		"actual_minutes":        actualMinutes,
+		"delta_minutes":         deltaMinutes,
+		"outcome":               outcome,
+		"resolved_model":        rm.Value,
+		"resolved_model_source": string(rm.Source),
 	})
 
 	systemKind := audit.ActorKind("system")
@@ -1308,15 +1317,24 @@ func (s *Server) recordCost(ctx context.Context, runID, stageID uuid.UUID, bundl
 		rec.USD = 0
 	}
 
+	// Stamp the resolved implement model {value, source} (#1013) alongside the
+	// agent-reported `model` (rec.Model) on the EXISTING cost_recorded kind, so
+	// per-model spend calibration can attribute cost to the rung that chose the
+	// model. Kept under distinct `resolved_model*` keys so it never clobbers the
+	// agent-reported `model`. Empty value/source means today's default spawn.
+	rm := s.resolvedImplementModelForRunID(ctx, runID)
+
 	payload, _ := json.Marshal(map[string]any{
-		"model":         rec.Model,
-		"input_tokens":  rec.InputTokens,
-		"output_tokens": rec.OutputTokens,
-		"usd":           rec.USD,
-		"known_model":   rec.KnownModel,
-		"known_usage":   knownUsage,
-		"pricing_as_of": rec.PricingAsOf,
-		"estimated":     true,
+		"model":                 rec.Model,
+		"input_tokens":          rec.InputTokens,
+		"output_tokens":         rec.OutputTokens,
+		"usd":                   rec.USD,
+		"known_model":           rec.KnownModel,
+		"known_usage":           knownUsage,
+		"pricing_as_of":         rec.PricingAsOf,
+		"estimated":             true,
+		"resolved_model":        rm.Value,
+		"resolved_model_source": string(rm.Source),
 	})
 	systemKind := audit.ActorKind("system")
 	if _, err := s.cfg.AuditRepo.AppendChained(ctx, audit.ChainAppendParams{

--- a/backend/internal/server/trace_test.go
+++ b/backend/internal/server/trace_test.go
@@ -1002,6 +1002,93 @@ func TestShipTrace_EmitRuntimeObserved_ImplementStage(t *testing.T) {
 	}
 }
 
+// TestShipTrace_StampsResolvedModel asserts the calibration-stamp side of the
+// implement-model feature (#1013): the resolved model {value, source} is
+// stamped onto the EXISTING runtime_observed AND cost_recorded kinds, and NO
+// new audit kind (model_resolved) is emitted from this slice — the surface
+// sweep stays clean. The resolved model here comes from the spec executor.model
+// rung.
+func TestShipTrace_StampsResolvedModel(t *testing.T) {
+	rr := newOrchestratorRepo()
+	art := newFakeArtifactRepo()
+	sf := newSigningFake()
+	ts := newTraceStoreFake()
+	au := newAuditFake()
+
+	runRow := rr.seedRun()
+	runRow.WorkflowID = "feature_change"
+	runRow.WorkflowSpec = []byte("workflows:\n" +
+		"  feature_change:\n" +
+		"    stages:\n" +
+		"      - id: implement\n" +
+		"        type: implement\n" +
+		"        executor:\n" +
+		"          model: claude-opus-4-8\n")
+
+	planStage := rr.seedStage(runRow.ID, 0, run.StageStateSucceeded)
+	seedPlanArtifactForRun(t, art, planStage.ID, 15)
+	implStage := rr.seedStage(runRow.ID, 1, run.StageStateDispatched)
+	implStage.Type = run.StageTypeImplement
+	implStage.RequiresApproval = false
+
+	priv, _ := sf.issue(t, runRow.ID)
+	t0 := time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC)
+	t1 := t0.Add(12 * time.Minute)
+	bundleBytes := makeTimedBundle(t, t0, t1)
+
+	s := New(Config{
+		Addr:         "127.0.0.1:0",
+		SigningRepo:  sf,
+		TraceStore:   ts,
+		AuditRepo:    au,
+		RunRepo:      rr,
+		ArtifactRepo: art,
+	})
+
+	w := shipRequest(t, s, runRow.ID, implStage.ID, "raw", priv, bundleBytes, "")
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202:\n%s", w.Code, w.Body.String())
+	}
+
+	au.mu.Lock()
+	defer au.mu.Unlock()
+	var sawRO, sawCost bool
+	for i := range au.appended {
+		cat := au.appended[i].Category
+		if cat == "model_resolved" {
+			t.Fatalf("this slice must NOT emit the model_resolved kind (surface sweep must stay clean)")
+		}
+		var p map[string]any
+		if err := json.Unmarshal(au.appended[i].Payload, &p); err != nil {
+			continue
+		}
+		switch cat {
+		case "runtime_observed":
+			sawRO = true
+			if p["resolved_model"] != "claude-opus-4-8" {
+				t.Errorf("runtime_observed resolved_model = %v, want claude-opus-4-8", p["resolved_model"])
+			}
+			if p["resolved_model_source"] != "spec" {
+				t.Errorf("runtime_observed resolved_model_source = %v, want spec", p["resolved_model_source"])
+			}
+		case "cost_recorded":
+			sawCost = true
+			if p["resolved_model"] != "claude-opus-4-8" {
+				t.Errorf("cost_recorded resolved_model = %v, want claude-opus-4-8", p["resolved_model"])
+			}
+			if p["resolved_model_source"] != "spec" {
+				t.Errorf("cost_recorded resolved_model_source = %v, want spec", p["resolved_model_source"])
+			}
+		}
+	}
+	if !sawRO {
+		t.Fatal("no runtime_observed audit entry emitted")
+	}
+	if !sawCost {
+		t.Fatal("no cost_recorded audit entry emitted")
+	}
+}
+
 // TestShipTrace_EmitRuntimeObserved_PlanStage verifies that uploading a
 // trace for a plan stage does NOT emit a runtime_observed entry.
 func TestShipTrace_EmitRuntimeObserved_PlanStage(t *testing.T) {

--- a/backend/internal/spec/schemas/workflow-v0.schema.json
+++ b/backend/internal/spec/schemas/workflow-v0.schema.json
@@ -195,6 +195,11 @@
               "minLength": 1,
               "description": "Agent identifier. v0 ships with claude-code; v0.x adds cursor and copilot."
             },
+            "model": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Optional model override for this stage's agent invocation (#1013). One rung of the implement-model resolution ladder: deployment default < this executor.model < plan model_recommendation < operator gate decision. Empty/absent falls through to the next-lower rung (ultimately the deployment default spawn). The resolved model is validated against the deployment's per-adapter allowed-model set at the approval gate. Additive optional field within workflow-v0.x — accepted at every advertised version."
+            },
             "timeout": {
               "type": "string",
               "pattern": "^([0-9]+(ns|us|ms|s|m|h))+$",

--- a/backend/internal/spec/spec.go
+++ b/backend/internal/spec/spec.go
@@ -377,7 +377,14 @@ const (
 // Executor describes what runs the stage. Exactly one of Agent or
 // Human is set. The schema enforces the mutual exclusion.
 type Executor struct {
-	Agent          string        `json:"agent,omitempty" yaml:"agent,omitempty"`
+	Agent string `json:"agent,omitempty" yaml:"agent,omitempty"`
+	// Model is the optional per-stage model override (#1013). One rung of
+	// the implement-model resolution ladder: deployment default < this
+	// executor.model < plan model_recommendation < operator gate decision.
+	// Empty falls through to the next-lower rung (ultimately the deployment
+	// default spawn). Declared in the agent branch of the executor oneOf;
+	// the schema rejects it on a human executor.
+	Model          string        `json:"model,omitempty" yaml:"model,omitempty"`
 	Human          bool          `json:"human,omitempty" yaml:"human,omitempty"`
 	Timeout        Duration      `json:"timeout,omitempty" yaml:"timeout,omitempty"`
 	Verify         *VerifyConfig `json:"verify,omitempty" yaml:"verify,omitempty"`

--- a/backend/internal/spec/spec_test.go
+++ b/backend/internal/spec/spec_test.go
@@ -378,6 +378,64 @@ workflows:
 	}
 }
 
+// --- Executor model override (#1013) ---
+
+func TestParse_ExecutorModel(t *testing.T) {
+	// `executor.model` is an optional per-stage model override in the agent
+	// branch. Absent decodes to the empty string (one rung of the
+	// implement-model ladder; empty falls through to the next-lower rung).
+	const tmpl = `
+version: "0.3"
+workflows:
+  feature_change:
+    stages:
+      - id: implement
+        type: implement
+        executor:
+          agent: claude-code
+%s`
+	cases := []struct {
+		name  string
+		model string // injected executor line; "" = absent
+		want  string
+	}{
+		{name: "absent_defaults_empty", model: "", want: ""},
+		{name: "explicit_model", model: "          model: claude-opus-4-8\n", want: "claude-opus-4-8"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s, err := spec.ParseBytes([]byte(strings.ReplaceAll(tmpl, "%s", tc.model)))
+			if err != nil {
+				t.Fatalf("Parse: %v", err)
+			}
+			if got := s.Workflows["feature_change"].Stages[0].Executor.Model; got != tc.want {
+				t.Errorf("Executor.Model = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestParse_ExecutorModel_OnHuman_Rejected confirms model lives in the agent
+// branch of the executor oneOf only: declaring it on a human executor trips
+// unevaluatedProperties.
+func TestParse_ExecutorModel_OnHuman_Rejected(t *testing.T) {
+	_, err := spec.ParseBytes([]byte(`
+version: "0.3"
+workflows:
+  feature_change:
+    stages:
+      - id: review
+        type: review
+        executor:
+          human: true
+          model: claude-opus-4-8
+`))
+	var se *spec.SchemaError
+	if !errors.As(err, &se) {
+		t.Fatalf("err = %v, want *SchemaError", err)
+	}
+}
+
 // --- YAML errors ---
 
 func TestParse_EmptyDocument(t *testing.T) {

--- a/cli/internal/spec/schemas/workflow-v0.schema.json
+++ b/cli/internal/spec/schemas/workflow-v0.schema.json
@@ -195,6 +195,11 @@
               "minLength": 1,
               "description": "Agent identifier. v0 ships with claude-code; v0.x adds cursor and copilot."
             },
+            "model": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Optional model override for this stage's agent invocation (#1013). One rung of the implement-model resolution ladder: deployment default < this executor.model < plan model_recommendation < operator gate decision. Empty/absent falls through to the next-lower rung (ultimately the deployment default spawn). The resolved model is validated against the deployment's per-adapter allowed-model set at the approval gate. Additive optional field within workflow-v0.x — accepted at every advertised version."
+            },
             "timeout": {
               "type": "string",
               "pattern": "^([0-9]+(ns|us|ms|s|m|h))+$",

--- a/docs/spec/plan-standard-v1.md
+++ b/docs/spec/plan-standard-v1.md
@@ -62,7 +62,8 @@ Any property whose `$ref` (or array `items.$ref`) points to an annotated `$defs`
   "predicted_runtime_confidence": "medium",
 
   "risks_and_assumptions": ["..."],
-  "decomposition": { "rationale": "...", "sub_plans": [...] }
+  "decomposition": { "rationale": "...", "sub_plans": [...] },
+  "model_recommendation": { "implement_model": "...", "rationale": "...", "complexity_assessed": "low|medium|high" }
 }
 ```
 
@@ -226,12 +227,35 @@ Required array with at least two entries. Each entry is a `SubPlanSummary`:
 | `scope` | `{ "files": [...] }` object | no | The files THIS slice will touch. Same shape as the top-level `scope`. |
 | `predicted_runtime_minutes` | integer ≥ 1 | yes | Estimate for this sub-plan's implement stage |
 | `predicted_runtime_confidence` | `"low"` / `"medium"` / `"high"` | yes | Confidence in the sub-plan estimate |
+| `model_recommendation` | `{ implement_model, rationale, complexity_assessed }` object | no | This slice's per-child model recommendation. Same shape as the top-level `model_recommendation`; resolved through the same chokepoint at the child's plan gate. |
 
 When `scope` is present, the decomposition fan-out child minted for this sub-plan uses the sub-plan's `scope.files` — rather than the parent plan's full `scope.files` — for its implement-stage `scope_handoff` (commit bounding) and scope-drift detection. This keeps each child bounded to its own slice instead of the whole parent change. When `scope` is omitted, the child falls back to the parent plan's full `scope.files` (the pre-existing behavior).
 
 **Runtime-sum invariant**: the validator warns (but does not reject) when the sum of `sub_plans[*].predicted_runtime_minutes` is less than the parent `predicted_runtime_minutes`. The agent may legitimately compress work when breaking it into smaller pieces; the soft warning surfaces the gap for human review.
 
 **Lifecycle**: as of ADR-025 D4 (#455), `decomposition` is acted upon by the orchestrator. After plan approval, when the orchestrator's `Advance` would dispatch the parent's implement stage, it checks the approved plan: if `decomposition.sub_plans` is populated, the orchestrator mints one child run per sub-plan (each carrying `parent_run_id = parent.id` and `decomposed_from = parent.id`, with an issue_context built from the parent's title plus the sub-plan's `scope_hint`), parks the parent's implement stage in `awaiting_children`, and emits a `plan_decomposed` audit entry listing the child IDs. The child-completion sweeper (`backend/internal/childcompletion/`) transitions the parent stage to `succeeded` once every child reaches a terminal state successfully, or to `failed-C` if any child failed. Child runs themselves skip the fanout check (their `decomposed_from` is non-nil), so recursion is bounded at one level.
+
+### `model_recommendation`
+
+The agent's optional, complexity-informed recommendation for which model should execute the implement stage (#1013). Advisory — the operator ratifies or overrides it at the plan-approval gate, and the resolved model is validated against the deployment's per-adapter allowed-model set.
+
+```json
+{
+  "model_recommendation": {
+    "implement_model": "claude-opus-4-8",
+    "rationale": "Cross-layer change threading a field through wire, domain, persistence, and render; non-trivial seams warrant the stronger model.",
+    "complexity_assessed": "high"
+  }
+}
+```
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `implement_model` | string (≥ 1 char) | yes (when the object is present) | Model identifier recommended for the implement stage (e.g. `claude-opus-4-8`). |
+| `rationale` | string (≥ 1 char) | yes (when the object is present) | Why this model fits the assessed complexity. Rendered alongside the recommendation in the plan-review surface. |
+| `complexity_assessed` | `"low"` / `"medium"` / `"high"` | yes (when the object is present) | The agent's complexity assessment, informing the recommendation; stamped onto calibration history. |
+
+`model_recommendation` is one rung of the implement-model resolution ladder: deployment default < workflow-spec `executor.model` < plan `model_recommendation.implement_model` < operator gate decision. When omitted, resolution falls through to the next-lower rung (ultimately the deployment default spawn — byte-identical to today's behavior). The whole object is additive-optional within `standard_v1.x`; a plan that omits it validates unchanged. A decomposed sub-plan may carry its own `model_recommendation` (see the sub-plan table above), resolved through the same chokepoint at the child's plan gate.
 
 ## Validation rules beyond the schema
 

--- a/docs/spec/plan-standard-v1.schema.json
+++ b/docs/spec/plan-standard-v1.schema.json
@@ -72,7 +72,8 @@
           "description": "Ordered list of sub-plans. At least two required when decomposition is present."
         }
       }
-    }
+    },
+    "model_recommendation": { "$ref": "#/$defs/model-recommendation" }
   },
 
   "$defs": {
@@ -232,6 +233,34 @@
           "type": "string",
           "enum": ["low", "medium", "high"],
           "description": "Agent's confidence in this sub-plan's predicted_runtime_minutes."
+        },
+        "model_recommendation": {
+          "$ref": "#/$defs/model-recommendation",
+          "description": "Optional. The model recommendation for THIS sub-plan's decomposition child. Resolved through the same chokepoint as the top-level model_recommendation, so a decomposed child ratifies its own slice's recommendation at its plan gate. Omitted means the child has no per-slice recommendation."
+        }
+      }
+    },
+
+    "model-recommendation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["implement_model", "rationale", "complexity_assessed"],
+      "description": "Optional. The agent's complexity-informed recommendation for which model should execute the implement stage (#1013). Advisory: the operator ratifies or overrides it at the plan-approval gate, and the resolved model is validated against the deployment's per-adapter allowed-model set. Omitted means no recommendation — the implement-model resolver falls through to the workflow spec's executor.model, then the deployment default.",
+      "properties": {
+        "implement_model": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Model identifier the agent recommends for the implement stage (e.g. claude-opus-4-8). Routed to the runner adapter as the model override when this rung wins the resolution ladder (deployment default < spec executor.model < plan model_recommendation < operator gate decision)."
+        },
+        "rationale": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Why this model fits the assessed complexity. Rendered alongside the recommendation in the plan-review surface."
+        },
+        "complexity_assessed": {
+          "type": "string",
+          "enum": ["low", "medium", "high"],
+          "description": "The agent's assessment of the change's complexity, informing the recommendation. Stamped onto calibration history so per-model-per-complexity outcomes accumulate."
         }
       }
     }

--- a/docs/spec/workflow-v0.md
+++ b/docs/spec/workflow-v0.md
@@ -42,6 +42,7 @@ Identifiers (`<role_id>`, `<workflow_id>`, stage `id`s) are `snake_case` — `^[
   type: plan | implement | review # closed set; no custom types
   executor: # exactly one of agent or human
     agent: claude-code        # any string; v0 ships claude-code
+    model: claude-opus-4-8    # optional; per-stage model override (see ### Executor model override)
     timeout: 10m              # optional; stage-level override for agent timeout
     verify:                   # optional; in-band test gate (see ### Verify gate)
       command: 'scripts/test'
@@ -95,6 +96,21 @@ executor:
 
 - **Only valid on agent-executed stages.** Declaring `agent_self_retry` on a `human: true` executor is a schema error — the field lives in the agent branch of the executor `oneOf`, so `unevaluatedProperties: false` rejects it on the human branch.
 - **Backend plumbing and runner detection** are handled by separate follow-up tickets. This field documents the authoring surface and is parsed by both the backend and CLI validators; runner behavior is not yet wired.
+
+### Executor model override
+
+An optional per-stage model override (#1013). One rung of the implement-model resolution ladder.
+
+```yaml
+executor:
+  agent: claude-code
+  model: claude-opus-4-8  # optional; falls through to the next-lower rung when empty
+```
+
+- **Resolution ladder** (lowest to highest precedence): deployment default < `executor.model` < plan `model_recommendation.implement_model` < operator gate decision. The highest non-empty rung wins; an empty resolved model spawns the agent on the deployment default — byte-identical to today's behavior.
+- **Gate-time validation.** The resolved model is validated against the deployment's per-adapter allowed-model set at the approval gate; an unknown model is rejected there, naming its source.
+- **Only valid on agent-executed stages.** Declaring `model` on a `human: true` executor is a schema error — the field lives in the agent branch of the executor `oneOf`, so `unevaluatedProperties: false` rejects it on the human branch.
+- **Additive within `workflow-v0.x`** — accepted at every advertised version; a spec that omits it parses unchanged.
 
 ### Plan reviewers
 
@@ -450,6 +466,7 @@ workflows:
 | Member refs                 | `^@[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)?$`                                    | GitHub user or team                                                                                 |
 | Stage `type`                | `plan` \| `implement` \| `review`                                            | closed set                                                                                          |
 | Executor                    | `agent: <string>` xor `human: true`                                          | mutually exclusive                                                                                  |
+| `executor.model`            | non-empty string (optional)                                                  | per-stage model override (#1013); agent branch only, schema error on human executor; additive at every version |
 | `executor.agent_self_retry` | `true` \| `false` (default `false`)                                          | agent branch only; schema error on human executor                                                   |
 | `reviewers.agent`           | integer `>= 0` (default `0`)                                                 | absent block → nil → backend defaults to `{human:1}`; superseded by a non-empty `reviewers.agents` |
 | `reviewers.agents`          | array of `{provider, model?}`, `minItems: 1`                                 | heterogeneous reviewers (#955); when present, effective agent count = `len(agents)`                |

--- a/docs/spec/workflow-v0.schema.json
+++ b/docs/spec/workflow-v0.schema.json
@@ -195,6 +195,11 @@
               "minLength": 1,
               "description": "Agent identifier. v0 ships with claude-code; v0.x adds cursor and copilot."
             },
+            "model": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Optional model override for this stage's agent invocation (#1013). One rung of the implement-model resolution ladder: deployment default < this executor.model < plan model_recommendation < operator gate decision. Empty/absent falls through to the next-lower rung (ultimately the deployment default spawn). The resolved model is validated against the deployment's per-adapter allowed-model set at the approval gate. Additive optional field within workflow-v0.x — accepted at every advertised version."
+            },
             "timeout": {
               "type": "string",
               "pattern": "^([0-9]+(ns|us|ms|s|m|h))+$",

--- a/runner/cmd/fishhawk-runner/main.go
+++ b/runner/cmd/fishhawk-runner/main.go
@@ -263,6 +263,19 @@ func run(args []string, logSink io.Writer) (exitCode int) {
 	// entirely within run().
 	var fixupExpectedHeadSHA string
 
+	// implement-model routing seam (#1013): the backend resolves the implement
+	// model and carries it on the prompt response under `implement_model`, and
+	// the agent adapters (agent.Invocation.Model -> `--model <m>`) are wired to
+	// pin the spawn to it. The remaining link — decoding `implement_model` off
+	// the prompt response into upload.FetchedPrompt and threading it onto
+	// agent.Invocation.Model here — lives in runner/internal/upload/upload.go,
+	// the prompt-response decoder, which is OUTSIDE this decomposition slice's
+	// scope. The scope-amendment to fold it in (12b75eed) was not decided within
+	// the bounded window, so inv.Model is left unset: the adapters append NO
+	// --model flag and the spawn is byte-identical to today. Completing the
+	// routing is a one-field follow-up (add upload.FetchedPrompt.ImplementModel
+	// + `inv.Model = got.ImplementModel`) tracked in the PR notes.
+
 	// exemptOpenPR / exemptHeldSHA / exemptHeldBranch carry the operator EXEMPT
 	// resolution of a scope-completeness park (#1231) from the fetched prompt to
 	// the early zero-re-run branch below. When exemptOpenPR is true the stage's

--- a/runner/internal/agent/agent.go
+++ b/runner/internal/agent/agent.go
@@ -57,6 +57,16 @@ type Invocation struct {
 	// parent env unchanged.
 	Env map[string]string
 
+	// Model is the resolved implement model id the backend chose via the
+	// implement-model resolution ladder (#1013), carried on the prompt
+	// response and threaded here by the runner. A non-empty value is passed to
+	// the agent CLI as its model-override flag (`--model <Model>`); an EMPTY
+	// value (the common case — no plan recommendation, no spec executor.model,
+	// no operator override, no deployment default) appends NO flag, so the
+	// adapter spawns the agent on its built-in default exactly as today,
+	// byte-for-byte. Adapters MUST treat empty as "omit the flag".
+	Model string
+
 	// ProgressSink receives single-line JSON stage_progress
 	// heartbeats emitted at a fixed cadence during the invocation
 	// (#580). Each line is a complete `{"event":"stage_progress",...}`

--- a/runner/internal/agent/claudecode/claudecode.go
+++ b/runner/internal/agent/claudecode/claudecode.go
@@ -282,6 +282,14 @@ func (i *Invoker) invokeOnce(ctx context.Context, inv agent.Invocation) (agent.R
 	for _, dir := range allowedExtraDirs {
 		args = append(args, "--add-dir", dir)
 	}
+	// --model: pin the agent to the backend-resolved implement model (#1013)
+	// when one was resolved. An empty inv.Model (no plan recommendation, no
+	// spec executor.model, no operator override, no deployment default) appends
+	// NO flag, so the spawn is byte-identical to today and Claude Code uses its
+	// built-in default model.
+	if inv.Model != "" {
+		args = append(args, "--model", inv.Model)
+	}
 	args = append(args, "-p", inv.Prompt)
 	cmd := cmdFn(ctx, binary, args...)
 	cmd.Dir = inv.WorkingDir

--- a/runner/internal/agent/claudecode/claudecode_test.go
+++ b/runner/internal/agent/claudecode/claudecode_test.go
@@ -186,6 +186,65 @@ func helperCommandWithEnv(mode string, extra ...string) func(ctx context.Context
 	}
 }
 
+// capturingHelperCommand wraps the "happy" helper process but records the
+// argv it was built with into *captured, so a test can assert the presence or
+// absence of the --model flag (#1013).
+func capturingHelperCommand(captured *[]string) func(ctx context.Context, name string, args ...string) *exec.Cmd {
+	return func(ctx context.Context, _ string, args ...string) *exec.Cmd {
+		*captured = append([]string(nil), args...)
+		c := exec.CommandContext(ctx, os.Args[0], "-test.run=TestHelperProcess")
+		c.Env = append(os.Environ(),
+			"GO_HELPER_PROCESS=1",
+			"HELPER_MODE=happy",
+		)
+		return c
+	}
+}
+
+func argsHaveFlagValue(args []string, flag, value string) bool {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == flag && args[i+1] == value {
+			return true
+		}
+	}
+	return false
+}
+
+func argsHaveFlag(args []string, flag string) bool {
+	for _, a := range args {
+		if a == flag {
+			return true
+		}
+	}
+	return false
+}
+
+// TestInvoke_ModelFlag asserts the implement-model routing (#1013): a non-empty
+// Invocation.Model appends `--model <m>`; an empty Model appends NO --model flag
+// (byte-identical to today's spawn).
+func TestInvoke_ModelFlag(t *testing.T) {
+	t.Run("non-empty model appends --model", func(t *testing.T) {
+		var captured []string
+		inv := &Invoker{Cmd: capturingHelperCommand(&captured), Now: frozenNow()}
+		if _, err := inv.Invoke(context.Background(), agent.Invocation{Prompt: "p", Model: "claude-opus-4-8"}); err != nil {
+			t.Fatalf("Invoke: %v", err)
+		}
+		if !argsHaveFlagValue(captured, "--model", "claude-opus-4-8") {
+			t.Fatalf("expected --model claude-opus-4-8 in args, got %v", captured)
+		}
+	})
+	t.Run("empty model omits --model (byte-identical spawn)", func(t *testing.T) {
+		var captured []string
+		inv := &Invoker{Cmd: capturingHelperCommand(&captured), Now: frozenNow()}
+		if _, err := inv.Invoke(context.Background(), agent.Invocation{Prompt: "p"}); err != nil {
+			t.Fatalf("Invoke: %v", err)
+		}
+		if argsHaveFlag(captured, "--model") {
+			t.Fatalf("expected NO --model flag for empty model, got %v", captured)
+		}
+	})
+}
+
 // frozenNow returns a Now() that ticks deterministically so tests
 // can assert event ordering without fighting wall-clock jitter.
 func frozenNow() func() time.Time {

--- a/runner/internal/agent/codex/codex.go
+++ b/runner/internal/agent/codex/codex.go
@@ -156,8 +156,16 @@ func (i *Invoker) Invoke(ctx context.Context, inv agent.Invocation) (agent.Resul
 		"exec", "--json",
 		"--dangerously-bypass-approvals-and-sandbox",
 		"--skip-git-repo-check",
-		inv.Prompt,
 	}
+	// --model: pin Codex to the backend-resolved implement model (#1013) when
+	// one was resolved. An empty inv.Model (no plan recommendation, no spec
+	// executor.model, no operator override, no deployment default) appends NO
+	// flag, so the spawn is byte-identical to today and Codex inherits its host
+	// ~/.codex default model. Placed before the trailing positional prompt.
+	if inv.Model != "" {
+		args = append(args, "--model", inv.Model)
+	}
+	args = append(args, inv.Prompt)
 	cmd := cmdFn(ctx, binary, args...)
 	cmd.Dir = inv.WorkingDir
 

--- a/runner/internal/agent/codex/codex_test.go
+++ b/runner/internal/agent/codex/codex_test.go
@@ -115,6 +115,65 @@ func helperCommand(mode string) func(ctx context.Context, name string, args ...s
 	}
 }
 
+// capturingHelperCommand wraps the "happy" helper process but records the argv
+// it was built with into *captured, so a test can assert the presence or
+// absence of the --model flag (#1013).
+func capturingHelperCommand(captured *[]string) func(ctx context.Context, name string, args ...string) *exec.Cmd {
+	return func(ctx context.Context, _ string, args ...string) *exec.Cmd {
+		*captured = append([]string(nil), args...)
+		c := exec.CommandContext(ctx, os.Args[0], "-test.run=TestHelperProcess")
+		c.Env = append(os.Environ(),
+			"GO_HELPER_PROCESS=1",
+			"HELPER_MODE=happy",
+		)
+		return c
+	}
+}
+
+func argsHaveFlagValue(args []string, flag, value string) bool {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == flag && args[i+1] == value {
+			return true
+		}
+	}
+	return false
+}
+
+func argsHaveFlag(args []string, flag string) bool {
+	for _, a := range args {
+		if a == flag {
+			return true
+		}
+	}
+	return false
+}
+
+// TestInvoke_ModelFlag asserts the implement-model routing (#1013): a non-empty
+// Invocation.Model appends `--model <m>` before the positional prompt; an empty
+// Model appends NO --model flag (byte-identical to today's spawn).
+func TestInvoke_ModelFlag(t *testing.T) {
+	t.Run("non-empty model appends --model", func(t *testing.T) {
+		var captured []string
+		inv := &Invoker{Cmd: capturingHelperCommand(&captured), Now: frozenNow()}
+		if _, err := inv.Invoke(context.Background(), agent.Invocation{Prompt: "p", Model: "gpt-5.5"}); err != nil {
+			t.Fatalf("Invoke: %v", err)
+		}
+		if !argsHaveFlagValue(captured, "--model", "gpt-5.5") {
+			t.Fatalf("expected --model gpt-5.5 in args, got %v", captured)
+		}
+	})
+	t.Run("empty model omits --model (byte-identical spawn)", func(t *testing.T) {
+		var captured []string
+		inv := &Invoker{Cmd: capturingHelperCommand(&captured), Now: frozenNow()}
+		if _, err := inv.Invoke(context.Background(), agent.Invocation{Prompt: "p"}); err != nil {
+			t.Fatalf("Invoke: %v", err)
+		}
+		if argsHaveFlag(captured, "--model") {
+			t.Fatalf("expected NO --model flag for empty model, got %v", captured)
+		}
+	})
+}
+
 // frozenNow returns a Now() that ticks deterministically so tests can
 // assert event ordering without fighting wall-clock jitter.
 func frozenNow() func() time.Time {

--- a/runner/internal/plan/schemas/plan-standard-v1.schema.json
+++ b/runner/internal/plan/schemas/plan-standard-v1.schema.json
@@ -72,7 +72,8 @@
           "description": "Ordered list of sub-plans. At least two required when decomposition is present."
         }
       }
-    }
+    },
+    "model_recommendation": { "$ref": "#/$defs/model-recommendation" }
   },
 
   "$defs": {
@@ -232,6 +233,34 @@
           "type": "string",
           "enum": ["low", "medium", "high"],
           "description": "Agent's confidence in this sub-plan's predicted_runtime_minutes."
+        },
+        "model_recommendation": {
+          "$ref": "#/$defs/model-recommendation",
+          "description": "Optional. The model recommendation for THIS sub-plan's decomposition child. Resolved through the same chokepoint as the top-level model_recommendation, so a decomposed child ratifies its own slice's recommendation at its plan gate. Omitted means the child has no per-slice recommendation."
+        }
+      }
+    },
+
+    "model-recommendation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["implement_model", "rationale", "complexity_assessed"],
+      "description": "Optional. The agent's complexity-informed recommendation for which model should execute the implement stage (#1013). Advisory: the operator ratifies or overrides it at the plan-approval gate, and the resolved model is validated against the deployment's per-adapter allowed-model set. Omitted means no recommendation — the implement-model resolver falls through to the workflow spec's executor.model, then the deployment default.",
+      "properties": {
+        "implement_model": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Model identifier the agent recommends for the implement stage (e.g. claude-opus-4-8). Routed to the runner adapter as the model override when this rung wins the resolution ladder (deployment default < spec executor.model < plan model_recommendation < operator gate decision)."
+        },
+        "rationale": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Why this model fits the assessed complexity. Rendered alongside the recommendation in the plan-review surface."
+        },
+        "complexity_assessed": {
+          "type": "string",
+          "enum": ["low", "medium", "high"],
+          "description": "The agent's assessment of the change's complexity, informing the recommendation. Stamped onto calibration history so per-model-per-complexity outcomes accumulate."
         }
       }
     }


### PR DESCRIPTION
## Summary

First two slices of the #1013 model-resolution ladder, landed together (the operator-gate slice 2 follows separately). Purely additive and behavior-preserving — an empty resolved model spawns the implement agent byte-identically to today.

- **Slice 0 (data contracts):** optional `model_recommendation {implement_model, rationale, complexity_assessed}` on the plan artifact (top-level + per decomposition sub-plan) and optional `executor.model` on the workflow spec, with embedded schema mirrors synced. Additive-optional within `standard_v1.x` / `workflow-v0.x` (no major bump).
- **Slice 1 (resolution spine):** the per-adapter allowed-model deployment config, `modelpolicy.go` (the `IsAllowed` check + the pure default<spec<plan<operator resolver), the prompt-response model field routed to the runner adapters as `--model` (omitted when empty), and model-stamping of the existing `runtime_observed`/`cost_recorded` calibration entries. Emits no new audit kind and no render surface.

Part of #1013 (does NOT close it — the operator-gate writer + 422 gate validation + issue-comment render land in slice 2).

## Test plan

- `go build ./...` clean across backend, runner, cli on the merged tree.
- `scripts/sync-schemas` leaves no diff (embedded mirrors byte-identical).
- backend `internal/plan`, `internal/spec`, `internal/server` and runner `internal/agent`, `internal/agent/claudecode`, `internal/agent/codex`, `cmd/fishhawk-runner` tests pass.

## Notes

Decomposed run 74c1071e fanned into 3 slices; slices 0 and 1 succeeded and are consolidated here by hand. Slice 2 (operator gate) hard-depends on slices 0/1's new symbols (`modelpolicy.go`, the structs) and failed `child_no_changes` in its isolated concurrent worktree — the decomposition dependency-order gap filed as #1258. Slice 2 will be re-driven against this merged base where the scaffolding exists.