### PR TITLE
Bound the Actions runner pool under decomposition fan-out (#1227)

### DIFF
--- a/.github/workflows/fishhawk.yml
+++ b/.github/workflows/fishhawk.yml
@@ -43,6 +43,32 @@ on:
         required: false
         type: string
         default: claude-code
+      parent_run_id:
+        # The decomposition-parent run UUID, set by the backend dispatcher
+        # (orchestrator.go fireDispatch) ONLY for a decomposed-fan-out child;
+        # empty for a normal run. The concurrency: group below keys off it so
+        # the sibling child jobs of one fan-out share a group. (#1227)
+        description: 'Decomposition-parent run UUID — set only for fan-out children; keys the runner-pool concurrency guard'
+        required: false
+        type: string
+        default: ''
+
+# #1227: bound the customer's GitHub Actions runner pool under a decomposition
+# fan-out. The backend dispatches a distinct workflow_dispatch per decomposed
+# child (capped by FISHHAWKD_MAX_PARALLEL_CHILDREN), but that does not bound the
+# customer's concurrent-job capacity. Sibling children of one fan-out share
+# parent_run_id, so this group queues them — cancel-in-progress: false NEVER
+# cancels a running stage — serializing the fan-out to one runner at a time as a
+# capacity guard. A normal run has an empty parent_run_id, so the group falls
+# back to the unique Actions run id and is NEVER serialized.
+#
+# Tradeoff: a fan-out runs sequentially at the Actions layer regardless of how
+# many runners are free. A well-provisioned customer who wants parallel children
+# can widen the group (e.g. add a bucket to parent_run_id) or remove this block;
+# it is a conservative safe default for capacity-constrained pools.
+concurrency:
+  group: fishhawk-run-${{ inputs.parent_run_id || github.run_id }}
+  cancel-in-progress: false
 
 permissions:
   # id-token: write — the auth pre-step (#201) mints a GitHub

--- a/backend/internal/orchestrator/fanout_test.go
+++ b/backend/internal/orchestrator/fanout_test.go
@@ -1103,6 +1103,12 @@ func TestDispatchDecomposedChildren_GitHubActions_FiresPerChildDispatch(t *testi
 		if stageID != wantStage {
 			t.Errorf("call %d stage_id = %q, want %q (child %s implement stage)", i, stageID, wantStage, runID)
 		}
+		// #1227: every decomposed child carries its decomposition-parent id as
+		// parent_run_id so the customer workflow can key an Actions concurrency:
+		// group on the run family and serialize siblings.
+		if got := call.Inputs["parent_run_id"]; got != parent.ID.String() {
+			t.Errorf("call %d parent_run_id = %q, want %q (the decomposition parent / run family)", i, got, parent.ID.String())
+		}
 		// Pairwise distinct run_id + stage_id across calls — proves per-slice
 		// independence (no shared branch target).
 		if seenRun[runID] {

--- a/backend/internal/orchestrator/orchestrator.go
+++ b/backend/internal/orchestrator/orchestrator.go
@@ -1927,13 +1927,24 @@ func (o *Orchestrator) fireDispatch(ctx context.Context, r *run.Run, next *run.S
 		)
 	}
 
-	return o.GitHub.DispatchWorkflow(ctx, *r.InstallationID, repo,
-		actionsFile, ref, githubclient.DispatchInputs{
-			"run_id":      r.ID.String(),
-			"stage_id":    next.ID.String(),
-			"workflow_id": r.WorkflowID,
-			"stage":       next.ExecutorRef,
-		})
+	inputs := githubclient.DispatchInputs{
+		"run_id":      r.ID.String(),
+		"stage_id":    next.ID.String(),
+		"workflow_id": r.WorkflowID,
+		"stage":       next.ExecutorRef,
+	}
+	// #1227: a decomposed child carries its decomposition-parent id so the
+	// customer workflow can key an Actions `concurrency:` group on the run
+	// FAMILY and queue/serialize sibling child jobs as a runner-capacity guard
+	// (complements the backend dispatch cap, FISHHAWKD_MAX_PARALLEL_CHILDREN).
+	// DecomposedFrom (the fan-out parent), NOT ParentRunID (retry/related-run
+	// threading), is the sibling family. A non-decomposed run omits the input,
+	// so the workflow's group falls back to a per-run unique key (no
+	// serialization). Empty when DecomposedFrom is nil.
+	if r.DecomposedFrom != nil {
+		inputs["parent_run_id"] = r.DecomposedFrom.String()
+	}
+	return o.GitHub.DispatchWorkflow(ctx, *r.InstallationID, repo, actionsFile, ref, inputs)
 }
 
 func (o *Orchestrator) logger() *slog.Logger {

--- a/backend/internal/orchestrator/orchestrator_test.go
+++ b/backend/internal/orchestrator/orchestrator_test.go
@@ -502,6 +502,12 @@ func TestAdvance_DispatchesNextAgentStage(t *testing.T) {
 	if call.Inputs["run_id"] != r.ID.String() {
 		t.Errorf("inputs.run_id = %q", call.Inputs["run_id"])
 	}
+	// #1227: a non-decomposed run carries no parent_run_id, so the customer
+	// workflow's concurrency group falls back to a per-run unique key and never
+	// serializes.
+	if got, ok := call.Inputs["parent_run_id"]; ok {
+		t.Errorf("non-decomposed run set parent_run_id=%q, want it absent", got)
+	}
 	if call.Inputs["stage_id"] != stages[1].ID.String() {
 		t.Errorf("inputs.stage_id = %q", call.Inputs["stage_id"])
 	}


### PR DESCRIPTION
## Summary

The backend dispatches a distinct `workflow_dispatch` per decomposed child (capped by `FISHHAWKD_MAX_PARALLEL_CHILDREN`), but that bounds how many we **dispatch**, not the customer's GitHub Actions concurrent-job capacity — a wide fan-out can still saturate their runner pool. This adds an Actions `concurrency:` group keyed off the **run family** so sibling child jobs of one fan-out queue/serialize as a runner-capacity guard, complementing the dispatch cap (the deferred human-led half of E24.5 / #1145).

- **`backend/internal/orchestrator/orchestrator.go`** (`fireDispatch`): a decomposed child now carries its **`DecomposedFrom`** (the fan-out parent) — *not* `ParentRunID` (retry/related-run threading) — as a new `parent_run_id` `workflow_dispatch` input. A non-decomposed run omits the input.
- **`.github/workflows/fishhawk.yml`**: the `parent_run_id` input + `concurrency: { group: fishhawk-run-${{ inputs.parent_run_id || github.run_id }}, cancel-in-progress: false }`. Siblings of one fan-out share `parent_run_id` → one group → serialize (queued, **never cancel a running stage**). A normal run has an empty `parent_run_id` → the group falls back to the unique `github.run_id` → **never serialized**.
- **tests**: a decomposed child's dispatch carries `parent_run_id` = the decomposition parent; a non-decomposed run's dispatch omits it.

## Design note / tradeoff

GitHub Actions `concurrency` is **1-per-group** (no native max-N), so this **serializes a fan-out to one runner at a time** at the Actions layer, regardless of how many runners are free — the conservative capacity guard #1227 asks for. A well-provisioned customer who wants parallel children can widen the group (add a bucket to `parent_run_id`) or remove the block; it's a safe default for constrained pools. The backend dispatch cap remains the primary control. Only affects the `github_actions` runner_kind path (local-drive has no Actions dispatch).

## Test plan

- `cd backend && go test ./internal/orchestrator/...` — the per-child fan-out dispatch test asserts `parent_run_id` = the decomposition parent; the normal-dispatch test asserts it's absent. `golangci-lint run ./internal/orchestrator/...` clean.
- Workflow YAML validated (`concurrency.group` expression + the new input parse).

Closes #1227