### PR TITLE
Strip all x-* vendor keywords from the derived --json-schema

### DIFF
--- a/runner/internal/plan/derive.go
+++ b/runner/internal/plan/derive.go
@@ -14,17 +14,32 @@ import (
 // handling); the rest are stripped wherever they appear:
 //   - format ............ (uri / date-time) — unsupported assertion keyword
 //   - $schema / $id ..... dialect/identifier metadata the subset rejects
-//   - x-coerce-principal / x-coerce-defaults — Fishhawk runtime-coercion
-//     annotations (#537) with no meaning to the CLI
+//
+// Every "x-"-prefixed key is dropped by isDroppedKeyword's prefix rule, so
+// vendor annotations need no per-name entry here.
 //
 // oneOf is rejected too, but the canonical standard_v1 schema uses none, so
 // there is no oneOf to strip — derive_test asserts none sneaks in.
 var structuredOutputDroppedKeywords = map[string]bool{
-	"format":             true,
-	"$schema":            true,
-	"$id":                true,
-	"x-coerce-principal": true,
-	"x-coerce-defaults":  true,
+	"format":  true,
+	"$schema": true,
+	"$id":     true,
+}
+
+// isDroppedKeyword reports whether a schema key must be elided from the
+// derived structured-output schema. Beyond the named keyword set, EVERY
+// "x-"-prefixed vendor-extension key is dropped: JSON Schema 2020-12 treats
+// unknown keywords as inert annotations, but claude CLI 2.1.205 introduced
+// strict --json-schema validation that hard-rejects them (#1741 — the
+// x-intended-required annotation the AGENTS.md schema checklist places on
+// soaking fields took down every plan stage when the CLI auto-updated).
+// Stripping by prefix keeps the canonical schema free to carry annotations
+// while the CLI always receives a strict-clean derivation. Note the walk
+// applies this at every object level (same positional naivety as "format"),
+// so a property literally NAMED "x-…" would be elided — the canonical
+// schema has none, and derive_test pins the real derivation end to end.
+func isDroppedKeyword(k string) bool {
+	return structuredOutputDroppedKeywords[k] || strings.HasPrefix(k, "x-")
 }
 
 // maxInlineDepth bounds the recursive $ref inlining so a future cyclic
@@ -103,7 +118,7 @@ func inlineNode(node any, defs map[string]any, depth int) (any, error) {
 				return inlined, nil
 			}
 			for k, v := range n {
-				if k == "$ref" || k == "$defs" || structuredOutputDroppedKeywords[k] {
+				if k == "$ref" || k == "$defs" || isDroppedKeyword(k) {
 					continue
 				}
 				iv, err := inlineNode(v, defs, depth+1)
@@ -116,7 +131,7 @@ func inlineNode(node any, defs map[string]any, depth int) (any, error) {
 		}
 		out := make(map[string]any, len(n))
 		for k, v := range n {
-			if k == "$defs" || structuredOutputDroppedKeywords[k] {
+			if k == "$defs" || isDroppedKeyword(k) {
 				continue
 			}
 			iv, err := inlineNode(v, defs, depth+1)

--- a/runner/internal/plan/derive_test.go
+++ b/runner/internal/plan/derive_test.go
@@ -2,6 +2,7 @@ package plan
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/santhosh-tekuri/jsonschema/v6"
@@ -13,7 +14,7 @@ import (
 // subset rejects (verified 2026-06-23). The derivation must strip every one
 // ANYWHERE in the document — a single survivor makes the CLI silently emit no
 // structured_output.
-var rejectedKeywords = []string{"$ref", "$defs", "format", "$schema", "$id", "x-coerce-principal", "x-coerce-defaults", "oneOf"}
+var rejectedKeywords = []string{"$ref", "$defs", "format", "$schema", "$id", "x-coerce-principal", "x-coerce-defaults", "x-intended-required", "oneOf"}
 
 // walkKeys invokes fn for every object key anywhere in the decoded JSON tree.
 func walkKeys(node any, fn func(key string)) {
@@ -46,6 +47,28 @@ func TestStructuredOutputSchema_StripsRejectedKeywords(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestStructuredOutputSchema_StripsAllVendorExtensionKeys pins the #1741
+// prefix rule directly: claude CLI 2.1.205's strict --json-schema validation
+// rejects ANY unknown keyword, so no "x-"-prefixed key of any name may
+// survive the derivation — not just the ones enumerated in rejectedKeywords.
+// This fails if a future annotation (the next x-something the schema
+// checklist invents) reaches the CLI and re-runs the outage.
+func TestStructuredOutputSchema_StripsAllVendorExtensionKeys(t *testing.T) {
+	b, err := StructuredOutputSchema()
+	if err != nil {
+		t.Fatalf("StructuredOutputSchema: %v", err)
+	}
+	var tree any
+	if err := json.Unmarshal(b, &tree); err != nil {
+		t.Fatalf("derived schema is not valid JSON: %v", err)
+	}
+	walkKeys(tree, func(key string) {
+		if strings.HasPrefix(key, "x-") {
+			t.Errorf("derived schema still contains vendor-extension key %q (claude CLI 2.1.205 strict mode hard-rejects it, #1741)", key)
+		}
+	})
 }
 
 // compileDerived compiles the derived schema with the jsonschema library, the


### PR DESCRIPTION
## Summary

Claude CLI 2.1.205 (auto-updated 2026-07-08 17:40) validates `--json-schema` in strict mode and hard-rejects unknown keywords. The `x-intended-required` annotation — in the plan schema since #1541 and legal per JSON Schema 2020-12 §10.3 — therefore took down **every plan stage** with an instant category-A zero-token failure (#1741). The loop could not ship its own fix (bootstrap deadlock), so this PR is operator-authored per founder direction.

The fix generalizes the existing derivation strip (`structuredOutputDroppedKeywords`, which already elided two hard-coded `x-coerce-*` entries) into an `isDroppedKeyword` prefix rule: **every `x-*` key is elided** from the schema the runner hands to `--json-schema`. Canonical schemas stay free to carry annotations (the AGENTS.md soak-period checklist convention survives untouched); strict validators always receive a clean derivation. Future annotations can never re-run this outage.

## Test plan

- `TestStructuredOutputSchema_StripsAllVendorExtensionKeys` (new): walks the real derived schema and fails on ANY surviving `x-*` key, regardless of name.
- `rejectedKeywords` sweep extended with `x-intended-required`.
- Full runner module: `go test ./... -count=1` green; `golangci-lint run` clean.
- **Live verification:** the derived schema fed to claude 2.1.205 via `--json-schema` now succeeds (structured output emitted); pre-fix it errored `strict mode: unknown keyword: "x-intended-required"`. Also verified on 2.1.204.

## Notes

Part of #1741 — this resolves the outage leg. The hardening legs (record agent CLI version per invocation; `FISHHAWK_AGENT_BIN` operator override) stay on #1741 to ship through the loop once it is back up. Operator-authored (loop-down bootstrap exception); founder review + merge required since operator-authored PRs cannot be self-approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)