### PR TITLE
Drop $schema dialect from the acceptance verdict schema

### DIFF
--- a/runner/cmd/fishhawk-runner/acceptance.go
+++ b/runner/cmd/fishhawk-runner/acceptance.go
@@ -57,8 +57,16 @@ var acceptanceVerdictPath = "/tmp/fishhawk-acceptance.json"
 // TestAcceptanceVerdictSchema_LockstepWithValidator: a verdict this
 // schema admits must pass validateAcceptanceVerdict, whose rules mirror
 // the backend validator.
+//
+// Deliberately carries NO "$schema" dialect declaration: claude CLI
+// 2.1.205's strict --json-schema validator tries to RESOLVE the dialect
+// URI and fails ("no schema with key or ref ..."), killing the stage
+// pre-spawn — the acceptance-side sibling of the #1741/#1742 plan-stage
+// outage. The plan path strips $schema in its derivation
+// (structuredOutputDroppedKeywords); this hand-authored constant must
+// stay dialect-free for the same reason, pinned by
+// TestAcceptanceVerdictSchema_NoDialectOrVendorKeys.
 const acceptanceVerdictJSONSchema = `{
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
   "additionalProperties": false,
   "required": ["verdict"],

--- a/runner/cmd/fishhawk-runner/acceptance_test.go
+++ b/runner/cmd/fishhawk-runner/acceptance_test.go
@@ -412,6 +412,36 @@ func TestValidateAcceptanceVerdict_Coercions(t *testing.T) {
 	})
 }
 
+// TestAcceptanceVerdictSchema_NoDialectOrVendorKeys pins the strict-CLI
+// compatibility of the hand-authored verdict schema (#1741 acceptance-side
+// sibling): claude CLI 2.1.205's strict --json-schema validator resolves a
+// "$schema" dialect URI (and hard-rejects unknown x-* keywords), so neither
+// may appear anywhere in the constant. The plan path gets this from its
+// derivation strip; this constant must hold the invariant by hand.
+func TestAcceptanceVerdictSchema_NoDialectOrVendorKeys(t *testing.T) {
+	var tree any
+	if err := json.Unmarshal([]byte(acceptanceVerdictJSONSchema), &tree); err != nil {
+		t.Fatalf("acceptanceVerdictJSONSchema does not parse: %v", err)
+	}
+	var walk func(node any)
+	walk = func(node any) {
+		switch n := node.(type) {
+		case map[string]any:
+			for k, v := range n {
+				if k == "$schema" || k == "$id" || strings.HasPrefix(k, "x-") {
+					t.Errorf("verdict schema contains strict-CLI-rejected key %q (claude 2.1.205 --json-schema, #1741)", k)
+				}
+				walk(v)
+			}
+		case []any:
+			for _, v := range n {
+				walk(v)
+			}
+		}
+	}
+	walk(tree)
+}
+
 // TestAcceptanceVerdictSchema_LockstepWithValidator guards the
 // three-way shape lockstep (JSON schema ↔ runner validator ↔ backend
 // acceptanceBody): the schema must parse, its enums/required must match


### PR DESCRIPTION
## Summary
- claude CLI 2.1.205's strict `--json-schema` validation resolves the `"$schema"` dialect URI and fails (`no schema with key or ref "https://json-schema.org/draft/2020-12/schema"`), killing every acceptance stage pre-spawn — the acceptance-side sibling of the #1741/#1742 plan-stage outage. The plan path was fixed in #1742 via the derivation strip; the hand-authored `acceptanceVerdictJSONSchema` constant is passed to `inv.JSONSchema` directly (`main.go` acceptance path) and bypassed that sanitizer.
- Remove the `$schema` line from the constant and pin the invariant with `TestAcceptanceVerdictSchema_NoDialectOrVendorKeys` (walks the constant, fails on `$schema`/`$id`/any `x-*` key — same rule #1742 pins for the derived plan schema).

## Test plan
- `go test -race ./...` in `runner/` — all green, including the existing `TestAcceptanceVerdictSchema_LockstepWithValidator` (constant still parses and matches the backend wire shape).
- `golangci-lint run` clean.
- Live repro/verify: the pre-fix constant fed to `~/.local/share/claude/versions/2.1.205 --json-schema` reproduces the resolve error; the trimmed constant is accepted and the CLI emits a structured verdict.

## Notes
- Second leg of the 2.1.205 strict-schema outage (#1741). Run 979da236 (#1727) went terminal-failed on this; after merge + `scripts/dev post-merge` I'll retry its acceptance stage.
- Operator-authored under the standing "drive this fix class outside the loop" authorization — needs founder approval/merge.

Refs #1741

🤖 Generated with [Claude Code](https://claude.com/claude-code)