### PR TITLE
Fix red main: calibration replay skips Tier-A-only corpus cases (#1174/#1298)

### DIFF
--- a/backend/internal/agenteval/calibration_test.go
+++ b/backend/internal/agenteval/calibration_test.go
@@ -178,8 +178,8 @@ func TestCalibrateEmptyCases(t *testing.T) {
 // JudgeCard domain type, and the agreement-scoring consumer.
 func TestCalibrateCorpusReplay(t *testing.T) {
 	cases := loadCorpusCases(t)
-	if len(cases) != 4 {
-		t.Fatalf("want 4 corpus cases, got %d", len(cases))
+	if len(cases) < 4 {
+		t.Fatalf("want at least the 4 labeled seed corpus cases, got %d", len(cases))
 	}
 	for _, c := range cases {
 		if !c.Labels.Synthetic {
@@ -274,7 +274,18 @@ func loadCorpusCases(t *testing.T) []CalibrationCase {
 			continue
 		}
 		dir := filepath.Join(corpusDir, e.Name())
-		labels, err := loadHumanLabels(filepath.Join(dir, "human_labels.json"))
+		labelsPath := filepath.Join(dir, "human_labels.json")
+		if _, statErr := os.Stat(labelsPath); errors.Is(statErr, os.ErrNotExist) {
+			// Tier-A-only corpus case: it carries expected.json (exercised by
+			// the scorer's TestScore) but no Tier-B human_labels.json yet, so
+			// it is not part of the judge-calibration subset. Skip it rather
+			// than forcing every corpus case to be Tier-B-labeled — this
+			// decouples Tier-A corpus growth (#819) from Tier-B labeling and
+			// is why a labels-free case (e.g. a freshly distilled real trace)
+			// must not break calibration replay (#1174 / #1298).
+			continue
+		}
+		labels, err := loadHumanLabels(labelsPath)
 		if err != nil {
 			t.Fatalf("load labels for %s: %v", e.Name(), err)
 		}


### PR DESCRIPTION
## Summary

**Red-main hotfix.** `backend/internal/agenteval` `TestCalibrateCorpusReplay` is failing on `main` (since #1298 merged): it hard-required `human_labels.json` for *every* corpus case and asserted exactly 4, but #1298's real-trace cases (`1255-wait-parser-healthy-minimal`, `1258-waves-healthy-cross-boundary`) carry `expected.json` (Tier-A) without Tier-B human labels → `load labels … no such file or directory`, breaking `scripts/test verify`.

This slipped through #1298's CI because **testdata-only changes skip CI's Go job** (the path-filter coverage gap). The next Go-changing run (#1174, shared testcontainers) surfaced it as a category-B verify failure.

## Fix

- `loadCorpusCases` now **skips a corpus dir that has no `human_labels.json`** — a Tier-A-only case (real distilled trace, not yet Tier-B-labeled) is valid for the scorer's `TestScore` but simply isn't part of the judge-calibration subset. Decouples Tier-A corpus growth (#819) from Tier-B labeling.
- The replay asserts **≥ the 4 labeled seed cases** rather than `== 4`.

## Test plan

- `go test ./backend/internal/agenteval/` → green (was FAIL). This is a `.go` change so CI's Go job runs it (unlike the testdata-only #1298).

## Notes

Unblocks #1174's verify (its own change — pgtest shared container — passed; only this pre-existing red-main test failed). Follow-ups to file: the **CI path-filter gap** (corpus/testdata changes should trigger the agenteval Go tests — this incident is the proof) and optionally Tier-B human labels for the two real corpus cases (operator curation, #819). Refs #1298, #1174, #820, #819.