### PR TITLE
ci: run the Go test job on testdata-only changes (#1301)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,11 @@ jobs:
               - 'go.work'
               - 'go.work.sum'
               - '.golangci.yml'
+              # Go-test fixtures (e.g. backend/internal/agenteval/testdata/corpus)
+              # are consumed by Go tests (TestScore, TestCalibrateCorpusReplay), so a
+              # fixture-only change must run the Go job — otherwise it merges
+              # unvalidated and can red-line main post-merge (#1298/#1301).
+              - '**/testdata/**'
               - '.github/workflows/ci.yml'
             ts:
               - 'frontend/**'


### PR DESCRIPTION
## Summary

**Human-led** (`.github/workflows` change — agent drafted, operator authored; needs your review/merge).

CI's "Detect changed paths" filter skipped the **Go (lint + build + test)** job when a PR touched only non-`.go` files, so a change under `backend/internal/agenteval/testdata/corpus/**` merged **without ever running the Go tests that consume those fixtures** (`TestScore`, `TestCalibrateCorpusReplay`). PR #1298 added corpus cases that way and broke `main` post-merge (hotfix #1300).

Fix: add `'**/testdata/**'` to the `go` path filter so any Go-test fixture change routes to the Go job. The principle from the issue: *a change that can break a Go test must run that Go test in CI.* Chose the general `**/testdata/**` glob over the agenteval-specific path so it covers all Go test fixtures, not just the corpus.

## Test plan

- The PR itself touches `.github/workflows/ci.yml`, which is in the `go` filter, so the Go job runs on this PR and validates the workflow still parses/executes.
- Done-means: a future PR that changes only `backend/internal/agenteval/testdata/**` (or any `**/testdata/**`) will run the Go test job and fail if the consuming tests fail — so a fixture change can no longer red-line `main` post-merge.

## Notes

Drafted by the operator-agent during the dogfood loop; per the human-led convention for `.github/workflows`, I did not route it through the implement loop and am not self-approving — over to you to review + merge. Companion to #1298 (exposed it), #1174 (surfaced it), #1300 (hotfix).

Closes #1301

🤖 Generated with [Claude Code](https://claude.com/claude-code)