### PR TITLE
Add backend/internal/pgtest shared-container test helper (#1174 slice 0)

### DIFF
--- a/backend/internal/pgtest/pgtest.go
+++ b/backend/internal/pgtest/pgtest.go
@@ -1,0 +1,359 @@
+// Package pgtest gives every backend integration test a freshly-migrated
+// Postgres database while starting only ONE container for the whole
+// `scripts/test` run, eliminating the base start-contention flake (#1174,
+// #972). Instead of one testcontainers Postgres per package, a single
+// process-singleton, WithReuseByName-keyed container (fishhawk-test-postgres)
+// is shared across every test binary, and each test gets its own cheap
+// ephemeral database via CREATE DATABASE ... TEMPLATE.
+//
+// Because `scripts/test` runs with TESTCONTAINERS_RYUK_DISABLED=true, the
+// named container persists across package processes, so three concurrency
+// hazards arise and are each handled with a pure, unit-testable classifier:
+//
+//   - First-start name-conflict race (isContainerNameConflict): two test
+//     binaries can both try to create the named container; the loser gets a
+//     docker name conflict. A bounded attach-retry re-resolves to the now
+//     existing container instead of erroring or starting a second one.
+//   - Cross-process template bootstrap (isDuplicateDatabase): each process
+//     has its own sync.Once, so the 2nd+ processes re-attempt CREATE DATABASE
+//     fishhawk_tmpl and hit SQLSTATE 42P04. The advisory-locked bootstrap
+//     tolerates 42P04 and adopts the already-bootstrapped template.
+//   - Per-test template contention (isTemplate1Contention): concurrent
+//     CREATE DATABASE ... TEMPLATE can fail with SQLSTATE 55006; a bounded
+//     retry rides it out.
+//
+// When Docker is unreachable (isDockerUnavailable) the helpers Skip so devs
+// without Docker still pass the rest of the suite — preserving the old
+// per-package skip behavior at the shared level.
+package pgtest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/testcontainers/testcontainers-go"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+
+	"github.com/kuhlman-labs/fishhawk/backend/internal/postgres"
+)
+
+const (
+	// containerName keys the shared, reused container. Slice 1's
+	// scripts/test teardown removes it by this name after the run.
+	containerName = "fishhawk-test-postgres"
+	baseDB        = "fishhawk"
+	baseUser      = "fishhawk"
+	basePass      = "fishhawk"
+
+	// templateDB is migrated once per container and used as the source
+	// for each per-test CREATE DATABASE ... TEMPLATE.
+	templateDB = "fishhawk_tmpl"
+
+	// bootstrapLockKey serializes the template bootstrap across the
+	// processes sharing the container. Advisory locks are cluster-wide,
+	// so locking on the base database serializes every bootstrapper.
+	bootstrapLockKey int64 = 1174
+
+	attachAttempts     = 12
+	attachRetryDelay   = 500 * time.Millisecond
+	contentionAttempts = 12
+	contentionDelay    = 250 * time.Millisecond
+	startTimeout       = 120 * time.Second
+)
+
+var (
+	sharedOnce sync.Once
+	sharedBase string
+	sharedErr  error
+)
+
+// NewURL returns the connection URL of a freshly-migrated, per-test
+// ephemeral database on the single process-shared container. The database
+// is dropped via t.Cleanup. Skips the test if Docker is unavailable.
+func NewURL(t *testing.T) string {
+	t.Helper()
+	baseURL := sharedBaseURL(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	conn, err := pgx.Connect(ctx, baseURL)
+	if err != nil {
+		t.Fatalf("connect base db: %v", err)
+	}
+	defer func() { _ = conn.Close(ctx) }()
+
+	dbName := "fh_" + strings.ReplaceAll(uuid.NewString(), "-", "")
+	create := func() error {
+		_, err := conn.Exec(ctx, fmt.Sprintf("CREATE DATABASE %s TEMPLATE %s",
+			pgx.Identifier{dbName}.Sanitize(),
+			pgx.Identifier{templateDB}.Sanitize()))
+		return err
+	}
+	if err := createWithContentionRetry(contentionAttempts, contentionDelay, create); err != nil {
+		t.Fatalf("create per-test db: %v", err)
+	}
+
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		c, err := pgx.Connect(ctx, baseURL)
+		if err != nil {
+			return // best-effort drop
+		}
+		defer func() { _ = c.Close(ctx) }()
+		_, _ = c.Exec(ctx, "DROP DATABASE IF EXISTS "+pgx.Identifier{dbName}.Sanitize()+" WITH (FORCE)")
+	})
+
+	return replaceDBName(baseURL, dbName)
+}
+
+// NewPool returns a connected pgxpool against a freshly-migrated per-test
+// database. The pool is closed (before the database is dropped) via
+// t.Cleanup. Skips the test if Docker is unavailable.
+func NewPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dbURL := NewURL(t)
+	pool, err := postgres.Connect(context.Background(), dbURL)
+	if err != nil {
+		t.Fatalf("connect per-test pool: %v", err)
+	}
+	// Registered AFTER NewURL's drop cleanup, so it runs FIRST (LIFO):
+	// the pool must close before the database can be dropped.
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+// sharedBaseURL returns the base (admin) connection URL of the shared
+// container, starting it on first use. Skips on Docker-unavailable or the
+// FISHHAWK_SKIP_INTEGRATION override; fatals on any other start failure.
+func sharedBaseURL(t *testing.T) string {
+	t.Helper()
+	if os.Getenv("FISHHAWK_SKIP_INTEGRATION") != "" {
+		t.Skipf("FISHHAWK_SKIP_INTEGRATION set; skipping integration test")
+	}
+	base, err := sharedContainerBaseURL()
+	if err != nil {
+		failStart(t, err)
+	}
+	return base
+}
+
+func sharedContainerBaseURL() (string, error) {
+	sharedOnce.Do(func() {
+		sharedBase, sharedErr = startSharedContainer()
+	})
+	return sharedBase, sharedErr
+}
+
+func startSharedContainer() (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), startTimeout)
+	defer cancel()
+
+	container, err := attachWithRetry(attachAttempts, attachRetryDelay, func() (*tcpostgres.PostgresContainer, error) {
+		return tcpostgres.Run(ctx,
+			"postgres:16-alpine",
+			tcpostgres.WithDatabase(baseDB),
+			tcpostgres.WithUsername(baseUser),
+			tcpostgres.WithPassword(basePass),
+			tcpostgres.BasicWaitStrategies(),
+			testcontainers.WithReuseByName(containerName),
+		)
+	})
+	if err != nil {
+		return "", err
+	}
+	// Intentionally NOT terminated: the container is shared across package
+	// processes (ryuk disabled) and reaped by slice 1's scripts/test teardown.
+
+	baseURL, err := container.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		return "", fmt.Errorf("connection string: %w", err)
+	}
+
+	if err := bootstrapTemplate(ctx, baseURL); err != nil {
+		return "", err
+	}
+	return baseURL, nil
+}
+
+// bootstrapTemplate creates and migrates the shared template database under
+// a cluster-wide advisory lock, tolerating the cross-process duplicate.
+func bootstrapTemplate(ctx context.Context, baseURL string) error {
+	conn, err := pgx.Connect(ctx, baseURL)
+	if err != nil {
+		return fmt.Errorf("connect base db: %w", err)
+	}
+	defer func() { _ = conn.Close(ctx) }()
+
+	if _, err := conn.Exec(ctx, "SELECT pg_advisory_lock($1)", bootstrapLockKey); err != nil {
+		return fmt.Errorf("acquire bootstrap lock: %w", err)
+	}
+	defer func() { _, _ = conn.Exec(ctx, "SELECT pg_advisory_unlock($1)", bootstrapLockKey) }()
+
+	createTemplate := func() error {
+		_, err := conn.Exec(ctx, "CREATE DATABASE "+pgx.Identifier{templateDB}.Sanitize())
+		return err
+	}
+	migrateTemplate := func() error {
+		return postgres.MigrateUp(replaceDBName(baseURL, templateDB))
+	}
+	return bootstrapWith(createTemplate, migrateTemplate)
+}
+
+// bootstrapWith is the pure, injectable core of bootstrapTemplate: create
+// the template, TOLERATING SQLSTATE 42P04 (duplicate_database) so a process
+// that lost the cross-process race ADOPTS the already-created template,
+// then run migrations (golang-migrate no-ops at head, so re-verifying an
+// adopted template is safe).
+func bootstrapWith(createTemplate, migrate func() error) error {
+	if err := createTemplate(); err != nil {
+		if !isDuplicateDatabase(err) {
+			return fmt.Errorf("create template db: %w", err)
+		}
+		// Adopted an already-bootstrapped template (cross-process race).
+	}
+	if err := migrate(); err != nil {
+		return fmt.Errorf("migrate template db: %w", err)
+	}
+	return nil
+}
+
+// attachWithRetry runs the container start, retrying ONLY on a docker
+// name conflict (isContainerNameConflict) — the first-start race where a
+// sibling process won the create. On retry, WithReuseByName re-resolves to
+// the now-existing container, converging to a single shared handle. Any
+// other error returns immediately.
+func attachWithRetry[T any](attempts int, delay time.Duration, run func() (T, error)) (T, error) {
+	var zero T
+	var lastErr error
+	for i := 0; i < attempts; i++ {
+		v, err := run()
+		if err == nil {
+			return v, nil
+		}
+		if !isContainerNameConflict(err) {
+			return zero, err
+		}
+		lastErr = err
+		time.Sleep(delay)
+	}
+	return zero, fmt.Errorf("attach to shared container: name conflict persisted after %d attempts: %w", attempts, lastErr)
+}
+
+// createWithContentionRetry runs the per-test CREATE DATABASE ... TEMPLATE,
+// retrying ONLY on SQLSTATE 55006 (isTemplate1Contention) — transient
+// template-in-use contention under concurrency. Any other error returns
+// immediately; exhausting the attempts returns a wrapped error.
+func createWithContentionRetry(attempts int, delay time.Duration, create func() error) error {
+	var lastErr error
+	for i := 0; i < attempts; i++ {
+		err := create()
+		if err == nil {
+			return nil
+		}
+		if !isTemplate1Contention(err) {
+			return err
+		}
+		lastErr = err
+		time.Sleep(delay)
+	}
+	return fmt.Errorf("create from template: contention (55006) persisted after %d attempts: %w", attempts, lastErr)
+}
+
+// fataler is the subset of *testing.T that failStart needs, so the skip vs
+// fatal routing is unit-testable with a fake.
+type fataler interface {
+	Helper()
+	Skipf(format string, args ...any)
+	Fatalf(format string, args ...any)
+}
+
+// failStart routes a shared-container start failure: Docker-unavailable
+// skips (preserving the old per-package behavior), anything else fatals.
+func failStart(tb fataler, err error) {
+	tb.Helper()
+	if isDockerUnavailable(err) {
+		tb.Skipf("Docker not available; skipping integration test: %v", err)
+		return
+	}
+	tb.Fatalf("start shared postgres: %v", err)
+}
+
+// replaceDBName rewrites the database path of a Postgres URL, preserving
+// host, credentials, and query parameters.
+func replaceDBName(baseURL, dbName string) string {
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return baseURL
+	}
+	u.Path = "/" + dbName
+	return u.String()
+}
+
+// isContainerNameConflict reports whether err is the docker "container
+// name is already in use" conflict (HTTP 409) raised when a sibling test
+// process won the concurrent create of the shared named container.
+func isContainerNameConflict(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	if strings.Contains(msg, "container name") && strings.Contains(msg, "already in use") {
+		return true
+	}
+	return strings.Contains(msg, "status code 409") && strings.Contains(msg, "conflict")
+}
+
+// isDuplicateDatabase reports whether err carries SQLSTATE 42P04
+// (duplicate_database) — the cross-process template bootstrap race.
+func isDuplicateDatabase(err error) bool {
+	var pg *pgconn.PgError
+	if errors.As(err, &pg) {
+		return pg.Code == "42P04"
+	}
+	return false
+}
+
+// isTemplate1Contention reports whether err carries SQLSTATE 55006
+// (object_in_use) — the template "is being accessed by other users"
+// contention raised by concurrent CREATE DATABASE ... TEMPLATE.
+func isTemplate1Contention(err error) bool {
+	var pg *pgconn.PgError
+	if errors.As(err, &pg) {
+		return pg.Code == "55006"
+	}
+	return false
+}
+
+// isDockerUnavailable reports whether err is the daemon-absent / cannot
+// connect shape, so the helpers can Skip rather than Fatal.
+func isDockerUnavailable(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	for _, marker := range []string{
+		"cannot connect to the docker daemon",
+		"docker: not found",
+		"executable file not found",
+		"dial unix /var/run/docker.sock",
+		"is the docker daemon running",
+	} {
+		if strings.Contains(msg, marker) {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/pgtest/pgtest_test.go
+++ b/backend/internal/pgtest/pgtest_test.go
@@ -1,0 +1,296 @@
+package pgtest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// --- pure classifier unit tests (no container) ---
+
+func TestIsContainerNameConflict(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"docker conflict", errors.New(`Error response from daemon: Conflict. The container name "/fishhawk-test-postgres" is already in use by container "abc123". You have to remove (or rename) that container to be able to reuse that name.`), true},
+		{"409 conflict", errors.New("create container: request returned status code 409: Conflict"), true},
+		{"unrelated docker error", errors.New("error during connect: dial tcp: lookup docker"), false},
+		{"pg error", &pgconn.PgError{Code: "42P04", Message: "database already exists"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isContainerNameConflict(tt.err); got != tt.want {
+				t.Errorf("isContainerNameConflict() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsDuplicateDatabase(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"42P04", &pgconn.PgError{Code: "42P04", Message: `database "fishhawk_tmpl" already exists`}, true},
+		{"wrapped 42P04", fmt.Errorf("create template db: %w", &pgconn.PgError{Code: "42P04"}), true},
+		{"55006 not duplicate", &pgconn.PgError{Code: "55006"}, false},
+		{"plain error", errors.New("boom"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isDuplicateDatabase(tt.err); got != tt.want {
+				t.Errorf("isDuplicateDatabase() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsTemplate1Contention(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"55006", &pgconn.PgError{Code: "55006", Message: "source database is being accessed by other users"}, true},
+		{"wrapped 55006", fmt.Errorf("create db: %w", &pgconn.PgError{Code: "55006"}), true},
+		{"42P04 not contention", &pgconn.PgError{Code: "42P04"}, false},
+		{"plain error", errors.New("boom"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isTemplate1Contention(tt.err); got != tt.want {
+				t.Errorf("isTemplate1Contention() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsDockerUnavailable(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"daemon down", errors.New("Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?"), true},
+		{"socket dial", errors.New("dial unix /var/run/docker.sock: connect: no such file or directory"), true},
+		{"binary missing", errors.New("exec: \"docker\": executable file not found in $PATH"), true},
+		{"unrelated error", errors.New("relation does not exist"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isDockerUnavailable(tt.err); got != tt.want {
+				t.Errorf("isDockerUnavailable() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// --- behavioral tests, one per failure mode (no container) ---
+
+// TestSharedContainer_NameConflictAttaches injects a name-conflict error
+// followed by success and asserts attachWithRetry converges to ONE attached
+// handle (no second start) rather than erroring or restarting.
+func TestSharedContainer_NameConflictAttaches(t *testing.T) {
+	conflict := errors.New(`Conflict. The container name "/fishhawk-test-postgres" is already in use`)
+	calls := 0
+	got, err := attachWithRetry(5, time.Millisecond, func() (string, error) {
+		calls++
+		if calls == 1 {
+			return "", conflict
+		}
+		return "attached", nil
+	})
+	if err != nil {
+		t.Fatalf("attachWithRetry: unexpected error %v", err)
+	}
+	if got != "attached" {
+		t.Errorf("attachWithRetry returned %q, want %q", got, "attached")
+	}
+	if calls != 2 {
+		t.Errorf("run invoked %d times, want 2 (one conflict, one success)", calls)
+	}
+
+	// Give-up: a persistent conflict exhausts the attempts and errors.
+	calls = 0
+	if _, err := attachWithRetry(3, time.Millisecond, func() (string, error) {
+		calls++
+		return "", conflict
+	}); err == nil {
+		t.Error("attachWithRetry: expected error after attempts exhausted, got nil")
+	}
+	if calls != 3 {
+		t.Errorf("run invoked %d times, want 3 (the attempt cap)", calls)
+	}
+
+	// A non-conflict error returns immediately without retrying.
+	calls = 0
+	other := errors.New("disk full")
+	if _, err := attachWithRetry(5, time.Millisecond, func() (string, error) {
+		calls++
+		return "", other
+	}); !errors.Is(err, other) {
+		t.Errorf("attachWithRetry returned %v, want the non-conflict error", err)
+	}
+	if calls != 1 {
+		t.Errorf("run invoked %d times on non-conflict error, want 1 (no retry)", calls)
+	}
+}
+
+// TestBootstrap_DuplicateDatabaseTolerated injects SQLSTATE 42P04 and
+// asserts the bootstrap ADOPTS the existing template (returns nil) instead
+// of failing — the cross-process race fix.
+func TestBootstrap_DuplicateDatabaseTolerated(t *testing.T) {
+	dup := &pgconn.PgError{Code: "42P04", Message: `database "fishhawk_tmpl" already exists`}
+	migrated := false
+	err := bootstrapWith(
+		func() error { return dup },
+		func() error { migrated = true; return nil },
+	)
+	if err != nil {
+		t.Fatalf("bootstrapWith tolerating 42P04: unexpected error %v", err)
+	}
+	if !migrated {
+		t.Error("bootstrapWith did not run migrate after adopting the template")
+	}
+
+	// A non-duplicate create error propagates (not tolerated).
+	createErr := errors.New("permission denied")
+	if err := bootstrapWith(
+		func() error { return createErr },
+		func() error { return nil },
+	); !errors.Is(err, createErr) {
+		t.Errorf("bootstrapWith returned %v, want the create error", err)
+	}
+
+	// A migrate error after a clean create propagates.
+	migErr := errors.New("bad migration")
+	if err := bootstrapWith(
+		func() error { return nil },
+		func() error { return migErr },
+	); !errors.Is(err, migErr) {
+		t.Errorf("bootstrapWith returned %v, want the migrate error", err)
+	}
+}
+
+// TestNewURL_Template1ContentionRetries injects SQLSTATE 55006 transiently
+// and asserts the bounded retry rides it out, then a give-up variant after
+// the cap, then immediate return on a non-contention error.
+func TestNewURL_Template1ContentionRetries(t *testing.T) {
+	contention := &pgconn.PgError{Code: "55006", Message: "source database is being accessed by other users"}
+	calls := 0
+	if err := createWithContentionRetry(5, time.Millisecond, func() error {
+		calls++
+		if calls < 3 {
+			return contention
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("createWithContentionRetry: unexpected error %v", err)
+	}
+	if calls != 3 {
+		t.Errorf("create invoked %d times, want 3 (two contended, one success)", calls)
+	}
+
+	// Give-up: persistent 55006 exhausts attempts and errors.
+	calls = 0
+	if err := createWithContentionRetry(3, time.Millisecond, func() error {
+		calls++
+		return contention
+	}); err == nil {
+		t.Error("createWithContentionRetry: expected error after attempts exhausted, got nil")
+	}
+	if calls != 3 {
+		t.Errorf("create invoked %d times, want 3 (the attempt cap)", calls)
+	}
+
+	// A non-contention error returns immediately without retrying.
+	calls = 0
+	other := &pgconn.PgError{Code: "42501", Message: "permission denied"}
+	if err := createWithContentionRetry(5, time.Millisecond, func() error {
+		calls++
+		return other
+	}); !errors.Is(err, other) {
+		t.Errorf("createWithContentionRetry returned %v, want the non-contention error", err)
+	}
+	if calls != 1 {
+		t.Errorf("create invoked %d times on non-contention error, want 1 (no retry)", calls)
+	}
+}
+
+// recordingTB is a fake fataler that records which branch failStart took.
+type recordingTB struct {
+	skipped bool
+	fataled bool
+}
+
+func (r *recordingTB) Helper()               {}
+func (r *recordingTB) Skipf(string, ...any)  { r.skipped = true }
+func (r *recordingTB) Fatalf(string, ...any) { r.fataled = true }
+
+// TestNew_DockerUnavailableSkips asserts the daemon-absent shape routes to
+// the skip branch while any other start error routes to fatal.
+func TestNew_DockerUnavailableSkips(t *testing.T) {
+	skipTB := &recordingTB{}
+	failStart(skipTB, errors.New("Cannot connect to the Docker daemon at unix:///var/run/docker.sock"))
+	if !skipTB.skipped || skipTB.fataled {
+		t.Errorf("docker-unavailable: skipped=%v fataled=%v, want skipped=true fataled=false", skipTB.skipped, skipTB.fataled)
+	}
+
+	fatalTB := &recordingTB{}
+	failStart(fatalTB, errors.New("some other start failure"))
+	if fatalTB.skipped || !fatalTB.fataled {
+		t.Errorf("other-error: skipped=%v fataled=%v, want skipped=false fataled=true", fatalTB.skipped, fatalTB.fataled)
+	}
+}
+
+func TestReplaceDBName(t *testing.T) {
+	got := replaceDBName("postgres://fishhawk:fishhawk@localhost:32768/fishhawk?sslmode=disable", "fh_abc")
+	want := "postgres://fishhawk:fishhawk@localhost:32768/fh_abc?sslmode=disable"
+	if got != want {
+		t.Errorf("replaceDBName() = %q, want %q", got, want)
+	}
+}
+
+// --- Docker-guarded integration test ---
+
+// TestSharedContainer_SharesAndIsolates calls NewPool twice in one process
+// and asserts both pools share the container (same host:port) yet are
+// isolated (a table created via pool A is invisible via pool B).
+func TestSharedContainer_SharesAndIsolates(t *testing.T) {
+	poolA := NewPool(t)
+	poolB := NewPool(t)
+
+	cfgA := poolA.Config().ConnConfig
+	cfgB := poolB.Config().ConnConfig
+	if cfgA.Host != cfgB.Host || cfgA.Port != cfgB.Port {
+		t.Errorf("pools not on the same container: A=%s:%d B=%s:%d", cfgA.Host, cfgA.Port, cfgB.Host, cfgB.Port)
+	}
+	if cfgA.Database == cfgB.Database {
+		t.Errorf("pools share the same database %q; want distinct per-test databases", cfgA.Database)
+	}
+
+	ctx := context.Background()
+	if _, err := poolA.Exec(ctx, "CREATE TABLE iso_check (id int)"); err != nil {
+		t.Fatalf("create table in pool A: %v", err)
+	}
+	var n int
+	if err := poolB.QueryRow(ctx,
+		`SELECT count(*) FROM information_schema.tables WHERE table_name = 'iso_check'`,
+	).Scan(&n); err != nil {
+		t.Fatalf("query table presence in pool B: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("iso_check visible in pool B (count=%d); databases are not isolated", n)
+	}
+}


### PR DESCRIPTION
## Summary

Adds `backend/internal/pgtest`, a shared-container Postgres test-support package: a process-singleton `fishhawk-test-postgres` container (testcontainers `WithReuse`+`WithName`) with a bounded attach-retry on the first-start name-conflict race, an advisory-locked idempotent migrated-template bootstrap (tolerates SQLSTATE 42P04 duplicate_database across processes), and per-test ephemeral `CREATE DATABASE ... TEMPLATE` databases (55006 contention retry) for isolation. Pure classifiers (`isContainerNameConflict`, `isTemplate1Contention`, `isDuplicateDatabase`, `isDockerUnavailable`) are unit-tested without a container; a Docker-guarded test proves two pools share one container yet stay isolated.

This is **slice 0** of #1174 — the foundation package, no consumers yet. The consumer migration (~18 `*_test.go` files) + the conditional `FISHHAWK_TEST_P` 2→4 restore ships as a follow-up run on top of this.

## Provenance

This is loop-produced output, recovered from a fan-out product bug. It was implemented by run `acbe1677` child `c64229d4` (the wave-0 slice) and integrated onto `fishhawk/run-acbe1677-consolidated`, but the parent fan-out wedged on **#1302** (`run_children` did not base the wave-1 slice on this integrated branch → empty dependent child → unrecoverable parent). The parent run was cancelled; this PR lands the clean, already-built slice-0 work directly so it isn't wasted.

## Test plan

- `go test -race ./backend/internal/pgtest/...` (unit classifiers + Docker-guarded sharing/isolation integration test)
- `golangci-lint run ./backend/internal/pgtest/...`
- CI: full suite + coverage gate

## Notes

- Refs #1174 (slice 0; issue stays open until the consumer migration lands).
- Root-cause of the fan-out failure tracked in #1302.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>