### PR TITLE
Correct the refinement edit endpoint path in the OpenAPI spec

### DIFF
--- a/docs/api/v0.openapi.yaml
+++ b/docs/api/v0.openapi.yaml
@@ -5455,6 +5455,8 @@ paths:
         '404': { description: "`refinement_session_not_found` — no session with that id." }
         '503': { description: "`refinement_repo_unconfigured`." }
 
+
+  /v0/refinement/sessions/{session_id}/draft:
     patch:
       operationId: editRefinementDraft
       summary: Edit a refinement draft (agent amendment or direct field edit)


### PR DESCRIPTION
## Summary
Moves the `editRefinementDraft` patch operation to its own `/v0/refinement/sessions/{session_id}/draft` path node, matching the route the backend actually registers (`handlers.go:52`) and what `docs/api/v0.md:537` already documents. Spec-faithful consumers previously 405'd — E34.4's `fishhawk_draft_epic` edit arm hit exactly this, caught live by the #1595 acceptance stage (run 49f13795, criterion `arms-map-one-to-one`): the first cross-PR seam acceptance has caught that both review pairs missed, since nothing cross-checks the spec against the mux.

The registered route is canonical (matches the `.../decision` / `.../file` sub-resource family).

## Test plan
- `npx -y @redocly/cli@2.31.5 lint` — valid, same 4 pre-existing warnings as main.
- Docs-only, +2 lines; no behavior change.

## Notes
Operator-authored docs correction (the salvage/docs exception); companion to the in-flight #1595 fixup that re-points the MCP edit arm to `/draft`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)