### PR TITLE
Run the CI Go gate through scripts/test for testcontainer env parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,42 +127,36 @@ jobs:
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v2.8.0/install.sh \
             | sh -s -- -b "$(go env GOPATH)/bin" v2.8.0
 
-      - name: Lint, build, and test each module
+      # Route the Go gate through scripts/test instead of an inline `go test`
+      # loop so CI runs the suite in the SAME tuned environment as the local
+      # and runner gates (#1413, the #1402 testcontainer flake). The inline
+      # loop bypassed scripts/test entirely, so in CI the testcontainers ryuk
+      # reaper stayed ENABLED — a shared single-point-of-failure container that
+      # times out under daemon load and cascades one flake into a whole-suite
+      # red (#972) — and the shared fishhawk-test-postgres container (#1174)
+      # was never reaped, so stale named containers accumulated across runs
+      # (the `No such container` stale-reuse symptom). scripts/test exports
+      # TESTCONTAINERS_RYUK_DISABLED=true and reaps fishhawk-test-postgres in
+      # an EXIT trap, so both causes are removed at the source.
+      - name: Lint each module
         if: steps.have-modules.outputs.yes == 'true'
-        run: |
-          set -eu
-          GOLANGCI_LINT="$(go env GOPATH)/bin/golangci-lint"
-          for m in $(go work edit -json | jq -r '.Use[].DiskPath'); do
-            echo "::group::go module: $m"
-            (
-              cd "$m"
-              "$GOLANGCI_LINT" run ./...
-              go build ./...
-              go test -race -coverprofile=coverage.out -covermode=atomic ./...
-            )
-            echo "::endgroup::"
-          done
+        # `scripts/test lint` is byte-for-byte the prior per-module
+        # `golangci-lint run ./...` (AGENTS.md "Build, test, lint") and fails
+        # closed when golangci-lint is missing (installed in the step above).
+        # The dropped `go build ./...` is redundant: lint typechecks/builds and
+        # the test pass compiles every package — exactly what the runner's
+        # `scripts/test verify` gate already relies on.
+        run: scripts/test lint
 
-      - name: Coverage threshold (≥ 80% aggregate, excl. sqlc-generated)
+      - name: Test + coverage threshold (≥ 80% aggregate, excl. sqlc-generated)
         if: steps.have-modules.outputs.yes == 'true'
-        run: |
-          set -eu
-          # Build a list of per-module coverage profiles. The threshold
-          # script aggregates across all of them; --exclude drops generated
-          # packages before counting. Targets documented in
-          # docs/ARCHITECTURE.md §9.
-          #
-          # The /db/ exclude pattern matches every sqlc-generated package
-          # (convention: `internal/<feature>/db/`). New sqlc packages
-          # auto-skip without editing this list.
-          profiles=()
-          while IFS= read -r m; do
-            profiles+=("$m/coverage.out")
-          done < <(go work edit -json | jq -r '.Use[].DiskPath')
-          python3 scripts/check-coverage.py \
-            --threshold 80 \
-            --exclude '/db/' \
-            "${profiles[@]}"
+        # `scripts/test coverage` writes the per-module coverage.out profiles
+        # and runs scripts/check-coverage.py --threshold 80 --exclude '/db/'
+        # itself — identical to the gate this replaces (the /db/ exclude drops
+        # sqlc-generated packages; new ones auto-skip). Targets: ARCHITECTURE
+        # §9. Lower test-binary parallelism on a constrained daemon with
+        # FISHHAWK_TEST_P (default 4, #1174).
+        run: scripts/test coverage
 
   ts:
     name: TypeScript (lint + build + test)


### PR DESCRIPTION
## Summary

Part B of the #1402 testcontainer flake — the CI-side cause removal companion to the pgtest stale-ref retry hardening that shipped in #1412. Closes #1413.

The `Go (lint + build + test)` job ran an inline `go test` loop that **bypassed `scripts/test`**, so none of its shared-testcontainer tuning applied in CI:
- the testcontainers **ryuk reaper stayed ENABLED** — a shared single-point-of-failure container that times out under daemon load and cascades one flake into a whole-suite red (#972);
- the shared `fishhawk-test-postgres` container (#1174) was **never reaped**, so stale named containers accumulated across runs — the `No such container` stale-reuse symptom behind the flake (PR #1401).

This routes the gate through `scripts/test`, which exports `TESTCONTAINERS_RYUK_DISABLED=true` and reaps `fishhawk-test-postgres` in an EXIT trap — removing both causes at the source:

- **`scripts/test lint`** — byte-for-byte the prior per-module `golangci-lint run ./...` (AGENTS.md "Build, test, lint"); fails closed if golangci-lint is missing (installed in the step above).
- **`scripts/test coverage`** — writes the per-module `coverage.out` profiles **and** runs `scripts/check-coverage.py --threshold 80 --exclude '/db/'` itself, identical to the coverage gate it replaces (the `/db/` exclude drops sqlc-generated packages; new ones auto-skip).

The dropped `go build ./...` is redundant: lint typechecks/builds and the test pass compiles every package — exactly what the runner's `scripts/test verify` gate already relies on.

> Note on the issue's suggested fix: #1413 proposed `run: scripts/test verify`, but `verify` deliberately omits coverage, which would have left the separate coverage step with no profiles. The correct mapping that preserves the coverage gate is `lint` + `coverage`, as done here.

## Test plan

- [x] `yq` parses the workflow; the `go` job's steps are now `Lint each module` + `Test + coverage threshold`.
- [x] `scripts/test` is executable on checkout (`-rwxr-xr-x`) and `scripts/test -h` runs.
- [ ] **This PR's own CI run is the end-to-end validation** — `ci.yml` is in the `go` path filter, so the `go` job runs the new `scripts/test lint` + `scripts/test coverage` invocation against this tree. Confirm `Go (lint + build + test)` and `CI Pass` are green before merge.

## Notes

- **`.github/workflows/**` is human-led** (autonomy:low) — drafted by the operator agent and pushed over SSH; please review and merge. Not driven through the implement loop (forbidden path).
- Confined to the `go` job's lint/test/coverage steps. The `docker-build` / OpenAPI / TypeScript path-filtered jobs and the `CI Pass` rollup are unchanged.
- Parent epic: #389.

🤖 Generated with [Claude Code](https://claude.com/claude-code)