### PR TITLE
Point the acceptance egress target at the per-run branch preview (E31.18 companion)

### DIFF
--- a/.fishhawk/workflows.yaml
+++ b/.fishhawk/workflows.yaml
@@ -214,7 +214,7 @@ workflows:
         # they are not declarable here. Hosts, not URLs — no scheme, no path.
         egress:
           target_hosts:
-            - localhost:8080
+            - localhost:8090
         # Durable acceptance-evidence record (v1.2, ADR-049 / #1531): the
         # verdict + per-criterion results + content-hash refs to evidence blobs.
         # Valid ONLY on an acceptance stage.


### PR DESCRIPTION
## Summary

Final operator companion for #1569: repoints `feature_change`'s `egress.target_hosts` from `localhost:8080` (the orchestrating dev daemon serving main — the wrong-tree gap) to `localhost:8090` (the `scripts/dev preview` default, where the runner's provisioning hook serves the run's merge-candidate build).

Paired with the runner env config (`FISHHAWK_ACCEPTANCE_PREVIEW_CMD='scripts/dev preview'`, `FISHHAWK_ACCEPTANCE_PREVIEW_TEARDOWN_CMD='scripts/dev preview-down'`, set on the fishhawk MCP server env), this makes every future acceptance dispatch: provision the merge-candidate preview → probe `/healthz git_sha` → refuse stale/unreachable targets pre-spawn → validate the actual change → tear down.

## Test plan

- [x] `check-jsonschema` against workflow-v1.schema.json: ok.
- [x] The 8090 preview path was exercised live during run 9ba82e85's acceptance stage (preview up with git_sha-verified readiness, torn down cleanly — evidence retained).
- [ ] Next feature_change run demonstrates the full provision→probe→validate→teardown cycle end to end.

Companion to #1569 (merged as PR #1575). Human-led `.fishhawk/**` surface, same class as #1565.

🤖 Generated with [Claude Code](https://claude.com/claude-code)