### PR TITLE
Dogfood the deploy stage: workflow-v1 release workflow + delegating deploy.yml stub

### DIFF
--- a/.fishhawk/workflows.yaml
+++ b/.fishhawk/workflows.yaml
@@ -11,7 +11,7 @@
 # When the product can execute this spec, the syntax may be revised to
 # match the frozen v0 schema. The intent expressed here will not change.
 
-version: "0.5"
+version: "1.0"
 
 roles:
   founder:
@@ -249,3 +249,56 @@ workflows:
           # side gate is degenerate now — it just lets the run
           # advance once branch protection clears.
           - type: check
+
+  # Delegating deploy (ADR-038 / E23, workflow-v1). Operator-triggered
+  # after the corresponding feature_change run merges. Fishhawk holds no
+  # deploy logic or credentials: the deploy stage TRIGGERS an external
+  # pipeline (.github/workflows/deploy.yml via workflow_dispatch, passing
+  # the fishhawk_run_id + fishhawk_stage_id correlation inputs the
+  # deployreconciler re-resolves the run by) and MONITORS it to terminal,
+  # recording a `deployment` artifact + audit trail.
+  #
+  # `required_upstream` is intentionally OMITTED here: it evaluates the
+  # CURRENT run's own implement/review state, which a deploy-only release
+  # run lacks, so it would fail closed. Declarative cross-workflow gating
+  # on the feature_change run is tracked in #1417; until it lands, the
+  # fail-closed approval gate below is the control point and the operator
+  # confirms the change merged before triggering the release.
+  #
+  # deploy.yml is an echo/no-op validation stub for now (echo-now-real-later,
+  # #1418) — it exercises the full dispatch -> poll -> deployment-artifact
+  # loop without touching real infrastructure.
+  release:
+    description: >-
+      Delegating deploy workflow (ADR-038): triggers an external release
+      pipeline via workflow_dispatch and monitors it to terminal. Fishhawk
+      holds no deploy logic or credentials. Operator-triggered after the
+      feature_change run merges.
+    # Drive mode (#1023): surface next_action and auto-advance mechanical
+    # transitions; the deploy approval below still parks for the human (no
+    # operator_agent delegation is configured, so a production deploy always
+    # pages rather than auto-approving).
+    drive: true
+    policy:
+      max_stage_runtime: "30m"
+
+    stages:
+      - id: deploy
+        type: deploy
+        # A deploy stage MUST delegate (ADR-038): no agent/human executor.
+        executor:
+          delegate:
+            target: github_actions
+            workflow_ref: deploy.yml
+            git_ref: main
+        # Pre-flight deploy constraints (evaluated BEFORE execution at the
+        # gate). change_freeze:false declares the surface without blocking.
+        constraints:
+          - allowed_environments: [staging, production]
+          - change_freeze: false
+        produces:
+          - artifact: deployment
+        gates:
+          - type: approval
+            approvers:
+              any_of: [founder]

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,54 @@
+name: Deploy (dogfood stub)
+
+# Delegating-deploy target for Fishhawk's `release` workflow (ADR-038 / E23).
+#
+# Fishhawk's deploy stage triggers this workflow via workflow_dispatch, passing
+# the fishhawk_run_id + fishhawk_stage_id correlation inputs (and fishhawk_rollback
+# on the rollback sub-action). The deployreconciler re-resolves the dispatched run
+# by matching those inputs (ResolveDispatchedRun → inputsMatchCorrelation) and polls
+# it to terminal, recording a `deployment` artifact + audit trail.
+#
+# This is a VALIDATION STUB (echo-now-real-later, #1418): it echoes the correlation
+# inputs and exits 0, exercising the full dispatch → poll → deployment-artifact loop
+# and the success outcome mapping WITHOUT touching real infrastructure. A follow-up
+# (#1418) will point it at a real target (k8s/Helm or GitHub Pages).
+#
+# The three inputs below are exactly what the backend may send:
+#   - forward deploy  → fishhawk_run_id, fishhawk_stage_id
+#   - rollback action → fishhawk_run_id, fishhawk_stage_id, fishhawk_rollback=true
+# GitHub Actions rejects an undeclared workflow_dispatch input, so all three are
+# declared even though the forward path omits fishhawk_rollback (it defaults below).
+
+on:
+  workflow_dispatch:
+    inputs:
+      fishhawk_run_id:
+        description: "Fishhawk run id (correlation token; set by the deploy stage)"
+        required: true
+      fishhawk_stage_id:
+        description: "Fishhawk deploy stage id (correlation token)"
+        required: true
+      fishhawk_rollback:
+        description: "Set to true by the rollback sub-action; the stub treats it as a no-op rollback"
+        required: false
+        default: "false"
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy (stub)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Echo deploy correlation and outcome
+        run: |
+          echo "::notice::Fishhawk dogfood deploy stub — no-op (echo-now-real-later, #1418)"
+          echo "fishhawk_run_id:   ${{ inputs.fishhawk_run_id }}"
+          echo "fishhawk_stage_id: ${{ inputs.fishhawk_stage_id }}"
+          echo "fishhawk_rollback: ${{ inputs.fishhawk_rollback }}"
+          if [ "${{ inputs.fishhawk_rollback }}" = "true" ]; then
+            echo "rollback path (stub) — succeeding"
+          else
+            echo "forward deploy path (stub) — succeeding"
+          fi


### PR DESCRIPTION
## Summary

Stand up Fishhawk's own deploy-stage dogfood (ADR-038 / E23). Two changes:

1. **`.fishhawk/workflows.yaml`** — bump `version: "0.5"` → `"1.0"` and add a standalone **`release`** workflow with one delegating **`deploy`** stage. workflow-v1 is a superset of v0, so the existing `feature_change` / `human_led_change` / `routine_change` workflows validate unchanged (confirmed locally with `check-jsonschema --schemafile docs/spec/workflow-v1.schema.json .fishhawk/workflows.yaml` → `ok`).
2. **`.github/workflows/deploy.yml`** — the `workflow_dispatch` target the deploy stage triggers. An **echo/no-op validation stub** for now (#1418): it declares exactly the inputs the backend sends and exits 0.

The deploy stage triggers `deploy.yml` via `workflow_dispatch` and the `deployreconciler` polls it to terminal, recording a `deployment` artifact. Fishhawk holds no deploy logic or credentials.

### Why the stub declares those three inputs

The backend deploy trigger sends `fishhawk_run_id` + `fishhawk_stage_id` (`backend/internal/server/deploy_trigger.go:161`); the rollback sub-action adds `fishhawk_rollback=true` (`deploy_rollback.go:302`). `ResolveDispatchedRun` re-resolves the dispatched run by matching those inputs (`inputsMatchCorrelation`). GitHub Actions **rejects an undeclared `workflow_dispatch` input**, so all three are declared even though the forward path omits `fishhawk_rollback` (it defaults).

### Design notes

- **`required_upstream` intentionally omitted.** It evaluates the *current run's own* implement/review state (`deployCIGreen`/`deployReviewMerged`, `approvals.go:1797,1823`), which a deploy-only `release` run lacks — so it would fail closed. Declarative cross-workflow gating on the `feature_change` run is filed as **#1417**; until it lands, the fail-closed approval gate is the control point and the operator confirms the change merged before triggering the release.
- **Model selection needs no spec change.** Leaving `executor.model` unset is already the automatic posture. The backend gaps that make automatic selection actually fire — the plan prompt emitting `model_recommendation`, and per-stage selection beyond implement — are filed as **#1415** and **#1416**.

## Test plan

- [x] `check-jsonschema` validates the full `.fishhawk/workflows.yaml` against `docs/spec/workflow-v1.schema.json` → `ok` (existing workflows + the new `release`).
- [x] `deploy.yml` parses; declares exactly `fishhawk_run_id`, `fishhawk_stage_id`, `fishhawk_rollback`.
- [x] The `deploy` stage matches the ADR-038 rules: delegating executor (no agent/human), pre-flight constraints only (`allowed_environments`, `change_freeze`), `produces: deployment`, approval gate.
- [ ] **After merge:** reload the stack, then trigger a `release` run to dogfood the full dispatch → poll → `deployment`-artifact loop end-to-end (the stub run should map to a `succeeded` outcome). `deploy.yml` must be on `main` for `workflow_dispatch` to be dispatchable.

## Notes

- **`.github/workflows/**` is human-led** (autonomy:low) — drafted by the operator agent, pushed over SSH; please review + merge. Committing the spec to base first also avoids the dogfood gotcha where an uncommitted `.fishhawk/workflows.yaml` edit gets swept into an implement commit.
- Follow-ups filed: **#1417** (cross-workflow gating), **#1418** (point `deploy.yml` at a real target), **#1415** / **#1416** (automatic model selection backend).

Refs #924, #1417, #1418

🤖 Generated with [Claude Code](https://claude.com/claude-code)